### PR TITLE
set onChange to call back for indexed db

### DIFF
--- a/src/adapters/pouch.idb.js
+++ b/src/adapters/pouch.idb.js
@@ -631,6 +631,9 @@ var IdbPouch = function(opts, callback) {
     }
     if (callback) {
       opts.complete = callback;
+      if (!opts.onChange){
+        opts.onChange = callback;
+      }
     }
     if (!opts.seq) {
       opts.seq = 0;
@@ -638,6 +641,7 @@ var IdbPouch = function(opts, callback) {
     if (opts.since) {
       opts.seq = opts.since;
     }
+
 
     console.info(name + ': Start Changes Feed: continuous=' + opts.continuous);
 


### PR DESCRIPTION
you can only get an event listener for changes if you manually set the onChange option to be the same as the callback, this does that by default
