### PR TITLE
(#1191) - Lazy openDB() 

### DIFF
--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -17,7 +17,6 @@ function openDB() {
       return window.openDatabase.apply(window, arguments);
     }
   }
-  return null;
 }
 
 var POUCH_VERSION = 1;


### PR DESCRIPTION
To fix #1191 this PR makes the openDatabase check lazy so it will be able to find the sqlite plugin.
