### PR TITLE
Gruntfile changes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,14 +43,14 @@ module.exports = function(grunt) {
   var testResults = {};
 
   grunt.initConfig({
-    pkg: '<json:package.json>',
+    'pkg': '<json:package.json>',
 
-    clean: {
+    'clean': {
       build : ["./dist"],
       "node-qunit": ["./testdb_*"]
     },
 
-    concat: {
+    'concat': {
       options: {
         banner: "/*PouchDB*/\n(function() {\n ",
         footer: "\n })(this);"
@@ -83,7 +83,7 @@ module.exports = function(grunt) {
       }
     },
 
-    uglify: {
+    'uglify': {
       dist: {
         src: "./dist/pouchdb-nightly.js",
         dest: 'dist/pouchdb-nightly.min.js'
@@ -95,7 +95,7 @@ module.exports = function(grunt) {
     },
 
     // Servers
-    connect : {
+    'connect' : {
       server: {
         options: {
           base: '.',
@@ -129,7 +129,7 @@ module.exports = function(grunt) {
         globalstrict: true
       },
       globals: {
-          // Tests.
+        // Tests.
         _: true,
         QUnit: true,
         asyncTest: true,
@@ -154,6 +154,7 @@ module.exports = function(grunt) {
         Pouch: true
       }
     },
+
     'node-qunit': {
       all: {
         deps: ['./src/deps/extend.js','./src/deps/ajax.js','./src/pouch.js'],
@@ -175,34 +176,34 @@ module.exports = function(grunt) {
         })(),
         done: function(err, res) {
           !err && (testResults['node'] = res);
-	       return true;
+          return true;
         }
       }
     },
 
     'saucelabs-qunit': {
       all: {
-	username: 'pouchdb',
-	key: '97de9ee0-2712-49f0-9b17-4b9751d79073',
-	testname: 'PouchDB Tests',
-	tags: [process.env.TRAVIS_BRANCH || "unknown"],
-	testTimeout: 1000 * 60 * 15, // 15 minutes
-	testInterval: 1000 * 30, // 30 seconds
-  tunnelTimeout: 1000 * 60 * 15, // 15 minutes
-	urls: ["http://127.0.0.1:8000/tests/test.html?test=release-min&id=" +
-               testStartTime.getTime() + "&testFiles=" + testFiles.join(',')],
-	browsers: browserConfig,
-	onTestComplete: function(status, page, config, browser) {
-	  var done = this.async();
-	  var browserDB = nano('http://127.0.0.1:5984').use('test_results');
-          var retries = 0;
-	  (function getResults() {
-	    browser.eval("window.testReport", function(err, val) {
-	      testResults[config.name] = err ? "No results" : val;
-	      done(true);
-	    });
-	  }());
-	}
+        username: 'pouchdb',
+        key: '97de9ee0-2712-49f0-9b17-4b9751d79073',
+        testname: 'PouchDB Tests',
+        tags: [process.env.TRAVIS_BRANCH || "unknown"],
+        testTimeout: 1000 * 60 * 15, // 15 minutes
+        testInterval: 1000 * 30, // 30 seconds
+        tunnelTimeout: 1000 * 60 * 15, // 15 minutes
+        urls: ["http://127.0.0.1:8000/tests/test.html?test=release-min&id=" +
+                     testStartTime.getTime() + "&testFiles=" + testFiles.join(',')],
+        browsers: browserConfig,
+        onTestComplete: function(status, page, config, browser) {
+          var done = this.async();
+          var browserDB = nano('http://127.0.0.1:5984').use('test_results');
+                var retries = 0;
+          (function getResults() {
+            browser.eval("window.testReport", function(err, val) {
+              testResults[config.name] = err ? "No results" : val;
+              done(true);
+            });
+          }());
+        }
       }
     },
     'publish-results': {
@@ -214,7 +215,7 @@ module.exports = function(grunt) {
   // Custom tasks
   grunt.registerTask("forever", 'Runs forever', function(){
     this.async();
-  })
+  });
 
   grunt.registerTask("cors-server", "Runs a CORS proxy", function(){
     var corsPort = arguments[0] || grunt.config("cors-server.port");
@@ -231,28 +232,28 @@ module.exports = function(grunt) {
     var done = this.async();
     cp.exec('git rev-list HEAD --max-count=1', function(err, stdout, stderr) {
       var results = {
-	started: testStartTime,
-	completed: new Date(),
-	git_hash: stdout.replace(/[\n\r]/g, ''),
-	passed: true,
-	runs: {},
-	runner: 'grunt'
+        started: testStartTime,
+        completed: new Date(),
+        git_hash: stdout.replace(/[\n\r]/g, ''),
+        passed: true,
+        runs: {},
+        runner: 'grunt'
       };
       for (var key in testResults) {
-	results.runs[key] = {
-	  started: testResults[key].started || "",
-	  completed: testResults[key].completed || "",
-	  passed: !!(testResults[key].passed),
-	  report: testResults[key]
-	};
-  console.log("Test Result for %s is %s".yellow , key , results.runs[key].passed);
-	results.passed = results.passed && results.runs[key].passed;
+        results.runs[key] = {
+          started: testResults[key].started || "",
+          completed: testResults[key].completed || "",
+          passed: !!(testResults[key].passed),
+          report: testResults[key]
+        };
+        console.log("Test Result for %s is %s".yellow , key , results.runs[key].passed);
+        results.passed = results.passed && results.runs[key].passed;
       }
       nano(grunt.config("publish-results.server"))
         .use(grunt.config("publish-results.db"))
         .insert(results, testStartTime.getTime() + "", function(err, body){
-	  console.log(testStartTime.getTime(), err ? err.message : body);
-	  done(results.passed && err == null);
+          console.log(testStartTime.getTime(), err ? err.message : body);
+          done(results.passed && err === null);
         });
     });
   });
@@ -268,7 +269,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
 
   grunt.registerTask("build", ["concat:amd", "concat:all" , "uglify:dist"]);
-  
+
   grunt.registerTask("testSetup", ["jshint", "build", "connect", "cors-server"]);
   grunt.registerTask("test", ["testSetup", "node-qunit" ,"saucelabs-qunit", "publish-results"]);
   grunt.registerTask("full", ["concat", "uglify"]);


### PR DESCRIPTION
- Added a `--test` option for running `node-qunit` test

``` sh
# run all tests (node)
$ grunt node-qunit

# run all tests where filename matches /_all_docs/
$ grunt node-qunit --test=_all_docs
```
- Minor indentation and consistency fixes
