### PR TITLE
1533 reformat adapter.js to be < 80 char/line

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -24,7 +24,7 @@ function arrayFirst(arr, callback) {
 // Wrapper for functions that call the bulkdocs api with a single doc,
 // if the first result is an error, return an error
 function yankError(callback) {
-  return function(err, results) {
+  return function (err, results) {
     if (err || results[0].error) {
       callback(err || results[0]);
     } else {
@@ -38,7 +38,7 @@ function yankError(callback) {
 function computeHeight(revs) {
   var height = {};
   var edges = [];
-  merge.traverseRevTree(revs, function(isLeaf, pos, id, prnt) {
+  merge.traverseRevTree(revs, function (isLeaf, pos, id, prnt) {
     var rev = pos + "-" + id;
     if (isLeaf) {
       height[rev] = 0;
@@ -53,7 +53,7 @@ function computeHeight(revs) {
   });
 
   edges.reverse();
-  edges.forEach(function(edge) {
+  edges.forEach(function (edge) {
     if (height[edge.from] === undefined) {
       height[edge.from] = 1 + height[edge.to];
     } else {
@@ -69,22 +69,22 @@ module.exports = AbstractPouchDB;
 function AbstractPouchDB() {
   var self = this;
   EventEmitter.call(this);
-  self.autoCompact = function(callback) {
+  self.autoCompact = function (callback) {
     if (!self.auto_compaction) {
       return callback;
     }
-    return function(err, res) {
+    return function (err, res) {
       if (err) {
         callback(err);
       } else {
         var count = res.length;
-        var decCount = function() {
+        var decCount = function () {
           count--;
           if (!count) {
             callback(null, res);
           }
         };
-        res.forEach(function(doc) {
+        res.forEach(function (doc) {
           if (doc.ok) {
             // TODO: we need better error handling
             self.compactDocument(doc.id, 1, decCount);
@@ -98,7 +98,7 @@ function AbstractPouchDB() {
 
   var listeners = 0, changes;
   var eventNames = [ 'change', 'delete', 'create', 'update' ];
-  this.on('newListener', function(eventName) {
+  this.on('newListener', function (eventName) {
     if (~eventNames.indexOf(eventName)) {
       if (listeners) {
         listeners++;
@@ -115,7 +115,7 @@ function AbstractPouchDB() {
       include_docs : true,
       continuous : true,
       since : 'latest',
-      onChange : function(change) {
+      onChange : function (change) {
         if (change.seq <= lastChange) {
           return;
         }
@@ -131,7 +131,7 @@ function AbstractPouchDB() {
       }
     });
   });
-  this.on('removeListener', function(eventName) {
+  this.on('removeListener', function (eventName) {
     if (~eventNames.indexOf(eventName)) {
       listeners--;
       if (listeners) {
@@ -145,7 +145,7 @@ function AbstractPouchDB() {
 }
 
 AbstractPouchDB.prototype.post =
-    utils.adapterFun('post', function(doc, opts, callback) {
+    utils.adapterFun('post', function (doc, opts, callback) {
       if (typeof opts === 'function') {
         callback = opts;
         opts = {};
@@ -159,7 +159,7 @@ AbstractPouchDB.prototype.post =
     });
 
 AbstractPouchDB.prototype.put =
-    utils.adapterFun('put', utils.getArguments(function(args) {
+    utils.adapterFun('put', utils.getArguments(function (args) {
       var temp, temptype, opts, callback;
       var doc = args.shift();
       var id = '_id' in doc;
@@ -196,7 +196,7 @@ AbstractPouchDB.prototype.put =
     }));
 
 AbstractPouchDB.prototype.putAttachment =
-    utils.adapterFun('putAttachment', function(docId, attachmentId, rev, blob,
+    utils.adapterFun('putAttachment', function (docId, attachmentId, rev, blob,
         type, callback) {
       var api = this;
       if (typeof type === 'function') {
@@ -220,7 +220,7 @@ AbstractPouchDB.prototype.putAttachment =
         api.put(doc, callback);
       }
 
-      api.get(docId, function(err, doc) {
+      api.get(docId, function (err, doc) {
         // create new doc
         if (err && err.error === errors.MISSING_DOC.error) {
           createAttachment({
@@ -243,10 +243,10 @@ AbstractPouchDB.prototype.putAttachment =
     });
 
 AbstractPouchDB.prototype.removeAttachment =
-    utils.adapterFun('removeAttachment', function(docId, attachmentId, rev,
+    utils.adapterFun('removeAttachment', function (docId, attachmentId, rev,
         callback) {
       var self = this;
-      self.get(docId, function(err, obj) {
+      self.get(docId, function (err, obj) {
         if (err) {
           callback(err);
           return;
@@ -267,7 +267,7 @@ AbstractPouchDB.prototype.removeAttachment =
     });
 
 AbstractPouchDB.prototype.remove =
-    utils.adapterFun('remove', function(doc, opts, callback) {
+    utils.adapterFun('remove', function (doc, opts, callback) {
       if (typeof opts === 'function') {
         callback = opts;
         opts = {};
@@ -288,7 +288,7 @@ AbstractPouchDB.prototype.remove =
     });
 
 AbstractPouchDB.prototype.revsDiff =
-    utils.adapterFun('revsDiff', function(req, opts, callback) {
+    utils.adapterFun('revsDiff', function (req, opts, callback) {
       if (typeof opts === 'function') {
         callback = opts;
         opts = {};
@@ -311,7 +311,7 @@ AbstractPouchDB.prototype.revsDiff =
         // Is this fast enough? Maybe we should switch to a set simulated by a
         // map
         var missingForId = req[id].slice(0);
-        merge.traverseRevTree(rev_tree, function(isLeaf, pos, revHash, ctx,
+        merge.traverseRevTree(rev_tree, function (isLeaf, pos, revHash, ctx,
             opts) {
           var rev = pos + '-' + revHash;
           var idx = missingForId.indexOf(rev);
@@ -327,13 +327,13 @@ AbstractPouchDB.prototype.revsDiff =
 
         // Traversing the tree is synchronous, so now `missingForId` contains
         // revisions that were not found in the tree
-        missingForId.forEach(function(rev) {
+        missingForId.forEach(function (rev) {
           addToMissing(id, rev);
         });
       }
 
-      ids.map(function(id) {
-        this._getRevisionTree(id, function(err, rev_tree) {
+      ids.map(function (id) {
+        this._getRevisionTree(id, function (err, rev_tree) {
           if (err && err.name === 'not_found' && err.message === 'missing') {
             missing[id] = {
               missing : req[id]
@@ -355,22 +355,22 @@ AbstractPouchDB.prototype.revsDiff =
 // by compacting we mean removing all revisions which
 // are further from the leaf in revision tree than max_height
 AbstractPouchDB.prototype.compactDocument =
-    function(docId, max_height, callback) {
+    function (docId, max_height, callback) {
       var self = this;
-      this._getRevisionTree(docId, function(err, rev_tree) {
+      this._getRevisionTree(docId, function (err, rev_tree) {
         if (err) {
           return callback(err);
         }
         var height = computeHeight(rev_tree);
         var candidates = [];
         var revs = [];
-        Object.keys(height).forEach(function(rev) {
+        Object.keys(height).forEach(function (rev) {
           if (height[rev] > max_height) {
             candidates.push(rev);
           }
         });
 
-        merge.traverseRevTree(rev_tree, function(isLeaf, pos, revHash, ctx,
+        merge.traverseRevTree(rev_tree, function (isLeaf, pos, revHash, ctx,
             opts) {
           var rev = pos + '-' + revHash;
           if (opts.status === 'available' && candidates.indexOf(rev) !== -1) {
@@ -385,14 +385,14 @@ AbstractPouchDB.prototype.compactDocument =
 // compact the whole database using single document
 // compaction
 AbstractPouchDB.prototype.compact =
-    utils.adapterFun('compact', function(opts, callback) {
+    utils.adapterFun('compact', function (opts, callback) {
       if (typeof opts === 'function') {
         callback = opts;
         opts = {};
       }
       var self = this;
       this.changes({
-        complete : function(err, res) {
+        complete : function (err, res) {
           if (err) {
             callback(); // TODO: silently fail
             return;
@@ -402,8 +402,8 @@ AbstractPouchDB.prototype.compact =
             callback();
             return;
           }
-          res.results.forEach(function(row) {
-            self.compactDocument(row.id, 0, function() {
+          res.results.forEach(function (row) {
+            self.compactDocument(row.id, 0, function () {
               count--;
               if (!count) {
                 callback();
@@ -419,7 +419,7 @@ AbstractPouchDB.prototype.compact =
  * _[method]
  */
 AbstractPouchDB.prototype.get =
-    utils.adapterFun('get', function(id, opts, callback) {
+    utils.adapterFun('get', function (id, opts, callback) {
       if (typeof opts === 'function') {
         callback = opts;
         opts = {};
@@ -436,12 +436,12 @@ AbstractPouchDB.prototype.get =
           return callback(null, result);
         }
         // order with open_revs is unspecified
-        leaves.forEach(function(leaf) {
+        leaves.forEach(function (leaf) {
           self.get(id, {
             rev : leaf,
             revs : opts.revs,
             attachments : opts.attachments
-          }, function(err, doc) {
+          }, function (err, doc) {
             if (!err) {
               result.push({
                 ok : doc
@@ -461,13 +461,13 @@ AbstractPouchDB.prototype.get =
 
       if (opts.open_revs) {
         if (opts.open_revs === "all") {
-          this._getRevisionTree(id, function(err, rev_tree) {
+          this._getRevisionTree(id, function (err, rev_tree) {
             if (err) {
               // if there's no such document we should treat this
               // situation the same way as if revision tree was empty
               rev_tree = [];
             }
-            leaves = merge.collectLeaves(rev_tree).map(function(leaf) {
+            leaves = merge.collectLeaves(rev_tree).map(function (leaf) {
               return leaf.rev;
             });
             finishOpenRevs();
@@ -492,7 +492,7 @@ AbstractPouchDB.prototype.get =
         return; // open_revs does not like other options
       }
 
-      return this._get(id, opts, function(err, result) {
+      return this._get(id, opts, function (err, result) {
         opts = utils.extend(true, {}, opts);
         if (err) {
           return callback(err);
@@ -511,13 +511,13 @@ AbstractPouchDB.prototype.get =
 
         if (opts.revs || opts.revs_info) {
           var paths = merge.rootToLeaf(metadata.rev_tree);
-          var path = arrayFirst(paths, function(arr) {
-            return arr.ids.map(function(x) {
+          var path = arrayFirst(paths, function (arr) {
+            return arr.ids.map(function (x) {
               return x.id;
             }).indexOf(doc._rev.split('-')[1]) !== -1;
           });
 
-          path.ids.splice(path.ids.map(function(x) {
+          path.ids.splice(path.ids.map(function (x) {
             return x.id;
           }).indexOf(doc._rev.split('-')[1]) + 1);
           path.ids.reverse();
@@ -525,14 +525,14 @@ AbstractPouchDB.prototype.get =
           if (opts.revs) {
             doc._revisions = {
               start : (path.pos + path.ids.length) - 1,
-              ids : path.ids.map(function(rev) {
+              ids : path.ids.map(function (rev) {
                 return rev.id;
               })
             };
           }
           if (opts.revs_info) {
             var pos = path.pos + path.ids.length;
-            doc._revs_info = path.ids.map(function(rev) {
+            doc._revs_info = path.ids.map(function (rev) {
               pos--;
               return {
                 rev : pos + '-' + rev.id,
@@ -552,11 +552,11 @@ AbstractPouchDB.prototype.get =
           if (count === 0) {
             return callback(null, doc);
           }
-          Object.keys(attachments).forEach(function(key) {
+          Object.keys(attachments).forEach(function (key) {
             this._getAttachment(attachments[key], {
               encode : true,
               ctx : ctx
-            }, function(err, data) {
+            }, function (err, data) {
               doc._attachments[key].data = data;
               if (!--count) {
                 callback(null, doc);
@@ -565,7 +565,7 @@ AbstractPouchDB.prototype.get =
           }, self);
         } else {
           if (doc._attachments) {
-            for ( var key in doc._attachments) {
+            for (var key in doc._attachments) {
               if (doc._attachments.hasOwnProperty(key)) {
                 doc._attachments[key].stub = true;
               }
@@ -577,7 +577,7 @@ AbstractPouchDB.prototype.get =
     });
 
 AbstractPouchDB.prototype.getAttachment =
-    utils.adapterFun('getAttachment', function(docId, attachmentId, opts,
+    utils.adapterFun('getAttachment', function (docId, attachmentId, opts,
         callback) {
       var self = this;
       if (opts instanceof Function) {
@@ -585,7 +585,7 @@ AbstractPouchDB.prototype.getAttachment =
         opts = {};
       }
       opts = utils.extend(true, {}, opts);
-      this._get(docId, opts, function(err, res) {
+      this._get(docId, opts, function (err, res) {
         if (err) {
           return callback(err);
         }
@@ -600,7 +600,7 @@ AbstractPouchDB.prototype.getAttachment =
     });
 
 AbstractPouchDB.prototype.allDocs =
-    utils.adapterFun('allDocs', function(opts, callback) {
+    utils.adapterFun('allDocs', function (opts, callback) {
       if (typeof opts === 'function') {
         callback = opts;
         opts = {};
@@ -608,12 +608,12 @@ AbstractPouchDB.prototype.allDocs =
       opts = utils.extend(true, {}, opts);
       if ('keys' in opts) {
         var incompatibleOpt =
-            [ 'startkey', 'endkey', 'key' ].filter(function(incompatibleOpt) {
+            [ 'startkey', 'endkey', 'key' ].filter(function (incompatibleOpt) {
               return incompatibleOpt in opts;
             })[0];
         if (incompatibleOpt) {
-          callback(errors.error(errors.QUERY_PARSE_ERROR, 'Query parameter `'
-              + incompatibleOpt + '` is not compatible with multi-get'));
+          callback(errors.error(errors.QUERY_PARSE_ERROR, 'Query parameter `' +
+              incompatibleOpt + '` is not compatible with multi-get'));
           return;
         }
       }
@@ -629,7 +629,7 @@ function processChange(doc, metadata, opts) {
     rev : doc._rev
   } ];
   if (opts.style === 'all_docs') {
-    changeList = merge.collectLeaves(metadata.rev_tree).map(function(x) {
+    changeList = merge.collectLeaves(metadata.rev_tree).map(function (x) {
       return {
         rev : x.rev
       };
@@ -667,7 +667,7 @@ function doChanges(api, opts, promise) {
     opts.since = 0;
   }
   if (opts.since === 'latest') {
-    api.info(function(err, info) {
+    api.info(function (err, info) {
       if (promise.isCancelled) {
         callback(null, {
           status : 'cancelled'
@@ -689,7 +689,7 @@ function doChanges(api, opts, promise) {
       if (opts.view && typeof opts.view === 'string') {
         // fetch a view from a design doc, make it behave like a filter
         var viewName = opts.view.split('/');
-        api.get('_design/' + viewName[0], function(err, ddoc) {
+        api.get('_design/' + viewName[0], function (err, ddoc) {
           if (promise.isCancelled) {
             callback(null, {
               status : 'cancelled'
@@ -703,13 +703,13 @@ function doChanges(api, opts, promise) {
           if (ddoc && ddoc.views && ddoc.views[viewName[1]]) {
             /* jshint evil: true */
             var filter =
-                eval('(function () {' + '  return function (doc) {'
-                    + '    var emitted = false;'
-                    + '    var emit = function (a, b) {'
-                    + '      emitted = true;' + '    };' + '    var view = '
-                    + ddoc.views[viewName[1]].map + ';' + '    view(doc);'
-                    + '    if (emitted) {' + '      return true;' + '    }'
-                    + '  }' + '})()');
+                eval('(function () {' + '  return function (doc) {' +
+                    '    var emitted = false;' +
+                    '    var emit = function (a, b) {' +
+                    '      emitted = true;' + '    };' + '    var view = ' +
+                    ddoc.views[viewName[1]].map + ';' + '    view(doc);' +
+                    '    if (emitted) {' + '      return true;' + '    }' +
+                    '  }' + '})()');
             opts.filter = filter;
             doChanges(api, opts, promise, callback);
             return;
@@ -732,7 +732,7 @@ function doChanges(api, opts, promise) {
     } else {
       // fetch a filter from a design doc
       var filterName = opts.filter.split('/');
-      api.get('_design/' + filterName[0], function(err, ddoc) {
+      api.get('_design/' + filterName[0], function (err, ddoc) {
         if (promise.isCancelled) {
           callback(null, {
             status : 'cancelled'
@@ -746,8 +746,8 @@ function doChanges(api, opts, promise) {
         if (ddoc && ddoc.filters && ddoc.filters[filterName[1]]) {
           /* jshint evil: true */
           var filter =
-              eval('(function () { return ' + ddoc.filters[filterName[1]]
-                  + ' })()');
+              eval('(function () { return ' + ddoc.filters[filterName[1]] +
+                  ' })()');
           opts.filter = filter;
           doChanges(api, opts, promise, callback);
           return;
@@ -774,14 +774,14 @@ function doChanges(api, opts, promise) {
   var newPromise = api._changes(opts);
   if (newPromise && typeof newPromise.cancel === 'function') {
     var cancel = promise.cancel;
-    promise.cancel = utils.getArguments(function(args) {
+    promise.cancel = utils.getArguments(function (args) {
       newPromise.cancel();
       cancel.apply(this, args);
     });
   }
 }
 
-AbstractPouchDB.prototype.changes = function(opts, promise) {
+AbstractPouchDB.prototype.changes = function (opts, promise) {
 
   var self = this;
 
@@ -799,12 +799,12 @@ AbstractPouchDB.prototype.changes = function(opts, promise) {
   }
 
   opts = opts ? utils.extend(true, {}, opts) : {};
-  opts.complete = opts.complete || function() {
+  opts.complete = opts.complete || function () {
   };
   var complete = utils.once(opts.complete);
 
-  promise = new Promise(function(fulfill, reject) {
-    opts.complete = function(err, res) {
+  promise = new Promise(function (fulfill, reject) {
+    opts.complete = function (err, res) {
       if (err) {
         reject(err);
       } else {
@@ -813,15 +813,15 @@ AbstractPouchDB.prototype.changes = function(opts, promise) {
     };
   });
 
-  promise.then(function(result) {
+  promise.then(function (result) {
     complete(null, result);
-  }, function(err) {
+  }, function (err) {
     complete(err);
   });
 
   // this will be overwritten in doChanges, dont fire complete until
   // the task is ready
-  promise.cancel = function() {
+  promise.cancel = function () {
     promise.isCancelled = true;
     if (self.taskqueue.isReady) {
       opts.complete(null, {
@@ -839,36 +839,37 @@ AbstractPouchDB.prototype.changes = function(opts, promise) {
   }
 };
 
-AbstractPouchDB.prototype.close = utils.adapterFun('close', function(callback) {
-  return this._close(callback);
-});
+AbstractPouchDB.prototype.close =
+    utils.adapterFun('close', function (callback) {
+      return this._close(callback);
+    });
 
 AbstractPouchDB.prototype.info =
-    utils.adapterFun('info', function(callback) {
+    utils.adapterFun('info', function (callback) {
       var self = this;
-      this._info(function(err, info) {
+      this._info(function (err, info) {
         if (err) {
           return callback(err);
         }
         var len = self.prefix.length;
-        if (info.db_name.length > len
-            && info.db_name.slice(0, len) === self.prefix) {
+        if (info.db_name.length > len &&
+            info.db_name.slice(0, len) === self.prefix) {
           info.db_name = info.db_name.slice(len);
         }
         callback(null, info);
       });
     });
 
-AbstractPouchDB.prototype.id = utils.adapterFun('id', function(callback) {
+AbstractPouchDB.prototype.id = utils.adapterFun('id', function (callback) {
   return this._id(callback);
 });
 
-AbstractPouchDB.prototype.type = function() {
+AbstractPouchDB.prototype.type = function () {
   return (typeof this._type === 'function') ? this._type() : this.adapter;
 };
 
 AbstractPouchDB.prototype.bulkDocs =
-    utils.adapterFun('bulkDocs', function(req, opts, callback) {
+    utils.adapterFun('bulkDocs', function (req, opts, callback) {
       if (typeof opts === 'function') {
         callback = opts;
         opts = {};


### PR DESCRIPTION
Done using eclipse's formatter, and then manually fixing some lines to comply with the style guide.

Some of the spacing, other line breaks changed, and )'s and }'s now align with the line containing the ( or {.
