### PR TITLE
Changed the location of saucelabs module

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -136,7 +136,7 @@ module.exports = function(grunt){
 		});
 	});
 	
-	grunt.loadNpmTasks('grunt-saucelabs-qunit');
+	grunt.loadNpmTasks('grunt-saucelabs');
 	grunt.loadNpmTasks('grunt-node-qunit');
 	
 	grunt.registerTask("build", "concat min");

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
         "assert": "*",
         "nano": "*",
         "send": "*",
-		"grunt" : "*",
-		"grunt-saucelabs-qunit" : "*",
-		"grunt-node-qunit" : "*"
+		    "grunt" : "*",
+		    "grunt-saucelabs" : "~1.1.2",
+		    "grunt-node-qunit" : "*"
   },
   "maintainers":[
         {


### PR DESCRIPTION
Changed the location of saucelabs npm module - the module now does more than qunit tests, and I plan to maintain that.

I plan to deprecate this soon - https://npmjs.org/package/grunt-saucelabs-qunit and use this instead 
 https://npmjs.org/package/grunt-saucelabs
