### PR TITLE
Make binary blobs work

### DIFF
--- a/src/adapters/pouch.idb.js
+++ b/src/adapters/pouch.idb.js
@@ -92,6 +92,17 @@ var IdbPouch = function(opts, callback) {
     db.createObjectStore(DETECT_BLOB_SUPPORT_STORE);
   }
 
+  // From http://stackoverflow.com/questions/14967647/encode-decode-image-with-base64-breaks-image (2013-04-21)
+  function fixBinary(bin) {
+    var length = bin.length;
+    var buf = new ArrayBuffer(length);
+    var arr = new Uint8Array(buf);
+    for (var i = 0; i < length; i++) {
+      arr[i] = bin.charCodeAt(i);
+    }
+    return buf;
+  }
+
   req.onsuccess = function(e) {
 
     idb = e.target.result;
@@ -251,6 +262,7 @@ var IdbPouch = function(opts, callback) {
         att.digest = 'md5-' + Crypto.MD5(data);
         if (blobSupport) {
           var type = att.content_type;
+          data = fixBinary(data);
           att.data = new Blob([data], {type: type});
         }
         return finish();
@@ -514,7 +526,8 @@ var IdbPouch = function(opts, callback) {
         if (blobSupport) {
           result = data;
         } else {
-          result = new Blob([atob(data)], {type: type});
+          data = fixBinary(atob(data));
+          result = new Blob([data], {type: type});
         }
         call(callback, null, result);
       }

--- a/src/pouch.utils.js
+++ b/src/pouch.utils.js
@@ -302,10 +302,16 @@ if (typeof module !== 'undefined' && module.exports) {
     arrayFirst: arrayFirst,
     filterChange: filterChange,
     atob: function(str) {
-      return decodeURIComponent(escape(new Buffer(str, 'base64').toString('binary')));
+      var base64 = new Buffer(str, 'base64');
+      // Node.js will just skip the characters it can't encode instead of
+      // throwing and exception
+      if (base64.toString('base64') !== str) {
+        throw("Cannot base64 encode full string");
+      }
+      return base64.toString('binary');
     },
     btoa: function(str) {
-      return new Buffer(unescape(encodeURIComponent(str)), 'binary').toString('base64');
+      return new Buffer(str, 'binary').toString('base64');
     },
     extend: extend,
     ajax: ajax,

--- a/tests/test.attachments.js
+++ b/tests/test.attachments.js
@@ -1,7 +1,7 @@
 /*globals initTestDB: false, emit: true, generateAdapterUrl: false */
 /*globals PERSIST_DATABASES: false, initDBPair: false, utils: true, strictEqual: false */
 /*globals ajax: true, LevelPouch: true, makeDocs: false */
-/*globals readBlob: false, makeBlob: false */
+/*globals readBlob: false, makeBlob: false, base64Blob: false */
 /*globals cleanupTestDatabases: false */
 
 "use strict";
@@ -68,6 +68,16 @@ adapters.map(function(adapter) {
     }
   };
 
+  var pngAttDoc = {
+    _id: "png_doc",
+    _attachments: {
+      "foo.png": {
+        content_type: "image/png",
+        data: "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAMFBMVEX+9+j+9OD+7tL95rr93qT80YD7x2L6vkn6syz5qRT4ogT4nwD4ngD4nQD4nQD4nQDT2nT/AAAAcElEQVQY002OUQLEQARDw1D14f7X3TCdbfPnhQTqI5UqvGOWIz8gAIXFH9zmC63XRyTsOsCWk2A9Ga7wCXlA9m2S6G4JlVwQkpw/YmxrUgNoMoyxBwSMH/WnAzy5cnfLFu+dK2l5gMvuPGLGJd1/9AOiBQiEgkzOpgAAAABJRU5ErkJggg=="
+      }
+    }
+  };
+
   asyncTest("Test some attachments", function() {
     var db;
     initTestDB(this.name, function(err, _db) {
@@ -125,6 +135,21 @@ adapters.map(function(adapter) {
           ok(!err, "Attachment read");
           readBlob(res, function(data) {
             strictEqual(data, "This is a base64 encoded text", "correct data");
+            start();
+          });
+        });
+      });
+    });
+  });
+
+  asyncTest("Test getAttachment with PNG", function() {
+    initTestDB(this.name, function(err, db) {
+      db.put(pngAttDoc, function(err, res) {
+        db.getAttachment("png_doc/foo.png", function(err, res) {
+          ok(!err, "Attachment read");
+          base64Blob(res, function(data) {
+            strictEqual(data, pngAttDoc._attachments['foo.png'].data,
+                        "correct data");
             start();
           });
         });

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -120,6 +120,19 @@ function readBlob(blob, callback) {
   }
 }
 
+function base64Blob(blob, callback) {
+  if (typeof module !== 'undefined' && module.exports) {
+    callback(blob.toString('base64'));
+  } else {
+    var reader = new FileReader();
+    reader.onloadend = function(e) {
+      var base64 = this.result.replace(/data:.*;base64,/, '');
+      callback(base64);
+    };
+    reader.readAsDataURL(blob);
+  }
+}
+
 function openTestAsyncDB(name) {
   return new Pouch(name, function(err,db) {
     if (err) {
@@ -246,6 +259,7 @@ if (typeof module !== 'undefined' && module.exports) {
     makeDocs: makeDocs,
     makeBlob: makeBlob,
     readBlob: readBlob,
+    base64Blob: base64Blob,
     initTestDB: initTestDB,
     initDBPair: initDBPair,
     openTestDB: openTestDB,


### PR DESCRIPTION
For example PNGs weren't encoded properly into Blobs.
Now the roundtrip from base64 -> Blob -> base64 works
as expected.
