### PR TITLE
(#1255) - Improve API documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -19,19 +19,21 @@ Additionally, any method that only returns a single thing (e.g. `db.get`, but no
 new PouchDB([name], [options])
 {% endhighlight %}
 
-This method creates a database or opens an existing one. If you use a URL like `http://domain.com/dbname` then PouchDB will work as a client to an online CouchDB instance, otherwise it will create a local database using whatever backend is present (i.e. IndexedDB, WebSQL, or LevelDB).
+This method creates a database or opens an existing one. If you use a URL like `http://domain.com/dbname` then PouchDB will work as a client to an online CouchDB instance.  Otherwise it will create a local database using whatever backend is present (i.e. IndexedDB, WebSQL, or LevelDB).
+
+### Options
+
+* `options.name`: You can omit the `name` argument and specify it via `options` instead. Note that the name is required.
+* `options.auto_compaction`: This turns on auto compaction (experimental). Defaults to `false`.
+* `options.cache`: Appends a random string to the end of all HTTP GET requests to avoid them being cached on IE. Set this to `true` to prevent this happening (can also be set per request). Defaults to `false`.
+* `options.adapter` One of `'idb'`, `'leveldb'`, `'websql'`, or `'http'`. If unspecified, PouchDB will infer this automatically, preferring IndexedDB to WebSQL in browsers that support both (e.g. Chrome).
 
 **Notes:** 
 
-1. If you are also using indexedDB directly, PouchDB will use `_pouch_` to prefix the internal database names. Don't manually create databases with the same prefix.
+1. In IndexedDB and WebSQL, PouchDB will use `_pouch_` to prefix the internal database names. Do not manually create databases with the same prefix.
 2. When acting as a client on Node, any other options given will be passed to [request][].
 
   [request]: https://github.com/mikeal/request
-
-* `options.name`: You can omit the name argument and specify it via options.
-* `options.auto_compaction`: This turns on auto compaction (experimental).
-* `options.cache` (default false) Appends a random string to the end of all get requests to avoid them being cached, set this to be true to prevent this happening (can also be set per request). See []issue #1233](https://github.com/daleharvey/pouchdb/issues/1233) for details.
-* `options.adapter` One of `'idb'`, `'leveldb'`, `'websql'`, or `'http'`. By default, PouchDB infers this automatically, preferring IndexedDB to WebSQL in browsers that support both (e.g. Chrome).
 
 
 #### Example Usage:
@@ -47,9 +49,9 @@ var db = new PouchDB('http://localhost:5984/dbname');
 PouchDB.destroy(name, [options], [callback])
 {% endhighlight %}
 
-Delete database with given name
+Delete database with given name.
 
-**Notes:** With a remote couch on node options are passed to [request][].
+**Notes:** With a remote CouchDB on Node, options are passed to [request][].
 
 #### Example Usage:
 {% highlight js %}
@@ -63,9 +65,9 @@ PouchDB.destroy('dbname', function(err, info) { });
 db.put(doc, [options], [callback])
 {% endhighlight %}
 
-Create a new document or update an existing document. If the document already exists you must specify its revision `_rev`, otherwise a conflict will occur.
+Create a new document or update an existing document. If the document already exists, you must specify its revision `_rev`, otherwise a conflict will occur.
 
-There are some restrictions on valid property names of the documents, these are explained [here](http://wiki.apache.org/couchdb/HTTP_Document_API#Special_Fields).
+There are some restrictions on valid property names of the documents. These are explained [here](http://wiki.apache.org/couchdb/HTTP_Document_API#Special_Fields).
 
 #### Example Usage:
 
@@ -79,26 +81,26 @@ db.put({
 
 ## Update an existing doc
 {% highlight js %}
-db.get('myOtherDoc', function(err, resp) {
+db.get('myOtherDoc', function(err, otherDoc) {
   db.put({
     _id: 'myOtherDoc',
-    _rev: resp._rev,
-    title: 'Lets Dance',
+    _rev: otherDoc._rev,
+    title: "Let's Dance",
   }, function(err, response) { });
 });
 {% endhighlight %}
 
-## with a promise
+## With a promise
 {% highlight js %}
-db.get('myOtherDoc').then(function(resp) {
+db.get('myOtherDoc').then(function(otherDoc) {
   return db.put({
     _id: 'myOtherDoc',
-    _rev: resp._rev,
-    title: 'Lets Dance',
+    _rev: otherDoc._rev,
+    title: "Let's Dance",
   });
-}).then(function(resp){
+}).then(function(response){
   // on success
-}, function(e){
+}, function(err){
   // any errors
 });
 
@@ -123,9 +125,20 @@ Create a new document and let PouchDB generate an `_id` for it.
 #### Example Usage:
 {% highlight js %}
 db.post({
-  title: 'Heroes'
+  title: 'Ziggy Stardust'
 }, function (err, response) { });
 {% endhighlight %}
+
+### Example Response:
+{% highlight js %}
+{
+  "ok" : true,
+  "id" : "8A2C3761-FFD5-4770-9B8C-38C33CED300A",
+  "rev" : "1-d3a8e0e5aa7c8fff0c376dac2d8a4007"
+}
+{% endhighlight %}
+
+**Put vs. post**: The basic rule of thumb is: put new documents with an `_id`, post new documents without an `_id`.
 
 ## Fetch document<a id="fetch_document"></a>
 
@@ -135,15 +148,19 @@ db.get(docid, [options], [callback])
 
 Retrieves a document, specified by `docid`.
 
-* `options.rev`: Fetch specific revision of a document. Defaults to winning revision (see [couchdb guide](http://guide.couchdb.org/draft/conflicts.html)).
-* `options.revs`: Include revision history of the document
+### Options
+
+All options default to `false` unless otherwise specified.
+
+* `options.rev`: Fetch specific revision of a document. Defaults to winning revision (see [the CouchDB guide](http://guide.couchdb.org/draft/conflicts.html)).
+* `options.revs`: Include revision history of the document.
 * `options.revs_info`: Include a list of revisions of the document, and their availability.
-* `options.open_revs`: Fetch all leaf revisions if `open_revs="all"` or fetch all leaf revisions specified in open_revs array. Leaves will be returned in the same order as specified in input array
-* `options.conflicts`: If specified conflicting leaf revisions will be attached in `_conflicts` array
-* `options.attachments`: Include attachment data
-* `options.local_seq`: Include sequence number of the revision in the database
-* `options.ajax`: an object of options to be sent to the ajax requester. In Node they are sent verbetem to [request][] with the exception of:
-    * `options.ajax.cache` with controls if a cache busting param gets added to the url, defaults to false.
+* `options.open_revs`: Fetch all leaf revisions if `open_revs="all"` or fetch all leaf revisions specified in `open_revs` array. Leaves will be returned in the same order as specified in input array.
+* `options.conflicts`: If specified, conflicting leaf revisions will be attached in `_conflicts` array.
+* `options.attachments`: Include attachment data.
+* `options.local_seq`: Include sequence number of the revision in the database.
+* `options.ajax`: An object of options to be sent to the ajax requester. In Node they are sent ver batim to [request][] with the exception of:
+    * `options.ajax.cache`: Appends a random string to the end of all HTTP GET requests to avoid them being cached on IE. Set this to `true` to prevent this happening.
 
 <span></span>
 
@@ -167,7 +184,7 @@ db.get('mydoc', function(err, doc) { });
 db.remove(doc, [options], [callback])
 {% endhighlight %}
 
-Delete a document, `doc` is required to be a document with at least an `_id` and a `_rev` property, sending the full document will work.
+Deletes the document. `doc` is required to be a document with at least an `_id` and a `_rev` property. Sending the full document will work as well.
 
 #### Example Usage:
 {% highlight js %}
@@ -180,7 +197,7 @@ db.get('mydoc', function(err, doc) {
 {% highlight js %}
 db.get('mydoc').then(function(doc) {
   return db.remove(doc);
-}).catch(function(e){
+}).catch(function(err){
   //errors
 });
 {% endhighlight %}
@@ -200,22 +217,32 @@ db.get('mydoc').then(function(doc) {
 db.bulkDocs(docs, [options], [callback])
 {% endhighlight %}
 
-Modify, create or delete multiple documents. The docs argument is an object with property `docs` which is an array of documents. You can also specify a `new_edits` property on the `docs` object that when set to `false` allows you to post [existing documents](http://wiki.apache.org/couchdb/HTTP_Bulk_Document_API#Posting_Existing_Revisions).
+Modify, create or delete multiple documents. The `docs` argument is an object with property `docs` which is an array of documents. You can also specify a `new_edits` property on the `docs` object that when set to `false` allows you to post [existing documents](http://wiki.apache.org/couchdb/HTTP_Bulk_Document_API#Posting_Existing_Revisions).
 
-If you omit an `_id` parameter on a given document, the database will create a new document and assign an ID for you. To update a document you must include both an `_id` parameter and a `_rev` parameter, which should match the ID and revision of the document on which to base your updates. Finally, to delete a document, include a `_deleted` parameter with the value `true`.
+If you omit an `_id` parameter on a given document, the database will create a new document and assign the ID for you. To update a document, you must include both an `_id` parameter and a `_rev` parameter, which should match the ID and revision of the document on which to base your updates. Finally, to delete a document, include a `_deleted` parameter with the value `true`.
 
 #### Example Usage:
 {% highlight js %}
-db.bulkDocs({docs: [{title: 'Lisa Says'}]}, function(err, response) { });
+db.bulkDocs({docs: [
+  {title : 'Lisa Says'},
+  {title : 'Space Oddity'}
+]}, function(err, response) { });
 {% endhighlight %}
 
 #### Example Response:
 {% highlight js %}
-[{
-  "ok": true,
-  "id": "828124B9-3973-4AF3-9DFD-A94CE4544005",
-  "rev": "1-A8BC08745E62E58830CA066D99E5F457"
-}]
+[
+    {
+        "ok": true, 
+        "id": "06F1740A-8E8A-4645-A2E9-0D8A8C0C983A", 
+        "rev": "1-84abc2a942007bee7cf55007cba56198"
+    }, 
+    {
+        "ok": true, 
+        "id": "6244FB45-91DB-41E5-94FF-58C540E91844", 
+        "rev": "1-7b80fc50b6af7a905f368670429a757e"
+    }
+]
 {% endhighlight %}
 
 
@@ -225,20 +252,26 @@ db.bulkDocs({docs: [{title: 'Lisa Says'}]}, function(err, response) { });
 db.allDocs([options], [callback])
 {% endhighlight %}
 
-Fetch multiple documents, deleted document are only included if `options.keys` is specified.
+Fetch multiple documents.  Deleted documents are only included if `options.keys` is specified.
 
-* `options.include_docs`: Include the document in each row in the `doc` field
-    - `options.conflicts`: Include conflicts in the `_conflicts` field of a doc
-* `options.startkey` & `options.endkey`: Get documents with keys in a certain range
-* `options.descending`: Reverse the order of the output table
-* `options.keys`: array of keys you want to get
-    - neither `startkey` nor `endkey` can be specified with this option
-    - the rows are returned in the same order as the supplied "keys" array
-    - the row for a deleted document will have the revision ID of the deletion, and an extra key "deleted":true in the "value" property
-    - the row for a nonexistent document will just contain an "error" property with the value "not_found"
-* `options.attachments`: Include attachment data
+### Options
 
-**Notes:** For pagination, `options.limit` and `options.skip` are also available, but the same performance concerns as in CouchDB apply. Use the [startkey/endkey pattern](http://docs.couchdb.org/en/latest/couchapp/views/pagination.html).
+All options default to `false` unless otherwise specified.
+
+* `options.include_docs`: Include the document itself in each row in the `doc` field. Otherwise by default you only get the `_id` and `_rev` properties.
+    - `options.conflicts`: Include conflict information in the `_conflicts` field of a doc.
+	- `options.attachments`: Include attachment data.
+* `options.startkey` & `options.endkey`: Get documents with keys in a certain range (inclusive/inclusive).
+* `options.descending`: Reverse the order of the output documents.
+* `options.key`: Only return rows matching this string key.
+* `options.keys`: Array of string keys to fetch in a single shot.
+    - Neither `startkey` nor `endkey` can be specified with this option.
+    - The rows are returned in the same order as the supplied `keys` array.
+    - The row for a deleted document will have the revision ID of the deletion, and an extra key `"deleted":true` in the `value` property.
+    - The row for a nonexistent document will just contain an `"error"` property with the value `"not_found"`.
+    - For details, see the [CouchDB query options documentation](http://wiki.apache.org/couchdb/HTTP_view_API#Querying_Options).
+
+**Notes:** For pagination, `options.limit` and `options.skip` are also available, but the same performance concerns as in CouchDB apply. Use the [startkey/endkey pattern](http://docs.couchdb.org/en/latest/couchapp/views/pagination.html) instead.
 
 #### Example Usage:
 {% highlight js %}
@@ -253,7 +286,7 @@ db.allDocs({include_docs: true}, function(err, response) { });
     "doc": {
       "_id": "0B3358C1-BA4B-4186-8795-9024203EB7DD",
       "_rev": "1-5782E71F1E4BF698FA3793D9D5A96393",
-      "blog_post": "my blog post"
+      "title": "Sound and Vision"
     },
    "id": "0B3358C1-BA4B-4186-8795-9024203EB7DD",
    "key": "0B3358C1-BA4B-4186-8795-9024203EB7DD",
@@ -271,16 +304,21 @@ db.changes(options)
 {% endhighlight %}
 
 A list of changes made to documents in the database, in the order they were made.
-If `options.continuous` is set it returns object with one method `cancel` which you call if you don't want to listen to new changes anymore. `options.onChange` will be be called for each change that is encountered.
+If `options.continuous` is set to `true`, it returns an object with one method `cancel` which you call if you don't want to listen to new changes anymore. `options.onChange` will be be called for each change that is encountered.
 
-* `options.include_docs`: Include the associated document with each change
-* `options.conflicts`: Include conflicts
-* `options.descending`: Reverse the order of the output table
-* `options.filter`: Reference a filter function from a design document to selectively get updates
-* `options.since`: Start the results from the change immediately after the given sequence number
-* `options.complete`: Function called when all changes have been processed
-* `options.continuous`: Use _longpoll_ feed
-* `options.onChange`: Function called on each change after deduplication (only sends the most recent for each document), not called as a callback but called as onChange(change). Use with `continuous` flag. If you want to
+### Options
+
+All options default to `false` unless otherwise specified.
+
+* `options.include_docs`: Include the associated document with each change.
+	* `options.conflicts`: Include conflicts.
+	* `options.attachments`: Include attachments.
+* `options.descending`: Reverse the order of the output documents.
+* `options.filter`: Reference a filter function from a design document to selectively get updates.
+* `options.since`: Start the results from the change immediately after the given sequence number.
+* `options.complete`: Function called when all changes have been processed.
+* `options.continuous`: Use _longpoll_ feed.
+* `options.onChange`: Function called on each change after deduplication (only sends the most recent for each document). Not called as a callback but called as `onChange(change)`. Can also be used with the `continuous` flag.
 
 #### Example Usage:
 {% highlight js %}
@@ -302,8 +340,8 @@ changes.cancel();
     "rev":"1-8e6e4c0beac3ec54b27d1df75c7183a8"
   }],
   "doc":{
-    "value":"somevalue",
-    "_id":"somestuff",
+    "title":"Ch-Ch-Ch-Ch-Changes",
+    "_id":"someDocId",
     "_rev":"1-8e6e4c0beac3ec54b27d1df75c7183a8"
   }
 }
@@ -351,16 +389,20 @@ db.changes({complete: function(err, response) { }});
 PouchDB.replicate(source, target, [options])
 {% endhighlight %}
 
-Replicate data from `source` to `target`.  Both the `source` and `target` can be strings used to represent a database of a PouchDB object. If `options.continuous` is `true`, then this will track future changes and also replicate them.
+Replicate data from `source` to `target`.  Both the `source` and `target` can be a string representing a CouchDB database url or the name a local PouchDB database. If `options.continuous` is `true`, then this will track future changes and also replicate them automatically.
 
-If you want to sync data in both directions you can call this twice, reversing the `source` and `target` arguments.
+If you want to sync data in both directions, you can call this twice, reversing the `source` and `target` arguments.
+
+### Options
+
+All options default to `false` unless otherwise specified.
 
 * `options.filter`: Reference a filter function from a design document to selectively get updates.
-* `options.query_params`: Query params send to the filter function.
+* `options.query_params`: Query params sent to the filter function.
 * `options.doc_ids`: Only replicate docs with these ids.
 * `options.complete`: Function called when all changes have been processed.
 * `options.onChange`: Function called on each change processed.
-* `options.continuous`: If true starts subscribing to future changes in the `source` database and continue replicating them.
+* `options.continuous`: If `true`, starts subscribing to future changes in the `source` database and continue replicating them.
 * `options.server`: Initialize the replication on the server. The response is the CouchDB `POST _replicate` response and is different from the PouchDB replication response. Also, `options.onChange` is not supported on server replications.
 * `options.create_target`: Create target database if it does not exist. Only for server replications.
 
@@ -372,7 +414,7 @@ PouchDB.replicate('mydb', 'http://localhost:5984/mydb', {
 });;
 {% endhighlight %}
 
-There are also shorthands for replication given existing PouchDB objects, these behave the same as `PouchDB.replicate()`:
+There are also shorthands for replication given existing PouchDB objects. These behave the same as `PouchDB.replicate()`:
 
 {% highlight js %}
 db.replicate.to(remoteDB, [options]);
@@ -390,7 +432,8 @@ db.replicate.from(remoteDB, [options]);
   'end_time': "Sun Sep 23 2012 08:14:45 GMT-0500 (CDT)"
 }
 {% endhighlight %}
-Note that the response for server replications (via `options.server`) is slightly different. See the [CouchDB Wiki](http://wiki.apache.org/couchdb/Replication).
+
+Note that the response for server replications (via `options.server`) is slightly different. See the [CouchDB replication documentation](http://wiki.apache.org/couchdb/Replication) for details.
 
 ## Save an attachment<a id="save_attachment"></a>
 
@@ -421,16 +464,17 @@ PouchDB also offers a `createBlob` function, which will work around browser inco
 var doc = PouchDB.utils.createBlob(["It's a God awful small affair"]);
 {% endhighlight %}
 
-Within Node, you must use a Buffer:
+Within Node, you must use a `Buffer`:
 
 {% highlight js %}
 var doc = new Buffer("It's a God awful small affair");
 {% endhighlight %}
 
+For details, see the [Mozilla docs on `Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) or the [Node docs on `Buffer`](http://nodejs.org/api/buffer.html).
+
 ### Save an inline attachment
 
-You can inline attachments inside the document.
-In this case the attachment data must be supplied as a base64 encoded string:
+You can also inline attachments inside the document. In this case, the attachment data must be supplied as a base64-encoded string:
 
 {% highlight js %}
 {
@@ -447,12 +491,12 @@ In this case the attachment data must be supplied as a base64 encoded string:
 {% endhighlight %}
 
 See [Inline Attachments](http://wiki.apache.org/couchdb/HTTP_Document_API#Inline_Attachments)
-on the CouchDB Wiki.
+on the CouchDB wiki for details.
 
 ## Get an attachment<a id="get_attachment"></a>
 
 {% highlight js %}
-db.getAttachment(docId, attachmentId, [opts], [callback])
+db.getAttachment(docId, attachmentId, [options], [callback])
 {% endhighlight %}
 
 Get attachment data.
@@ -463,11 +507,11 @@ Get attachment data.
 db.getAttachment('otherdoc', 'text', function(err, res) { });
 {% endhighlight %}
 
-In node you get Buffers and Blobs in the browser.
+In Node you get `Buffer`s, and in the browser you get `Blob`s.
 
 ### Inline attachments
 
-You can specify `attachments: true` to most read operations, the attachment data will then be included in the result.
+You can specify `attachments: true` to most read operations. The attachment data will then be included inlined in the resulting list of docs.
 
 ## Delete an attachment<a id="delete_attachment"></a>
 
@@ -501,11 +545,25 @@ db.query(fun, [options], [callback])
 
 Retrieve a view, which allows you to perform more complex queries on PouchDB. The [CouchDB documentation for map reduce](http://docs.couchdb.org/en/latest/ddocs.html#view-functions) applies to PouchDB.
 
-* `fun`: Name of a view function or the function itself.
-* `options.reduce`: Reduce function, or the name of a built-in function: `'_sum'`, `'_count'`, or `'_stats'`.  Typically, if you're not using a built-in, [you're doing it wrong](https://www.youtube.com/watch?v=BKQ9kXKoHS8).
-* `options.key`: Only return rows matching this key.
-* `options.keys`: Return rows matching more than one key.
-* `options.startkey` & `options.endkey`: Get documents with keys in a certain range.
+### Options
+
+All options default to `false` unless otherwise specified.
+
+* `fun`: Name of an existing view, the map function itself, or a full CouchDB-style mapreduce object: `{map : ..., reduce: ...}`.
+* `options.reduce`: Reduce function, or the string name of a built-in function: `'_sum'`, `'_count'`, or `'_stats'`.  Defaults to `false` (no reduce).
+    * Tip: if you're not using a built-in, [you're probably doing it wrong](http://youtu.be/BKQ9kXKoHS8?t=865s).
+* `options.include_docs`: Include the document in each row in the `doc` field.
+    - `options.conflicts`: Include conflicts in the `_conflicts` field of a doc.
+	- `options.attachments`: Include attachment data.
+* `options.startkey` & `options.endkey`: Get documents with keys in a certain range (inclusive/inclusive).
+* `options.descending`: Reverse the order of the output documents.
+* `options.key`: Only return rows matching this string key.
+* `options.keys`: Array of string keys to fetch in a single shot.
+    - Neither `startkey` nor `endkey` can be specified with this option.
+    - The rows are returned in the same order as the supplied `keys` array.
+    - The row for a deleted document will have the revision ID of the deletion, and an extra key `"deleted":true` in the `value` property.
+    - The row for a nonexistent document will just contain an `"error"` property with the value `"not_found"`.
+    - For details, see the [CouchDB query options documentation](http://wiki.apache.org/couchdb/HTTP_view_API#Querying_Options).
 
 #### Example Usage:
 {% highlight js %}
@@ -602,10 +660,10 @@ db.info(function(err, info) { })
 ## Compact the database<a id="compaction"></a>
 
 {% highlight js %}
-db.compact([opts], [callback])
+db.compact([options], [callback])
 {% endhighlight %}
 
-Runs compaction of the database. Fires callback when compaction is done. If you use http adapter and have specified callback Pouch will ping the remote database in regular intervals unless the compaction is finished.
+Runs compaction of the database. Fires callback when compaction is done. If you use the http adapter and have specified a callback, Pouch will ping the remote database in regular intervals unless the compaction is finished.
 
 * `options.interval`: Number of milliseconds Pouch waits before asking again if compaction is already done. Only for http adapter.
 
@@ -643,7 +701,7 @@ db.revsDiff({
 PouchDB.allDbs(callback)
 {% endhighlight %}
 
-Retrieves all databases from PouchDB. By default, this feature is turned off and this function will return an empty list.  To enable this feature and obtain a list of all the databases, set `PouchDB.enableAllDbs` to true before creating any databases.
+Retrieves all databases from PouchDB. By default, this feature is turned off and this function will return an empty list.  To enable this feature and obtain a list of all the databases, set `PouchDB.enableAllDbs` to `true` before creating any databases.
 
 #### Example Usage:
 {% highlight js %}


### PR DESCRIPTION
Adds better documentation for the query()
API and harmonizes our usage of
terminology and punctuation.
