### PR TITLE
Get existing checkpoint doc _rev before writing to avoid conflicts

### DIFF
--- a/src/pouch.replicate.js
+++ b/src/pouch.replicate.js
@@ -81,12 +81,17 @@ var fetchCheckpoint = function(src, target, id, callback) {
 };
 
 var writeCheckpoint = function(src, target, id, checkpoint, callback) {
-  var check = {
-    _id: id,
-    last_seq: checkpoint
+  var updateCheckpoint = function (db, callback) {
+    db.get(id, function(err, doc) {
+      if (err && err.status === 404) {
+          doc = {_id: id};
+      }
+      doc.last_seq = checkpoint;
+      db.put(doc, callback);
+    });
   };
-  target.put(check, function(err, doc) {
-    src.put(check, function(err, doc) {
+  updateCheckpoint(target, function(err, doc) {
+    updateCheckpoint(src, function(err, doc) {
       callback();
     });
   });


### PR DESCRIPTION
When replicating from CouchDB to IndexedDB I was getting document update conflicts on the _local docs used to store replication checkpoints. Getting the existing doc to ensure we update based on the existing _rev fixes this issue.
