### PR TITLE
update mapreduce

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "level": "~0.18.0",
     "request": "~2.28.0",
-    "pouchdb-mapreduce": "0.5.0",
+    "pouchdb-mapreduce": "0.6.0",
     "bluebird": "~1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
to be merged after we publish 0.6 in mapreduce which is waiting on pouchdb/mapreduce#43. #1348 should wait on this one
