### PR TITLE
(#1112) - Closing db causes a crash in leveldb even if changes have been...

### DIFF
--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -581,6 +581,7 @@ function LevelPouch(opts, callback) {
       var changeStream = stores[BY_SEQ_STORE].readStream(streamOpts);
       changeStream
         .on('data', function (data) {
+          if(opts.cancelled){return;}
           if (utils.isLocalId(data.key)) {
             return;
           }
@@ -627,6 +628,7 @@ function LevelPouch(opts, callback) {
           }
         })
         .on('close', function () {
+          if(opts.cancelled){return;}
           var filter = utils.filterChange(opts);
           changeListener = function (change) {
             if (filter(change)) {
@@ -656,7 +658,9 @@ function LevelPouch(opts, callback) {
             //console.log(name + ': Cancel Changes Feed');
           }
           opts.cancelled = true;
-          change_emitter.removeListener('change', changeListener);
+          if(changeListener){
+            change_emitter.removeListener('change', changeListener);            
+          }
         }
       };
     }

--- a/tests/test.changes.js
+++ b/tests/test.changes.js
@@ -1025,3 +1025,22 @@ asyncTest("Changes reports errors", function (){
     }
   });
 });
+
+asyncTest("Closing db dosent cause a crash if changes cancelled", function (){
+  initTestDB(this.name, function (err, db) {
+      db.bulkDocs({docs: [
+        { foo: 'bar' }
+      ]}, function (err, data) {
+        ok(!err, 'bulked ok');
+        var changes = db.changes({
+          continuous: true,
+          onChange: function(){}
+        });
+        changes.cancel();
+        db.close(function(error){
+          ok(!error, 'closed ok');
+          start();
+        });
+      });
+    });
+});


### PR DESCRIPTION
Was getting a crash in the levedb adaptor when opening and closing a db even if changes had been cancelled. The cancel can happen before any data is read from leveldb so it needs to check when data is returned whether it has already been cancelled.
