### PR TITLE
Last seq init fix

### DIFF
--- a/src/pouch.replicate.js
+++ b/src/pouch.replicate.js
@@ -6,7 +6,7 @@
       var results = [];
       var completed = false;
       var pending = 0;
-      var last_seq = 0;
+      var last_seq = checkpoint;
       var continuous = opts.continuous || false;
       var result = {
         ok: true,


### PR DESCRIPTION
There is a last_seq initialization issue that results in improper storage of the sequence as 0.  Every other replication it is corrected when the changes api does a full replication (starting in err from 0).  If onChange is not called, then last_seq = 0 stands and it quickly overwrites the real value.  Rinse, repeat.
