### PR TITLE
(#1239) - Favor GETs over POSTs for Safari

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -662,11 +662,23 @@ function HttpPouch(opts, callback) {
       params = '?' + params;
     }
 
-    // If keys are supplied, issue a POST request to circumvent GET query string limits
-    // see http://wiki.apache.org/couchdb/HTTP_view_API#Querying_Options
     if (typeof opts.keys !== 'undefined') {
-      method = 'POST';
-      body = JSON.stringify({keys: opts.keys});
+
+      var MAX_URL_LENGTH = 2000;
+      // according to http://stackoverflow.com/a/417184/680742,
+      // the de factor URL length limit is 2000 characters
+
+      var keysAsString = 'keys=' + encodeURIComponent(JSON.stringify(opts.keys));
+      if (keysAsString.length + params.length + 1 <= MAX_URL_LENGTH) {
+        // If the keys are short enough, do a GET. we do this to work around
+        // Safari not understanding 304s on POSTs (see issue #1239)
+        params += (params.indexOf('?') !== -1 ? '&' : '?') + keysAsString;
+      } else {
+        // If keys are too long, issue a POST request to circumvent GET query string limits
+        // see http://wiki.apache.org/couchdb/HTTP_view_API#Querying_Options
+        method = 'POST';
+        body = JSON.stringify({keys: opts.keys});
+      }
     }
 
     // Get the document listing


### PR DESCRIPTION
The test "all_docs: http-1: Testing allDocs opts.keys" breaks
in Safari because Safari cannot comprehend why a POST
would return a 304.  This commit fixes that.

Currently we always turn a GET into
a POST if "keys" is provided. So my proposal is to only do this
if "keys" would make the URL longer than 2000 characters,
since CouchDB accepts both a GET and a POST.
