### PR TITLE
Fix error determining end of replication

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -221,11 +221,7 @@ function replicate(repId, src, target, opts, promise) {
     }
 
     if (batches.length === 0) {
-      if (changesCompleted) {
-        replicationComplete();
-      } else if (pendingBatch.changes.length > 0) {
-        processPendingBatch();
-      }
+      processPendingBatch();
       return;
     }
 


### PR DESCRIPTION
This change fixes a small error in determination of whether replication is complete. If the changes feed calls its complete callback before all changes have been sent, as recent versions of changes in HttpPouch did, then replication could terminate without completing processing of already queued changes. While it doesn't prevent premature termination in this case, it slightly reduces the impact.
