### PR TITLE
(#1139) - put() should return error for empty _id

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -139,7 +139,7 @@ module.exports = function (Pouch) {
       if (typeof doc !== 'object') {
         return call(callback, errors.NOT_AN_OBJECT);
       }
-      if (!('_id' in doc)) {
+      if (!utils.isValidId(doc._id)) {
         return call(callback, errors.MISSING_ID);
       }
       return customApi.bulkDocs({docs: [doc]}, opts,

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -491,7 +491,7 @@ function HttpPouch(opts, callback) {
     if (typeof doc !== 'object') {
       return utils.call(callback, errors.NOT_AN_OBJECT);
     }
-    if (!('_id' in doc)) {
+    if (!utils.isValidId(doc._id)) {
       return utils.call(callback, errors.MISSING_ID);
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -48,12 +48,15 @@ exports.uuid = function (options) {
 // Determine id an ID is valid
 //   - invalid IDs begin with an underescore that does not begin '_design' or '_local'
 //   - any other string value is a valid id
-function isValidId(id) {
+exports.isValidId = function (id) {
+  if (!id || (typeof id !== 'string')) {
+    return false;
+  }
   if (/^_/.test(id)) {
     return (/^_(design|local)/).test(id);
   }
   return true;
-}
+};
 
 function isChromeApp() {
   return (typeof chrome !== "undefined" &&
@@ -197,7 +200,7 @@ exports.parseDoc = function (doc, newEdits) {
   if (typeof doc._id !== 'string') {
     error = errors.INVALID_ID;
   }
-  else if (!isValidId(doc._id)) {
+  else if (!exports.isValidId(doc._id)) {
     error = errors.RESERVED_ID;
   }
 

--- a/tests/test.basics.js
+++ b/tests/test.basics.js
@@ -430,4 +430,16 @@ adapters.map(function(adapter) {
       });
     });
   });
+
+  asyncTest("Can't add docs with empty ids", 6, function() {
+    var docs = [{}, {_id : null}, {_id : undefined}, {_id : ''}, {_id : {}}, {_id : '_underscored_id'}];
+    initTestDB(this.name, function(err, db) {
+      docs.forEach(function(doc) {
+        db.put(doc, function (err, info) {
+          ok(err, "didn't get an error for doc: " + JSON.stringify(doc) +'; response was ' + JSON.stringify(info));
+          start();
+        });
+      });
+    });
+  });
 });

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -265,9 +265,9 @@ var writeDocs = function(db, docs, callback, res) {
     return callback(null, res);
   }
   var doc = docs.shift();
-  db.put(doc, function(err, doc) {
-    ok(doc.ok, 'docwrite returned ok');
-    res.push(doc);
+  db.put(doc, function(err, info) {
+    ok(info && info.ok, 'docwrite returned ok');
+    res.push(info);
     writeDocs(db, docs, callback, res);
   });
 };


### PR DESCRIPTION
Ensure that put() returns an error when the _id is
undefined/null/empty.
