### PR TITLE
(#1315) - [Replicator] Fetch missing revisions

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -362,7 +362,7 @@ module.exports = function (Pouch) {
         }
         // order with open_revs is unspecified
         leaves.forEach(function (leaf) {
-          api.get(id, {rev: leaf, revs: opts.revs}, function (err, doc) {
+          api.get(id, {rev: leaf, revs: opts.revs, attachments: opts.attachments}, function (err, doc) {
             if (!err) {
               result.push({ok: doc});
             } else {

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -113,7 +113,7 @@ function replicate(src, target, opts, promise) {
   }
 
 
-  function onGet(err, doc) {
+  function onGet(err, docs) {
     if (promise.cancelled) {
       return replicationComplete();
     }
@@ -122,9 +122,16 @@ function replicate(src, target, opts, promise) {
       return abortReplication('src.get completed with error', err);
     }
 
-    result.docs_read++;
-    batches[0].pendingRevs++;
-    batches[0].docs.push(doc);
+    Object.keys(docs).forEach(function (revpos) {
+      var doc = docs[revpos].ok;
+
+      if (doc) {
+        result.docs_read++;
+        batches[0].pendingRevs++;
+        batches[0].docs.push(doc);
+      }
+    });
+
     fetchRev();
   }
 
@@ -138,12 +145,10 @@ function replicate(src, target, opts, promise) {
     }
 
     var id = Object.keys(diffs)[0];
-    var rev = diffs[id].missing.splice(0, 1)[0];
-    if (diffs[id].missing.length === 0) {
-      delete diffs[id];
-    }
+    var revs = diffs[id].missing;
+    delete diffs[id];
 
-    src.get(id, {revs: true, rev: rev, attachments: true}, onGet);
+    src.get(id, {revs: true, open_revs: revs, attachments: true}, onGet);
   }
 
 
@@ -189,7 +194,7 @@ function replicate(src, target, opts, promise) {
       finishBatch();
       return;
     }
-
+    
     batches[0].diffs = diffs;
     batches[0].pendingRevs = 0;
     fetchRev();


### PR DESCRIPTION
Use `open_revs` to fetch missing revisions in one go.
