### PR TITLE
Replace deprecated arguments.callee with simple self-references.

### DIFF
--- a/src/pouch.js
+++ b/src/pouch.js
@@ -1,6 +1,6 @@
-window.Pouch = function(name, opts, callback) {
+window.Pouch = function Pouch(name, opts, callback) {
 
-  if (!(this instanceof arguments.callee)) {
+  if (!(this instanceof Pouch)) {
     return new Pouch(name, opts, callback);
   }
 

--- a/tests/qunit/qunit.js
+++ b/tests/qunit/qunit.js
@@ -903,7 +903,7 @@
                 }
 
                 // apply transition with (1..n) arguments
-            })(args[0], args[1]) && arguments.callee.apply(this, args.splice(1, args.length - 1));
+            })(args[0], args[1]) && innerEquiv.apply(this, args.splice(1, args.length - 1));
         };
 
         return innerEquiv;


### PR DESCRIPTION
Arguments.callee is now deprecated by ECMAScript 5 ([details](https://developer.mozilla.org/en/JavaScript/Reference/Functions_and_function_scope/arguments/callee)), so we should avoid using it!

The attached patch replaces all uses of arguments.callee with simple by-name self-references.
