### PR TITLE
Adding support for CouchDB grouping

### DIFF
--- a/src/plugins/pouchdb.mapreduce.js
+++ b/src/plugins/pouchdb.mapreduce.js
@@ -165,7 +165,7 @@ var MapReduce = function(db) {
       params.push('group=' + opts.group);
     }
     if (typeof opts.group_level !== 'undefined') {
-      params.push('group_level=' opts.group_level);
+      params.push('group_level=' + opts.group_level);
     }
 
     // If keys are supplied, issue a POST request to circumvent GET query string limits


### PR DESCRIPTION
This adds support for using CouchDB's grouping feature (http://wiki.apache.org/couchdb/Introduction_to_CouchDB_views#Grouping), by setting an 'group' or 'group_level' option when querying a CouchDB, which is simply added to the url.

Tests can be found on https://travis-ci.org/redtrumpet/pouchdb .
