### PR TITLE
IDB Transaction Mode Chrome Canary

### DIFF
--- a/src/adapters/pouch.idb.js
+++ b/src/adapters/pouch.idb.js
@@ -7,9 +7,13 @@ window.indexedDB = window.indexedDB ||
 
 // still needed for R/W transactions in Android Chrome. follow MDN example:
 // https://developer.mozilla.org/en-US/docs/IndexedDB/IDBDatabase#transaction
-window.IDBTransaction = window.IDBTransaction ||
-  window.webkitIDBTransaction ||
-  { READ_WRITE: 'readwrite' };
+// note though that Chrome Canary fails on undefined READ_WRITE constants
+// on the native IDBTransaction object
+window.IDBTransaction = (window.IDBTransaction && window.IDBTransaction.READ_WRITE)
+  ? window.IDBTransaction
+  : (window.webkitIDBTransaction && window.webkitIDBTransaction.READ_WRITE)
+    ? window.webkitIDBTransaction
+    : { READ_WRITE: 'readwrite' };
 
 window.IDBKeyRange = window.IDBKeyRange ||
   window.webkitIDBKeyRange;


### PR DESCRIPTION
In Chrome Canary, the test suite fails on almost all of the "local-1" class tests because of a TypeError [here](https://github.com/daleharvey/pouchdb/blob/master/src/adapters/pouch.idb.js#L88) and [here](https://github.com/daleharvey/pouchdb/blob/master/src/adapters/pouch.idb.js#L366). This falls back to this line: https://github.com/daleharvey/pouchdb/blob/master/src/adapters/pouch.idb.js#L10.

Reading through the issues list I see that it's been dealt with before in #219 and #305, but the solution proposed in 305 (which is currently implemented on the master branch) fails on Chrome Canary (I'm running v26.0.1389.0 on OS X), because `window.IDBTransaction` is natively supported, but `IDBTransaction.READ_WRITE` is `undefined`.

I was able to get the test suite to pass just by replacing `IDBTransaction.READ_WRITE` with `'readwrite'` on each of the problematic lines pointed to above, but in one of the previous discussions about this issue, it was mentioned that firefox doesn't support the string literals. To address that, I ran the same suite in FF 18.0.1 with the `'readwrite'` literals, and everything checked out fine. 

I can't speak for older versions of FF, and I don't know the status in other browsers, but I wanted to bring this issue up. Thoughts?
