### PR TITLE
Dont crash bulkDocs in http if only one argument is provided (fixes #143...

### DIFF
--- a/src/adapters/pouch.http.js
+++ b/src/adapters/pouch.http.js
@@ -408,6 +408,9 @@ var HttpPouch = function(opts, callback) {
       callback = opts;
       opts = {};
     }
+    if (!opts) {
+      opts = {}
+    }
 
     // If opts.new_edits exists add it to the document data to be
     // send to the database.

--- a/tests/test.changes.js
+++ b/tests/test.changes.js
@@ -132,7 +132,7 @@
           },
           continuous: true
         });
-        db.bulkDocs({docs: docs2}, function() { });
+        db.bulkDocs({docs: docs2});
       });
     });
   });


### PR DESCRIPTION
...)
