### PR TITLE
`conflicts` in db.query results

### DIFF
--- a/src/plugins/pouchdb.mapreduce.js
+++ b/src/plugins/pouchdb.mapreduce.js
@@ -25,11 +25,6 @@ var MapReduce = function(db) {
       options.reduce = false;
     }
 
-    // Including conflicts by default
-    var conflicts = 'conflicts' in options
-      ? options.conflicts
-      : true;
-
     function sum(values) {
       return values.reduce(function(a, b) { return a + b; }, 0);
     }
@@ -109,7 +104,7 @@ var MapReduce = function(db) {
     }
 
     db.changes({
-      conflicts: conflicts,
+      conflicts: true,
       include_docs: true,
       onChange: function(doc) {
         if (!('deleted' in doc)) {

--- a/tests/test.views.js
+++ b/tests/test.views.js
@@ -242,7 +242,7 @@ adapters.map(function(adapter) {
   });
 
 
-  asyncTest('Views should include _conflict by default', function() {
+  asyncTest('Views should include _conflicts', function() {
     var self = this;
     var doc1 = {_id: '1', foo: 'bar'};
     var doc2 = {_id: '1', foo: 'baz'};
@@ -253,21 +253,9 @@ adapters.map(function(adapter) {
           db.replicate.from(remote, function(err, res) {
             db.get(doc1._id, {conflicts: true}, function(err, res) {
               ok(res._conflicts,'Conflict exists in db');
-
-              // Default behaviour
               db.query(queryFun, function(err, res) {
                 ok(res.rows[0].value, 'Conflicts included.');
-
-                // conflicts:  true
-                db.query(queryFun, {conflicts: true}, function(err, res) {
-                  ok(res.rows[0].value, 'Conflicts included.');
-
-                  // conflicts: false
-                  db.query(queryFun, {conflicts: false}, function(err, res) {
-                    ok(!res.rows[0].value, 'Conflicts excluded.');
-                    start();
-                  });
-                });
+                start();
               });
             });
           });


### PR DESCRIPTION
`conflicts` should be included in the results of db.query by default, but they shouldn't be included in the results no matter what: https://github.com/daleharvey/pouchdb/commit/22b5ac14a9b7ef64dfc91c97ff44a04504710e10#L0R29

(That is, the user should have the ability to specify conflicts = false).
