### PR TITLE
(#926) - HTTP Basic Auth for Userinfo in the url.

### DIFF
--- a/src/adapters/pouch.http.js
+++ b/src/adapters/pouch.http.js
@@ -134,9 +134,10 @@ var HttpPouch = function(opts, callback) {
   var host = getHost(opts.name);
 
   host.headers = opts.headers || {};
-  if (opts.auth) {
-    var token = PouchUtils.btoa(opts.auth.username + ':' + opts.auth.password);
-    host.headers.Authorization = 'Basic ' + token;
+  if (opts.auth || host.auth) { 
+    var nAuth = opts.auth || host.auth;
+    var token = PouchUtils.btoa(nAuth.username + ':' + nAuth.password);
+    host.headers.Authorization = 'Basic ' + token; 
   }
 
   if (opts.headers) {


### PR DESCRIPTION
Before, HTTP Basic Authorization header was set only when user/password were passed in the `opts` object for the instantiation of PouchDB, now `http://user:password@host` works also.
