### PR TITLE
Fixed IE delay when delete database

### DIFF
--- a/src/pouch.js
+++ b/src/pouch.js
@@ -77,7 +77,7 @@ var Pouch = function Pouch(name, opts, callback) {
 };
 
 Pouch.DEBUG = false;
-
+Pouch.openReqList = {};
 Pouch.adapters = {};
 Pouch.plugins = {};
 


### PR DESCRIPTION
Hello,

I fixed the delay that comment on Issue #378

The delay is because the deleteDatabase operation is blocked for open request.

The solution is save this open request, an before deleteDatabase, close this request.

I hope that this fix will be usefull.
