### PR TITLE
Make sure all stores are closed if an error occurs with one of them.

### DIFF
--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -66,7 +66,7 @@ function LevelPouch(opts, callback) {
     uuid = fs.readFileSync(uuidPath);
   }
 
-  api.closeStores = function (callback) {
+  function closeStores(callback) {
     var dbpath = path.resolve(opts.name);
     var stores = [
       path.join(dbpath, DOC_STORE),
@@ -116,7 +116,7 @@ function LevelPouch(opts, callback) {
       }
       if (err) {
         stores.err = err;
-        api.closeStores();
+        closeStores();
         return call(callback, err);
       }
 
@@ -702,7 +702,7 @@ function LevelPouch(opts, callback) {
     if (!opened) {
       return call(callback, errors.NOT_OPEN);
     }
-    api.closeStores(callback);
+    closeStores(callback);
   };
 
   api._getRevisionTree = function (docId, callback) {


### PR DESCRIPTION
Allows two processes trying to access the same database at the same time to
backoff and retry until the other one releases it.
Otherwise one can end up with some of the database's stores and the other one
with the rest, meaning neither can open it.

Note: It doesn't seem there's test infrastructure for adapter-specific tests.
