### PR TITLE
Fix #101 speed up api.changes' deduping

### DIFF
--- a/src/adapters/pouch.idb.js
+++ b/src/adapters/pouch.idb.js
@@ -574,7 +574,6 @@ var IdbPouch = function(opts, callback) {
           var result = results[i];
           if (result) dedupResults.push(result);
         }
-        results = newResults;
 
         dedupResults.map(function(c) {
           if (opts.filter && !opts.filter.apply(this, [c.doc])) {


### PR DESCRIPTION
Now uses a `resultIndices` object to find and remove duplicate results.

At the end it goes through and removes the `null` values.

Since I am new to this codebase, please take a look at the diff before accepting.

This is for #101.
