### PR TITLE
Fix replicate error handling on get error

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -84,7 +84,7 @@ function replicate(repId, src, target, opts, promise) {
   var batches = [];     // queue of batches of changes to be processed
   var pendingBatch = new Batch();
   var changesCompleted = false;
-  var replicationCompleted = false;
+  var completeCalled = false;
   var last_seq = 0;
   var continuous = opts.continuous || false;
   var batch_size = opts.batch_size || 1;
@@ -159,6 +159,9 @@ function replicate(repId, src, target, opts, promise) {
 
 
   function abortReplication(reason, err) {
+    if (completeCalled) {
+      return;
+    }
     result.ok = false;
     result.status = 'aborted';
     result.errors.push(err);
@@ -173,6 +176,7 @@ function replicate(repId, src, target, opts, promise) {
       reason: reason,
       details: err
     };
+    completeCalled = true;
     PouchUtils.call(opts.complete, error, result);
   }
 
@@ -260,13 +264,14 @@ function replicate(repId, src, target, opts, promise) {
 
   
   function replicationComplete() {
-    if (!replicationCompleted) {
-      replicationCompleted = true;
-      result.status = result.status || 'complete';
-      result.end_time = new Date();
-      result.last_seq = last_seq;
-      return PouchUtils.call(opts.complete, null, result);
+    if (completeCalled) {
+      return;
     }
+    result.status = result.status || 'complete';
+    result.end_time = new Date();
+    result.last_seq = last_seq;
+    completeCalled = true;
+    return PouchUtils.call(opts.complete, null, result);
   }
 
 
@@ -275,7 +280,7 @@ function replicate(repId, src, target, opts, promise) {
       return replicationCancelled();
     }
 
-    if (replicationCompleted) {
+    if (completeCalled) {
       // This should never happen
       // The complete callback has already been called
       // How to raise an exception in PouchDB?


### PR DESCRIPTION
An error from get could result in the complete callback being called twice. Prevent this from happening.
Add a test of complete callback arguments after a get error to confirm the error is handled correctly.
