### PR TITLE
(#1356) Fix end of changes detection in HttpPouch adapter .changes

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -725,7 +725,6 @@ function HttpPouch(opts, callback) {
   // TODO According to the README, there should be two other methods here,
   // api.changes.addListener and api.changes.removeListener.
   api.changes = function (opts) {
-
     // We internally page the results of a changes request, this means
     // if there is a large set of changes to be returned we can start
     // processing them quicker instead of waiting on the entire
@@ -745,12 +744,22 @@ function HttpPouch(opts, callback) {
       };
     }
     opts = utils.extend(true, {}, opts);
+    opts.timeout = opts.timeout || 0;
     if (opts.since === 'latest') {
-      var changes;
-      api.info(function (err, info) {
-        if (!opts.aborted) {
-          opts.since = info.update_seq;
-          changes = api.changes(opts);
+      var changes = api.changes({
+        descending: true,
+        limit: 1,
+        timeout: opts.timeout,
+        complete: function (err, info) {
+          if (err) {
+            opts.aborted = true;
+            utils.call(opts.complete, err, null);
+            return;
+          }
+          if (!opts.aborted) {
+            opts.since = info.last_seq;
+            changes = api.changes(opts);
+          }
         }
       });
       // Return a method to cancel this method from processing any more
@@ -814,14 +823,19 @@ function HttpPouch(opts, callback) {
 
     var xhr;
     var lastFetchedSeq;
-    var remoteLastSeq = 0;
 
     // Get all the changes starting wtih the one immediately after the
     // sequence number given by since.
     var fetch = function (since, callback) {
       params.since = since;
-      params.limit = (!limit || leftToFetch > CHANGES_LIMIT) ?
-        CHANGES_LIMIT : leftToFetch;
+      if (opts.descending) {
+        if (limit) {
+          params.limit = leftToFetch;
+        }
+      } else {
+        params.limit = (!limit || leftToFetch > CHANGES_LIMIT) ?
+          CHANGES_LIMIT : leftToFetch;
+      }
 
       var paramStr = '?' + Object.keys(params).map(function (k) {
         return k + '=' + params[k];
@@ -833,7 +847,7 @@ function HttpPouch(opts, callback) {
         method: 'GET',
         url: genDBUrl(host, '_changes' + paramStr),
         // _changes can take a long time to generate, especially when filtered
-        timeout: null
+        timeout: opts.timeout
       };
       lastFetchedSeq = since;
 
@@ -854,8 +868,10 @@ function HttpPouch(opts, callback) {
     var results = {results: []};
 
     var fetched = function (err, res) {
+      var raw_results_length = 0;
       // If the result of the ajax call (res) contains changes (res.results)
       if (res && res.results) {
+        raw_results_length = res.results.length;
         results.last_seq = res.last_seq;
         // For each change
         var req = {};
@@ -873,6 +889,7 @@ function HttpPouch(opts, callback) {
         // In case of an error, stop listening for changes and call opts.complete
         opts.aborted = true;
         utils.call(opts.complete, err, null);
+        return;
       }
 
       // The changes feed may have timed out with no results
@@ -884,8 +901,8 @@ function HttpPouch(opts, callback) {
       var resultsLength = res && res.results.length || 0;
 
       var finished = (limit && leftToFetch <= 0) ||
-        (res && res.last_seq >= remoteLastSeq) ||
-        (opts.descending && lastFetchedSeq !== 0);
+        (res && raw_results_length < CHANGES_LIMIT) ||
+        (opts.descending);
 
       if (opts.continuous || !finished) {
         // Increase retry delay exponentially as long as errors persist
@@ -900,6 +917,7 @@ function HttpPouch(opts, callback) {
 
         if (retryWait > maximumWait) {
           utils.call(opts.complete, err || errors.UNKNOWN_ERROR, null);
+          return;
         }
 
         // Queue a call to fetch again with the newest sequence number
@@ -910,20 +928,7 @@ function HttpPouch(opts, callback) {
       }
     };
 
-    // If we arent doing a continuous changes request we need to know
-    // the current update_seq so we know when to stop processing the
-    // changes
-    if (opts.continuous) {
-      fetch(opts.since || 0, fetched);
-    } else {
-      api.info(function (err, res) {
-        if (err) {
-          return utils.call(opts.complete, err);
-        }
-        remoteLastSeq = res.update_seq;
-        fetch(opts.since || 0, fetched);
-      });
-    }
+    fetch(opts.since || 0, fetched);
 
     // Return a method to cancel this method from processing any more
     return {


### PR DESCRIPTION
Here is my scantly informed offering of a fix. Accept it with caution.

This assumes that update_seq from db info is not the sequence number of the last document change, based on [COUCHDB-1367](https://issues.apache.org/jira/browse/COUCHDB-1367) and related discussions in the couchdb-dev mailing list. Therefore, all reference to update_seq from db info has been removed from HttpPouch adapter's changes.

This also assumes that _changes returning a changes array with fewer than 'limit' changes only happens when the last change, as at the time the request was processed at source, has been returned. Therefore, the setting of var finished has been simplified.

Part of the removal of reference to update_seq included removing an initial call to db.info for non-continuous changes, which broke test 'Changes reports errors' in test.changes.js. This test attempts to call changes against an uninitialized database on a server which accepts connections but never returns anything or closes the connection (at least that is my inference from the name (http://infiniterequest.com) and observed behaviour). With the initial call to db.info removed and no timeout on the request for _changes, this resulted in the test itself timing out. To resolve this, I added opts.timeout to changes for the HttpPouch adapter, which defaults to 0 (no timeout - as it was before this change), and added option timeout: 10000 to the 'Changes reports errors' test so the test completes before the test timeout. With these changes, the test does return an error, as expected, although for rather different reasons. It isn't clear to me what fundamental behaviours of PouchDB this test is testing.

While this may not be an optimum or even a valid solution to the problem, it does pass all tests.
