### PR TITLE
(#909) - Enabled paging for replication of doc_id's

### DIFF
--- a/src/adapters/pouch.http.js
+++ b/src/adapters/pouch.http.js
@@ -752,11 +752,15 @@ var HttpPouch = function(opts, callback) {
     var xhr;
     var lastFetchedSeq;
     var remoteLastSeq;
+    var pagingCount;
 
     // Get all the changes starting wtih the one immediately after the
     // sequence number given by since.
     var fetch = function(since, callback) {
       params.since = since;
+      if (!opts.continuous && !pagingCount) {
+        pagingCount = remoteLastSeq;
+      }
       params.limit = (!limit || leftToFetch > CHANGES_LIMIT) ?
         CHANGES_LIMIT : leftToFetch;
 
@@ -814,8 +818,11 @@ var HttpPouch = function(opts, callback) {
       }
 
       var resultsLength = res && res.results.length || 0;
+
+      pagingCount-=CHANGES_LIMIT;
+
       var finished = (limit && leftToFetch <= 0) ||
-        (res && !resultsLength) ||
+        (res && !resultsLength && pagingCount <=0) ||
         (resultsLength && res.last_seq === remoteLastSeq) ||
         (opts.descending && lastFetchedSeq !== 0);
 

--- a/tests/test.replication.js
+++ b/tests/test.replication.js
@@ -680,6 +680,31 @@ adapters.map(function(adapters) {
     });
   });
 
+  asyncTest("issue #909 Filtered replication bails at paging limit", function() {
+    var self = this;
+    var docs = [];
+    var num = 100;
+    for (var i = 0; i < num; i++) {
+      docs.push({_id: 'doc_' + i, foo: 'bar_' + i});
+    }
+    num = 100;
+    var docList = [];
+    for (i = 0; i < num; i+=5) {
+      docList.push('doc_' + i);
+    }
+    // uncomment this line to test only docs higher than paging limit
+    docList = ['doc_33', 'doc_60', 'doc_90'];
+    initDBPair(this.name, this.remote, function(db, remote) {
+      remote.bulkDocs({docs: docs}, {}, function(err, results) {
+        db.replicate.from(self.remote, {continuous: false, doc_ids: docList}, function(err, result) {
+          ok(result.ok, 'replication was ok');
+          ok(result.docs_written === docList.length, 'correct # docs written');
+          start();
+        });
+      });
+    });
+  });
+
 });
 
 // test a basic "initialize pouch" scenario when couch instance contains deleted revisions


### PR DESCRIPTION
Currently the finished value is incorrectly set to true when there are
no results in the first 25 records
(CHANGES_LIMIT = 25) when filtering by a list of doc_ids. This stops
the loop and prevents the doc_id's from being replicated.
Created the new pagingCount field and set it to the remoteLastSeq
value. PagingCount is decremented by
CHANGES_LIMIT every time the fetched callback runs. The logic for
finished has been modified so that even if
resultsLength ===0, finished will be false if pagingCount > 0. This may
also work for other types of filtered replication.
