### PR TITLE
same change can be called more then once

### DIFF
--- a/tests/test.changes.js
+++ b/tests/test.changes.js
@@ -1039,18 +1039,24 @@ describe('changes', function () {
           });
         });
       });
-      it('changes arn\'t duplicated', function (done) {
+      it('changes are not duplicated', function (done) {
         testUtils.initTestDB(testHelpers.name, function (err, db) {
-          db.changes({
+          var called = 0;
+          var changs = db.changes({
             since: 'latest',
             continuous: true,
             onChange: function () {
-              done();
+              called++;
             }
           });
           db.put({
             key: 'value'
           }, '_id');
+          setTimeout(function () {
+            called.should.equal(1);
+            changes.cancel();
+            done();
+          }, 1000);
         });
       });
     });


### PR DESCRIPTION
noticed a bug where 2 changes are generated from adding one document, the only difference is one has in the changes array items, an `opts` key with the value `{status: 'available'}` so far this pull is just a test case that fails
