### PR TITLE
(#1384) Test db.sync cancel function

### DIFF
--- a/tests/test.replication.js
+++ b/tests/test.replication.js
@@ -1081,6 +1081,24 @@ describe('replication', function () {
         });
       });
 
+      it("Test sync cancel", function (done) {
+        var completed = 0;
+        testUtils.initDBPair(testHelpers.name, testHelpers.remote, function(db, remote) {
+          
+          var replications = db.replicate.sync(remote, {
+            complete: function(err, result) {
+              completed++;
+              if(completed === 2) {
+                done();
+              }
+            }
+          });
+          ok(replications, 'got some stuff');
+          replications.cancel();
+          return;
+        });
+      });
+
       it("Test syncing two endpoints (issue 838)", function (start) {
         var doc1 = {_id: 'adoc', foo:'bar'};
         var doc2 = {_id: 'anotherdoc', foo:'baz'};


### PR DESCRIPTION
Add a simple test to see of db.sync cancel function is working.

Not only does db.sync cancel function appear not to be working at the moment. The test of db.sync interferes with subsequent tests somehow. Possibly by causing failure when the subsequent test attempts to initialize the test database, including destroying that left by the previous test, but I'm not at all certain about this. What I do know is that the db.sync cancel function sometimes is called and failed after a subsequent test starts.
