### PR TITLE
(#706) - fix limit implementation in api.changes

### DIFF
--- a/src/adapters/pouch.idb.js
+++ b/src/adapters/pouch.idb.js
@@ -1,5 +1,5 @@
 /*globals call: false, extend: false, parseDoc: false, Crypto: false */
-/*globals isLocalId: false, isDeleted: false, Changes: false, filterChange: false */
+/*globals isLocalId: false, isDeleted: false, Changes: false, filterChange: false, processChanges: false */
 
 'use strict';
 
@@ -674,13 +674,7 @@ var IdbPouch = function(opts, callback) {
 
       var req;
 
-      if (opts.limit && descending) {
-        req = txn.objectStore(BY_SEQ_STORE)
-            .openCursor(IDBKeyRange.bound(opts.since, opts.since + opts.limit, true), descending);
-      } else if (opts.limit && !descending) {
-        req = txn.objectStore(BY_SEQ_STORE)
-            .openCursor(IDBKeyRange.bound(opts.since, opts.since + opts.limit, true));
-      } else if (descending) {
+      if (descending) {
         req = txn.objectStore(BY_SEQ_STORE)
             .openCursor(IDBKeyRange.lowerBound(opts.since, true), descending);
       } else {
@@ -780,8 +774,7 @@ var IdbPouch = function(opts, callback) {
     }
 
     function onTxnComplete() {
-      dedupResults = dedupResults.filter(filterChange(opts));
-      call(opts.complete, null, {results: dedupResults, last_seq: last_seq});
+      processChanges(opts, dedupResults, last_seq);
     }
 
     function onerror(error) {

--- a/src/adapters/pouch.websql.js
+++ b/src/adapters/pouch.websql.js
@@ -1,5 +1,5 @@
 /*globals call: false, extend: false, parseDoc: false, Crypto: false */
-/*globals isLocalId: false, isDeleted: false, Changes: false, filterChange: false */
+/*globals isLocalId: false, isDeleted: false, Changes: false, filterChange: false, processChanges: false */
 /*global isCordova*/
 
 'use strict';
@@ -563,10 +563,6 @@ var webSqlPouch = function(opts, callback) {
         DOC_STORE + '.winningseq WHERE ' + DOC_STORE + '.seq > ' + opts.since +
         ' ORDER BY ' + DOC_STORE + '.seq ' + (descending ? 'DESC' : 'ASC');
 
-      if (opts.limit) {
-        sql += ' LIMIT ' + opts.limit;
-      }
-
       db.transaction(function(tx) {
         tx.executeSql(sql, [], function(tx, result) {
           var last_seq = 0;
@@ -598,8 +594,7 @@ var webSqlPouch = function(opts, callback) {
               results.push(change);
             }
           }
-          results = results.filter(filterChange(opts));
-          call(opts.complete, null, {results: results, last_seq: last_seq});
+          processChanges(opts, results, last_seq);
         });
       });
     }

--- a/src/pouch.utils.js
+++ b/src/pouch.utils.js
@@ -227,9 +227,22 @@ var filterChange = function(opts) {
     if (!opts.include_docs) {
       delete change.doc;
     }
-    call(opts.onChange, change);
     return true;
   };
+};
+
+var processChanges = function(opts, changes, last_seq) {
+  // TODO: we should try to filter and limit as soon as possible
+  changes = changes.filter(filterChange(opts));
+  if (opts.limit) {
+    if (opts.limit < changes.length) {
+      changes.length = opts.limit;
+    }
+  }
+  changes.forEach(function(change){
+    call(opts.onChange, change);
+  });
+  call(opts.complete, null, {results: changes, last_seq: last_seq});
 };
 
 var rootToLeaf = function(tree) {
@@ -302,6 +315,7 @@ if (typeof module !== 'undefined' && module.exports) {
     computeHeight: computeHeight,
     arrayFirst: arrayFirst,
     filterChange: filterChange,
+    processChanges: processChanges,
     atob: function(str) {
       var base64 = new Buffer(str, 'base64');
       // Node.js will just skip the characters it can't encode instead of

--- a/tests/test.all_docs.js
+++ b/tests/test.all_docs.js
@@ -1,7 +1,7 @@
 /*globals initTestDB: false, emit: true, generateAdapterUrl: false */
 /*globals PERSIST_DATABASES: false, initDBPair: false, utils: true */
 /*globals ajax: true, LevelPouch: true, makeDocs: false */
-/*globals cleanupTestDatabases: false */
+/*globals cleanupTestDatabases: false, writeDocs: false */
 
 "use strict";
 
@@ -38,18 +38,6 @@ adapters.map(function(adapter) {
     {_id:"1",a:2,b:4},
     {_id:"2",a:3,b:9}
   ];
-
-
-  function writeDocs(db, docs, callback) {
-    if (!docs.length) {
-      return callback();
-    }
-    var doc = docs.shift();
-    db.put(doc, function(err, doc) {
-      ok(doc.ok, 'docwrite returned ok');
-      writeDocs(db, docs, callback);
-    });
-  }
 
   asyncTest('Testing all docs', function() {
     initTestDB(this.name, function(err, db) {

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -252,6 +252,21 @@ var putTree = function(db, tree, callback) {
   insert(0);
 };
 
+var writeDocs = function(db, docs, callback, res) {
+  if (!res) {
+    res = [];
+  }
+  if (!docs.length) {
+    return callback(null, res);
+  }
+  var doc = docs.shift();
+  db.put(doc, function(err, doc) {
+    ok(doc.ok, 'docwrite returned ok');
+    res.push(doc);
+    writeDocs(db, docs, callback, res);
+  });
+};
+
 if (typeof module !== 'undefined' && module.exports) {
   Pouch = require('../src/pouch.js');
   module.exports = {
@@ -268,6 +283,7 @@ if (typeof module !== 'undefined' && module.exports) {
     putAfter: putAfter,
     putBranch: putBranch,
     putTree: putTree,
+    writeDocs: writeDocs,
     cleanupTestDatabases: cleanupTestDatabases,
     PERSIST_DATABASES: PERSIST_DATABASES
   };


### PR DESCRIPTION
- limit action should be done after deduplication and
  filter aplication
- this implementation could be much less performant as
  we don't limit the result set (but how can we improve it?)
