### PR TITLE
(#1257) - Escape _id in bulkDocs for WebSQL

### DIFF
--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -34,10 +34,15 @@ var META_STORE = quote('metadata-store');
 
 function unknownError(callback) {
   return function (event) {
+
+    // event may actually be a SQLError object, so report is as such
+    var errorNameMatch = event && event.constructor.toString().match(/function ([^\(]+)/);
+    var errorName = errorNameMatch && errorNameMatch[1];
+
     utils.call(callback, {
       status: 500,
-      error: event.type,
-      reason: event.target
+      error: event.type || errorName,
+      reason: event.target || event.message
     });
   };
 }
@@ -417,11 +422,10 @@ function webSqlPouch(opts, callback) {
     preprocessAttachments(function () {
       db.transaction(function (txn) {
         tx = txn;
-        var ids = '(' + docInfos.map(function (d) {
-          return quote(d.metadata.id);
-        }).join(',') + ')';
-        var sql = 'SELECT * FROM ' + DOC_STORE + ' WHERE id IN ' + ids;
-        tx.executeSql(sql, [], metadataFetched);
+        var sql = 'SELECT * FROM ' + DOC_STORE + ' WHERE id IN ' +
+          '(' + docInfos.map(function () {return '?'; }).join(',') + ')';
+        var queryArgs = docInfos.map(function (d) { return d.metadata.id; });
+        tx.executeSql(sql, queryArgs, metadataFetched);
       }, unknownError(callback));
     });
   };

--- a/tests/test.bulk_docs.js
+++ b/tests/test.bulk_docs.js
@@ -209,4 +209,19 @@ adapters.map(function(adapter) {
       });
     });
   });
+
+  asyncTest('Test quotes in doc ids', function () {
+    testUtils.initTestDB(this.name, function (err, db) {
+      db.bulkDocs({docs: [
+        {_id: "'your_sql_injection_script_here'"}
+      ]}, function (err, res) {
+        ok(!err, 'got error: ' + JSON.stringify(err));
+        db.get("foo", function (err, res) {
+          ok(err, "deleted");
+          start();
+        });
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
Before this fix, quotes in doc ids inserted using
bulkDocs would crash WebSQL, since we were just
wrapping quotes around the id string.

I also went ahead and ensured that the WebSQL
adapter properly reports SQLError objects, since
before it would only give an unhelpful 500 with
no message.
