### PR TITLE
Prefixed names (e.g. idb://) do not add prefixes

### DIFF
--- a/tests/test.basics.js
+++ b/tests/test.basics.js
@@ -595,5 +595,17 @@ adapters.map(function (adapter) {
       });
     });
 
+    it('should use the same db when prefixed with adapter name', function (done) {
+      var db = new PouchDB(dbs.name);
+      db.put({_id : 'foo'}, function (err, info) {
+        var db2Name = db.adapter !== 'http' ? db.adapter + '://' + dbs.name : dbs.name;
+        var db2 = new PouchDB(db2Name);
+        db2.get('foo', function (err, doc) {
+          should.not.exist(err, 'error: ' + JSON.stringify(err));
+          done();
+        });
+      });
+    });
+
   });
 });


### PR DESCRIPTION
Unfortunately the attached test fails, because the prefix is not added when e.g. 'idb://' or 'websql://' are present.

We'll need to add migration logic and a test to `browser.migration.js`, since otherwise there's the potential for user data loss.
