### PR TITLE
(#1507) Fix changes test fire-complete-on-cancel

### DIFF
--- a/tests/test.changes.js
+++ b/tests/test.changes.js
@@ -951,17 +951,18 @@ adapters.map(function (adapter) {
     });
 
     it('fire-complete-on-cancel', function (done) {
-      var db = new PouchDB(dbs.name);
-      var changes = db.changes({
-        continuous: true,
-        complete: function (err, result) {
-          result.status.should.equal('cancelled');
-          done();
-        }
+      new PouchDB(dbs.name, function (err, db) {
+        var changes = db.changes({
+          continuous: true,
+          complete: function (err, result) {
+            result.status.should.equal('cancelled');
+            done();
+          }
+        });
+        setTimeout(function () {
+          changes.cancel();
+        }, 100);
       });
-      setTimeout(function () {
-        changes.cancel();
-      }, 100);
     });
 
   });


### PR DESCRIPTION
Wait for DB setup to complete before starting changes.

This avoids the buggy code rather than fixing it.

A separate test that delays database setup until after changes is called would test the buggy code reliably, but I don't know how to write that.
