### PR TITLE
LevelDB adapter _getAttachment ignores opts.encode when returning an empty attachment buffer

### DIFF
--- a/src/adapters/pouch.leveldb.js
+++ b/src/adapters/pouch.leveldb.js
@@ -286,9 +286,7 @@ LevelPouch = module.exports = function(opts, callback) {
 
           if (err && err.name === 'NotFoundError') {
             // Empty attachment
-            data = opts.encode
-              ? Pouch.utils.btoa(new Buffer(''))
-              : new Buffer('');
+            data = opts.encode ? '' : new Buffer('');
             return call(callback, null, data);
           }
 
@@ -297,7 +295,7 @@ LevelPouch = module.exports = function(opts, callback) {
           }
 
           data = opts.encode
-            ? Pouch.utils.btoa(attach)
+            ? btoa(attach)
             : attach;
           
           call(callback, null, data);


### PR DESCRIPTION
https://github.com/daleharvey/pouchdb/blob/master/src/adapters/pouch.leveldb.js#L287, in comparison to, https://github.com/daleharvey/pouchdb/blob/master/src/adapters/pouch.leveldb.js#L293
