### PR TITLE
Adding Scrolling to tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -164,7 +164,7 @@ module.exports = function(grunt) {
           testInterval: 1000 * 30, // 30 seconds
           tunnelTimeout: 1000 * 60 * 15, // 15 minutes
           urls: ["http://127.0.0.1:8000/tests/test.html?test=release-min&id=" +
-                       testStartTime.getTime() + "&testFiles=" + testFiles.join(',')],
+                       testStartTime.getTime() + "&scroll=true&testFiles=" + testFiles.join(',')],
           browsers: browserConfig,
           detailedError : true,
           onTestComplete: function(status, page, config, browser) {

--- a/tests/webrunner.js
+++ b/tests/webrunner.js
@@ -41,6 +41,33 @@ var sourceFiles = {
   'release-min': ['../dist/pouchdb-nightly.min.js', '../src/deps/extend.js', '../src/deps/ajax.js']
 };
 
+// Logic to automatically scoll qunit tests. Required for saucelabs output, to exactly see whta is happening
+(function() {
+  var scroll = window.location.search.match(/[?&]scroll=true/);
+  if (!scroll) {
+    return;
+  }
+
+  function findPos(obj) {
+    var curtop = 0;
+    if (obj.offsetParent) {
+      do {
+        curtop += obj.offsetTop;
+      } while ((obj = obj.offsetParent));
+      return [curtop];
+    }
+  }
+
+  window.setInterval(function() {
+    try {
+      var running = document.getElementsByClassName('running')[0];
+      window.scroll(0, findPos(running) - 100);
+    } catch (e) {
+      // dont do anything here
+    }
+  }, 2000);
+}());
+
 // Thanks to http://engineeredweb.com/blog/simple-async-javascript-loader/
 function asyncLoadScript(url, callback) {
 


### PR DESCRIPTION
Adding scrolling to the Qunit tests so that we can see what the actual errors are, when viewing the actual test results. Requires adding scroll=true to the URL, and that will be the tests will scroll, so this should run only on CI. 
