### PR TITLE
add logger that can be overridden

### DIFF
--- a/src/adapters/pouch.http.js
+++ b/src/adapters/pouch.http.js
@@ -496,7 +496,7 @@ var HttpPouch = function(opts, callback) {
       opts.complete = callback;
     }
 
-    console.info(db_url + ': Start Changes Feed: continuous=' + opts.continuous);
+    Pouch.log('info', db_url + ': Start Changes Feed: continuous=' + opts.continuous);
 
     // Query string of all the parameters to add to the GET request
     var params = '?style=all_docs'
@@ -609,7 +609,7 @@ var HttpPouch = function(opts, callback) {
     // Return a method to cancel this method from processing any more
     return {
       cancel: function() {
-        console.info(db_url + ': Cancel Changes Feed');
+        Pouch.log('info', db_url + ': Cancel Changes Feed');
         opts.aborted = true;
         xhr.abort();
       }

--- a/src/adapters/pouch.idb.js
+++ b/src/adapters/pouch.idb.js
@@ -50,7 +50,7 @@ var IdbPouch = function(opts, callback) {
   var api = {};
   var idb;
 
-  console.info(name + ': Open Database');
+  Pouch.log('info', name + ': Open Database');
 
   req.onupgradeneeded = function(e) {
     var db = e.target.result;
@@ -259,7 +259,7 @@ var IdbPouch = function(opts, callback) {
       function finish() {
         var dataReq = txn.objectStore(BY_SEQ_STORE).put(docInfo.data);
         dataReq.onsuccess = function(e) {
-          console.info(name + ': Wrote Document ', docInfo.metadata.id);
+          Pouch.log('info', name + ': Wrote Document ', docInfo.metadata.id);
           docInfo.metadata.seq = e.target.result;
           // Current _rev is calculated from _rev_tree on read
           delete docInfo.metadata.rev;
@@ -638,7 +638,7 @@ var IdbPouch = function(opts, callback) {
       opts.seq = opts.since;
     }
 
-    console.info(name + ': Start Changes Feed: continuous=' + opts.continuous);
+    Pouch.log('info', name + ': Start Changes Feed: continuous=' + opts.continuous);
 
     var descending = 'descending' in opts ? opts.descending : false;
     descending = descending ? 'prev' : null;
@@ -743,7 +743,7 @@ var IdbPouch = function(opts, callback) {
     if (opts.continuous) {
       return {
         cancel: function() {
-          console.info(name + ': Cancel Changes Feed');
+          Pouch.log('info', name + ': Cancel Changes Feed');
           opts.cancelled = true;
           IdbPouch.Changes.removeListener(name, id);
         }
@@ -889,7 +889,7 @@ var IdbPouch = function(opts, callback) {
     return Array.prototype.slice.call(list || [], 0);
   }
   function fileErrorHandler(e) {
-    console.error('File system error',e);
+    Pouch.log('error', 'File system error',e);
   }
 
   //Delete attachments that are no longer referenced by any existing documents
@@ -919,7 +919,7 @@ var IdbPouch = function(opts, callback) {
               };
               if (!entryIsReferenced){
                 entries[i].remove(function() {
-                  console.info("Removed orphaned attachment: "+entries[i].name);
+                  Pouch.log('info', "Removed orphaned attachment: "+entries[i].name);
                 }, fileErrorHandler);
               }
             };
@@ -948,7 +948,7 @@ var IdbPouch = function(opts, callback) {
         newQuota=2*currentQuota; //double the quota when we hit 90% usage
       }
 
-      console.info("Current file quota: "+currentQuota+", current usage:"+currentUsage+", new quota will be: "+newQuota);
+      Pouch.log('info', "Current file quota: "+currentQuota+", current usage:"+currentUsage+", new quota will be: "+newQuota);
 
       //Ask for file quota. This does nothing if the proper quota size has already been granted.
       storageInfo.requestQuota(window.PERSISTENT, newQuota, function(grantedBytes) {
@@ -957,10 +957,10 @@ var IdbPouch = function(opts, callback) {
             fs.root.getFile(digest, {create: true}, function(fileEntry) {
               fileEntry.createWriter(function(fileWriter) {
                 fileWriter.onwriteend = function(e) {
-                  console.info('Wrote attachment');
+                  Pouch.log('info', 'Wrote attachment');
                 };
                 fileWriter.onerror = function(e) {
-                  console.info('File write failed: ' + e.toString());
+                  Pouch.log('info', 'File write failed: ' + e.toString());
                 };
                 var blob = new Blob([data], {type: type});
                 fileWriter.write(blob);
@@ -980,7 +980,7 @@ var IdbPouch = function(opts, callback) {
             var reader = new FileReader();
             reader.onloadend = function(e) {
               data = this.result;
-              console.info("Read attachment");
+              Pouch.log('info', "Read attachment");
               callback(data);
             };
             reader.readAsBinaryString(file);
@@ -995,14 +995,14 @@ var IdbPouch = function(opts, callback) {
 
 IdbPouch.valid = function idb_valid() {
   if (!document.location.host) {
-    console.warn('indexedDB cannot be used in pages served from the filesystem');
+    Pouch.log('warn', 'indexedDB cannot be used in pages served from the filesystem');
   }
   return !!window.indexedDB && !!document.location.host;
 };
 
 IdbPouch.destroy = function idb_destroy(name, callback) {
 
-  console.info(name + ': Delete Database');
+  Pouch.log('info', name + ': Delete Database');
   //delete the db id from localStorage so it doesn't get reused.
   delete localStorage[name+"_id"];
   IdbPouch.Changes.clearListeners(name);

--- a/src/adapters/pouch.leveldb.js
+++ b/src/adapters/pouch.leveldb.js
@@ -552,7 +552,7 @@ LevelPouch = module.exports = function(opts, callback) {
 
         stores[BY_SEQ_STORE].put(doc.metadata.seq, doc.data, function(err) {
           if (err) {
-            return console.error(err);
+            return Pouch.log('error', err);
           }
 
           stores[DOC_STORE].put(doc.metadata.id, doc.metadata, function(err) {
@@ -576,7 +576,7 @@ LevelPouch = module.exports = function(opts, callback) {
       stores[ATTACH_STORE].get(digest, function(err, oldAtt) {
         if (err && err.name !== 'NotFoundError') {
           callback(err);
-          return console.error(err);
+          return Pouch.log('error', err);
         }
 
         var ref = [docInfo.metadata.id, docInfo.metadata.rev].join('@');
@@ -598,7 +598,7 @@ LevelPouch = module.exports = function(opts, callback) {
         stores[ATTACH_STORE].put(digest, newAtt, function(err) {
           callback(err);
           if (err) {
-            return console.error(err);
+            return Pouch.log('error', err);
           }
         });
       });
@@ -702,7 +702,7 @@ LevelPouch = module.exports = function(opts, callback) {
     });
     docstream.on('error', function(err) {
       // TODO: handle error
-      console.error(err);
+      Pouch.log('error', err);
     });
     docstream.on('end', function() {
     });
@@ -823,7 +823,7 @@ LevelPouch = module.exports = function(opts, callback) {
         })
         .on('error', function(err) {
           // TODO: handle errors
-          console.error(err);
+          Pouch.log('error', err);
         })
         .on('close', function() {
           changeListener = Pouch.utils.filterChange(opts)
@@ -839,7 +839,7 @@ LevelPouch = module.exports = function(opts, callback) {
     if (opts.continuous) {
       return {
         cancel: function() {
-          console.info(name + ': Cancel Changes Feed');
+          Pouch.log('info', name + ': Cancel Changes Feed');
           opts.cancelled = true;
           change_emitter.removeListener('change', changeListener);
         }

--- a/src/pouch.js
+++ b/src/pouch.js
@@ -27,6 +27,10 @@ var Pouch = this.Pouch = function Pouch(name, opts, callback) {
   }
 }
 
+Pouch.log = function() {
+  var args = Array.prototype.slice.call(arguments)
+  console[args[0]].call(console, args.slice(1, args.length))
+}
 
 Pouch.parseAdapter = function(name) {
 


### PR DESCRIPTION
pouch currently violates the unix rule of silence. this pull req implements a logger than can be overwritten with a no-op: `Pouch.log = function() {}`
