### PR TITLE
Fetch uuids from remote http for use in POST requests

### DIFF
--- a/src/adapters/pouch.http.js
+++ b/src/adapters/pouch.http.js
@@ -374,14 +374,14 @@ var HttpPouch = function(opts, callback) {
       data: doc
     }, callback);
   };
-  var uuids = {list:[]};
+  var uuids = {list: []};
   uuids.get = function(opts, callback) {
     if (typeof opts === 'function') {
       callback = opts;
       opts = {count: 10};
     }
     var cb = function(err, body) {
-      if(err){
+      if (err){
         call(callback, err);
       } else {
         uuids.list = uuids.list.concat(body.uuids);


### PR DESCRIPTION
grabs uuids from a remote http source so that they are attached to POST before being sent talked about in #250. 

uuid has a list property that contains a ... list of uuids, it also has a get property that takes an optional options and a callback, the only option it takes is "count" which is how many uuids to take and it defaults to 10.

POST now checks the size of the list and if its greater then 0 pops one off the end, if 0 it calls uuid.get and then pops one off the end.

Lastly it does a PUT request with the new uuid as _id.

Would it make sense to expose the number of uuids to fetch as an option when creating an http adaptor 
