### PR TITLE
(#1211) - Uniquify GET requests to bust IE caching

### DIFF
--- a/lib/deps/ajax.js
+++ b/lib/deps/ajax.js
@@ -4,6 +4,7 @@ var request = require('request');
 var extend = require('./extend.js');
 var createBlob = require('./blob.js');
 var errors = require('./errors');
+var uuid = require('../deps/uuid');
 
 function ajax(options, callback) {
 
@@ -29,6 +30,13 @@ function ajax(options, callback) {
   };
 
   options = extend(true, defaultOptions, options);
+
+  // cache-buster, specifically designed to work around IE's aggressive caching
+  // see http://www.dashbay.com/2011/05/internet-explorer-caches-ajax/
+  if (options.method === 'GET') {
+    var hasArgs = options.url.indexOf('?') !== -1;
+    options.url += (hasArgs ? '&' : '?') + '_nonce=' + uuid(16);
+  }
 
   function onSuccess(obj, resp, cb) {
     if (!options.binary && !options.json && options.processData &&


### PR DESCRIPTION
IE10/11 fail in a variety of scenarios where we expect
that the result of an HTTP GET is always fresh,
because IE often aggressively caches AJAX requests.
CouchDB doesn't even get the request, and IE pretends
it got a 304.  Apparently this bug has been around since
2006; there's a good writeup here:
http://www.dashbay.com/2011/05/internet-explorer-caches-ajax/

My solution is to make the ajax library similar to jQuery's;
i.e. there's a param "cache" that, if set to false, adds
a nonce to each GET request. I'd love to make this an IE-only
thing, but apparently IE11 masquerades as Firefox with
its user-agent, so it's better just to do it everywhere.
