### PR TITLE
(#1507) Fix changes in adapter.js

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -604,19 +604,8 @@ function processChange(doc, metadata, opts) {
   }
   return change;
 }
-AbstractPouchDB.prototype.changes = function (opts) {
-  if (!this.taskqueue.isReady) {
-    var task = this.taskqueue.addTask('changes', arguments);
-    return {
-      cancel: function () {
-        if (task.task) {
-          return task.task.cancel();
-        }
-        task.parameters[0].aborted = true;
-      }
-    };
-  }
-  var api = this;
+
+function doChanges(api, opts, promise, callback) {
   opts = utils.extend(true, {}, opts);
   opts.processChange = processChange;
 
@@ -624,22 +613,19 @@ AbstractPouchDB.prototype.changes = function (opts) {
     opts.since = 0;
   }
   if (opts.since === 'latest') {
-    var changes;
     api.info(function (err, info) {
-      if (!opts.aborted) {
-        opts.since = info.update_seq  - 1;
-        changes = api.changes(opts);
+      if (promise.isCancelled) {
+        callback(null, {status: 'cancelled'});
+        return;
       }
+      if (err) {
+        callback(err);
+        return;
+      }
+      opts.since = info.update_seq  - 1;
+      doChanges(api, opts, promise, callback);
     });
-    // Return a method to cancel this method from processing any more
-    return {
-      cancel: function () {
-        if (changes) {
-          return changes.cancel();
-        }
-        opts.aborted = true;
-      }
-    };
+    return;
   }
 
   if (opts.filter && typeof opts.filter === 'string') {
@@ -648,6 +634,14 @@ AbstractPouchDB.prototype.changes = function (opts) {
         // fetch a view from a design doc, make it behave like a filter
         var viewName = opts.view.split('/');
         api.get('_design/' + viewName[0], function (err, ddoc) {
+          if (promise.isCancelled) {
+            callback(null, {status: 'cancelled'});
+            return;
+          }
+          if (err) {
+            callback(err);
+            return;
+          }
           if (ddoc && ddoc.views && ddoc.views[viewName[1]]) {
             /*jshint evil: true */
             var filter = eval('(function () {' +
@@ -663,50 +657,52 @@ AbstractPouchDB.prototype.changes = function (opts) {
                               '    }' +
                               '  }' +
                               '})()');
-            if (!opts.aborted) {
-              opts.filter = filter;
-              api.changes(opts);
-            }
+            opts.filter = filter;
+            doChanges(api, opts, promise, callback);
+            return;
           } else {
             var msg = ddoc.views ? 'missing json key: ' + viewName[1] :
               'missing json key: views';
             err = err || errors.error(errors.MISSING_DOC, msg);
-            opts.complete(err);
+            callback(err);
+            return;
           }
         });
       } else {
         var err = errors.error(errors.BAD_REQUEST,
                               '`view` filter parameter is not provided.');
-        opts.complete(err);
+        callback(err);
+        return;
       }
     } else {
       // fetch a filter from a design doc
       var filterName = opts.filter.split('/');
       api.get('_design/' + filterName[0], function (err, ddoc) {
+        if (promise.isCancelled) {
+          callback(null, {status: 'cancelled'});
+          return;
+        }
+        if (err) {
+          callback(err);
+          return;
+        }
         if (ddoc && ddoc.filters && ddoc.filters[filterName[1]]) {
           /*jshint evil: true */
           var filter = eval('(function () { return ' +
                             ddoc.filters[filterName[1]] + ' })()');
-          if (!opts.aborted) {
-            opts.filter = filter;
-            api.changes(opts);
-          }
+          opts.filter = filter;
+          doChanges(api, opts, promise, callback);
+          return;
         } else {
           var msg = (ddoc && ddoc.filters) ? 'missing json key: ' + filterName[1]
             : 'missing json key: filters';
           err = err || errors.error(errors.MISSING_DOC, msg);
-          opts.complete(err);
+          callback(err);
+          return;
         }
       });
     }
-    // Return a method to cancel this method from processing any more
-    return {
-      cancel: function () {
-        opts.complete(null, {status: 'cancelled'});
-        opts.complete = null;
-        opts.aborted = true;
-      }
-    };
+    return;
   }
 
   if (!('descending' in opts)) {
@@ -715,7 +711,75 @@ AbstractPouchDB.prototype.changes = function (opts) {
 
   // 0 and 1 should return 1 document
   opts.limit = opts.limit === 0 ? 1 : opts.limit;
-  return this._changes(opts);
+  opts.complete = callback;
+  var newPromise = api._changes(opts);
+  var cancel = promise.cancel;
+  promise.cancel = function () {
+    cancel.apply(this, arguments);
+    newPromise.cancel();
+  };
+}
+
+// promise is optional and should be set iff call was deferred through taskqueue
+AbstractPouchDB.prototype.changes = function (opts, promise, callback) {
+  if (typeof promise === 'function') {
+    callback = promise;
+    promise = null;
+  }
+  if (promise) {
+    doChanges(this, opts, promise, callback);
+    return promise;
+  }
+
+  var changes = utils.toPromise(function (opts, promise, callback) {
+    if (typeof opts === 'function') {
+      promise = callback;
+      callback = opts;
+      opts = {};
+    }
+    if (!opts) {
+      opts = {};
+    } else {
+      opts = utils.extend(true, {}, opts);
+    }
+    if (opts.complete) {
+      var complete = opts.complete;
+      promise.then(
+        function (result) {
+          complete(null, result);
+        },
+        complete
+      );
+    }
+    delete opts.complete;
+
+    var origCancel = promise.cancel;
+    promise.cancel = function (reason) {
+      callback(null, {status: 'cancelled', reason: reason});
+      origCancel.apply(this);
+    };
+
+    if (promise.isCancelled) {
+      callback(null, {status: 'cancelled'});
+      return;
+    }
+
+    if (!this.taskqueue.isReady) {
+      this.taskqueue.addTask('changes', [opts, promise, callback]);
+      return;
+    }
+
+    doChanges(this, opts, promise, callback);
+  }, true);
+
+  promise = changes.apply(this, arguments);
+  var origCancel = promise.cancel;
+  promise.isCancelled = false;
+  promise.cancel = function () {
+    promise.isCancelled = true;
+    origCancel.apply(this, arguments);
+  };
+  return promise;
 };
 
 AbstractPouchDB.prototype.close = utils.toPromise(function (callback) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -350,7 +350,7 @@ exports.fixBinary = function (bin) {
   return buf;
 };
 
-exports.toPromise = function (func) {
+exports.toPromise = function (func, passPromise) {
   //create the function we will be returning
   return function () {
     var self = this;
@@ -359,8 +359,8 @@ exports.toPromise = function (func) {
     // if the last argument is a function, assume its a callback
     var usedCB;
     if (tempCB) {
-      // if it was a callback, create a new callback which calls the callback function
-      // but we do so async so we don't trap any errors
+      // if it was a callback, create a new callback which calls it,
+      // but do so async so we don't trap any errors
       usedCB = function (err, resp) {
         process.nextTick(function () {
           tempCB(err, resp);
@@ -376,9 +376,18 @@ exports.toPromise = function (func) {
         }
       }
       // create a callback for this invocation
-      args.push(callback);
-      func.apply(self, args);
       // apply the function in the orig context
+      if (passPromise) {
+        // Defer until after promise is set
+        process.nextTick(function () {
+          args.push(promise);
+          args.push(callback);
+          func.apply(self, args);
+        });
+      } else {
+        args.push(callback);
+        func.apply(self, args);
+      }
     });
     // if there is a callback, call it back
     if (usedCB) {

--- a/tests/test.changes.js
+++ b/tests/test.changes.js
@@ -567,13 +567,17 @@ adapters.map(function (adapter) {
     it('Multiple watchers', function (done) {
       var db = new PouchDB(dbs.name);
       var count = 0;
+      var changes1Complete = false;
+      var changes2Complete = false;
       function checkCount() {
-        if (count === 2) {
+        if (changes1Complete && changes2Complete) {
+          count.should.equal(2);
           done();
         }
       }
       var changes1 = db.changes({
         complete: function () {
+          changes1Complete = true;
           checkCount();
         },
         onChange: function (change) {
@@ -585,6 +589,7 @@ adapters.map(function (adapter) {
       });
       var changes2 = db.changes({
         complete: function () {
+          changes2Complete = true;
           checkCount();
         },
         onChange: function (change) {
@@ -952,15 +957,21 @@ adapters.map(function (adapter) {
 
     it('fire-complete-on-cancel', function (done) {
       var db = new PouchDB(dbs.name);
+      var cancelled = false;
       var changes = db.changes({
         continuous: true,
         complete: function (err, result) {
+          cancelled.should.equal(true);
           should.not.exist(err);
-          result.status.should.equal('cancelled');
+          should.exist(result);
+          if (result) {
+            result.status.should.equal('cancelled');
+          }
           done();
         }
       });
       setTimeout(function () {
+        cancelled = true;
         changes.cancel();
       }, 100);
     });


### PR DESCRIPTION
This fixes AbstractPouchDB.prototype.changes in adapter.js to pass test fire-complete-on-cancel.
In passing, changes in adapter.js (but not http.js) returns a full promise, detects more errors and cancels changes when promise.cancel is called in more cases (including but not limited to the case tested in fire-complete-on-cancel), to the extent that the various adapters implement their cancel functions correctly. Several cases of recursive calls to db.changes were eliminated, to eliminate errors in their implementations (promise cancel and resolution not propagated effectively) and to avoid nested promises generally.

The promise implementation uses no features of Promise not already in use in utils.toPromise: new Promise and the then function.

For consistency with prior implementation, on cancel the promise is fulfilled with {status: 'cancelled'}, though I note that draft Cancellation/A+ (https://github.com/promises-aplus/cancellation-spec/issues/7) indicates the promise should be rejected with an error on cancel. If a decision is made to align PouchDB's implementation of cancel with Cancellation/A+, the change required to AbstractPouchDB.prototype.changes will be trivial.

AbstractPouchDB.prototype.changes uses a toPromise function, but it is a modification of that in utils. It passes the promise to the called function, along with opts and callback, so that the called function can modify the cancel function as necessary to implement an immediate active cancellation, rather than merely setting a flag which may not be acted on for an indefinite time after it is set (not ever, in some cases I have seen testing replicate). This, in fact, was one of my primary motivations for making this change: to eliminate a case where cancelling replicate hangs indefinitely, waiting to cancellation of changes which never happens.
