### PR TITLE
(#979) - Destroy local db whith open changes

### DIFF
--- a/src/pouch.utils.js
+++ b/src/pouch.utils.js
@@ -248,7 +248,9 @@ PouchUtils.Changes = function() {
   };
 
   api.removeListener = function(db_name, id) {
-    delete listeners[db_name][id];
+    if (listeners[db_name]) {
+      delete listeners[db_name][id];
+    }
   };
 
   api.clearListeners = function(db_name) {

--- a/tests/test.changes.js
+++ b/tests/test.changes.js
@@ -444,6 +444,27 @@ adapters.map(function(adapter) {
     });
   });
 
+  asyncTest("Kill database while listening to continuous changes", function() {
+    var name = this.name;
+    initTestDB(this.name, function(err, db) {
+      var count = 0;
+      var changes = db.changes({
+        onChange: function(change) {
+          count += 1;
+          if (count === 1) {
+            PouchDB.destroy(name, function(err, resp) {
+              changes.cancel();
+              ok(true);
+              start();
+            });
+          }
+        },
+        continuous: true
+      });
+      db.post({test:"adoc"});
+    });
+  });
+
   asyncTest("Changes filter", function() {
 
     var docs1 = [


### PR DESCRIPTION
Check for the existence of database listener hash before
deleting the listener.

With a test.
