### PR TITLE
(#1221) - Add ES5 shims for common functions

### DIFF
--- a/lib/deps/es5_shims.js
+++ b/lib/deps/es5_shims.js
@@ -1,0 +1,48 @@
+// some small shims for es5 just for the features we commonly use
+// some of this is copied from https://github.com/kriskowal/es5-shim/blob/master/es5-shim.js
+'use strict';
+
+if (!Object.keys) {
+  Object.keys = function keys(object) {
+
+    if ((typeof object !== 'object' && typeof object !== 'function') || object === null) {
+      throw new TypeError('Object.keys called on a non-object');
+    }
+
+    var mykeys = [];
+    for (var name in object) {
+      if (Object.prototype.hasOwnProperty.call(object, name)) {
+        mykeys.push(name);
+      }
+    }
+    return mykeys;
+  };
+}
+
+if (!Array.isArray) {
+  Array.isArray = function isArray(obj) {
+    return Object.prototype.toString.call(obj) === '[object Array]';
+  };
+}
+
+if (!('forEach' in Array.prototype)) {
+  Array.prototype.forEach = function (action, that /*opt*/) {
+    for (var i = 0, n = this.length; i < n; i++) {
+      if (i in this) {
+        action.call(that, this[i], i, this);
+      }
+    }
+  };
+}
+
+if (!('map' in Array.prototype)) {
+  Array.prototype.map = function (mapper, that /*opt*/) {
+    var other = new Array(this.length);
+    for (var i = 0, n = this.length; i < n; i++) {
+      if (i in this) {
+        other[i] = mapper.call(that, this[i], i, this);
+      }
+    }
+    return other;
+  };
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 "use strict";
 
+require('./deps/es5_shims');
+
 var PouchDB = require('./setup');
 
 module.exports = PouchDB;


### PR DESCRIPTION
This adds the minimal shims I found were necessary
to allow basic Pouch functionality on older
browsers that we could still be reasonably expected
to support (i.e. because they at least have WebSQL).

The oldest browser tested was an HTC Magic running
Android 2.1 WebView.
