### PR TITLE
(#1405) - Remove defunct troubleshooting from docs

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -19,10 +19,6 @@ There is a limit of one database per app in some versions of the Android WebView
 
 If you're storing large amounts of data, such as PNG attachments, the [SQLite plugin][sqlite] is again your friend. (See [issue #1260](https://github.com/daleharvey/pouchdb/issues/1260) for details.)
 
-### `put()` is throwing 412: "_id is required for puts"
-
-As in CouchDB, documents are `put` with an `_id` and `post`ed without an `_id`.  Document IDs must be unique strings that do not start with the reserved underscore character `'_'`.
-
 ### CouchDB returns a 404 for GETs from a CouchApp
 
 Certain URL rewrites are broken by PouchDB's cache-busting; try adding `{cache : false}` to the PouchDB constructor. (See [issue #1233](https://github.com/daleharvey/pouchdb/issues/1233) for details.)


### PR DESCRIPTION
The unhelpful _id error message was fixed by
issue #1369, so an explanation is no longer
needed in the docs.
