### PR TITLE
server got renamed to connect

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ The PouchDB test suite expects an instance of CouchDB running on http://127.0.0.
 
 ### Browser Tests
 
-    $ grunt server cors-server forever
+    $ grunt connect cors-server forever
     # Now visit http://127.0.0.1:8000/tests/test.html in your browser
 
 Git Essentials


### PR DESCRIPTION
After grunt upgrade we need to write connect instead of server. Fix docs.
