### PR TITLE
Enhancement: Add status to replicate response

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -438,7 +438,9 @@ db.replicate.from(remoteDB, [options]);
   'docs_read': 2,
   'docs_written': 2,
   'start_time': "Sun Sep 23 2012 08:14:45 GMT-0500 (CDT)",
-  'end_time': "Sun Sep 23 2012 08:14:45 GMT-0500 (CDT)"
+  'end_time': "Sun Sep 23 2012 08:14:45 GMT-0500 (CDT)",
+  'status': 'Complete',
+  'errors': []
 }
 {% endhighlight %}
 

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -119,7 +119,7 @@ function replicate(repId, src, target, opts, promise) {
 
   function onGet(err, docs) {
     if (promise.cancelled) {
-      return replicationComplete();
+      return replicationCancelled();
     }
 
     if (err) {
@@ -158,6 +158,7 @@ function replicate(repId, src, target, opts, promise) {
 
   function abortReplication(reason, err) {
     result.ok = false;
+    result.status = 'Aborted';
     result.errors.push(err);
     result.end_time = new Date();
     promise.cancel();
@@ -187,7 +188,7 @@ function replicate(repId, src, target, opts, promise) {
 
   function onRevsDiff(err, diffs) {
     if (promise.cancelled) {
-      return replicationComplete();
+      return replicationCancelled();
     }
 
     if (err) {
@@ -217,7 +218,7 @@ function replicate(repId, src, target, opts, promise) {
 
   function startNextBatch() {
     if (promise.cancelled) {
-      return replicationComplete();
+      return replicationCancelled();
     }
 
     if (batches.length === 0) {
@@ -252,9 +253,16 @@ function replicate(repId, src, target, opts, promise) {
   }
 
 
+  function replicationCancelled() {
+    result.status = 'Cancelled';
+    replicationComplete();
+  }
+
+  
   function replicationComplete() {
     if (!replicationCompleted) {
       replicationCompleted = true;
+      result.status = result.status || 'Complete';
       result.end_time = new Date();
       return PouchUtils.call(opts.complete, null, result);
     }
@@ -263,7 +271,7 @@ function replicate(repId, src, target, opts, promise) {
 
   function onChange(change) {
     if (promise.cancelled) {
-      return replicationComplete();
+      return replicationCancelled();
     }
 
     if (replicationCompleted) {
@@ -283,7 +291,7 @@ function replicate(repId, src, target, opts, promise) {
   function complete(err, result) {
     changesCompleted = true;
     if (promise.cancelled) {
-      return replicationComplete();
+      return replicationCancelled();
     }
 
     if (err) {
@@ -304,7 +312,7 @@ function replicate(repId, src, target, opts, promise) {
     // Was the replication cancelled by the caller before it had a chance
     // to start. Shouldnt we be calling complete?
     if (promise.cancelled) {
-      return replicationComplete();
+      return replicationCancelled();
     }
 
     // Call changes on the source database, with callbacks to onChange for


### PR DESCRIPTION
Add a status field to the result returned by replicate, with value 'Complete', 'Cancelled' or 'Aborted', according to how the replication ended. An aborted replication will have an error, so it was already possible to distinguish this case, but previously it was not easy to distinguish a completed replication from one that was cancelled, in the complete callback.
