### PR TITLE
(#1132) - ensure it cleans up after itself

### DIFF
--- a/tests/test.basics.js
+++ b/tests/test.basics.js
@@ -414,7 +414,7 @@ adapters.map(function(adapter) {
   });
 
   asyncTest('Fail to fetch a doc after db was deleted', function() {
-    var dbName = 'foodb';
+    var dbName = this.name;
     var docid = 'foodoc';
     var pouchDB = new PouchDB({name : dbName}, function onCreate() {
       pouchDB.put({_id : docid}, function onPut() {


### PR DESCRIPTION
#1132 didn't delete the db after it was made, this fixes it so you don't have 'foodb' laying around
