### PR TITLE
(#1643) - fix build-site

### DIFF
--- a/bin/build-site.sh
+++ b/bin/build-site.sh
@@ -23,7 +23,7 @@ node_modules/less/bin/lessc docs/static/less/pouchdb/pouchdb.less > docs/static/
 cd docs
 
 if [ ! $BUILD ]; then
-    jekyll serve
+    jekyll -w serve --baseurl=''
 else
     jekyll build
 fi


### PR DESCRIPTION
Prior to this running npm run build-site would fail because the baseurl was set to /pouchdb in docs/_config.yml
