### PR TITLE
(#1591) - handle undefined promise.cancel

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -759,7 +759,9 @@ AbstractPouchDB.prototype.changes = function (opts, promise, callback) {
     var origCancel = promise.cancel;
     promise.cancel = function (reason) {
       callback(null, {status: 'cancelled', reason: reason});
-      origCancel.apply(this);
+      if (typeof origCancel === 'function') {
+        origCancel.apply(this);
+      }
     };
 
     if (promise.isCancelled) {


### PR DESCRIPTION
The original promise (from Promise in utils.toPromise) may not have a cancel method, which is OK.
