### PR TITLE
(#514) - Add grunt-cli to build instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Building PouchDB
 All dependancies installed? great, now building PouchDB itself is a breeze:
 
     $ cd pouchdb
-    $ npm install -g grunt
+    $ npm install -g grunt-cli
     $ npm install
     $ grunt
 


### PR DESCRIPTION
In grunt 0.4 the cli tools are in a separate package
called grunt-cli. You need to install it as well
