### PR TITLE
(#923) - No more commas in uuids

### DIFF
--- a/src/deps/uuid.js
+++ b/src/deps/uuid.js
@@ -37,8 +37,10 @@ var uuid;
 
 (function() {
 
-  var CHARS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ' +
-    'abcdefghijklmnopqrstuvwxyz'.split('');
+  var CHARS = (
+    '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ' +
+    'abcdefghijklmnopqrstuvwxyz'
+    ).split('');
 
   uuid = function uuid_inner(len, radix) {
     var chars = CHARS;


### PR DESCRIPTION
The previous implementation resulted in the CHARS array actually being a string with a bunch of commas in it (eg `"...XYZa,b,c..."`).

It would be awkward to test for the absence of commas without groping the implementation, but the existing test suite passes fine.
