### PR TITLE
upgrade browserify, point to local version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "corsproxy": "~0.2.13",
     "http-server": "~0.5.5",
     "qunit": "~0.5.17",
-    "browserify": "~2.36.1",
-    "tin": "~0.3.1"
+    "tin": "~0.3.1",
+    "browserify": "~3.14.1"
   },
   "maintainers": [
     {
@@ -47,15 +47,15 @@
     }
   ],
   "scripts": {
-    "jshint": "jshint -c .jshintrc lib/*.js lib/adapters/*.js",
-    "build-js": "mkdir -p dist && browserify lib/index.js -s PouchDB -o dist/pouchdb-nightly.js",
-    "watch-js": "mkdir -p dist && watchify lib/index.js -s PouchDB -o dist/pouchdb-nightly.js",
-    "uglify": "uglifyjs dist/pouchdb-nightly.js -mc > dist/pouchdb-nightly.min.js",
+    "jshint": "./node_modules/bin/jshint -c .jshintrc lib/*.js lib/adapters/*.js",
+    "build-js": "mkdir -p dist && ./node_modules/.bin/browserify lib/index.js -s PouchDB -o dist/pouchdb-nightly.js",
+    "watch-js": "mkdir -p dist && ./node_modules/.bin/watchify lib/index.js -s PouchDB -o dist/pouchdb-nightly.js",
+    "uglify": "./node_modules/.bin/uglifyjs dist/pouchdb-nightly.js -mc > dist/pouchdb-nightly.min.js",
     "build": "npm run build-js && npm run uglify",
     "test-node": "./bin/test-node.js",
     "test-browser": "npm run build-js && ./bin/test-browser.js",
     "dev-server": "npm run watch-js & ./bin/dev-server.js",
-    "test": "npm run jshint && npm run test-node && npm run test-browser"
+    "test": "npm run ./node_modules/.bin/jshint && npm run test-node && npm run test-browser"
   },
   "browser": {
     "./adapters/leveldb": false,


### PR DESCRIPTION
upgrades browserify to version 3, and also points to the local versions of browserify jshint etc instead of the global ones
