### PR TITLE
Catch errors retrieving revisions during replication

### DIFF
--- a/src/pouch.replicate.js
+++ b/src/pouch.replicate.js
@@ -43,6 +43,12 @@ if (typeof module !== 'undefined' && module.exports) {
           var diff = {};
           diff[change.id] = change.changes.map(function(x) { return x.rev; });
           target.revsDiff(diff, function(err, diffs) {
+            if (err) {
+              if (continuous)
+                replicateRet.cancel();
+              call(callback, err, null);
+              return;
+            }
             if (Object.keys(diffs).length === 0) {
               pending--;
               isCompleted();


### PR DESCRIPTION
If you are doing a replication such as:

``` js
db.replicate("idb://localdb", "http://remotedb", {continuous: true})
```

and the network connection to the remote server drops while the replication is active, the interpreter will error out on the Object.keys(diffs) line (because an error was returned and diffs is null-ish.  Instead, catch that error, canceling the continuous replication if applicable, and pass it on to the callback so the client has the opportunity to restart replication at a later date.

I don't know how to test this as it would require simulating a failed HTTP request, but happy to add that if you know how.
