### PR TITLE
Fix race condition in the changes notifier

### DIFF
--- a/src/pouch.utils.js
+++ b/src/pouch.utils.js
@@ -544,22 +544,28 @@ var Changes = function() {
   api.notify = function(db_name) {
     if (!listeners[db_name]) { return; }
     for (var i in listeners[db_name]) {
-      /*jshint loopfunc: true */
-      var opts = listeners[db_name][i].opts;
-      listeners[db_name][i].db.changes({
-        include_docs: opts.include_docs,
-        conflicts: opts.conflicts,
-        continuous: false,
-        filter: opts.filter,
-        since: opts.since,
-        onChange: function(c) {
-          if (c.seq > opts.since) {
-            opts.since = c.seq;
-            call(opts.onChange, c);
-          }
-        }
-      });
+      api.notifyListener(listeners[db_name][i]);
     }
+  };
+
+  api.notifyListener = function(listener) {
+    /*jshint loopfunc: true */
+    var opts = listener.opts;
+    listener.db.changes({
+      include_docs: opts.include_docs,
+      conflicts: opts.conflicts,
+      continuous: false,
+      filter: opts.filter,
+      since: opts.since,
+      style: opts.style,
+      query_params: opts.query_params,
+      onChange: function(c) {
+        if (c.seq > opts.since) {
+          opts.since = c.seq;
+          call(opts.onChange, c);
+        }
+      }
+    });
   };
 
   return api;


### PR DESCRIPTION
The Pouch.utils.Changes module has an issue if more than one listener is set up for the same database.  The `var opts` line gets reassigned in the loop, so when the callback is made to the onChange handler, it ends up calling the callback of the last listener in the array (provided the IDB or other adapter calls don't execute synchronously).  I just moved the vulnerable code to a separate function, so the `opts` variable gets captured and doesn't change.
