### PR TITLE
(#1572) - Remove emit on destroy for WebSQL

### DIFF
--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -892,7 +892,6 @@ WebSqlPouch.valid = function () {
 };
 
 WebSqlPouch.destroy = utils.toPromise(function (name, opts, callback) {
-  var self = this;
   var db = openDB(name, POUCH_VERSION, name, POUCH_SIZE);
   db.transaction(function (tx) {
     tx.executeSql('DROP TABLE IF EXISTS ' + DOC_STORE, []);
@@ -900,7 +899,6 @@ WebSqlPouch.destroy = utils.toPromise(function (name, opts, callback) {
     tx.executeSql('DROP TABLE IF EXISTS ' + ATTACH_STORE, []);
     tx.executeSql('DROP TABLE IF EXISTS ' + META_STORE, []);
   }, unknownError(callback), function () {
-    self.emit('destroyed');
     callback();
   });
 });


### PR DESCRIPTION
The "destroy a pouch" test is currently
broken for WebSQL, because of this line
added in 1e2601fbfefa0b2ebe8dba431983e1bcfb8aa702.
