### PR TITLE
set Basic Authorization header for requests made through request

### DIFF
--- a/src/pouch.utils.js
+++ b/src/pouch.utils.js
@@ -327,6 +327,10 @@ var ajax = function ajax(options, callback) {
       options.method = options.type;
       delete options.type;
     }
+    if (options.auth) {
+      var token = btoa(options.auth.username + ':' + options.auth.password);
+      options.headers['Authorization'] = 'Basic ' + token;
+    }
 
     return request(options, function(err, response, body) {
       if (err) {


### PR DESCRIPTION
Fixes an error when using credentials in a URL like `http://user:pass@host.com/foo` for the http adapter under node.
