### PR TITLE
rename "ldb" to "leveldb"

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -26,7 +26,7 @@ Most of the Pouch API is exposed as `fun(arg, [options], [callback])` Where both
 
     Pouch('idb://dbname', [options], [callback])
 
-This method gets an existing database if one exists or creates a new one if one does not exist. The protocol field denotes which backend you want to use (current options are idb, http and ldb)
+This method gets an existing database if one exists or creates a new one if one does not exist. The protocol field denotes which backend you want to use (current options are `idb`, `http` and `leveldb`)
 
     var pouchdb;
     Pouch('idb://test', function(err, db) {

--- a/src/adapters/pouch.leveldb.js
+++ b/src/adapters/pouch.leveldb.js
@@ -936,6 +936,7 @@ LevelPouch.destroy = function(name, callback) {
 }
 
 Pouch.adapter('ldb', LevelPouch);
+Pouch.adapter('leveldb', LevelPouch);
 
 // recursive fs.rmdir for Pouch.destroy. Use with care.
 function rmdir(dir, callback) {

--- a/tests/test.all_docs.js
+++ b/tests/test.all_docs.js
@@ -12,7 +12,7 @@ if (typeof module !== undefined && module.exports) {
     global[k] = global[k] || utils[k];
   }
   qunit = QUnit.module;
-  adapters = ['ldb-1', 'http-1'];
+  adapters = ['leveldb-1', 'http-1'];
 }
 
 adapters.map(function(adapter) {

--- a/tests/test.attachments.js
+++ b/tests/test.attachments.js
@@ -22,11 +22,11 @@ if (typeof module !== undefined && module.exports) {
     global[k] = global[k] || this.utils[k];
   }
   qunit = QUnit.module;
-  adapters = ['ldb-1', 'http-1'];
-  repl_adapters = [['ldb-1', 'http-1'],
+  adapters = ['leveldb-1', 'http-1'];
+  repl_adapters = [['leveldb-1', 'http-1'],
          ['http-1', 'http-2'],
-         ['http-1', 'ldb-1'],
-         ['ldb-1', 'ldb-2']];
+         ['http-1', 'leveldb-1'],
+         ['leveldb-1', 'leveldb-2']];
 }
 
 adapters.map(function(adapter) {

--- a/tests/test.auth_replication.js
+++ b/tests/test.auth_replication.js
@@ -12,7 +12,7 @@ if (typeof module !== undefined && module.exports) {
   for (var k in utils) {
     global[k] = global[k] || utils[k];
   }
-  local = 'ldb://test_suite_db';
+  local = 'leveldb://test_suite_db';
   qunit = QUnit.module;
 }
 

--- a/tests/test.basics.js
+++ b/tests/test.basics.js
@@ -9,7 +9,7 @@ if (typeof module !== undefined && module.exports) {
   for (var k in this.utils) {
     global[k] = global[k] || this.utils[k];
   }
-  adapters = ['http-1', 'ldb-1']
+  adapters = ['http-1', 'leveldb-1']
   qunit = QUnit.module;
 }
 

--- a/tests/test.bulk_docs.js
+++ b/tests/test.bulk_docs.js
@@ -12,7 +12,7 @@ if (typeof module !== undefined && module.exports) {
   for (var k in utils) {
     global[k] = global[k] || utils[k];
   }
-  adapters = ['ldb-1', 'http-1']
+  adapters = ['leveldb-1', 'http-1']
   qunit = QUnit.module;
 }
 

--- a/tests/test.changes.js
+++ b/tests/test.changes.js
@@ -9,7 +9,7 @@ if (typeof module !== undefined && module.exports) {
   for (var k in utils) {
     global[k] = global[k] || utils[k];
   }
-  adapters = ['ldb-1', 'http-1']
+  adapters = ['leveldb-1', 'http-1']
   qunit = QUnit.module;
 }
 

--- a/tests/test.conflicts.js
+++ b/tests/test.conflicts.js
@@ -11,7 +11,7 @@ if (typeof module !== undefined && module.exports) {
   for (var k in utils) {
     global[k] = global[k] || utils[k];
   }
-  adapters = ['ldb-1', 'http-1']
+  adapters = ['leveldb-1', 'http-1']
   qunit = QUnit.module;
 }
 

--- a/tests/test.design_docs.js
+++ b/tests/test.design_docs.js
@@ -11,7 +11,7 @@ if (typeof module !== undefined && module.exports) {
   for (var k in utils) {
     global[k] = global[k] || utils[k];
   }
-  adapters = ['ldb-1', 'http-1']
+  adapters = ['leveldb-1', 'http-1']
   qunit = QUnit.module;
 }
 

--- a/tests/test.replication.js
+++ b/tests/test.replication.js
@@ -20,14 +20,13 @@ if (typeof module !== undefined && module.exports) {
   }
   qunit = QUnit.module;
   downAdapters = [];
-  deletedDocAdapters = [['ldb-1', 'http-1']];
+  deletedDocAdapters = [['leveldb-1', 'http-1']];
 
-  // TODO: get an http adapter working and test replication to http
   adapters = [
-      ['ldb-1', 'http-1'],
+      ['leveldb-1', 'http-1'],
       ['http-1', 'http-2'],
-      ['http-1', 'ldb-1'],
-      ['ldb-1', 'ldb-2']]
+      ['http-1', 'leveldb-1'],
+      ['leveldb-1', 'leveldb-2']]
 
 }
 

--- a/tests/test.revs_diff.js
+++ b/tests/test.revs_diff.js
@@ -11,7 +11,7 @@ if (typeof module !== undefined && module.exports) {
   for (var k in utils) {
     global[k] = global[k] || utils[k];
   }
-  adapters = ['ldb-1', 'http-1']
+  adapters = ['leveldb-1', 'http-1']
   qunit = QUnit.module;
 }
 

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -73,8 +73,8 @@ function generateAdapterUrl(id) {
   if (opt[0] === 'http') {
     return 'http://localhost:2020/testdb_' + testId + '_' + opt[1];
   }
-  if (opt[0] === 'ldb') {
-    return 'ldb://testdb_' + testId + '_' + opt[1];
+  if (opt[0] === 'leveldb') {
+    return 'leveldb://testdb_' + testId + '_' + opt[1];
   }
 }
 

--- a/tests/test.views.js
+++ b/tests/test.views.js
@@ -11,7 +11,7 @@ if (typeof module !== undefined && module.exports) {
   for (var k in utils) {
     global[k] = global[k] || utils[k];
   }
-  adapters = ['ldb-1', 'http-1']
+  adapters = ['leveldb-1', 'http-1']
   qunit = QUnit.module;
 }
 


### PR DESCRIPTION
Exposing "leveldb" as adapter name for enhanced readability. "ldb" still supported for backwards compatibility, but will likely go away at some point.
