### PR TITLE
Test replication with deleted docs

### DIFF
--- a/tests/test.replication.js
+++ b/tests/test.replication.js
@@ -411,6 +411,102 @@ adapters.map(function(adapters) {
   });
 });
 
+// test a basic "initialize pouch" scenario when couch instance contains deleted revisions
+var deletedDocAdapters = [['idb-1', 'http-1']];
+deletedDocAdapters.map(function(adapters) {
+
+    qunit('replication: ' + adapters[0] + ':' + adapters[1], {
+        setup : function () {
+            this.name = generateAdapterUrl(adapters[0]);
+            this.remote = generateAdapterUrl(adapters[1]);
+        }
+    });
+
+    asyncTest("Test document count after replication with deleted revisions.", function() {
+        console.info('Starting Test: Test document count after replication with deleted revisions.');
+
+        var self = this;
+        var runs = 2;
+
+        // helper.  remove each document in db and bulk load docs into same
+        function rebuildDocuments(db, docs, callback) {
+            db.allDocs({include_docs:true},function (err, response) {
+                var count= 0,limit=response.rows.length;
+                if(limit==0){
+                    bulkLoad(db, docs, callback);
+                }
+                $.each(response.rows, function () {
+                    db.remove(this.doc, function (err, response) {
+                        if (err) console.error(err);
+                        ++count;
+                        if(count==limit){
+                            bulkLoad(db, docs, callback);
+                        }
+                    });
+                });
+            });
+        }
+
+        // helper.
+        function bulkLoad(db, docs, callback){
+            db.bulkDocs({docs:docs}, function (err, results) {
+                if (err) {
+                    console.error("Unable to bulk load docs.  Err: " + JSON.stringify(err));
+                    return;
+                }
+                callback(results);
+            });
+        }
+
+        // a basic map function to mimic our testing situation
+        function map(doc) {
+            if (doc.common == true) {
+                emit(doc._id, doc.rev);
+            }
+        }
+
+        // The number of workflow cycles to perform. 2+ was always failing -- reason for this test.
+
+        var workflow = function(name, remote, x){
+
+            // some documents.  note that the variable Date component, thisVaries, makes a difference.
+            // when the document is otherwise static, couch gets the same hash when calculating revision.
+            // and the revisions get messed up in pouch
+            var docs = [
+                {_id: "0", integer: 0, thisVaries: new Date(), common: true},
+                {_id: "1", integer: 1, thisVaries: new Date(), common: true},
+                {_id: "2", integer: 2, thisVaries: new Date(), common: true},
+                {_id: "3", integer: 3, thisVaries: new Date(), common: true}
+            ];
+
+            openTestDB(remote, function(err, dbr){
+                rebuildDocuments(dbr, docs, function(){
+                    openTestDB(name, function(err, db){
+                        db.replicate.from(remote, function(err, result) {
+                            db.query({map:map}, {reduce:false}, function (err, result) {
+                                ok(result.rows.length===docs.length,
+                                    "correct # docs replicated. Expected " + docs.length + " got " + result.rows.length);
+                                if(--x){
+                                    workflow(name, remote, x);
+                                }else{
+                                    start();
+                                }
+                            });
+                        });
+                    });
+                });
+            });
+        };
+
+        // new pouch and couch
+        initDBPair(self.name, self.remote, function(){
+            // Rinse, repeat our workflow...
+            workflow(self.name, self.remote, runs);
+        });
+    });
+
+});
+
 // This test only needs to run for one configuration, and it slows stuff
 // down
 downAdapters.map(function(adapter) {


### PR DESCRIPTION
This is a test to illustrate the problem we are seeing when replicating _deleted documents from couch to pouch.   Even when the document is recreated, pouch still thinks that it is deleted.
