### PR TITLE
(#1204) - test.worker.js fix when run in isolation

### DIFF
--- a/tests/test.worker.js
+++ b/tests/test.worker.js
@@ -28,5 +28,5 @@ asyncTest('create db',1,function(){
     worker.terminate();
     start();
   });
-  worker.postMessage(['create',testUtils.generateAdapterUrl(adapter)]);
+  worker.postMessage(['create',testUtils.generateAdapterUrl('http-1')]);
 });


### PR DESCRIPTION
test.worker.js fails when run in isolation, i.e. with:
http://192.168.0.3:8000/tests/test.html?testFiles=test.worker.js

Apparently the other tests set the adapter variable to 'http-1'
by this point; I'm just making it explicit here.
