### PR TITLE
Make sure the change applies to the value we're watching

### DIFF
--- a/src/pouch.utils.js
+++ b/src/pouch.utils.js
@@ -215,7 +215,10 @@ PouchUtils.Changes = function() {
 
   if (isChromeApp()){
     chrome.storage.onChanged.addListener(function(e){
-      api.notify(e.db_name.newValue);//object only has oldValue, newValue members
+      // make sure it's event addressed to us
+      if (e.db_name != null) {
+        api.notify(e.db_name.newValue);//object only has oldValue, newValue members
+      }
     });
   } else if (typeof window !== 'undefined') {
     window.addEventListener("storage", function(e) {


### PR DESCRIPTION
If application used `chrome.storage` for other means, this listener would receive these 'external' changes and fail due to `db_name` not being present in the object representing the change.
