### PR TITLE
Fix #1132

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -51,6 +51,7 @@ PouchDB.destroy = function (name, opts, callback) {
     callback = function () {};
   }
   var backend = PouchDB.parseAdapter(opts.name || name);
+  var dbName = opts.name || backend.name;
 
   var cb = function (err, response) {
     if (err) {
@@ -59,12 +60,12 @@ PouchDB.destroy = function (name, opts, callback) {
     }
 
     for (var plugin in PouchDB.plugins) {
-      PouchDB.plugins[plugin]._delete(backend.name);
+      PouchDB.plugins[plugin]._delete(dbName);
     }
-    //console.log(backend.name + ': Delete Database');
+    //console.log(dbName + ': Delete Database');
 
     // call destroy method of the particular adaptor
-    PouchDB.adapters[backend.adapter].destroy(backend.name, opts, callback);
+    PouchDB.adapters[backend.adapter].destroy(dbName, opts, callback);
   };
 
   // remove PouchDB from allDBs

--- a/tests/test.basics.js
+++ b/tests/test.basics.js
@@ -412,4 +412,22 @@ adapters.map(function(adapter) {
       {status: 400, error: "bad_request", reason: "love needs no reason"},
       "should be the same");
   });
+
+  asyncTest('Fail to fetch a doc after db was deleted', function() {
+    var dbName = 'foodb';
+    var docid = 'foodoc';
+    var pouchDB = new PouchDB({name : dbName}, function onCreate() {
+      pouchDB.put({_id : docid}, function onPut() {
+        PouchDB.destroy({name : dbName}, function onDestroy() {
+          pouchDB = new PouchDB({name : dbName}, function onRecreate() {
+            pouchDB.get(docid, function onGet(err, doc) {
+              equal(doc, undefined, 'should not return the document, because db was deleted');
+              notEqual(err, undefined, 'should return error, because db was deleted');
+              start();
+            });
+          });
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixes #1132.  Seems the trick was to copy the `name = opts.name || backend.name` logic from the `Pouch` constructor (pouch.js line 29) to `destroy()`; otherwise `_pouch_{{dbName}}` would always override `{{dbName}}`.

Also sneaking in a commit to fix a few typos in the documentation, unless I misunderstood something.
