### PR TITLE
Enhancement: Add last_seq to the result from replicate

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -160,6 +160,7 @@ function replicate(repId, src, target, opts, promise) {
     result.ok = false;
     result.errors.push(err);
     result.end_time = new Date();
+    result.last_seq = last_seq;
     promise.cancel();
     batches = [];
     pendingBatch = new Batch();
@@ -179,6 +180,7 @@ function replicate(repId, src, target, opts, promise) {
         return abortReplication('writeCheckpoint completed with error', err);
       }
       last_seq = batches[0].seq;
+      result.last_seq = last_seq;
       PouchUtils.call(opts.onChange, null, result);
       batches.shift();
       startNextBatch();
@@ -256,6 +258,7 @@ function replicate(repId, src, target, opts, promise) {
     if (!replicationCompleted) {
       replicationCompleted = true;
       result.end_time = new Date();
+      result.last_seq = last_seq;
       return PouchUtils.call(opts.complete, null, result);
     }
   }


### PR DESCRIPTION
Add the last sequence number to the result returned by replicate. It's an aid in troubleshooting if nothing else.
