### PR TITLE
(#1318) - Run firefox tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,10 @@ node_js:
 
 services:
   - couchdb
+
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - "sleep 5"
+    # Workaround for Selenium #3280 issue
+  - "sudo sed -i 's/^127\\.0\\.0\\.1.*$/127.0.0.1 localhost/' /etc/hosts"

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -8,7 +8,7 @@ var devserver = require('./dev-server.js');
 
 var SELENIUM_PATH = '../node_modules/.bin/start-selenium';
 var testUrl = 'http://127.0.0.1:8000/tests/test.html';
-var testTimeout = 5 * 60 * 1000;
+var testTimeout = 30 * 60 * 1000;
 var currentTest = '';
 var results = {};
 var client = {};
@@ -20,10 +20,9 @@ var browsers = [
   'chrome'
 ];
 
-// Don't do it on trais
+// Travis supports only firefox
 if (process.env.TRAVIS) {
-  console.log('skipping tests on travis');
-  process.exit(0)
+  browsers = ['firefox'];
 }
 var numBrowsers = browsers.length;
 var finishedBrowsers = 0;


### PR DESCRIPTION
Ready.

This includes workaround for two-years-old Selenium issue: https://code.google.com/p/selenium/issues/detail?id=3280
