### PR TITLE
Reset version field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "release": "nightly",
   "description": "PouchDB is a pocket-sized database.",
   "author": "Dale Harvey",
-  "version": "0.0.9",
+  "version": "0.0.0",
   "main": "./src/pouch.js",
   "homepage": "https://github.com/daleharvey/pouchdb",
   "keywords": [ "db", "couchdb", "pouchdb" ],


### PR DESCRIPTION
@eckoit

So I think a sensible way to do this is, since especially at the early stages we are going to have a lot of minor releases and I dont want to spam the commit logs with version changes

We leave master on 0.0.1, when we publish a new package we make a release branch and version it there

Sound good?
