### PR TITLE
Enhancement: add options.since to replicate

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -412,6 +412,7 @@ All options default to `false` unless otherwise specified.
 * `options.complete`: Function called when all changes have been processed.
 * `options.onChange`: Function called on each change processed.
 * `options.continuous`: If `true`, starts subscribing to future changes in the `source` database and continue replicating them.
+* `options.since`: Replicate changes after the given sequence number.
 * `options.server`: Initialize the replication on the server. The response is the CouchDB `POST _replicate` response and is different from the PouchDB replication response. Also, `options.onChange` is not supported on server replications.
 * `options.create_target`: Create target database if it does not exist. Only for server replications.
 

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -303,48 +303,63 @@ function replicate(repId, src, target, opts, promise) {
   }
 
 
-  fetchCheckpoint(src, target, repId, function (err, checkpoint) {
-    if (err) {
-      return abortReplication('fetchCheckpoint completed with error', err);
-    }
+  function getChanges() {
+    fetchCheckpoint(src, target, repId, function (err, checkpoint) {
+      if (err) {
+        return abortReplication('fetchCheckpoint completed with error', err);
+      }
 
-    last_seq = checkpoint;
+      last_seq = checkpoint;
 
-    // Was the replication cancelled by the caller before it had a chance
-    // to start. Shouldnt we be calling complete?
-    if (promise.cancelled) {
-      return replicationCancelled();
-    }
+      // Was the replication cancelled by the caller before it had a chance
+      // to start. Shouldnt we be calling complete?
+      if (promise.cancelled) {
+        return replicationCancelled();
+      }
 
-    // Call changes on the source database, with callbacks to onChange for
-    // each change and complete when done.
-    var repOpts = {
-      continuous: continuous,
-      since: last_seq,
-      style: 'all_docs',
-      onChange: onChange,
-      complete: complete,
-      doc_ids: doc_ids
-    };
-
-    if (opts.filter) {
-      repOpts.filter = opts.filter;
-    }
-
-    if (opts.query_params) {
-      repOpts.query_params = opts.query_params;
-    }
-
-    var changes = src.changes(repOpts);
-
-    if (opts.continuous) {
-      var cancel = promise.cancel;
-      promise.cancel = function () {
-        cancel();
-        changes.cancel();
+      // Call changes on the source database, with callbacks to onChange for
+      // each change and complete when done.
+      var repOpts = {
+        continuous: continuous,
+        since: last_seq,
+        style: 'all_docs',
+        onChange: onChange,
+        complete: complete,
+        doc_ids: doc_ids
       };
-    }
-  });
+
+      if (opts.filter) {
+        repOpts.filter = opts.filter;
+      }
+
+      if (opts.query_params) {
+        repOpts.query_params = opts.query_params;
+      }
+
+      var changes = src.changes(repOpts);
+
+      if (opts.continuous) {
+        var cancel = promise.cancel;
+        promise.cancel = function () {
+          cancel();
+          changes.cancel();
+        };
+      }
+    });
+  }
+
+  // If opts.since is given, set the checkpoint to opts.since
+  if (typeof opts.since === 'undefined') {
+    getChanges();
+  } else {
+    writeCheckpoint(src, target, repId, opts.since, function (err, res) {
+      if (err) {
+        return abortReplication('writeCheckpoint completed with error', err);
+      }
+      last_seq = opts.since;
+      getChanges();
+    });
+  }
 }
 
 function toPouch(db, callback) {

--- a/tests/test.replication.js
+++ b/tests/test.replication.js
@@ -499,6 +499,36 @@ describe('changes', function () {
         });
       });
 
+      it("Replication since", function(start) {
+        var thedocs = [
+          {_id: '1', integer: 1, string: '1'},
+          {_id: '2', integer: 2, string: '2'},
+          {_id: '3', integer: 3, string: '3'},
+          {_id: '4', integer: 4, string: '4'},
+          {_id: '5', integer: 5, string: '5'}
+        ];
+
+        testUtils.initDBPair(testHelpers.name, testHelpers.remote, function(db, remote) {
+          remote.bulkDocs({docs: thedocs}, function(err, info) {
+            db.replicate.from(remote, {
+              since: 3,
+              complete: function(err, result) {
+                ok(!null, 'Replication completed without error');
+                result.docs_written.should.equal(2, 'Correct number of docs written');
+                db.replicate.from(remote, {
+                  since: 0,
+                  complete: function(err, result) {
+                    ok(!err, 'Replication completed without error');
+                    result.docs_written.should.equal(3, 'Correct number of docs written');
+                    start();
+                  }
+                });
+              }
+            });
+          });
+        });
+      });
+
       it("Replication with same filters", function(start) {
         var more_docs = [
           {_id: '3', integer: 3, string: '3'},


### PR DESCRIPTION
Currently, if the replication checkpoint is incorrect (advanced too far) it is necessary to manually reset the checkpoint. With this change the checkpoint can be reset to an arbitrary value by calling replicate with option since. For example options.since = 0 would reset the checkpoint to 0 and cause the entire changes feed to be re-processed.
