### PR TITLE
(#683) - _getAttachments called in generic adapter

### DIFF
--- a/src/adapters/pouch.leveldb.js
+++ b/src/adapters/pouch.leveldb.js
@@ -184,30 +184,7 @@ var LevelPouch = function(opts, callback) {
         doc._id = metadata.id;
         doc._rev = rev;
 
-        if (opts.attachments && doc._attachments) {
-          var attachments = doc._attachments;
-          var keys = Object.keys(attachments).filter(opts.attachmentsFilter);
-          var count = keys.length;
-          if (!count) {
-            callback(null, {doc: doc, metadata: metadata});
-          }
-          keys.forEach(function(key) {
-            api._getAttachment(attachments[key], {encode: opts.encode}, function(err, data) {
-              doc._attachments[key].data = data;
-              if (!--count) {
-                callback(null, {doc: doc, metadata: metadata});
-              }
-            });
-          });
-        }
-        else {
-          if (doc._attachments){
-            for (var key in doc._attachments) {
-              doc._attachments[key].stub = true;
-            }
-          }
-          callback(null, {doc: doc, metadata: metadata});
-        }
+        return call(callback, null, {doc: doc, metadata: metadata});
       });
     });
   };


### PR DESCRIPTION
This work moves getting attachments entirely to generic adapter leaving
_get of each adapter really simple and doing (almost) minimal work.

Reintroducted idea of txn in opts called now ctx. Usage here:

each adapter returns some ctx that is then passed to _getAttachment.
Using this we can ask about attachments in the same transaction as
get. This should be also used to ask about open_revs in the same
transaction.

---

I'm not yet sure how far should I continue this work of abstracting logic into generic adapter. If sth like:
_getMetadata and then _getDocument is ok? (and implement all logic in generic adapter)
I'm not sure if we can do the same with bulkDocs.
