### PR TITLE
api.revsDiff undocumented

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -21,7 +21,7 @@ Most of the Pouch API is exposed as `fun(arg, [options], [callback])` Where both
  * [Get database information](#get_database_information)
  * [Listen to database changes](#listen_to_database_changes)
  * [Replicate a database](#replicate_a_database)
- * [Get document revision diffs](#document_revisions)
+ * [Get document revision diffs](#document_revisions_diff)
 
 ## Create a database
 
@@ -351,7 +351,7 @@ Replicate one database to another.
       //
     })
 
-## Document Revisions
+## Document Revisions Diff
 
     db.revsDiff(diff, [callback])
 


### PR DESCRIPTION
It appears that each of the four current adapters support a method named `revsDiff` which either supports or mimics CouchDB's /_revs_diff route: [http://wiki.apache.org/couchdb/HttpPostRevsDiff](http://wiki.apache.org/couchdb/HttpPostRevsDiff), but there's no PouchDB documentation for it anywhere. 

I'm happy to write up the docs for it, but I wanted to open this issue to accumulate thoughts/suggestions before going ahead with it.
