### PR TITLE
Added opts argument to the compact() method globally.

### DIFF
--- a/src/pouch.adapter.js
+++ b/src/pouch.adapter.js
@@ -293,7 +293,11 @@ PouchAdapter = function(opts, callback) {
 
   // compact the whole database using single document
   // compaction
-  api.compact = function(callback) {
+  api.compact = function(opts, callback) {
+    if (typeof opts === 'function') {
+      callback = opts;
+      opts = {};
+    }
     api.changes({complete: function(err, res) {
       if (err) {
         call(callback); // TODO: silently fail

--- a/tests/test.compaction.js
+++ b/tests/test.compaction.js
@@ -58,6 +58,15 @@ adapters.map(function(adapter) {
     });
   });
 
+  asyncTest('Compation on empty db with interval option', function() {
+    initTestDB(this.name, function(err, db) {
+      db.compact({interval: 199}, function(){
+        ok(true, "compaction finished");
+        start();
+      });
+    });
+  });
+
   asyncTest('Simple compation test', function() {
     initTestDB(this.name, function(err, db) {
       var doc = {_id: "foo", value: "bar"};


### PR DESCRIPTION
The docs on the compact method specify an optional 'opts' argument. This argument is only used by the http adapter, and it's the only one which accepts it inside the function definition currently. This branch changes that, because that approach is suboptimal in at least two cases:

1) When switching from the http backend to another, the callback is never called (typeof {} !== "function" -> fails silently). There's a test included for this situation (depending on QUnit timing out sadly, but I can't find a better way and it seems that more tests are doing this.)
2) When making bindings for PouchDB so it can be used from another language (that was were I found out about this).
