### PR TITLE
(#1646) - disable cache-busting for db.id

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -219,7 +219,8 @@ function HttpPouch(opts, callback) {
     ajax({
       headers: host.headers,
       method: 'GET',
-      url: genUrl(host, '')
+      url: genUrl(host, ''),
+      cache : true
     }, function (err, result) {
       if (err) {
         callback(err);


### PR DESCRIPTION
Tested using:

``` javascript
var local = new PouchDB('local')
local.replicate.from('http://shielded-ridge-7287.herokuapp.com/typeit')
```

Which was throwing 304s before but now works fine.
