### PR TITLE
(#1351) - remove alldbs in node

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -73,7 +73,7 @@ PouchDB.destroy = function (name, opts, callback) {
   // remove PouchDB from allDBs
   PouchDB.removeFromAllDbs(backend, cb);
 };
-
+PouchDB.noAllDbs = ['http', 'https', 'ldb', 'leveldb'];
 PouchDB.removeFromAllDbs = function (opts, callback) {
   // Only execute function if flag is enabled
   if (!PouchDB.enableAllDbs) {
@@ -83,7 +83,7 @@ PouchDB.removeFromAllDbs = function (opts, callback) {
 
   // skip http and https adaptors for allDbs
   var adapter = opts.adapter;
-  if (adapter === "http" || adapter === "https") {
+  if (~PouchDB.noAllDbs.indexOf(adapter)) {
     callback();
     return;
   }
@@ -147,8 +147,8 @@ PouchDB.open = function (opts, callback) {
   }
 
   var adapter = opts.adapter;
-  // skip http and https adaptors for allDbs
-  if (adapter === "http" || adapter === "https") {
+  // skip http and leveldb adaptors for allDbs
+  if (~PouchDB.noAllDbs.indexOf(adapter)) {
     callback();
     return;
   }
@@ -238,7 +238,9 @@ PouchDB.allDbs = function (callback) {
       });
     });
   };
-  var adapters = Object.keys(PouchDB.adapters);
+  var adapters = Object.keys(PouchDB.adapters).filter(function (item) {
+    return item !== 'leveldb' && item !== 'ldb';
+  });
   accumulate(adapters, []);
 };
 

--- a/tests/test.all_dbs.js
+++ b/tests/test.all_dbs.js
@@ -29,7 +29,7 @@ function async(functions, callback) {
 describe('allDbs', function () {
   // Remove old allDbs to prevent DOM exception
   Object.keys(PouchDB.adapters).forEach(function (adapter) {
-    if (adapter === 'http' || adapter === 'https') {
+    if (~PouchDB.noAllDbs.indexOf(adapter)) {
       return;
     }
     PouchDB.destroy(PouchDB.allDBName(adapter), function () {
@@ -38,7 +38,7 @@ describe('allDbs', function () {
   // Loop through all availible adapters
   Object.keys(PouchDB.adapters).forEach(function (adapter) {
     // allDbs method only works for local adapters
-    if (adapter === 'http' || adapter === 'https') {
+    if (~PouchDB.noAllDbs.indexOf(adapter)) {
       return;
     }
     describe(adapter, function () {


### PR DESCRIPTION
I'm not sure if you guys are aware but I have a twin browser. When we young my parents were very scrupulous about treating us equally, if one of us needed new shoes, we both got new shoes. The thing was my brother and I are as different as day and a house, not even in the same category of things.  I, even when young, clomped around like a dutch tap dancer while my brother did not meaning I went through shoes roughly 3 times faster then him. Eventually my parents realized (probably due to my brothers massive shoe collection he acquired) that it made no sense to buy us both shoes at the same time and instead just started getting only me shoes. 

The point I'm trying to make is that it's ok to treat different platforms differently. Node.js is not the browser and while there are some very good reasons to have alldbs in the browser, there are less reasons for having them in node and in many ways it's a rather large hindrance to many things. The current solution adds complexity and leads to errors involving file locks while the only proposed solution prevents us from using other leveldb backends. 
