### PR TITLE
(#589) fix phonegap/cordova adapter api not filling bug

### DIFF
--- a/src/adapters/pouch.websql.js
+++ b/src/adapters/pouch.websql.js
@@ -1,5 +1,6 @@
 /*globals call: false, extend: false, parseDoc: false, Crypto: false */
 /*globals isLocalId: false, isDeleted: false, Changes: false, filterChange: false */
+/*global isCordova*/
 
 'use strict';
 

--- a/src/pouch.adapter.js
+++ b/src/pouch.adapter.js
@@ -1,6 +1,6 @@
 /*globals Pouch: true, yankError: false, extend: false, call: false, parseDocId: false, traverseRevTree: false */
 /*globals arrayFirst: false, rootToLeaf: false, computeHeight: false */
-/*global cordova */
+/*globals cordova, isCordova */
 
 "use strict";
 

--- a/src/pouch.utils.js
+++ b/src/pouch.utils.js
@@ -267,7 +267,7 @@ var isChromeApp = function(){
 
 var isCordova = function(){
   return (typeof cordova !== "undefined" || typeof PhoneGap !== "undefined" || typeof phonegap !== "undefined");
-}
+};
 
 if (typeof module !== 'undefined' && module.exports) {
   // use node.js's crypto library instead of the Crypto object created by deps/uuid.js
@@ -306,7 +306,8 @@ if (typeof module !== 'undefined' && module.exports) {
     extend: extend,
     ajax: ajax,
     rootToLeaf: rootToLeaf,
-    isChromeApp: isChromeApp
+    isChromeApp: isChromeApp,
+    isCordova: isCordova
   };
 }
 


### PR DESCRIPTION
Note that usage should be something like:

```
var database;
document.addEventListener("deviceready", onDeviceReady, false);
function onDeviceReady(){
    Pouch('listoutfitter', {}, function (err, db) {
        if (err) {
            console.log("Error while creating database: " + err)
            for( var e in err) {
                console.log("Error element: " + e + " -> "  + err[e]);
            }
            return;
        }
        console.log("Successfully made new database");
        database = db;
        db.post({_id: 'doc1', title: 'Cony Island Baby' }, {}, function (err, response) {
            console.log("created doc: " + response.ok);
            console.log("doc id:  " + response.id)
            console.log("rev: " + response.rev)
        })
    });
};
```

Note that we must create and use the db inside an `onDeviceReady()` function, because we use websql which only becomes available to us after the `deviceready` event.

In order to test, you have to stick the tests/ folder inside of a cordova app and wrap all of webrunner.js in a function that is triggered on a `deviceready` event.
