### PR TITLE
Disallow adding docs with leading underscore in id

### DIFF
--- a/src/pouch.js
+++ b/src/pouch.js
@@ -90,6 +90,11 @@ Pouch.Errors = {
     error: 'invalid_id',
     reason: '_id field must contain a string'
   },
+  RESERVED_ID: {
+    status: 400,
+    error: 'bad_request',
+    reason: 'Only reserved document ids may start with underscore.'
+  },
   UNKNOWN_ERROR: {
     status: 500,
     error: 'unknown_error',

--- a/src/pouch.utils.js
+++ b/src/pouch.utils.js
@@ -39,6 +39,16 @@ var parseDocId = function(id) {
   }
 }
 
+// Determine id an ID is valid
+//   - invalid IDs begin with an underescore that does not begin '_design' or '_local'
+//   - any other string value is a valid id
+var isValidId = function(id) {
+  if (/^_/.test(id)) {
+    return /^_(design|local)/.test(id);
+  }
+  return true;
+}
+
 // Preprocess documents, parse their revisions, assign an id and a
 // revision for new writes that are missing them, etc
 var parseDoc = function(doc, newEdits) {
@@ -113,6 +123,9 @@ var parseDoc = function(doc, newEdits) {
 
   if (typeof doc._id !== 'string') {
     error = Pouch.Errors.INVALID_ID;
+  }
+  else if (!isValidId(doc._id)) {
+    error = Pouch.Errors.RESERVED_ID;
   }
 
 

--- a/tests/test.basics.js
+++ b/tests/test.basics.js
@@ -87,6 +87,15 @@ adapters.map(function(adapter) {
     });
   });
 
+  asyncTest("Add a doc with leading underscore in id", function() {
+    initTestDB(this.name, function(err, db) {
+      db.post({_id: '_testing', value: 42}, function(err, info) {
+        ok(err);
+        start();
+      });
+    });
+  });
+
   asyncTest("Get revisions of removed doc", 1, function() {
     initTestDB(this.name, function(err, db) {
       db.post({test:"somestuff"}, function(err, info) {


### PR DESCRIPTION
CouchDB doesn't allow leading underscores in ids, and as a result docs with leading underscores can't be synced with CouchDB.
