### PR TITLE
_info should return doc_count/seqno from stores

### DIFF
--- a/src/adapters/pouch.leveldb.js
+++ b/src/adapters/pouch.leveldb.js
@@ -151,13 +151,24 @@ var LevelPouch = function(opts, callback) {
     return opts.name;
   };
 
-  api._info = function(callback) {
-    return call(callback, null, {
-      db_name: opts.name,
-      doc_count: doc_count,
-      update_seq: update_seq
-    });
-  };
+
+   api._info = function(callback) {
+
+     stores[BY_SEQ_STORE].get(DOC_COUNT_KEY, function(err, _doc_count) {
+       if(err) { _doc_count = doc_count }
+
+       stores[BY_SEQ_STORE].get(UPDATE_SEQ_KEY, function(err, _update_seq) {
+         if(err) { _update_seq = update_seq }
+
+         return call(callback, null, {
+           db_name: opts.name,
+           doc_count: _doc_count,
+           update_seq: _update_seq
+         });
+
+       })
+     })
+   };
 
   api._get = function(id, opts, callback) {
     stores[DOC_STORE].get(id, function(err, metadata) {


### PR DESCRIPTION
fixes problem where the db is being updated and doc_count is incremented
but _info is returing an old value. since doc_count is cached on writes then
_info should use this cached value instead.
