### PR TITLE
db.info() results inconsistent

### DIFF
--- a/src/adapters/pouch.leveldb.js
+++ b/src/adapters/pouch.leveldb.js
@@ -157,7 +157,7 @@ var LevelPouch = function(opts, callback) {
 
   api._info = function(callback) {
     return call(callback, null, {
-      name: opts.name,
+      db_name: opts.name,
       doc_count: doc_count,
       update_seq: update_seq
     });


### PR DESCRIPTION
https://github.com/daleharvey/pouchdb/blob/master/src/adapters/pouch.leveldb.js#L159
https://github.com/daleharvey/pouchdb/blob/master/src/adapters/pouch.websql.js#L98
https://github.com/daleharvey/pouchdb/blob/master/src/adapters/pouch.http.js#L250
https://github.com/daleharvey/pouchdb/blob/master/src/adapters/pouch.idb.js#L667

Above is a link to each of the adapter-specific implementations of db.info(). The latter 3 all return an object with a field `db_name`, whereas the first (leveldb) returns an object with a field `name`.

This one was caught by couchdb-harness, so I'm not sure if I should create a test case in the pouchdb suite for this? Also it's a pretty minor issue to formulate a test case around... I'll follow this up with some code in a minute.
