### PR TITLE
Fix a bug where _rev gets overwritten during a replicate with Couchdb

### DIFF
--- a/src/pouch.utils.js
+++ b/src/pouch.utils.js
@@ -130,7 +130,9 @@ var parseDoc = function(doc, newEdits) {
 
 
   doc._id = decodeURIComponent(doc._id);
-  doc._rev = [nRevNum, newRevId].join('-');
+  if(doc._rev === undefined) {
+    doc._rev = [nRevNum, newRevId].join('-');
+  }
 
   if (error) {
     return error;


### PR DESCRIPTION
Fix an annoying bug that causes replicating from CouchDB to change _rev numbers makeing the resulting entries unusable
