### PR TITLE
Fix since with leveldb adapter

### DIFF
--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -179,6 +179,14 @@ function LevelPouch(opts, callback) {
     });
   };
 
+  function formatSeq(n) {
+    return ('0000000000000000' + n).slice(-16);
+  }
+
+  function parseSeq(s) {
+    return parseInt(s);
+  }
+
   api._get = function (id, opts, callback) {
     stores[DOC_STORE].get(id, function (err, metadata) {
       if (err || !metadata) {
@@ -192,7 +200,7 @@ function LevelPouch(opts, callback) {
       rev = opts.rev ? opts.rev : rev;
       var seq = metadata.rev_map[rev];
 
-      stores[BY_SEQ_STORE].get(seq, function (err, doc) {
+      stores[BY_SEQ_STORE].get(formatSeq(seq), function (err, doc) {
         if (!doc) {
           return call(callback, errors.MISSING_DOC);
         }
@@ -362,7 +370,7 @@ function LevelPouch(opts, callback) {
         doc.metadata.seq = doc.metadata.seq || update_seq;
         doc.metadata.rev_map[doc.metadata.rev] = doc.metadata.seq;
 
-        stores[BY_SEQ_STORE].put(doc.metadata.seq, doc.data, function (err) {
+        stores[BY_SEQ_STORE].put(formatSeq(doc.metadata.seq), doc.data, function (err) {
           stores[DOC_STORE].put(doc.metadata.id, doc.metadata, function (err) {
             results.push(doc);
             return saveUpdateSeq(callback2);
@@ -524,7 +532,7 @@ function LevelPouch(opts, callback) {
       var metadata = entry.value;
       if (opts.include_docs) {
         var seq = metadata.rev_map[merge.winningRev(metadata)];
-        stores[BY_SEQ_STORE].get(seq, function (err, data) {
+        stores[BY_SEQ_STORE].get(formatSeq(seq), function (err, data) {
           allDocsInner(metadata, data);
         });
       }
@@ -575,7 +583,7 @@ function LevelPouch(opts, callback) {
       };
 
       if (!streamOpts.reverse) {
-        streamOpts.start = opts.since ? opts.since + 1 : 0;
+        streamOpts.start = formatSeq(opts.since ? opts.since + 1 : 0);
       }
 
       var changeStream = stores[BY_SEQ_STORE].readStream(streamOpts);
@@ -603,7 +611,7 @@ function LevelPouch(opts, callback) {
             }
 
             // Ensure duplicated dont overwrite winning rev
-            if (+data.key === metadata.rev_map[change.doc._rev]) {
+            if (parseSeq(data.key) === metadata.rev_map[change.doc._rev]) {
               results.push(change);
             }
           });
@@ -726,7 +734,7 @@ function LevelPouch(opts, callback) {
             return;
           }
 
-          stores[BY_SEQ_STORE].del(seq, function (err) {
+          stores[BY_SEQ_STORE].del(formatSeq(seq), function (err) {
             done();
           });
         });

--- a/tests/test.changes.js
+++ b/tests/test.changes.js
@@ -38,12 +38,22 @@ adapters.map(function(adapter) {
       {_id: "0", integer: 0},
       {_id: "1", integer: 1},
       {_id: "2", integer: 2},
-      {_id: "3", integer: 3}
+      {_id: "3", integer: 3},
+      {_id: "4", integer: 4},
+      {_id: "5", integer: 5},
+      {_id: "6", integer: 6},
+      {_id: "7", integer: 7},
+      {_id: "8", integer: 9},
+      {_id: "9", integer: 9},
+      {_id: "10", integer: 10},
+      {_id: "11", integer: 11},
+      {_id: "12", integer: 12},
+      {_id: "13", integer: 13}
     ];
     testUtils.initTestDB(this.name, function(err, db) {
       db.bulkDocs({docs: docs}, function(err, info) {
         db.changes({
-          since: 2,
+          since: 12,
           complete: function(err, results) {
             equal(results.results.length, 2, 'Partial results');
             start();


### PR DESCRIPTION
LevelDB keys are sorted lexicographically so without this change e.g. seq 2 appears to be after seq 12 and you can get way more results from `changes` than actually occurred.
