### PR TITLE
(#1137) - Harmonize db creation via opts/string

### DIFF
--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -21,9 +21,11 @@ function PouchDB(name, opts, callback) {
     callback = function () {};
   }
 
-  var backend = PouchDB.parseAdapter(opts.name || name);
-  opts.originalName = name;
-  opts.name = opts.name || backend.name;
+  var originalName = opts.name || name;
+  var backend = PouchDB.parseAdapter(originalName);
+  
+  opts.originalName = originalName;
+  opts.name = backend.name;
   opts.adapter = opts.adapter || backend.adapter;
 
   if (!PouchDB.adapters[opts.adapter]) {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -51,7 +51,7 @@ PouchDB.destroy = function (name, opts, callback) {
     callback = function () {};
   }
   var backend = PouchDB.parseAdapter(opts.name || name);
-  var dbName = opts.name || backend.name;
+  var dbName = backend.name;
 
   var cb = function (err, response) {
     if (err) {


### PR DESCRIPTION
Ensures that destroy() and the PouchDB() constructor work
the same, regardless of whether the database name is
specified via options or a string.

See comments in #1137.  This pull request constitutes breaking changes, so I'm leaving it up to the maintainer's judgment.
