### PR TITLE
(#1132) - ensure that destroy() deletes docs

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -51,6 +51,7 @@ PouchDB.destroy = function (name, opts, callback) {
     callback = function () {};
   }
   var backend = PouchDB.parseAdapter(opts.name || name);
+  var dbName = opts.name || backend.name;
 
   var cb = function (err, response) {
     if (err) {
@@ -59,12 +60,12 @@ PouchDB.destroy = function (name, opts, callback) {
     }
 
     for (var plugin in PouchDB.plugins) {
-      PouchDB.plugins[plugin]._delete(backend.name);
+      PouchDB.plugins[plugin]._delete(dbName);
     }
-    //console.log(backend.name + ': Delete Database');
+    //console.log(dbName + ': Delete Database');
 
     // call destroy method of the particular adaptor
-    PouchDB.adapters[backend.adapter].destroy(backend.name, opts, callback);
+    PouchDB.adapters[backend.adapter].destroy(dbName, opts, callback);
   };
 
   // remove PouchDB from allDBs

--- a/tests/test.basics.js
+++ b/tests/test.basics.js
@@ -412,4 +412,22 @@ adapters.map(function(adapter) {
       {status: 400, error: "bad_request", reason: "love needs no reason"},
       "should be the same");
   });
+
+  asyncTest('Fail to fetch a doc after db was deleted', function() {
+    var dbName = 'foodb';
+    var docid = 'foodoc';
+    var pouchDB = new PouchDB({name : dbName}, function onCreate() {
+      pouchDB.put({_id : docid}, function onPut() {
+        PouchDB.destroy({name : dbName}, function onDestroy() {
+          pouchDB = new PouchDB({name : dbName}, function onRecreate() {
+            pouchDB.get(docid, function onGet(err, doc) {
+              equal(doc, undefined, 'should not return the document, because db was deleted');
+              notEqual(err, undefined, 'should return error, because db was deleted');
+              start();
+            });
+          });
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Previously, destroy() would not actually delete data,
and you could recover it by recreating the database,
due to mistaken prepending of `_pouch_` to the database
name.

(This is a correction of pull request #1133, per your instructions.  Hopefully I did it right this time!  :smiley:
