### PR TITLE
LevelDB adapter assumes attachments are base64 encoded

### DIFF
--- a/src/adapters/pouch.leveldb.js
+++ b/src/adapters/pouch.leveldb.js
@@ -414,7 +414,11 @@ LevelPouch = module.exports = function(opts, callback) {
         if (!doc.data._attachments[key].stub) {
           var data = doc.data._attachments[key].data
           // if data is a string, it's likely to actually be base64 encoded
-          if (typeof data === 'string') data = Pouch.utils.atob(data);
+          if (typeof data === 'string') {
+            try {
+              data = Pouch.utils.atob(data);
+            } catch (e) {}
+          }
           var digest = 'md5-' + crypto.createHash('md5')
                 .update(data || '')
                 .digest('hex');


### PR DESCRIPTION
In the bulkDocs method on the leveldb adapter, when writing a document that contains an attachment, the adapter assumes that if the attachment is a string, it will necessarily be base64 encoded: https://github.com/daleharvey/pouchdb/blob/master/src/adapters/pouch.leveldb.js#L416

This breaks pouchdb-server in the case where our test suite sends a non-encoded attachment string, which then gets forwarded to this write method, which throws an error trying to decode a "malformed URI".
