### PR TITLE
Fix attachments in websql

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -87,17 +87,6 @@ function IdbPouch(opts, callback) {
     db.createObjectStore(DETECT_BLOB_SUPPORT_STORE);
   }
 
-  // From http://stackoverflow.com/questions/14967647/encode-decode-image-with-base64-breaks-image (2013-04-21)
-  function fixBinary(bin) {
-    var length = bin.length;
-    var buf = new ArrayBuffer(length);
-    var arr = new Uint8Array(buf);
-    for (var i = 0; i < length; i++) {
-      arr[i] = bin.charCodeAt(i);
-    }
-    return buf;
-  }
-
   req.onsuccess = function (e) {
 
     idb = e.target.result;
@@ -232,7 +221,7 @@ function IdbPouch(opts, callback) {
         att.digest = 'md5-' + utils.Crypto.MD5(data);
         if (blobSupport) {
           var type = att.content_type;
-          data = fixBinary(data);
+          data = utils.fixBinary(data);
           att.data = utils.createBlob([data], {type: type});
         }
         return finish();
@@ -495,7 +484,7 @@ function IdbPouch(opts, callback) {
         if (blobSupport) {
           result = data;
         } else {
-          data = fixBinary(atob(data));
+          data = utils.fixBinary(atob(data));
           result = utils.createBlob([data], {type: type});
         }
         utils.call(callback, null, result);

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -43,6 +43,46 @@ function unknownError(callback) {
   };
 }
 
+function parseHexString(str) {
+  var result = '';
+  for (var i = 0, len = str.length; i < len; i += 2) {
+    result += String.fromCharCode(parseInt(str.substring(i, i + 2), 16));
+  }
+  return result;
+}
+
+// Safari is weird, it encodes everything with bonus \u0000 characters after every character
+// Rather than user agent sniff, we test every odd character for \u0000
+function isMangledUnicode(str) {
+  for (var i = 1, len = str.length; i < len; i += 2) {
+    if (str.charAt(i) !== '\u0000') {
+      return false;
+    }
+  }
+  return true;
+}
+
+// unmangle the aforementioned Safari atrocity
+function unmangleUnicode(str) {
+  var result = '';
+  for (var i = 0, len = str.length; i < len; i += 2) {
+    result += str.charAt(i);
+  }
+  return result;
+}
+
+// used to deal with utf8 encoding that occurs in most sqlite implementations
+// partially taken from http://ecmanaut.blogspot.ca/2006/07/encoding-decoding-utf8-in-javascript.html
+function decodeUtf8(str) {
+  var result;
+  try {
+    result = decodeURIComponent(window.escape(str));
+  } catch (err) { // URI error in safari, string is already escaped but still possibly mangled
+    result = str;
+  }
+  return isMangledUnicode(result) ? unmangleUnicode(result) : result;
+}
+
 function webSqlPouch(opts, callback) {
 
   var api = {};
@@ -210,8 +250,8 @@ function webSqlPouch(opts, callback) {
                                 "Attachments need to be base64 encoded");
           return utils.call(callback, err);
         }
-        att.digest = 'md5-' + utils.Crypto.MD5(att.data);
-        return finish();
+        var data = utils.fixBinary(att.data);
+        att.data = utils.createBlob([data], {type: att.content_type});
       }
       var reader = new FileReader();
       reader.onloadend = function (e) {
@@ -636,12 +676,15 @@ function webSqlPouch(opts, callback) {
     var tx = opts.ctx;
     var digest = attachment.digest;
     var type = attachment.content_type;
-    var sql = 'SELECT body FROM ' + ATTACH_STORE + ' WHERE digest=?';
+    var sql = 'SELECT hex(body) as body FROM ' + ATTACH_STORE + ' WHERE digest=?';
     tx.executeSql(sql, [digest], function (tx, result) {
-      var data = result.rows.item(0).body;
+      // TODO: sqlite normally stores data as utf8, so even the hex() function "encodes" the binary
+      // data in utf8 before returning it, and yet hex() is the only way to get the full data. so we do this.
+      var data = decodeUtf8(parseHexString(result.rows.item(0).body));
       if (opts.encode) {
         res = btoa(data);
       } else {
+        data = utils.fixBinary(data);
         res = utils.createBlob([data], {type: type});
       }
       utils.call(callback, null, res);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -336,6 +336,23 @@ if (!process.browser || !('btoa' in global)) {
     return btoa(str);
   };
 }
+
+// From http://stackoverflow.com/questions/14967647/encode-decode-image-with-base64-breaks-image (2013-04-21)
+exports.fixBinary = function (bin) {
+  if (!process.browser) {
+    // don't need to do this in Node
+    return bin;
+  }
+
+  var length = bin.length;
+  var buf = new ArrayBuffer(length);
+  var arr = new Uint8Array(buf);
+  for (var i = 0; i < length; i++) {
+    arr[i] = bin.charCodeAt(i);
+  }
+  return buf;
+};
+
 exports.toPromise = function (func) {
   return function () {
     var self = this;

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -97,7 +97,7 @@ testUtils.makeBlob = function(data, type) {
   if (typeof module !== 'undefined' && module.exports) {
     return new Buffer(data);
   } else {
-    return new Blob([data], {type: type});
+    return PouchDB.utils.createBlob([data], {type: type});
   }
 }
 


### PR DESCRIPTION
Currently, `test.attachments.js` breaks in Safari (and websql in general) [at this test](https://github.com/daleharvey/pouchdb/blob/702e79f601915d9c82fa4dffff6ff65bb2a5a53b/tests/test.attachments.js#L197).  I also see this in the Android stock browser (4.4 KitKat).

The issue is really subtle and annoying: it's that the blob data gets converted to UTF8 (!) before being encoded to binary.  I have a solution, but it has the following limitations:
1. Assumes blobSupport in websql.
2. Doesn't work in leveldb yet. (@daleharvey, @calvinmetcalf: how do you guys debug `npm test`?  Can't seem to get node-inspector to work...)

Details for those who are interested:  [the little png](https://github.com/daleharvey/pouchdb/blob/702e79f601915d9c82fa4dffff6ff65bb2a5a53b/tests/test.attachments.js#L60) gets UTF8-encoded, so all the high ASCII characters get corrupted, and it turns into:

```
wolQTkcNChoKAAAADUlIRFIAAAAQAAAAEAgDAAAAKC0PUwAAADBQTFRFw77Dt8Oow77DtMOgw77DrsOSw73DpsK6w73DnsKkw7zDkcKAw7vDh2LDusK+ScO6wrMsw7nCqRTDuMKiBMO4wp8Aw7jCngDDuMKdAMO4wp0Aw7jCnQDDk8OadMO/AAAAcElEQVQYw5NNwo5RAsOEQARDw4NQw7XDocO+w5fDnTDCnW3Ds8OnwoUEw6ojwpUqwrxjwpYjPyAAwoXDhR/DnMOmC8Ktw5dHJMOsOsOAwpbCk2A9GcKuw7AJeUDDtm3CksOobgnClVwQwpLCnD9ibGtSA2gywozCsQcEwowfw7XCpwM8wrlyd8OLFsOvwp0raXnCgMOLw648YsOGJcOdf8O0A8KiBQjChMKCTMOOwqYAAAAASUVORMKuQmDCgg==
```

Undoubtedly this is related to #895 and #1008; we'll probably be able to close all three when this is fixed.
