### PR TITLE
Support for custom list of adapters/plugins in build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,15 +26,18 @@ module.exports = function(grunt) {
 
   var testStartTime = new Date();
   var testResults = {};
+  var buildName = '-nightly';
 
   var adapters = grunt.option('adapters') || ['http', 'idb', 'websql'];
   if (typeof adapters === 'string') {
     adapters = adapters.split(/[\s,]+/);
+    buildName = '-' + adapters.join('-') + buildName;
   }
 
   var plugins = grunt.option('plugins') || ['mapreduce'];
   if (typeof plugins === 'string') {
     plugins = plugins.split(/[\s,]+/);
+    buildName = '.' + plugins.join('-') + buildName;
   }
 
   function stripName(name) {
@@ -99,29 +102,15 @@ module.exports = function(grunt) {
         src: grunt.util._.flatten([
           "<banner:meta.amd.top>", srcFiles,"<banner:meta.amd.bottom>"
         ]),
-        dest: 'dist/pouchdb.amd-nightly.js'
+        dest: 'dist/pouchdb.amd' + buildName + '.js'
       },
       all: {
         src: grunt.util._.flatten([
           "src/deps/uuid.js", "src/deps/md5.js",
           "src/deps/polyfill.js", "src/deps/extend.js","src/deps/ajax.js", srcFiles
         ]),
-        dest: 'dist/pouchdb-nightly.js'
+        dest: 'dist/pouchdb' + buildName + '.js'
       },
-      spatial: {
-        src: grunt.util._.flatten([
-          "src/deps/uuid.js", "src/deps/md5.js",
-          "src/deps/polyfill.js", "src/deps/extend.js","src/deps/ajax.js", srcFiles,
-          "src/plugins/pouchdb.spatial.js"
-        ]),
-        dest: 'dist/pouchdb.spatial-nightly.js'
-      },
-      gql: {
-        src: grunt.util._.flatten([
-           srcFiles, "src/plugins/pouchdb.gql.js"
-        ]),
-        dest: 'dist/pouchdb.gql-nightly.js'
-      }
     },
 
     'uglify': {
@@ -129,17 +118,9 @@ module.exports = function(grunt) {
         banner: fileHeader
       },
       dist: {
-        src: "./dist/pouchdb-nightly.js",
-        dest: 'dist/pouchdb-nightly.min.js'
+        src: './dist/pouchdb' + buildName + '.js',
+        dest: 'dist/pouchdb' + buildName + '.min.js'
       },
-      spatial: {
-        src:  'dist/pouchdb.spatial-nightly.js',
-        dest:  'dist/pouchdb.spatial-nightly.min.js'
-      },
-      gql: {
-        src:  'dist/pouchdb.gql-nightly.js',
-        dest:  'dist/pouchdb.gql-nightly.min.js'
-      }
     },
 
     // Servers
@@ -296,8 +277,16 @@ module.exports = function(grunt) {
   grunt.registerTask("browser", ["connect", "cors-server", "forever"]);
   grunt.registerTask("full", ["concat", "uglify"]);
 
-  grunt.registerTask("spatial", ["concat:spatial", "uglify:spatial"]);
-  grunt.registerTask("gql", ["concat:gql", "uglify:gql"]);
+  grunt.registerTask("spatial", function() {
+    grunt.warn(
+      'This task is no longer supported. Use `grunt --plugins=spatial` instead.'
+    );
+  });
+  grunt.registerTask("gql", function() {
+    grunt.warn(
+      'This task is no longer supported. Use `grunt --plugins=gql` instead.'
+    );
+  });
 
   grunt.registerTask("test", ["jshint", "node-qunit"]);
   grunt.registerTask("test-travis", ["jshint", "build", "connect", "cors-server",


### PR DESCRIPTION
> Supports a comma/space separated list of adapters as cli parameter.
> 
> Eg:
> 
> To build only idb adapter, use
> 
> ```
> grunt --adapters=http
> ```
> 
> or to build idb and http adapter, use
> 
> ```
> grunt --adapters='idb http'
> ```

This is a crude implementation, with no tests. So, this **need not be merged just yet**. I have a superior and well integrated patch in mind, which spans adapters and plugins while also supporting corresponding subset of tests.

Basically the idea is to allow users to decrease the size of their assets based on their need.
