### PR TITLE
(#1207) - Switch to WebSQL if IDB is outdated

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -9,6 +9,28 @@ function idbError(callback) {
   };
 }
 
+function isModernIdb() {
+  // check for outdated implementations of IDB
+  // that rely on the setVersion method instead of onupgradeneeded (issue #1207)
+
+  // cache based on appVersion, in case the browser is updated
+  var cacheKey = "_pouch__checkModernIdb_" + (global.navigator && global.navigator.appVersion);
+  var cached = global.localStorage && global.localStorage[cacheKey];
+  if (cached) {
+    return JSON.parse(cached);
+  }
+
+  var dbName = '_pouch__checkModernIdb';
+  var result = global.indexedDB.open(dbName, 1).onupgradeneeded === null; // else undefined
+  if (global.indexedDB.deleteDatabase) {
+    global.indexedDB.deleteDatabase(dbName); // db no longer needed
+  }
+  if (global.localStorage) {
+    global.localStorage[cacheKey] = JSON.stringify(result); // cache
+  }
+  return result;
+}
+
 function IdbPouch(opts, callback) {
 
   // IndexedDB requires a versioned database structure, this is going to make
@@ -790,7 +812,7 @@ function IdbPouch(opts, callback) {
 }
 
 IdbPouch.valid = function () {
-  return typeof global !== 'undefined' && !!global.indexedDB;
+  return global.indexedDB && isModernIdb();
 };
 
 IdbPouch.destroy = utils.toPromise(function (name, opts, callback) {


### PR DESCRIPTION
Certain Samsung devices are running a legacy
version of the IndexedDB spec.  This commit
detects the outdated API and reports IDB as
invalid, so we switch to WebSQL.
