### PR TITLE
(#506) - putAttachment don't respect rev parameter

### DIFF
--- a/src/pouch.adapter.js
+++ b/src/pouch.adapter.js
@@ -54,6 +54,16 @@ var PouchAdapter = function(opts, callback) {
     }
     id = parseDocId(id);
     api.get(id.docId, function(err, obj) {
+      if (err) {
+        call(callback, err);
+        return;
+      }
+
+      if (obj._rev !== rev) {
+        call(callback, Pouch.Errors.REV_CONFLICT);
+        return;
+      }
+
       obj._attachments = obj._attachments || {};
       obj._attachments[id.attachmentId] = {
         content_type: type || doc.type,

--- a/tests/test.attachments.js
+++ b/tests/test.attachments.js
@@ -140,6 +140,26 @@ adapters.map(function(adapter) {
     });
   });
 
+  asyncTest("Testing with invalid rev", function() {
+    initTestDB(this.name, function(err, db) {
+      var doc = {_id: 'adoc'};
+      db.put(doc, function(err, resp) {
+        ok(!err, 'Doc has been saved');
+        doc._rev = resp.rev;
+        doc.foo = 'bar';
+        db.put(doc, function(err, resp) {
+          ok(!err, 'Doc has been updated');
+          var blob = makeBlob('bar');
+          db.putAttachment('adoc/foo.txt', doc._rev, blob, 'text/plain', function(err) {
+            ok(err, 'Attachment has not been saved');
+            equal(err.error, 'conflict', 'error is a conflict');
+            start();
+          });
+        });
+      });
+    });
+  });
+
   asyncTest("Test delete attachment from a doc", function() {
     initTestDB(this.name, function(erro, db) {
       db.put({ _id: 'mydoc' }, function(err, resp) {


### PR DESCRIPTION
One might be able to put an attachment with an old rev or even without any rev.

This PR comes with a test and the fix.
