### PR TITLE
#407 Corrected path requirement for grunt-node-qunit

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -87,12 +87,14 @@ module.exports = function(grunt) {
     },
 
     'node-qunit': {
-      deps: './src/pouch.js',
-      code: './src/adapters/pouch.leveldb.js',
-      tests: testFiles.map(function (n) { return "./tests/" + n; }),
-      done: function(err, res) {
-        !err && (testResults['node'] = res);
-	return true;
+      all: {
+        deps: './src/pouch.js',
+        code: './src/adapters/pouch.leveldb.js',
+        tests: testFiles.map(function (n) { return "./tests/" + n; }),
+        done: function(err, res) {
+          !err && (testResults['node'] = res);
+	       return true;
+        }
       }
     },
 


### PR DESCRIPTION
The grunt-node-qunit is now a multitask, hence changed this.

Note that this still does not mean that the node-qunit tests are passing, there is still an issue about winningRev. I am looking at that. Sending this commit, as this fixes node-execution. 
