### PR TITLE
Allow passing of timeout option to the ajax call

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -2,6 +2,7 @@
 
 var utils = require('../utils');
 var errors = require('../deps/errors');
+var HTTP_TIMEOUT = 10000;
 
 // parseUri 1.2.2
 // (c) Steven Levithan <stevenlevithan.com>
@@ -362,6 +363,10 @@ function HttpPouch(opts, callback) {
       method: 'GET',
       url: genDBUrl(host, id + params)
     };
+    
+    if (opts.hasOwnProperty('timeout')) {
+      options.timeout = opts.timeout;
+    }
 
     // If the given id contains at least one '/' and the part before the '/'
     // is NOT "_design" and is NOT "_local"
@@ -511,13 +516,19 @@ function HttpPouch(opts, callback) {
       params = '?' + params;
     }
 
-    // Add the document
-    ajax({
+    var options = {
       headers: host.headers,
       method: 'PUT',
       url: genDBUrl(host, encodeDocId(doc._id)) + params,
       body: doc
-    }, callback);
+    };
+
+    if (opts.hasOwnProperty('timeout')) {
+      options.timeout = opts.timeout;
+    }
+
+    // Add the document
+    ajax(options, callback);
   };
 
   // Add the document given by doc (in JSON string format) to the database
@@ -579,13 +590,19 @@ function HttpPouch(opts, callback) {
       req.new_edits = opts.new_edits;
     }
 
-    // Update/create the documents
-    ajax({
+    var options = {
       headers: host.headers,
       method: 'POST',
       url: genDBUrl(host, '_bulk_docs'),
       body: req
-    }, callback);
+    };
+
+    if (opts.hasOwnProperty('timeout')) {
+      options.timeout = opts.timeout;
+    }
+
+    // Update/create the documents
+    ajax(options, callback);
   };
 
   // Get a listing of the documents in the database given


### PR DESCRIPTION
Currently it is not possible to overrule the default ajax adapter timeout (10s)

My use case is a large attachment upload, uploaded using the inline format 

This https://github.com/daleharvey/pouchdb/blob/master/lib/deps/ajax.js#L128 cancels the request after `options.timeout` milliseconds
This https://github.com/daleharvey/pouchdb/blob/master/lib/deps/ajax.js#L27 injects the default seconds, which implies that when no timeout is specified, the request is aborted after the default of 10s

The http adapter sets ajax options, but these are not depending on the supplied options, see https://github.com/daleharvey/pouchdb/blob/master/lib/adapters/http.js#L361 and https://github.com/daleharvey/pouchdb/blob/master/lib/adapters/http.js#L382.
#1129 does not solve this problem but will allow big uploads/downloads over thin but stable connections
