### PR TITLE
(#939, #935) Change way of calculating revsDiff

### DIFF
--- a/src/pouch.adapter.js
+++ b/src/pouch.adapter.js
@@ -256,9 +256,50 @@ PouchAdapter = function(opts, callback) {
       }
     }
 
+    function addToMissing(id, revId) {
+      if (!missing[id]) {
+        missing[id] = {missing: []};
+      }
+      missing[id].missing.push(revId);
+    }
+
+    function processDoc(id, rev_tree) {
+      // Is this fast enough? Maybe we should switch to a set simulated by a map
+      var missingForId = req[id].slice(0);
+      PouchMerge.traverseRevTree(rev_tree, function(isLeaf, pos, revHash, ctx,
+        opts) {
+          var rev = pos + '-' + revHash;
+          var idx = missingForId.indexOf(rev);
+          if (idx === -1) {
+            return;
+          }
+
+          missingForId.splice(idx, 1);
+          if (opts.status !== 'available') {
+            addToMissing(id, rev);
+          }
+      });
+
+      // Traversing the tree is synchronous, so now `missingForId` contains
+      // revisions that were not found in the tree
+      missingForId.forEach(function(rev) {
+        addToMissing(id, rev);
+      });
+    }
+
     ids.map(function(id) {
-      api.get(id, {revs_info: true}, function(err, doc) {
-        readDoc(err, doc, id);
+      customApi._getRevisionTree(id, function(err, rev_tree) {
+        if (err && err.error === 'not_found' && err.reason === 'missing') {
+          missing[id] = {missing: req[id]};
+        } else if (err) {
+          return call(callback, err);
+        } else {
+          processDoc(id, rev_tree);
+        }
+
+        if (++count === ids.length) {
+          return call(callback, null, missing);
+        }
       });
     });
   };

--- a/tests/test.revs_diff.js
+++ b/tests/test.revs_diff.js
@@ -1,5 +1,5 @@
 /*globals initTestDB: false, emit: true, generateAdapterUrl: false */
-/*globals PERSIST_DATABASES: false */
+/*globals PERSIST_DATABASES: false, putAfter */
 /*globals cleanupTestDatabases: false */
 
 "use strict";
@@ -52,4 +52,57 @@ adapters.map(function(adapter) {
     });
   });
 
+  asyncTest('Missing docs should be returned with all revisions being asked for',
+    function() {
+      initTestDB(this.name, function(err, db) {
+        // empty database
+        var revs = ['1-a', '2-a', '2-b'];
+        db.revsDiff({'foo': revs}, function(err, results) {
+          ok('foo' in results, 'listed missing revs');
+          deepEqual(results.foo.missing, revs, 'listed all revs');
+          start();
+        });
+      });
+  });
+
+  asyncTest('Conflicting revisions that are available should not be marked as' +
+    ' missing (#939)', function() {
+    var doc = {_id: '939', _rev: '1-a'};
+
+    function createConflicts(db, callback) {
+      db.put(doc, {new_edits: false}, function(err, res) {
+        putAfter(db, {_id: '939', _rev: '2-a'}, '1-a', function(err, res) {
+            putAfter(db, {_id: '939', _rev: '2-b'}, '1-a', callback);
+        });
+      });
+    }
+
+    initTestDB(this.name, function(err, db) {
+      createConflicts(db, function() {
+        db.revsDiff({'939': ['1-a', '2-a', '2-b']}, function(err, results) {
+          ok(!('939' in results), 'no missing revs');
+          start();
+        });
+      });
+    });
+  });
+
+  asyncTest('Deleted revisions that are available should not be marked as' +
+    ' missing (#935)', function() {
+
+    function createDeletedRevision(db, callback) {
+      db.put({_id: '935', _rev: '1-a'}, {new_edits: false}, function (err, info) {
+        putAfter(db, {_id: '935', _rev: '2-a', _deleted: true}, '1-a', callback);
+      });
+    }
+
+    initTestDB(this.name, function(err, db) {
+      createDeletedRevision(db, function() {
+        db.revsDiff({'935': ['1-a', '2-a']}, function(err, results) {
+          ok(!('935' in results), 'should not return the deleted revs');
+          start();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Until now, `revsDiff` was using `rev_info` option to `get` routine as a
source of information for which revisions are present and which are
missing. This led to problems, as purpose of `rev_info` is to list
revision history of current winning revision, so it doesn't include any
information about conflicts or deleted revisions.

CouchDB itself is using internal index information for obtaining state
of revisions for a given document (see
https://github.com/apache/couchdb/blob/master/src/couchdb/couch_db.erl#L193),
so it seems valid to do the same in PouchDB, by traversing the whole
revision tree obtained by using custom (internal) API. HTTP adapter
overrides `revsDiff` to use a POST request, so it works fine.
