### PR TITLE
Special document member _doc_id_rev is leaking outside

### DIFF
--- a/src/adapters/pouch.idb.js
+++ b/src/adapters/pouch.idb.js
@@ -746,6 +746,7 @@ var IdbPouch = function(opts, callback) {
         var index = txn.objectStore(BY_SEQ_STORE).index('_doc_id_rev');
         index.get(key).onsuccess = function(docevent) {
           var doc = docevent.target.result;
+          delete doc['_doc_id_rev'];
           var changeList = [{rev: mainRev}];
           if (opts.style === 'all_docs') {
             changeList = Pouch.merge.collectLeaves(metadata.rev_tree)

--- a/tests/test.views.js
+++ b/tests/test.views.js
@@ -386,5 +386,24 @@ adapters.map(function(adapter) {
     });
   });
 
+  asyncTest("Special document member _doc_id_rev should never leak outside", function() {
+    initTestDB(this.name, function(err, db) {
+      db.bulkDocs({
+        docs: [
+          { foo: 'bar' }
+        ]
+      }, null, function() {
+
+        db.query(function (doc) {
+          if (doc.foo === 'bar') {
+            emit(doc.foo);
+          }
+        }, { include_docs: true }, function (err, res) {
+          ok((typeof res.rows[0].doc._doc_id_rev === 'undefined'), '_doc_id_rev is leaking but should not');
+          start();
+        });
+      });
+    });
+  });
 
 });


### PR DESCRIPTION
When querying with an idb-pouch and `{include_docs: true}`, the resulting documents have a the special document member _doc_id_rev on them which prevents later updating those docs.
