### PR TITLE
(#1493) - upgrade lie to 2.6.0 which includes all

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "level-sublevel": "~5.2.0",
     "leveldown": "~0.10.2",
     "levelup": "~0.18.2",
-    "lie": "^2.5.4",
+    "lie": "^2.6.0",
     "pouchdb-mapreduce": "1.0.0",
     "request": "~2.28.0"
   },


### PR DESCRIPTION
lack of all has been a complaint which this now fixes along with bringing lie up to version 1.1 of the spec
