### PR TITLE
(#738) - report error when no _rev

### DIFF
--- a/src/pouch.utils.js
+++ b/src/pouch.utils.js
@@ -123,6 +123,9 @@ var parseDoc = function(doc, newEdits) {
     }
     if (!doc._rev_tree) {
       revInfo = /^(\d+)-(.+)$/.exec(doc._rev);
+      if (!revInfo) {
+        return Pouch.Errors.BAD_ARG;
+      }
       nRevNum = parseInt(revInfo[1], 10);
       newRevId = revInfo[2];
       doc._rev_tree = [{

--- a/tests/test.bulk_docs.js
+++ b/tests/test.bulk_docs.js
@@ -93,6 +93,18 @@ adapters.map(function(adapter) {
     });
   });
 
+  asyncTest('No _rev and new_edits=false', function() {
+    initTestDB(this.name, function(err, db) {
+      var docs = [
+        {_id: "foo", integer: 1}
+      ];
+      db.bulkDocs({docs: docs}, {new_edits: false}, function(err, res) {
+        ok(err, "error reported");
+        start();
+      });
+    });
+  });
+
   asyncTest("Test errors on invalid doc id", function() {
     var docs = [
       {'_id': '_invalid', foo: 'bar'}


### PR DESCRIPTION
When bulk_docs with new_edits and no _rev then we have
to report error to our users. Previously Pouch just crashed
