### PR TITLE
results object not consistent with http results object in db.query

### DIFF
--- a/src/plugins/pouchdb.mapreduce.js
+++ b/src/plugins/pouchdb.mapreduce.js
@@ -89,7 +89,10 @@ var MapReduce = function(db) {
           results.reverse();
         }
         if (options.reduce === false) {
-          return options.complete(null, {rows: results});
+          return options.complete(null, {
+            rows: results,
+            total_rows: results.length
+          });
         }
 
         var groups = [];
@@ -106,7 +109,7 @@ var MapReduce = function(db) {
           e.value = fun.reduce(e.key, e.value) || null;
           e.key = e.key[0][0];
         });
-        options.complete(null, {rows: groups});
+        options.complete(null, {rows: groups, total_rows: groups.length});
       }
     }
 

--- a/tests/test.views.js
+++ b/tests/test.views.js
@@ -42,6 +42,7 @@ adapters.map(function(adapter) {
           db.remove(doc, function(_, resp) {
             db.query(queryFun, {include_docs: true, reduce: false}, function(_, res) {
               equal(res.rows.length, 1, 'Dont include deleted documents');
+              equal(res.total_rows, 1, 'Include total_rows property.');
               res.rows.forEach(function(x, i) {
                 ok(x.id, 'emitted row has id');
                 ok(x.key, 'emitted row has key');


### PR DESCRIPTION
After testing, @howonlee and I found that the results object returned from db.query is not consistent with the http implementation. The http version returns an object like this:

```
{ 
  total_rows: <number>
  rows: [<stuff>]
  offset: <number>
}
```

Our version returns an object without <code>total_rows</code> or <code>offset</code>:

```
{ 
  rows: [<stuff>]
}
```
