### PR TITLE
(#1443) test and fix sync interfaces

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -453,15 +453,28 @@ Note that the response for server replications (via `options.server`) is slightl
 ## Sync a database<a id="sync"></a>
 
 {% highlight js %}
-PouchDB.sync(target, [options])
+var sync = PouchDB.sync(src, target, [options])
 {% endhighlight %}
 
-Sync data from database to `target` and `target` to database. This is a convience method for bidirectional data replication, and is equivalent to:
+Sync data from `src` to `target` and `target` to `src`. This is a convience method for bidirectional data replication, and is mostly equivalent to:
 
 {% highlight js %}
-PouchDB.replicate(db1, db2, [options]);
-PouchDB.replicate(db2, db1, [options]);
+var sync = {
+  `push`: PouchDB.replicate(src, target, [options]);
+  `pull`: PouchDB.replicate(target, src, [options]);
+  `cancel`: function() {
+    if (sync.push) {
+      sync.push.cancel();
+    }
+    if (sync.pull) {
+      sync.pull.cancel();
+    }
+  }
+};
 {% endhighlight %}
+
+With the exception that if one replication fails the other is cancelled.
+
 
 ### Options
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -714,11 +714,13 @@ function doChanges(api, opts, promise, callback) {
   opts.limit = opts.limit === 0 ? 1 : opts.limit;
   opts.complete = callback;
   var newPromise = api._changes(opts);
-  var cancel = promise.cancel;
-  promise.cancel = function () {
-    cancel.apply(this, arguments);
-    newPromise.cancel();
-  };
+  if (newPromise && typeof newPromise.cancel === 'function') {
+    var cancel = promise.cancel;
+    promise.cancel = function () {
+      cancel.apply(this, arguments);
+      newPromise.cancel();
+    };
+  }
 }
 
 // promise is optional and should be set iff call was deferred through taskqueue

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -609,18 +609,16 @@ function LevelPouch(opts, callback) {
 
     fetchChanges();
 
-    if (opts.continuous) {
-      return {
-        cancel: function () {
-          opts.complete(null, {status: 'cancelled'});
-          opts.complete = null;
-          opts.cancelled = true;
-          if (changeListener) {
-            change_emitter.removeListener('change', changeListener);
-          }
+    return {
+      cancel: function () {
+        opts.complete(null, {status: 'cancelled'});
+        opts.complete = null;
+        opts.cancelled = true;
+        if (changeListener) {
+          change_emitter.removeListener('change', changeListener);
         }
-      };
-    }
+      }
+    };
   };
 
   api._close = function (callback) {

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -83,6 +83,7 @@ function writeCheckpoint(src, target, id, checkpoint, callback) {
 function replicate(repId, src, target, opts, promise) {
   var batches = [];     // queue of batches of changes to be processed
   var pendingBatch = new Batch();
+  var writingCheckpoint = false;
   var changesCompleted = false;
   var completeCalled = false;
   var last_seq = 0;
@@ -121,7 +122,7 @@ function replicate(repId, src, target, opts, promise) {
 
   function onGet(err, docs) {
     if (promise.cancelled) {
-      return replicationCancelled();
+      return cancelReplication();
     }
 
     if (err) {
@@ -167,7 +168,6 @@ function replicate(repId, src, target, opts, promise) {
     result.errors.push(err);
     result.end_time = new Date();
     result.last_seq = last_seq;
-    promise.cancel();
     batches = [];
     pendingBatch = new Batch();
     var error = {
@@ -178,11 +178,17 @@ function replicate(repId, src, target, opts, promise) {
     };
     completeCalled = true;
     PouchUtils.call(opts.complete, error, result);
+    promise.cancel();
   }
 
 
   function finishBatch() {
+    writingCheckpoint = true;
     writeCheckpoint(src, target, repId, batches[0].seq, function (err, res) {
+      writingCheckpoint = false;
+      if (promise.cancelled) {
+        return cancelReplication();
+      }
       if (err) {
         return abortReplication('writeCheckpoint completed with error', err);
       }
@@ -196,7 +202,7 @@ function replicate(repId, src, target, opts, promise) {
 
   function onRevsDiff(err, diffs) {
     if (promise.cancelled) {
-      return replicationCancelled();
+      return cancelReplication();
     }
 
     if (err) {
@@ -226,7 +232,7 @@ function replicate(repId, src, target, opts, promise) {
 
   function startNextBatch() {
     if (promise.cancelled) {
-      return replicationCancelled();
+      return cancelReplication();
     }
 
     if (batches.length === 0) {
@@ -257,9 +263,11 @@ function replicate(repId, src, target, opts, promise) {
   }
 
 
-  function replicationCancelled() {
+  function cancelReplication() {
     result.status = 'cancelled';
-    replicationComplete();
+    if (!writingCheckpoint) {
+      replicationComplete();
+    }
   }
 
   
@@ -277,7 +285,7 @@ function replicate(repId, src, target, opts, promise) {
 
   function onChange(change) {
     if (promise.cancelled) {
-      return replicationCancelled();
+      return cancelReplication();
     }
 
     if (completeCalled) {
@@ -297,7 +305,7 @@ function replicate(repId, src, target, opts, promise) {
   function complete(err, result) {
     changesCompleted = true;
     if (promise.cancelled) {
-      return replicationCancelled();
+      return cancelReplication();
     }
 
     if (err) {
@@ -319,7 +327,7 @@ function replicate(repId, src, target, opts, promise) {
       // Was the replication cancelled by the caller before it had a chance
       // to start. Shouldnt we be calling complete?
       if (promise.cancelled) {
-        return replicationCancelled();
+        return cancelReplication();
       }
 
       // Call changes on the source database, with callbacks to onChange for
@@ -343,13 +351,15 @@ function replicate(repId, src, target, opts, promise) {
 
       var changes = src.changes(repOpts);
 
-      if (opts.continuous) {
-        var cancel = promise.cancel;
-        promise.cancel = function () {
-          cancel();
+      var cancelPromise = promise.cancel;
+      promise.cancel = function () {
+        cancelPromise();
+        cancelReplication();
+        if (changes && changes.cancel instanceof Function) {
           changes.cancel();
-        };
-      }
+        }
+      };
+
     });
   }
 
@@ -422,12 +432,24 @@ function sync(db1, db2, opts, callback) {
   var push_promise;
   var pull_promise;
 
-  function complete(callback) {
+  if (opts instanceof Function) {
+    callback = opts;
+    opts = {};
+  }
+  if (opts === undefined) {
+    opts = {};
+  }
+  if (callback instanceof Function && !opts.complete) {
+    opts.complete = callback;
+  }
+
+  function complete(callback, direction) {
     return function (err, res) {
       if (err) {
         // cancel both replications if either experiences problems
         cancel();
       }
+      res.direction = direction;
       callback(err, res);
     };
   }
@@ -442,20 +464,20 @@ function sync(db1, db2, opts, callback) {
     };
   }
 
-  function makeOpts(src, opts) {
+  function makeOpts(src, opts, direction) {
     opts = PouchUtils.extend(true, {}, opts);
-    opts.complete = complete(opts.complete);
+    opts.complete = complete(opts.complete, direction);
     opts.onChange = onChange(src, opts.onChange);
     return opts;
   }
 
   function push() {
-    push_promise = replicateWrapper(db1, db2, makeOpts(db1, opts), callback);
+    push_promise = replicateWrapper(db1, db2, makeOpts(db1, opts, 'push'), callback);
     return push_promise;
   }
 
   function pull() {
-    pull_promise = replicateWrapper(db2, db1, makeOpts(db2, opts), callback);
+    pull_promise = replicateWrapper(db2, db1, makeOpts(db2, opts, 'pull'), callback);
     return pull_promise;
   }
 


### PR DESCRIPTION
PouchDB.sync was documented but untested and failing if the callback argument was passed.

db.sync was documented but untested and didn't exist.

Existing sync tests were in incorrect place in test.replication.js: where only one database was initialized, so only running successfully when run after other tests. Moved them to the section initializing two databases.

Added db.sync, fixed sync to handle the callback argument and test two variations of calling each of PouchDB.sync and db.sync.
