### PR TITLE
Disable client-level request timeout for _changes

### DIFF
--- a/src/adapters/pouch.http.js
+++ b/src/adapters/pouch.http.js
@@ -553,7 +553,8 @@ var HttpPouch = function(opts, callback) {
       // Set the options for the ajax call
       var xhrOpts = {
         auth: host.auth, type:'GET',
-        url: genDBUrl(host, '_changes' + params + '&since=' + since)
+        url: genDBUrl(host, '_changes' + params + '&since=' + since),
+        timeout: null          // _changes can take a long time to generate, especially when filtered
       };
       last_seq = since;
 


### PR DESCRIPTION
Let the browser decide if a request to _changes should be killed or not, so we don't continually spin up long filtered changes tasks on the server. Fixes #303.
