### PR TITLE
(#1479) Test that changes always returns a promise with cancel method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -7,7 +7,7 @@ title: API Reference - PouchDB
 
 Most of the PouchDB API is exposed as `fun(arg, [options], [callback])` where both the options and the callback are optional. Callbacks use the `function(err, result)` idiom where the first argument will be undefined unless there is an error, and the second argument holds the result. 
 
-Additionally, any method that only returns a single thing (e.g. `db.get`, but not `db.changes`) also returns a [promise][]. Promises come from the minimal library [lie][] in the browser, and the feature-rich [Bluebird][] in Node.
+Additionally, any method that only returns a single thing (e.g. `db.get`) also returns a [promise][]. Promises come from the minimal library [lie][] in the browser, and the feature-rich [Bluebird][] in Node.
 
   [promise]: http://www.html5rocks.com/en/tutorials/es6/promises/
   [lie]: https://github.com/calvinmetcalf/lie
@@ -316,7 +316,8 @@ db.changes(options)
 {% endhighlight %}
 
 A list of changes made to documents in the database, in the order they were made.
-If `options.continuous` is set to `true`, it returns an object with one method `cancel` which you call if you don't want to listen to new changes anymore. `options.onChange` will be be called for each change that is encountered.
+It returns an object with one method `cancel` which you call if you don't want to listen to new changes anymore. 
+`options.onChange` will be be called for each change that is encountered.
 
 ### Options
 

--- a/tests/test.changes.js
+++ b/tests/test.changes.js
@@ -22,13 +22,19 @@ adapters.map(function (adapter) {
     it('All changes', function (done) {
       var db = new PouchDB(dbs.name);
       db.post({ test: 'somestuff' }, function (err, info) {
-        db.changes({
+        var promise = db.changes({
           onChange: function (change) {
             change.should.not.have.property('doc');
             change.should.have.property('seq');
             done();
           }
         });
+        should.exist(promise);
+        if (promise) {
+          // The http adapter does not yet return a Promise
+          // promise.should.be.an.instanceof('Promise');
+          promise.cancel.should.be.a('function');
+        }
       });
     });
 
@@ -51,13 +57,19 @@ adapters.map(function (adapter) {
       ];
       var db = new PouchDB(dbs.name);
       db.bulkDocs({ docs: docs }, function (err, info) {
-        db.changes({
+        var promise = db.changes({
           since: 12,
           complete: function (err, results) {
             results.results.length.should.equal(2);
             done();
           }
         });
+        should.exist(promise);
+        if (promise) {
+          // The http adapter does not yet return a Promise
+          // promise.should.be.an.instanceof('Promise');
+          promise.cancel.should.be.a('function');
+        }
       });
     });
 
@@ -194,7 +206,7 @@ adapters.map(function (adapter) {
       ];
       var db = new PouchDB(dbs.name);
       testUtils.writeDocs(db, docs, function (err, info) {
-        db.changes({
+        var promise = db.changes({
           filter: 'foo/even',
           limit: 2,
           since: 2,
@@ -210,6 +222,12 @@ adapters.map(function (adapter) {
             done();
           }
         });
+        should.exist(promise);
+        if (promise) {
+          // The http adapter does not yet return a Promise
+          // promise.should.be.an.instanceof('Promise');
+          promise.cancel.should.be.a('function');
+        }
       });
     });
 
@@ -948,6 +966,8 @@ adapters.map(function (adapter) {
             done();
           }
         });
+        should.exist(changes);
+        changes.cancel.should.be.a('function');
         changes.cancel();
         db.close(function (error) {
           should.not.exist(error);
@@ -970,6 +990,8 @@ adapters.map(function (adapter) {
           done();
         }
       });
+      should.exist(changes);
+      changes.cancel.should.be.a('function');
       setTimeout(function () {
         cancelled = true;
         changes.cancel();


### PR DESCRIPTION
It is a bit excessive, but easier to always check for a promise and cancel than analyize the code to ensure full coverage with minimal tests.
