### PR TITLE
(#765) Pouch MapReduce crashes if view doesn't exist instead of returning error.

### DIFF
--- a/src/plugins/pouchdb.mapreduce.js
+++ b/src/plugins/pouchdb.mapreduce.js
@@ -236,6 +236,12 @@ var MapReduce = function(db) {
         if (callback) callback(err);
         return;
       }
+
+      if (!doc.views[parts[1]]) {
+        if (callback) callback({ error: 'not_found', reason: 'missing_named_view' });
+        return;
+      }
+
       viewQuery({
         map: doc.views[parts[1]].map,
         reduce: doc.views[parts[1]].reduce

--- a/tests/test.views.js
+++ b/tests/test.views.js
@@ -288,4 +288,25 @@ adapters.map(function(adapter) {
     });
   });
 
+  asyncTest("Query non existing view returns error", function() {
+    initTestDB(this.name, function(err, db) {
+      var doc = {
+        _id: '_design/barbar',
+        views: {
+          scores: {
+            map: 'function(doc) { if (doc.score) { emit(null, doc.score); } }'
+          }
+        }
+      };
+      db.post(doc, function (err, info) {
+        db.query('barbar/dontExist',{key: 'bar'}, function(err, res) {
+          equal(err.error, 'not_found');
+          equal(err.reason, 'missing_named_view');
+          start();
+        });
+      });
+    });
+  });
+
+
 });


### PR DESCRIPTION
Currently if a view from a design document is queried but the view doesn't exist in the view. Pouchdb crashed. Following Couchdb's api. It should return an error 'missing_named_view
