### PR TITLE
Stop after cancel in http changes

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -806,6 +806,9 @@ function HttpPouch(opts, callback) {
     // Get all the changes starting wtih the one immediately after the
     // sequence number given by since.
     var fetch = function (since, callback) {
+      if (opts.aborted) {
+        return;
+      }
       params.since = since;
       if (opts.descending) {
         if (limit) {
@@ -847,6 +850,9 @@ function HttpPouch(opts, callback) {
     var results = {results: []};
 
     var fetched = function (err, res) {
+      if (opts.aborted) {
+        return;
+      }
       var raw_results_length = 0;
       // If the result of the ajax call (res) contains changes (res.results)
       if (res && res.results) {


### PR DESCRIPTION
Stop processing sooner rather than later after changes are cancelled, in http adapter.
