### PR TITLE
(#885) Fix for cloudant error when writing a new checkpoint.

### DIFF
--- a/src/pouch.replicate.js
+++ b/src/pouch.replicate.js
@@ -93,6 +93,8 @@ var writeCheckpoint = function(src, target, id, checkpoint, callback) {
       src.get(check._id, function(err, doc) {
         if (doc && doc._rev) {
           check._rev = doc._rev;
+        } else {
+          delete check._rev;
         }
         src.put(check, function(err, doc) {
           callback();


### PR DESCRIPTION
When pouchdb went to write a new checkpoint to cloudant, it was accidentally getting the local db's _rev and trying to insert a new doc with that _rev. Cloundant servers had an issue with that. Please see SO question here for cloudant support's specific response to that bug.
http://stackoverflow.com/questions/17979689/cloudant-case-clause-error-with-pouchdb-when-replicating/17980994
