### PR TITLE
(#1330) - Don't depends on .ok in POST bulk_docs on Cloudant

### DIFF
--- a/lib/deps/ajax.js
+++ b/lib/deps/ajax.js
@@ -65,6 +65,8 @@ function ajax(options, callback) {
           obj = errors.MISSING_DOC;
           obj.missing = v.missing;
           return obj;
+        } else {
+          return v;
         }
       });
     }


### PR DESCRIPTION
(#1330) - Don't depends on .ok in POST bulk_docs on Cloudant
