### PR TITLE
Allow to specify auth data in options

### DIFF
--- a/src/adapters/pouch.http.js
+++ b/src/adapters/pouch.http.js
@@ -103,6 +103,7 @@ var HttpPouch = function(opts, callback) {
 
   // Parse the URI given by opts.name into an easy-to-use object
   var host = getHost(opts.name);
+  if (opts.auth) host.auth = opts.auth;
 
   // Generate the database URL based on the host
   var db_url = genDBUrl(host, '');


### PR DESCRIPTION
This allows connection like this to a couchdb instance running in the same domain

Pouch('pouch', {adapter:'http', auth:{username: 'admin', password: 'admin'}}, function(err, db) {

It will connect to '/pouch' which is correct.
