### PR TITLE
(#1082) - remove referenses to pouch global from adapters

### DIFF
--- a/src/adapters/pouch.http.js
+++ b/src/adapters/pouch.http.js
@@ -2,7 +2,7 @@
 
 var Pouch = require('../pouch.js');
 var PouchUtils = require('../pouch.utils.js');
-
+var errors = require('../deps/errors');
 var HTTP_TIMEOUT = 10000;
 
 // parseUri 1.2.2
@@ -155,7 +155,7 @@ function HttpPouch(opts, callback) {
       }
       var cb = function (err, body) {
         if (err || !('uuids' in body)) {
-          PouchUtils.call(callback, err || Pouch.Errors.UNKNOWN_ERROR);
+          PouchUtils.call(callback, err || errors.UNKNOWN_ERROR);
         } else {
           uuids.list = uuids.list.concat(body.uuids);
           PouchUtils.call(callback, null, "OK");
@@ -193,7 +193,7 @@ function HttpPouch(opts, callback) {
         // Continue as if there had been no errors
         PouchUtils.call(callback, null, api);
       } else {
-        PouchUtils.call(callback, Pouch.Errors.UNKNOWN_ERROR);
+        PouchUtils.call(callback, errors.UNKNOWN_ERROR);
       }
     });
   };
@@ -491,10 +491,10 @@ function HttpPouch(opts, callback) {
       opts = {};
     }
     if (typeof doc !== 'object') {
-      return PouchUtils.call(callback, Pouch.Errors.NOT_AN_OBJECT);
+      return PouchUtils.call(callback, errors.NOT_AN_OBJECT);
     }
     if (!('_id' in doc)) {
-      return PouchUtils.call(callback, Pouch.Errors.MISSING_ID);
+      return PouchUtils.call(callback, errors.MISSING_ID);
     }
 
     // List of parameter to add to the PUT request
