### PR TITLE
(#1359) - Also use GREP in browser tests.

### DIFF
--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -13,6 +13,10 @@ var currentTest = '';
 var results = {};
 var client = {};
 
+if( process.env.GREP ){
+  testUrl += '?grep=' + process.env.GREP;
+}
+
 var browsers = [
   'firefox',
   // Temporarily disable safari until it is fixed (#1068)


### PR DESCRIPTION
This way it'll be easy to run the grepped tests in both browser and node using `GREP=attachments npm test`.
