### PR TITLE
(#939, #935) Change way of calculating revsDiff

### DIFF
--- a/src/pouch.adapter.js
+++ b/src/pouch.adapter.js
@@ -285,18 +285,21 @@ PouchAdapter = function(opts, callback) {
       missingForId.forEach(function(rev) {
         addToMissing(id, rev);
       });
-
-      if (++count === ids.length) {
-        return call(callback, null, missing);
-      }
     }
 
     ids.map(function(id) {
       customApi._getRevisionTree(id, function(err, rev_tree) {
-        if (err) {
+        if (err && err.error === 'not_found' && err.reason === 'missing') {
+          missing[id] = {missing: req[id]};
+        } else if (err) {
           return call(callback, err);
+        } else {
+          processDoc(id, rev_tree);
         }
-        processDoc(id, rev_tree);
+
+        if (++count === ids.length) {
+          return call(callback, null, missing);
+        }
       });
     });
   };

--- a/tests/test.revs_diff.js
+++ b/tests/test.revs_diff.js
@@ -52,6 +52,19 @@ adapters.map(function(adapter) {
     });
   });
 
+  asyncTest('Missing docs should be returned with all revisions being asked for',
+    function() {
+      initTestDB(this.name, function(err, db) {
+        // empty database
+        var revs = ['1-a', '2-a', '2-b'];
+        db.revsDiff({'foo': revs}, function(err, results) {
+          ok('foo' in results, 'listed missing revs');
+          deepEqual(results.foo.missing, revs, 'listed all revs');
+          start();
+        });
+      });
+  });
+
   asyncTest('Conflicting revisions that are available should not be marked as' +
     ' missing (#939)', function() {
     var doc = {_id: '939', _rev: '1-a'};


### PR DESCRIPTION
Until now, `revsDiff` was using `rev_info` option to `get` routine as a
source of information for which revisions are present and which are
missing. This led to problems, as purpose of `rev_info` is to list
revision history of current winning revision, so it doesn't include any
information about conflicts or deleted revisions.

CouchDB itself is using internal index information for obtaining state
of revisions for a given document (see
https://github.com/apache/couchdb/blob/master/src/couchdb/couch_db.erl#L193),
so it seems valid to do the same in PouchDB, by traversing the whole
revision tree obtained by using custom (internal) API. HTTP adapter
overrides `revsDiff` to use a POST request, so it works fine.
