### PR TITLE
Check Database exists before deleting in node. ISSUE-915

### DIFF
--- a/src/adapters/pouch.leveldb.js
+++ b/src/adapters/pouch.leveldb.js
@@ -835,15 +835,16 @@ LevelPouch.destroy = function(name, opts, callback) {
     var uuidPath = name + '.uuid';
     if (fs.existsSync(uuidPath)) {
       fs.unlinkSync(uuidPath);
+      rmdir(name, function(err) {
+        if (err && err.code === 'ENOENT') {
+          // TODO: MISSING_DOC name is somewhat misleading in this context
+          return call(callback, Pouch.Errors.MISSING_DOC);
+        }
+        return call(callback, err);
+      });
+    } else {
+      return call(callback, Pouch.Errors.DB_MISSING);
     }
-
-    rmdir(name, function(err) {
-      if (err && err.code === 'ENOENT') {
-        // TODO: MISSING_DOC name is somewhat misleading in this context
-        return call(callback, Pouch.Errors.MISSING_DOC);
-      }
-      return call(callback, err);
-    });
   }
 };
 

--- a/src/pouch.js
+++ b/src/pouch.js
@@ -433,6 +433,11 @@ Pouch.Errors = {
     status: 400,
     error: 'bad_request',
     reason: 'Document must be a JSON object'
+  },
+  DB_MISSING: {
+    status: 404,
+    error: 'not_found',
+    reason: 'Database not found'
   }
 };
 

--- a/tests/test.issue915.js
+++ b/tests/test.issue915.js
@@ -1,0 +1,48 @@
+/*globals initTestDB: false, emit: true, generateAdapterUrl: false */
+/*globals PERSIST_DATABASES: false, initDBPair: false, utils: true */
+/*globals ajax: true, LevelPouch: true */
+
+"use strict";
+
+var qunit = module;
+var LevelPouch;
+var utils;
+var fs;
+
+if (typeof module !== undefined && module.exports) {
+  Pouch = require('../src/pouch.js');
+  LevelPouch = require('../src/adapters/pouch.leveldb.js');
+  utils = require('./test.utils.js');
+  fs = require('fs');
+
+  for (var k in utils) {
+    global[k] = global[k] || utils[k];
+  }
+  qunit = QUnit.module;
+}
+
+qunit("Remove DB", {
+  setup: function() {
+    //Create a dir
+    fs.mkdirSync('veryimportantfiles');
+  },
+  teardown: function() {
+      Pouch.destroy('name');
+      fs.rmdirSync('veryimportantfiles');
+  }
+});
+
+
+
+asyncTest("Create a pouch without DB setup", function() {
+  var instantDB;
+  instantDB = new Pouch('name', {skipSetup: true}, function() {
+    Pouch.destroy('veryimportantfiles', function( error, response ) {
+        equal(error.reason, 'Database not found', 'should return Database not found error');
+        equal(fs.existsSync('veryimportantfiles'), true, 'veryimportantfiles was not removed');
+        start();
+      });
+  });
+});
+
+


### PR DESCRIPTION
test can be run with grunt node-qunit --test=issue915

i didn't move the location of .uuid field since that sort of breaks old functionality,  all that really had ti be done was move the "rm" stuff into the "if" statement when checking for the existence of that .uuid file
