### PR TITLE
(#1487) - few more variable tweaks in leveldb

### DIFF
--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -77,7 +77,7 @@ function LevelPouch(opts, callback) {
         docCount = !err ? value : 0;
         stores.bySeqStore.get(UUID_KEY, function (err, value) {
           instanceId = !err ? value : utils.uuid();
-          stores.bySeqStore.get(UUID_KEY, function (err, value) {
+          stores.bySeqStore.put(UUID_KEY, instanceId, function (err, value) {
             process.nextTick(function () {
               callback(null, api);
             });


### PR DESCRIPTION
- better function name then `withDB`
- dot notation for the local sublevels
- UPPER_CASE for the sublevel prefixes
