### PR TITLE
(#693) Fixed error throwing in api.changes

### DIFF
--- a/src/adapters/pouch.http.js
+++ b/src/adapters/pouch.http.js
@@ -826,6 +826,10 @@ function HttpPouch(opts, callback) {
           }
           return ret;
         });
+      } else if (err) {
+        // In case of an error, stop listening for changes and call opts.complete
+        opts.aborted = true;
+        PouchUtils.call(opts.complete, err, null);
       }
 
       // The changes feed may have timed out with no results

--- a/src/pouch.adapter.js
+++ b/src/pouch.adapter.js
@@ -603,12 +603,17 @@ module.exports = function (Pouch) {
                   api.changes(opts);
                 }
               } else {
-                err = err || Pouch.error(Pouch.Errors.MISSING_DOC, 'missing json key: ' + viewName[1]);
+                err = err || 
+                     (ddoc.views ? 
+                      PouchUtils.error(Pouch.Errors.MISSING_DOC, 
+                                       'missing json key: ' + viewName[1]) :
+                      PouchUtils.error(Pouch.Errors.MISSING_DOC, 
+                                       'missing json key: views'));
                 PouchUtils.call(opts.complete, err);
               }
             });
           } else {
-            var err = Pouch.error(Pouch.Errors.BAD_REQUEST, '`view` filter parameter is not provided.');
+            var err = PouchUtils.error(Pouch.Errors.BAD_REQUEST, '`view` filter parameter is not provided.');
             PouchUtils.call(opts.complete, err);
           }
         } else {
@@ -624,7 +629,12 @@ module.exports = function (Pouch) {
                 api.changes(opts);
               }
             } else {
-              err = err || Pouch.error(Pouch.Errors.MISSING_DOC, 'missing json key: ' + filterName[1]);
+              err = err || 
+                   (ddoc.filters ? 
+                    PouchUtils.error(Pouch.Errors.MISSING_DOC, 
+                                     'missing json key: ' + filterName[1]) :
+                    PouchUtils.error(Pouch.Errors.MISSING_DOC, 
+                                     'missing json key: filters'));
               PouchUtils.call(opts.complete, err);
             }
           });


### PR DESCRIPTION
Fixed error reason messages for error throwing in
local adapters, mirroring CouchDB reason messages;

Added some error throwing functionality for http
adapter which stops the repetition of `_changes`
requests immediately and just calls `opts.complete`
with the error;

Added tests for ensuring the consistency of the
errors status codes and messages between local and
http adapters.
