### PR TITLE
Fix error handling writing checkpoint

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -66,16 +66,39 @@ function writeCheckpoint(src, target, id, checkpoint, callback) {
       if (err && err.status === 404) {
         doc = {_id: id};
       } else if (err) {
-        return callback(err);
+        return callback({
+          status: 500,
+          error: 'unknown error',
+          reason: 'error getting checkpoint',
+          details: err
+        });
       }
       doc.last_seq = checkpoint;
       db.put(doc, callback);
     });
   }
   updateCheckpoint(target, function (err, doc) {
-    updateCheckpoint(src, function (err, doc) {
-      callback();
-    });
+    if (err) {
+      callback({
+        status: 500,
+        error: 'unknown error',
+        reason: 'error updating checkpoint on target',
+        details: err
+      });
+    } else {
+      updateCheckpoint(src, function (err, doc) {
+        if (err) {
+          callback({
+            status: 500,
+            error: 'unknown error',
+            reason: 'error updating checkpoint on source',
+            details: err
+          });
+        } else {
+          callback();
+        }
+      });
+    }
   });
 }
 

--- a/tests/test.replication.js
+++ b/tests/test.replication.js
@@ -914,6 +914,40 @@ describe('changes', function () {
       //   });
       // });
 
+      it("error updating checkpoint", function(done) {
+        testUtils.initDBPair(testHelpers.name, testHelpers.remote, function(db, remote) {
+          remote.bulkDocs({docs: docs}, {}, function(err, results) {
+            var get = remote.get;
+            var local_count = 0;
+            // Mock remote.get to fail writing doc_3 (fourth doc)
+            remote.get = function() {
+              // Simulate failure to get the checkpoint
+              if(arguments[0].slice(0,6) === '_local') {
+                local_count++;
+                if(local_count === 2) {
+                  console.log('get local: ' + JSON.stringify(arguments));
+                  arguments[1].apply(null, [{
+                    status: 500,
+                    error: 'mock get error',
+                    reason: 'simulate an error updating the checkpoint'
+                  }]);
+                } else {
+                  get.apply(this, arguments);
+                }
+              } else {
+                get.apply(this, arguments);
+              }
+            };
+
+            db.replicate.from(remote, function(err, result) {
+              ok(!!err, 'Replication fails with an error');
+              ok(!result.ok, 'Replication result is not OK');
+              done();
+            });
+          });
+        });
+      });
+
       it("(#1307) - replicate empty database", function(start) {
         
 


### PR DESCRIPTION
Errors while updating checkpoint were being ignored, resulting in obscure replication failures.
This change improves error handling and adds a test for one case of error updating the checkpoint to confirm that an error is reported back to the replicate complete callback.
