### PR TITLE
On cancel, call changes complete last

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -720,8 +720,8 @@ function doChanges(api, opts, promise, callback) {
   if (newPromise && typeof newPromise.cancel === 'function') {
     var cancel = promise.cancel;
     promise.cancel = function () {
-      cancel.apply(this, arguments);
       newPromise.cancel();
+      cancel.apply(this, arguments);
     };
   }
 }
@@ -761,10 +761,10 @@ AbstractPouchDB.prototype.changes = function (opts, promise, callback) {
 
     var origCancel = promise.cancel;
     promise.cancel = function (reason) {
-      callback(null, {status: 'cancelled', reason: reason});
       if (typeof origCancel === 'function') {
         origCancel.apply(this);
       }
+      callback(null, {status: 'cancelled', reason: reason});
     };
 
     if (promise.isCancelled) {


### PR DESCRIPTION
A small adjustment to the order of processing cancel in changes: call the changes complete callback after all other (synchronous) processing of the cancel request is done.
