### PR TITLE
(#1308) - Support 'key' in allDocs()

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -522,15 +522,12 @@ module.exports = function (Pouch) {
       }
       opts = utils.extend(true, {}, opts);
       if ('keys' in opts) {
-        if ('startkey' in opts) {
+        var incompatibleOpt = ['startkey', 'endkey', 'key'].filter(function (incompatibleOpt) {
+          return incompatibleOpt in opts;
+        })[0];
+        if (incompatibleOpt) {
           call(callback, errors.error(errors.QUERY_PARSE_ERROR,
-            'Query parameter `start_key` is not compatible with multi-get'
-          ));
-          return;
-        }
-        if ('endkey' in opts) {
-          call(callback, errors.error(errors.QUERY_PARSE_ERROR,
-            'Query parameter `end_key` is not compatible with multi-get'
+            'Query parameter `' + incompatibleOpt + '` is not compatible with multi-get'
           ));
           return;
         }

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -631,13 +631,17 @@ function HttpPouch(opts, callback) {
       params.push('include_docs=true');
     }
 
+    if (opts.key) {
+      params.push('key=' + encodeURIComponent(JSON.stringify(opts.key)));
+    }
+
     // If opts.startkey exists, add the startkey value to the list of
     // parameters.
     // If startkey is given then the returned list of documents will
     // start with the document whose id is startkey.
     if (opts.startkey) {
       params.push('startkey=' +
-                  encodeURIComponent(JSON.stringify(opts.startkey)));
+        encodeURIComponent(JSON.stringify(opts.startkey)));
     }
 
     // If opts.endkey exists, add the endkey value to the list of parameters.

--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -506,18 +506,22 @@ function IdbPouch(opts, callback) {
   api._allDocs = function idb_allDocs(opts, callback) {
     var start = 'startkey' in opts ? opts.startkey : false;
     var end = 'endkey' in opts ? opts.endkey : false;
+    var key = 'key' in opts ? opts.key : false;
+    var keys = 'keys' in opts ? opts.keys : false;
+
 
     var descending = 'descending' in opts ? opts.descending : false;
     descending = descending ? 'prev' : null;
 
     var keyRange = start && end ? global.IDBKeyRange.bound(start, end)
       : start ? global.IDBKeyRange.lowerBound(start)
-      : end ? global.IDBKeyRange.upperBound(end) : null;
+      : end ? global.IDBKeyRange.upperBound(end)
+      : key ? global.IDBKeyRange.only(key) : null;
 
     var transaction = idb.transaction([DOC_STORE, BY_SEQ_STORE], 'readonly');
     transaction.oncomplete = function () {
-      if ('keys' in opts) {
-        opts.keys.forEach(function (key) {
+      if (keys) {
+        keys.forEach(function (key) {
           if (key in resultsMap) {
             results.push(resultsMap[key]);
           } else {
@@ -577,7 +581,7 @@ function IdbPouch(opts, callback) {
           }
         }
         if ('keys' in opts) {
-          if (opts.keys.indexOf(metadata.id) > -1) {
+          if (keys.indexOf(metadata.id) > -1) {
             if (utils.isDeleted(metadata)) {
               doc.value.deleted = true;
               doc.doc = null;

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -522,6 +522,9 @@ function LevelPouch(opts, callback) {
     if ('endkey' in opts && opts.endkey) {
       readstreamOpts.end = opts.endkey;
     }
+    if ('key' in opts && opts.key) {
+      readstreamOpts.start = readstreamOpts.end = opts.key;
+    }
     if ('descending' in opts && opts.descending) {
       readstreamOpts.reverse = true;
     }

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -479,6 +479,7 @@ function webSqlPouch(opts, callback) {
     var resultsMap = {};
     var start = 'startkey' in opts ? opts.startkey : false;
     var end = 'endkey' in opts ? opts.endkey : false;
+    var key = 'key' in opts ? opts.key : false;
     var descending = 'descending' in opts ? opts.descending : false;
     var sql = 'SELECT ' + DOC_STORE + '.id, ' + BY_SEQ_STORE + '.seq, ' +
       BY_SEQ_STORE + '.json AS data, ' + DOC_STORE + '.json AS metadata FROM ' +
@@ -499,6 +500,10 @@ function webSqlPouch(opts, callback) {
       if (end) {
         sql += (start ? ' AND ' : ' WHERE ') + DOC_STORE + '.id <= ?';
         sqlArgs.push(end);
+      }
+      if (key) {
+        sql += ((start || end) ? ' AND ' : ' WHERE ') + DOC_STORE + '.id = ?';
+        sqlArgs.push(key);
       }
       sql += ' ORDER BY ' + DOC_STORE + '.id ' + (descending ? 'DESC' : 'ASC');
     }

--- a/tests/test.all_docs.js
+++ b/tests/test.all_docs.js
@@ -271,4 +271,28 @@ adapters.map(function(adapter) {
     });
   });
 
+  asyncTest('test "key" option', function () {
+    testUtils.initTestDB(this.name, function (err, db) {
+      db.bulkDocs({docs : [{_id : '0'}, {_id : '1'}, {_id : '2'}]}, function(err) {
+        ok(!err);
+        db.allDocs({key : '1'}, function (err, res) {
+          equal(res.rows.length, 1, 'key option returned 1 doc');
+          db.allDocs({key : '1', keys : ['1', '2']}, function(err) {
+            ok(err, 'error correctly reported - keys is incompatible with key');
+            db.allDocs({key : '1', startkey : '1'}, function(err, res) {
+              ok(!err, 'error correctly unreported - startkey is compatible with key');
+              db.allDocs({key : '1', endkey : '1'}, function(err, res) {
+                ok(!err, 'error correctly unreported - endkey is compatible with key');
+                // when mixing key/startkey or key/endkey, the results
+                // are very weird and probably undefined, so don't go beyond
+                // verifying that there's no error
+                start();
+              })
+            })
+          })
+        });
+      })
+    });
+  })
+
 });


### PR DESCRIPTION
Currently allDocs doesn't correctly support
the 'key' param.  This is reproducible
in all 3 local adapters and the remote
http adapter.  This fix adds 'key' support
plus some tests to verify it's working.
