### PR TITLE
 (#963) - latest changes since info.update_seq

### DIFF
--- a/src/adapters/pouch.http.js
+++ b/src/adapters/pouch.http.js
@@ -697,7 +697,7 @@ var HttpPouch = function(opts, callback) {
     
     if (opts.since === 'latest') {
       api.info(function (err, info) {
-        opts.since = info.update_seq - 1;
+        opts.since = info.update_seq;
         api.changes(opts);
       });
       return;

--- a/tests/test.changes.js
+++ b/tests/test.changes.js
@@ -708,18 +708,21 @@ adapters.map(function(adapter) {
   });
   
   asyncTest('Calling db.changes({since: \'latest\'', function () {
-    expect(2);
+    expect(3);
     initTestDB(this.name, function (err, db) {
       db.bulkDocs({docs: [
         { foo: 'bar' }
       ]}, function (err, data) {
         ok(!err, 'bulkDocs passed');
-        db.changes({
-          since: 'latest',
-          complete: function(err, res) {
-            ok(!err, 'completed db.changes({since: \'latest\'}): ' + JSON.stringify(res));
-            start();
-          }
+        db.info(function(err, info) { 
+          db.changes({
+            since: 'latest',
+            complete: function(err, res) {
+              ok(!err, 'completed db.changes({since: \'latest\'}): ' + JSON.stringify(res));
+              equal(res.last_seq, info.update_seq, 'db.changes({since: \'latest\'}) listens since update_seq'); 
+              start();
+            }
+          });
         });
       });
     });


### PR DESCRIPTION
`changes({ since: 'latest' })` should listen for changes since `info.update_seq`
instead of `info.update_seq - 1`.
