### PR TITLE
(#1223) - xhr.upload does not exist in IE9

### DIFF
--- a/lib/deps/ajax.js
+++ b/lib/deps/ajax.js
@@ -160,10 +160,13 @@ function ajax(options, callback) {
 
     if (options.timeout > 0) {
       timer = setTimeout(abortReq, options.timeout);
-      xhr.upload.onprogress = xhr.onprogress = function () {
+      xhr.onprogress = function () {
         clearTimeout(timer);
         timer = setTimeout(abortReq, options.timeout);
       };
+      if (xhr.upload) { // does not exist in ie9
+        xhr.upload.onprogress = xhr.onprogress;
+      }
     }
     xhr.send(options.body);
     return {abort: abortReq};


### PR DESCRIPTION
We want to support IE9 at least for the
http adapter, but xhr.upload does not
exist, so this function is throwing.
