### PR TITLE
(#1175) - Handle HTTP codes other than 200/404 during repl

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -65,10 +65,14 @@ function fetchCheckpoint(src, target, id, callback) {
   target.get(id, function (err, targetDoc) {
     if (err && err.status === 404) {
       callback(null, 0);
+    } else if (err) {
+      callback(err);
     } else {
       src.get(id, function (err, sourceDoc) {
-        if (err && err.status === 404 || targetDoc.last_seq !== sourceDoc.last_seq) {
+        if (err && err.status === 404 || (!err && (targetDoc.last_seq !== sourceDoc.last_seq))) {
           callback(null, 0);
+        } else if (err) {
+          callback(err);
         } else {
           callback(null, sourceDoc.last_seq);
         }

--- a/tests/test.issue1175.js
+++ b/tests/test.issue1175.js
@@ -1,0 +1,97 @@
+"use strict";
+
+if (typeof module !== undefined && module.exports) {
+  var PouchDB = require('../lib');
+  var testUtils = require('./test.utils.js');
+}
+
+
+QUnit.module('replication-http-errors:');
+
+function MockDatabase(statusCodeToReturn, dataToReturn) {
+  this.id = function () {
+    return 123;
+  };
+
+  this.get = function (id, callback) {
+    setTimeout(function () {
+      if (statusCodeToReturn !== 200) {
+        callback({status: statusCodeToReturn}, dataToReturn)
+      } else {
+        callback(null, dataToReturn)
+      }
+    }, 0);
+  };
+
+  this.changes = function (opts) {
+    opts.complete();
+    return [];
+  }
+}
+
+function getCallback(expectError) {
+  // returns a function which expects to be called within a certain time. Fails the test otherwise
+
+  var maximumTimeToWait = 50;
+  var _hasBeenCalled;
+  var _result;
+  var _err;
+
+  var callback = function (err, result) {
+    _hasBeenCalled = true;
+    _result = result;
+    _err = err;
+  };
+
+  var timeOutCallback = function () {
+    ok(_hasBeenCalled , 'callback has been called');
+    ok(expectError || !_err , 'error expectation fulfilled');
+    start();
+  };
+
+  setTimeout(timeOutCallback, maximumTimeToWait);
+
+  return callback;
+}
+
+asyncTest("Initial replication is ok if source returns HTTP 404", function () {
+  var source = new MockDatabase(404, null);
+  var target = new MockDatabase(200, {});
+  PouchDB.replicate(source, target, {}, getCallback());
+});
+
+asyncTest("Initial replication is ok if target returns HTTP 404", function () {
+  var source = new MockDatabase(200, {});
+  var target = new MockDatabase(404, null);
+  PouchDB.replicate(source, target, {}, getCallback());
+});
+
+asyncTest("Initial replication is ok if source and target return HTTP 200", function () {
+  var source = new MockDatabase(200, {});
+  var target = new MockDatabase(200, {});
+  PouchDB.replicate(source, target, {}, getCallback());
+});
+
+asyncTest("Initial replication returns err if source returns HTTP 500", function () {
+  var source = new MockDatabase(500, null);
+  var target = new MockDatabase(200, {});
+  PouchDB.replicate(source, target, {}, getCallback(true));
+});
+
+asyncTest("Initial replication returns err if target returns HTTP 500", function () {
+  var source = new MockDatabase(200, {});
+  var target = new MockDatabase(500, null);
+  PouchDB.replicate(source, target, {}, getCallback(true));
+});
+
+asyncTest("Initial replication returns err if target and source return HTTP 500", function () {
+  var source = new MockDatabase(500, null);
+  var target = new MockDatabase(500, null);
+  PouchDB.replicate(source, target, {}, getCallback(true));
+});
+
+asyncTest("Subsequent replication returns err if source return HTTP 500", function () {
+  var source = new MockDatabase(500, null);
+  var target = new MockDatabase(200, {last_seq: 456});
+  PouchDB.replicate(source, target, {}, getCallback(true));
+});


### PR DESCRIPTION
Replication should invoke callback if it receives HTTP error codes
other than 404 and 200. (Which might be returned from the DB server
or from an intermediary reverse proxy). It seems that there was an
oversight which could lead to HTTP 500s to otherwise trigger neither
success nor err-callback behavior.
