### PR TITLE
#253 Browser test results now read only using grunt, not in webrunner

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "nano": "*",
         "send": "*",
 		    "grunt" : "*",
-		    "grunt-saucelabs" : "~1.1.2",
+		    "grunt-saucelabs" : "~1.1.3",
 		    "grunt-node-qunit" : "*"
   },
   "maintainers":[

--- a/tests/webrunner.js
+++ b/tests/webrunner.js
@@ -123,36 +123,7 @@ function submitResults() {
 
 var doc = {};
 QUnit.jUnitReport = function(report) {
-  var match = window.location.search.match(/[?&]id=([^&]+)/);
-  if (!match) return;
-  var id = match[1];
-  document.getElementById('submit-results').addEventListener('click', submitResults);
-
-  new Pouch('http://localhost:2020/test_results', function(err, db) {
-    if (err) {
-      return console.log('Cant open db to store results');
-    }
-    db.get(id, function(err, res){
-      if (err) {
-        var res = {
-          _id : id,
-          report: []
-        };
-      }
-      report.completed = new Date();
-      report.started = started;
-      report.passed = (report.results.failed === 0);
-      res.report.push(report);
-      db.put(res, function (err, info) {
-	if (err) {
-	  return ;
-	}
-	document.body.setAttribute('data-results-id', info.id);
-	document.body.classList.add('complete');
-	$('body').append('<p>Storing Results Complete.</p>');
-      });
-    });
-  });
+  window.testReport = report;
 };
 
 asyncParForEach(sourceFiles[source], asyncLoadScript, function() {


### PR DESCRIPTION
Changed the way tests were published.

Originally, web runner was writing test to a database, from where grunt read them and then published them. The test results were distributed in 2 places. 

With this commit, web runner simply exposes the jUnitReports in a variable, that grunt can read using the grunt-saucelabs plugin and publish.