@@ -536,7 +536,7 @@ function HttpPouch(opts, callback) {
       opts = {};
     }
     if (typeof doc !== 'object') {
-      return PouchUtils.call(callback, Pouch.Errors.NOT_AN_OBJECT);
+      return PouchUtils.call(callback, errors.NOT_AN_OBJECT);
     }
     if (! ("_id" in doc)) {
       if (uuids.list.length > 0) {
@@ -545,7 +545,7 @@ function HttpPouch(opts, callback) {
       } else {
         uuids.get(function (err, resp) {
           if (err) {
-            return PouchUtils.call(callback, Pouch.Errors.UNKNOWN_ERROR);
+            return PouchUtils.call(callback, errors.UNKNOWN_ERROR);
           }
           doc._id = uuids.list.pop();
           api.put(doc, opts, callback);
@@ -692,9 +692,7 @@ function HttpPouch(opts, callback) {
           if (task.task) {
             return task.task.cancel();
           }
-          if (Pouch.DEBUG) {
-            console.log(db_url + ': Cancel Changes Feed');
-          }
+          //console.log(db_url + ': Cancel Changes Feed');
           task.parameters[0].aborted = true;
         }
       };
@@ -714,17 +712,13 @@ function HttpPouch(opts, callback) {
           if (changes) {
             return changes.cancel();
           }
-          if (Pouch.DEBUG) {
-            console.log(db_url + ': Cancel Changes Feed');
-          }
+          //console.log(db_url + ': Cancel Changes Feed');
           opts.aborted = true;
         }
       };
     }
 
-    if (Pouch.DEBUG) {
-      console.log(db_url + ': Start Changes Feed: continuous=' + opts.continuous);
-    }
+    //console.log(db_url + ': Start Changes Feed: continuous=' + opts.continuous);
 
     var params = {};
     var limit = (typeof opts.limit !== 'undefined') ? opts.limit : false;
@@ -858,7 +852,7 @@ function HttpPouch(opts, callback) {
         var maximumWait = opts.maximumWait || 30000;
 
         if (retryWait > maximumWait) {
-          PouchUtils.call(opts.complete, err || Pouch.Errors.UNKNOWN_ERROR, null);
+          PouchUtils.call(opts.complete, err || errors.UNKNOWN_ERROR, null);
         }
 
         // Queue a call to fetch again with the newest sequence number
@@ -887,9 +881,7 @@ function HttpPouch(opts, callback) {
     // Return a method to cancel this method from processing any more
     return {
       cancel: function () {
-        if (Pouch.DEBUG) {
-          console.log(db_url + ': Cancel Changes Feed');
-        }
+        //console.log(db_url + ': Cancel Changes Feed');
         opts.aborted = true;
         xhr.abort();
       }

--- a/src/adapters/pouch.leveldb.js
+++ b/src/adapters/pouch.leveldb.js
@@ -363,10 +363,6 @@ function LevelPouch(opts, callback) {
         doc.metadata.rev_map[doc.metadata.rev] = doc.metadata.seq;
 
         stores[BY_SEQ_STORE].put(doc.metadata.seq, doc.data, function (err) {
-          if (err && false) {
-            return console.error(err);
-          }
-
           stores[DOC_STORE].put(doc.metadata.id, doc.metadata, function (err) {
             results.push(doc);
             return saveUpdateSeq(callback2);
@@ -392,7 +388,7 @@ function LevelPouch(opts, callback) {
       stores[ATTACH_STORE].get(digest, function (err, oldAtt) {
         if (err && err.name !== 'NotFoundError') {
           if (false) {
-            console.error(err);
+            //console.error(err);
           }
           return call(callback, err);
         }
@@ -414,18 +410,12 @@ function LevelPouch(opts, callback) {
         }
 
         stores[ATTACH_STORE].put(digest, newAtt, function (err) {
-          if (err && false) {
-            return console.error(err);
-          }
           // do not try to store empty attachments
           if (data.length === 0) {
             return callback(err);
           }
           stores[ATTACH_BINARY_STORE].put(digest, data, function (err) {
             callback(err);
-            if (err && false) {
-              return console.error(err);
-            }
           });
         });
       });
@@ -545,7 +535,7 @@ function LevelPouch(opts, callback) {
     docstream.on('error', function (err) {
       // TODO: handle error
       if (false) {
-        console.error(err);
+        //console.error(err);
       }
     });
     docstream.on('end', function () {
@@ -633,7 +623,7 @@ function LevelPouch(opts, callback) {
         .on('error', function (err) {
           // TODO: handle errors
           if (false) {
-            console.error(err);
+            //console.error(err);
           }
         })
         .on('close', function () {
@@ -676,7 +666,7 @@ function LevelPouch(opts, callback) {
       return {
         cancel: function () {
           if (false) {
-            console.log(name + ': Cancel Changes Feed');
+            //console.log(name + ': Cancel Changes Feed');
           }
           opts.cancelled = true;
           change_emitter.removeListener('change', changeListener);

--- a/src/pouch.adapter.js
+++ b/src/pouch.adapter.js
@@ -4,6 +4,7 @@
 
 var PouchUtils = require('./pouch.utils.js');
 var PouchMerge = require('./pouch.merge');
+var errors = require('./deps/errors');
 var call = PouchUtils.call;
 
 /*
@@ -124,7 +125,7 @@ module.exports = function (Pouch) {
         opts = {};
       }
       if (typeof doc !== 'object' || Array.isArray(doc)) {
-        return call(callback, Pouch.Errors.NOT_AN_OBJECT);
+        return call(callback, errors.NOT_AN_OBJECT);
       }
       return customApi.bulkDocs({docs: [doc]}, opts,
           autoCompact(yankError(callback)));
@@ -136,10 +137,10 @@ module.exports = function (Pouch) {
         opts = {};
       }
       if (typeof doc !== 'object') {
-        return call(callback, Pouch.Errors.NOT_AN_OBJECT);
+        return call(callback, errors.NOT_AN_OBJECT);
       }
       if (!('_id' in doc)) {
-        return call(callback, Pouch.Errors.MISSING_ID);
+        return call(callback, errors.MISSING_ID);
       }
       return customApi.bulkDocs({docs: [doc]}, opts,
           autoCompact(yankError(callback)));
@@ -173,7 +174,7 @@ module.exports = function (Pouch) {
 
       api.get(docId, function (err, doc) {
         // create new doc
-        if (err && err.error === Pouch.Errors.MISSING_DOC.error) {
+        if (err && err.error === errors.MISSING_DOC.error) {
           createAttachment({_id: docId});
           return;
         }
@@ -183,7 +184,7 @@ module.exports = function (Pouch) {
         }
 
         if (doc._rev !== rev) {
-          call(callback, Pouch.Errors.REV_CONFLICT);
+          call(callback, errors.REV_CONFLICT);
           return;
         }
 
@@ -198,7 +199,7 @@ module.exports = function (Pouch) {
           return;
         }
         if (obj._rev !== rev) {
-          call(callback, Pouch.Errors.REV_CONFLICT);
+          call(callback, errors.REV_CONFLICT);
           return;
         }
         if (!obj._attachments) {
@@ -393,13 +394,13 @@ module.exports = function (Pouch) {
               var l = leaves[i];
               // looks like it's the only thing couchdb checks
               if (!(typeof(l) === "string" && /^\d+-/.test(l))) {
-                return call(callback, Pouch.error(Pouch.Errors.BAD_REQUEST,
+                return call(callback, PouchUtils.error(errors.BAD_REQUEST,
                   "Invalid rev format"));
               }
             }
             finishOpenRevs();
           } else {
-            return call(callback, Pouch.error(Pouch.Errors.UNKNOWN_ERROR,
+            return call(callback, PouchUtils.error(errors.UNKNOWN_ERROR,
               'function_clause'));
           }
         }
@@ -499,7 +500,7 @@ module.exports = function (Pouch) {
           opts.ctx = res.ctx;
           customApi._getAttachment(res.doc._attachments[attachmentId], opts, callback);
         } else {
-          return call(callback, Pouch.Errors.MISSING_DOC);
+          return call(callback, errors.MISSING_DOC);
         }
       });
     };
@@ -515,13 +516,13 @@ module.exports = function (Pouch) {
       }
       if ('keys' in opts) {
         if ('startkey' in opts) {
-          call(callback, Pouch.error(Pouch.Errors.QUERY_PARSE_ERROR,
+          call(callback, PouchUtils.error(errors.QUERY_PARSE_ERROR,
             'Query parameter `start_key` is not compatible with multi-get'
           ));
           return;
         }
         if ('endkey' in opts) {
-          call(callback, Pouch.error(Pouch.Errors.QUERY_PARSE_ERROR,
+          call(callback, PouchUtils.error(errors.QUERY_PARSE_ERROR,
             'Query parameter `end_key` is not compatible with multi-get'
           ));
           return;
@@ -543,7 +544,7 @@ module.exports = function (Pouch) {
               return task.task.cancel();
             }
             if (Pouch.DEBUG) {
-              console.log('Cancel Changes Feed');
+              //console.log('Cancel Changes Feed');
             }
             task.parameters[0].aborted = true;
           }
@@ -569,7 +570,7 @@ module.exports = function (Pouch) {
               return changes.cancel();
             }
             if (Pouch.DEBUG) {
-              console.log('Cancel Changes Feed');
+              //console.log('Cancel Changes Feed');
             }
             opts.aborted = true;
           }
@@ -625,16 +626,16 @@ module.exports = function (Pouch) {
       }
 
       if (!req || !req.docs || req.docs.length < 1) {
-        return call(callback, Pouch.Errors.MISSING_BULK_DOCS);
+        return call(callback, errors.MISSING_BULK_DOCS);
       }
 
       if (!Array.isArray(req.docs)) {
-        return call(callback, Pouch.Errors.QUERY_PARSE_ERROR);
+        return call(callback, errors.QUERY_PARSE_ERROR);
       }
 
       for (var i = 0; i < req.docs.length; ++i) {
         if (typeof req.docs[i] !== 'object' || Array.isArray(req.docs[i])) {
-          return call(callback, Pouch.Errors.NOT_AN_OBJECT);
+          return call(callback, errors.NOT_AN_OBJECT);
         }
       }
 

--- a/src/pouch.js
+++ b/src/pouch.js
@@ -2,7 +2,6 @@
 
 var PouchUtils = require('./pouch.utils.js');
 var PouchAdapter = require('./pouch.adapter.js')(Pouch);
-
 function Pouch(name, opts, callback) {
 
   if (!(this instanceof Pouch)) {
@@ -77,8 +76,6 @@ function Pouch(name, opts, callback) {
   }
 }
 
-Pouch.DEBUG = false;
-Pouch.openReqList = {};
 Pouch.adapters = {};
 Pouch.plugins = {};
 
@@ -138,9 +135,7 @@ Pouch.destroy = function (name, opts, callback) {
     for (var plugin in Pouch.plugins) {
       Pouch.plugins[plugin]._delete(backend.name);
     }
-    if (Pouch.DEBUG) {
-      console.log(backend.name + ': Delete Database');
-    }
+    //console.log(backend.name + ': Delete Database');
 
     // call destroy method of the particular adaptor
     Pouch.adapters[backend.adapter].destroy(backend.name, opts, callback);
@@ -168,7 +163,7 @@ Pouch.removeFromAllDbs = function (opts, callback) {
   new Pouch(Pouch.allDBName(opts.adapter), function (err, db) {
     if (err) {
       // don't fail when allDbs fail
-      console.error(err);
+      //console.error(err);
       callback();
       return;
     }
@@ -180,7 +175,7 @@ Pouch.removeFromAllDbs = function (opts, callback) {
       } else {
         db.remove(doc, function (err, response) {
           if (err) {
-            console.error(err);
+            //console.error(err);
           }
           callback();
         });
@@ -232,7 +227,7 @@ Pouch.open = function (opts, callback) {
   new Pouch(Pouch.allDBName(adapter), function (err, db) {
     if (err) {
       // don't fail when allDb registration fails
-      console.error(err);
+      //console.error(err);
       callback();
       return;
     }
@@ -246,7 +241,7 @@ Pouch.open = function (opts, callback) {
           dbname: opts.originalName
         }, function (err) {
             if (err) {
-              console.error(err);
+              //console.error(err);
             }
 
             callback();
@@ -305,7 +300,7 @@ Pouch.allDbs = function (callback) {
         // code to clear allDbs.
         // response.rows.forEach(function (row) {
         //   db.remove(row.doc, function () {
-        //     console.log(arguments);
+        //     //console.log(arguments);
         //   });
         // });
 
@@ -318,20 +313,16 @@ Pouch.allDbs = function (callback) {
   accumulate(adapters, []);
 };
 
-Pouch.uuid = PouchUtils.uuid;
-Pouch.uuids = PouchUtils.uuids;
 // Enumerate errors, add the status code so we can reflect the HTTP api
 // in future
-Pouch.Errors = require('./deps/errors');
 
-Pouch.error = function (error, reason) {
-  return PouchUtils.extend({}, error, {reason: reason});
-};
 
 module.exports = Pouch;
 
 Pouch.ajax = require('./deps/ajax');
 Pouch.extend = require('./deps/extend');
+Pouch.utils = PouchUtils;
+Pouch.Errors = require('./deps/errors');
 Pouch.replicate = require('./pouch.replicate.js').replicate;
 Pouch.version = require('./version');
 var httpAdapter = require('./adapters/pouch.http.js');

--- a/src/pouch.utils.js
+++ b/src/pouch.utils.js
@@ -12,6 +12,9 @@ PouchUtils.Crypto = require('./deps/md5.js');
 var buffer = require('./deps/buffer');
 var errors = require('./deps/errors');
 
+PouchUtils.error = function (error, reason) {
+  return PouchUtils.extend({}, error, {reason: reason});
+};
 // List of top level reserved words for doc
 var reservedWords = [
   '_id',

--- a/tests/test.basics.js
+++ b/tests/test.basics.js
@@ -407,7 +407,7 @@ adapters.map(function(adapter) {
   });
 
   test('Error works', 1, function() {
-    deepEqual(Pouch.error(Pouch.Errors.BAD_REQUEST, "love needs no reason"),
+    deepEqual(Pouch.utils.error(Pouch.Errors.BAD_REQUEST, "love needs no reason"),
       {status: 400, error: "bad_request", reason: "love needs no reason"},
       "should be the same");
   });

--- a/tests/test.uuids.js
+++ b/tests/test.uuids.js
@@ -19,20 +19,20 @@ var rfcRegexp = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0
 test('UUID generation count', 1, function() {
   var count = 10;
 
-  equal(Pouch.uuids(count).length, count, "Correct number of uuids generated.");
+  equal(Pouch.utils.uuids(count).length, count, "Correct number of uuids generated.");
 });
 
 test('UUID RFC4122 test', 2, function() {
-  var uuid = Pouch.uuids()[0];
-  equal(rfcRegexp.test(Pouch.uuids()[0]), true,
+  var uuid = Pouch.utils.uuids()[0];
+  equal(rfcRegexp.test(Pouch.utils.uuids()[0]), true,
                        "Single UUID complies with RFC4122.");
-  equal(rfcRegexp.test(Pouch.uuid()), true,
-        "Single UUID through Pouch.uuid complies with RFC4122.");
+  equal(rfcRegexp.test(Pouch.utils.uuid()), true,
+        "Single UUID through Pouch.utils.uuid complies with RFC4122.");
 });
 
 test('UUID generation uniqueness', 1, function() {
   var count = 1000;
-  var uuids = Pouch.uuids(count);
+  var uuids = Pouch.utils.uuids(count);
 
   equal(eliminateDuplicates(uuids).length, count,
         "Generated UUIDS are unique.");
@@ -42,7 +42,7 @@ test('Test small uuid uniqness', 1, function() {
   var length = 8;
   var count = 2000;
 
-  var uuids = Pouch.uuids(count, {length: length});
+  var uuids = Pouch.utils.uuids(count, {length: length});
   equal(eliminateDuplicates(uuids).length, count,
         "Generated small UUIDS are unique.");
 });
@@ -52,9 +52,9 @@ test('Test custom length', 11, function() {
   var count = 10;
   var options = {length: length};
 
-  var uuids = Pouch.uuids(count, options);
+  var uuids = Pouch.utils.uuids(count, options);
   // Test single UUID wrapper
-  uuids.push(Pouch.uuid(options));
+  uuids.push(Pouch.utils.uuid(options));
 
   uuids.map(function (uuid) {
     equal(uuid.length, length, "UUID length is correct.");
@@ -67,9 +67,9 @@ test('Test custom length, redix', 22, function() {
   var radix = 5;
   var options = {length: length, radix: radix};
 
-  var uuids = Pouch.uuids(count, options);
+  var uuids = Pouch.utils.uuids(count, options);
   // Test single UUID wrapper
-  uuids.push(Pouch.uuid(options));
+  uuids.push(Pouch.utils.uuid(options));
 
   uuids.map(function (uuid) {
     var nums = uuid.split('').map(function(character) {


### PR DESCRIPTION
removes Pouch.DEBUG, moves Pouch.uuid, Pouch.uuids, and Pouch.error to the utils names space, moves Pouch.Errors to it's own namespace (which also hangs off of the root for use in tests) and attaches the utils name space to Pouch so that tests can see it. 

As of this commit no files in the src/ folder should be referencing `Pouch` or requiring that file. 
