### PR TITLE
Small fix to make uuid.get() work. Implementation did not handle the base directory of the url correctly.

### DIFF
--- a/src/adapters/pouch.http.js
+++ b/src/adapters/pouch.http.js
@@ -100,8 +100,15 @@ function genDBUrl(opts, path) {
 // Generate a URL with the host data given by opts and the given path
 function genUrl(opts, path) {
   if (opts.remote) {
-    return opts.protocol + '://' + opts.host + ':' + opts.port + '/' + path;
+    // If the host already has a path, then we need to have a path delimiter
+    // Otherwise, the path delimiter is the empty string
+    var pathDel = !opts.path ? '' : '/';
+    
+    // If the host already has a path, then we need to have a path delimiter
+    // Otherwise, the path delimiter is the empty string
+    return opts.protocol + '://' + opts.host + ':' + opts.port + '/' + opts.path + pathDel + path;
   }
+  
   return '/' + path;
 }
 


### PR DESCRIPTION
...g. couch available at http://myserver/couchdb/)

Change genUrl(...) to add the base path if required to the generated Url
