### PR TITLE
fix module check so it behaves as intended

### DIFF
--- a/src/deps/extend.js
+++ b/src/deps/extend.js
@@ -126,6 +126,6 @@ var extend = function() {
   return target;
 };
 
-if (typeof module !== undefined && module.exports) {
+if (typeof module !== 'undefined' && module.exports) {
   global.extend = extend;
 }


### PR DESCRIPTION
Commit 680c51f601998691d1b4e24273a7241ef5b449e0 broke PouchDB in the browser, `typeof` operator returns string and so its result will never be `=== undefined`.

NOTE: there's a ton of this brokenness in tests, but I'm assuming it's less harmful because tests get run from cmdline via node where `module` _is_ defined.
