### PR TITLE
(#611) - move opts cloning to generic adapter

### DIFF
--- a/src/adapters/pouch.idb.js
+++ b/src/adapters/pouch.idb.js
@@ -162,7 +162,7 @@ var IdbPouch = function(opts, callback) {
   api._bulkDocs = function idb_bulkDocs(req, opts, callback) {
 
     var newEdits = opts.new_edits;
-    var userDocs = extend(true, [], req.docs);
+    var userDocs = req.docs;
 
     // Parse the docs, give them a sequence number for the result
     var docInfos = userDocs.map(function(doc, i) {
@@ -467,7 +467,7 @@ var IdbPouch = function(opts, callback) {
         return;
       }
       if (isDeleted(metadata) && !opts.rev) {
-        result = extend({}, Pouch.Errors.MISSING_DOC, {reason:"deleted"});
+        result = Pouch.error(Pouch.Errors.MISSING_DOC, "deleted");
         return;
       }
 
@@ -686,8 +686,6 @@ var IdbPouch = function(opts, callback) {
     if (Pouch.DEBUG) {
       console.log(name + ': Start Changes Feed: continuous=' + opts.continuous);
     }
-
-    opts = extend(true, {}, opts);
 
     if (!opts.since) {
       opts.since = 0;

--- a/src/adapters/pouch.leveldb.js
+++ b/src/adapters/pouch.leveldb.js
@@ -169,7 +169,7 @@ var LevelPouch = function(opts, callback) {
         return call(callback, Pouch.Errors.MISSING_DOC);
       }
       if (isDeleted(metadata) && !opts.rev) {
-        return call(callback, extend({}, Pouch.Errors.MISSING_DOC, {reason:"deleted"}));
+        return call(callback, Pouch.error(Pouch.Errors.MISSING_DOC, "deleted"));
       }
 
       var rev = Pouch.merge.winningRev(metadata);
@@ -256,7 +256,7 @@ var LevelPouch = function(opts, callback) {
     var results = [];
 
     // parse the docs and give each a sequence number
-    var userDocs = extend(true, [], req.docs);
+    var userDocs = req.docs;
     info = userDocs.map(function(doc, i) {
       var newDoc = Pouch.utils.parseDoc(doc, newEdits);
       newDoc._bulk_seq = i;

--- a/src/adapters/pouch.websql.js
+++ b/src/adapters/pouch.websql.js
@@ -108,7 +108,7 @@ var webSqlPouch = function(opts, callback) {
   api._bulkDocs = function idb_bulkDocs(req, opts, callback) {
 
     var newEdits = opts.new_edits;
-    var userDocs = extend(true, [], req.docs);
+    var userDocs = req.docs;
 
     // Parse the docs, give them a sequence number for the result
     var docInfos = userDocs.map(function(doc, i) {
@@ -410,7 +410,7 @@ var webSqlPouch = function(opts, callback) {
         }
         metadata = JSON.parse(results.rows.item(0).json);
         if (isDeleted(metadata) && !opts.rev) {
-          result = extend({}, Pouch.Errors.MISSING_DOC, {reason:"deleted"});
+          result = Pouch.error(Pouch.Errors.MISSING_DOC, "deleted");
           return;
         }
 
@@ -535,8 +535,6 @@ var webSqlPouch = function(opts, callback) {
     if (Pouch.DEBUG) {
       console.log(name + ': Start Changes Feed: continuous=' + opts.continuous);
     }
-
-    opts = extend(true, {}, opts);
 
     if (!opts.since) {
       opts.since = 0;

--- a/src/pouch.adapter.js
+++ b/src/pouch.adapter.js
@@ -256,16 +256,14 @@ var PouchAdapter = function(opts, callback) {
             var l = leaves[i];
             // looks like it's the only thing couchdb checks
             if (!(typeof(l) === "string" && /^\d+-/.test(l))) {
-              return call(callback, extend({}, Pouch.Errors.BAD_REQUEST, {
-                reason: "Invalid rev format"
-              }));
+              return call(callback, Pouch.error(Pouch.Errors.BAD_REQUEST,
+                "Invalid rev format" ));
             }
           }
           finishOpenRevs();
         } else {
-          return call(callback, extend({}, Pouch.Errors.UNKNOWN_ERROR, {
-            reason: 'function_clause'
-          }));
+          return call(callback, Pouch.error(Pouch.Errors.UNKNOWN_ERROR,
+            'function_clause'));
         }
       }
       return; // open_revs does not like other options
@@ -363,15 +361,15 @@ var PouchAdapter = function(opts, callback) {
     }
     if ('keys' in opts) {
       if ('startkey' in opts) {
-        call(callback, extend({
-          reason: 'Query parameter `start_key` is not compatible with multi-get'
-        }, Pouch.Errors.QUERY_PARSE_ERROR));
+        call(callback, Pouch.error(Pouch.Errors.QUERY_PARSE_ERROR,
+          'Query parameter `start_key` is not compatible with multi-get'
+        ));
         return;
       }
       if ('endkey' in opts) {
-        call(callback, extend({
-          reason: 'Query parameter `end_key` is not compatible with multi-get'
-        }, Pouch.Errors.QUERY_PARSE_ERROR));
+        call(callback, Pouch.error(Pouch.Errors.QUERY_PARSE_ERROR,
+          'Query parameter `end_key` is not compatible with multi-get'
+        ));
         return;
       }
     }
@@ -384,6 +382,7 @@ var PouchAdapter = function(opts, callback) {
       api.taskqueue.addTask('changes', arguments);
       return;
     }
+    opts = extend(true, {}, opts);
     return customApi._changes(opts);
   };
 
@@ -422,6 +421,8 @@ var PouchAdapter = function(opts, callback) {
     }
     if (!opts) {
       opts = {};
+    } else {
+      opts = extend(true, {}, opts);
     }
 
     if (!req || !req.docs || req.docs.length < 1) {
@@ -432,6 +433,7 @@ var PouchAdapter = function(opts, callback) {
       return call(callback, Pouch.Errors.QUERY_PARSE_ERROR);
     }
 
+    req = extend(true, {}, req);
     if (!('new_edits' in opts)) {
       opts.new_edits = true;
     }


### PR DESCRIPTION
That is: get rid of extend in specific adapters as it can be done in
generic one. Also - use new Pouch.error method
