### PR TITLE
Listen to progress events to reset timeout

### DIFF
--- a/lib/deps/ajax.js
+++ b/lib/deps/ajax.js
@@ -126,6 +126,10 @@ function ajax(options, callback) {
 
     if (options.timeout > 0) {
       timer = setTimeout(abortReq, options.timeout);
+      xhr.upload.onprogress = xhr.onprogress = function() {
+      	clearTimeout(timer);
+      	timer = setTimeout(abortReq, options.timeout);
+      };
     }
     xhr.send(options.body);
     return {abort:abortReq};


### PR DESCRIPTION
Current implementation always kills transfers after 10s. It is more correct to kill a transfer after no response for 10s. This allows big transfers over thin lines, and enables uploading and downlaoding of big documents.
