### PR TITLE
Replication performance improvements

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -130,7 +130,7 @@ function replicate(src, target, opts, promise) {
   }
 
   function fetchGenerationOneRevs(ids, revs) {
-    src.allDocs({keys: ids, include_docs: true}, function(err, res) {
+    src.allDocs({keys: ids, include_docs: true}, function (err, res) {
       if (promise.cancelled) {
         return replicationComplete();
       }
@@ -138,7 +138,7 @@ function replicate(src, target, opts, promise) {
         return abortReplication('src.get completed with error', err);
       }
       
-      res.rows.forEach(function(row, i) {
+      res.rows.forEach(function (row, i) {
         // fetch document again via api.get when doc
         // * is deleted document (could have data)
         // * is no longer generation 1
@@ -180,12 +180,12 @@ function replicate(src, target, opts, promise) {
       return;
     }
 
-    var generationOne = Object.keys(diffs).reduce(function(memo, id) {
+    var generationOne = Object.keys(diffs).reduce(function (memo, id) {
       if (diffs[id].missing.length === 1 && parseInt(diffs[id].missing[0], 10) === 1) {
         memo.ids.push(id);
         memo.revs.push(diffs[id].missing[0]);
         delete diffs[id];
-      };
+      }
 
       return memo;
     }, {


### PR DESCRIPTION
#### (#932) - Use bulk API for _revs_diff

Queue revs diff requests and and send them in bulk.
#### (#993) - Use allDocs to batch generation 1 docs

Batch fetching docs of generation 1 via `allDocs` api in replication.
- handle deleted docs correctly (they could have been deleted via POST with
  `_deleted: true` without removing data)
- Handle docs, which revision has changed after change has been emitted
