### PR TITLE
Adapter tweaks

### DIFF
--- a/src/pouch.adapter.js
+++ b/src/pouch.adapter.js
@@ -140,7 +140,7 @@ var PouchAdapter = function(opts, callback) {
   };
 
 
-  /* Begin api wrappers. Specific funtionality to storage belongs in the _[method] */
+  /* Begin api wrappers. Specific functionality to storage belongs in the _[method] */
   api.get = function (id, opts, callback) {
     if (typeof opts === 'function') {
       callback = opts;


### PR DESCRIPTION
Here's a couple additions (and one whitespace tweak) to the generic adapter code. This way AFAICT all the public API methods are exposed directly in the adapter code, and one can grep for `customApi._` to find what needs to be implemented when writing a new adapter.
