### PR TITLE
(#1658) - index method for plugins

### DIFF
--- a/docs/_layouts/learn.html
+++ b/docs/_layouts/learn.html
@@ -15,6 +15,7 @@ layout: default
             <li><a href="{{ site.baseurl }}/faq.html">FAQ</a></li>
             <li><a href="{{ site.baseurl }}/errors.html">Common Errors</a></li>
             <li><a href="{{ site.baseurl }}/external.html">External Projects</a></li>
+            <li><a href="{{ site.baseurl }}/plugins.html">Write Plugins</a></li>
 
             <li><h3>API</h3></li>
             <li><a href="api.html#create_database">Create database</a></li>

--- a/docs/api.md
+++ b/docs/api.md
@@ -759,28 +759,3 @@ PouchDB.on('destroyed', function (dbName) {
   // called whenver a db is destroyed.
 });
 {% endhighlight %}
-
-{% include anchor.html title="Plugins" %}
-
-Writing a plugin is easy! The api is:
-
-{% highlight js %}
-PouchDB.plugin({
-  methodName: myFunction
-  }
-});
-{% endhighlight %}
-
-This will add the function as a method of all databases with the given method name.  It will always be called in context, so that `this` always refers to the database object.
-
-#### Example Usage:
-{% highlight js %}
-PouchDB.plugin({
-  sayMyName : function () {
-    this.info().then(function (info)   {
-      console.log('My name is ' + info.db_name);
-    }).catch(function (err) { });
-  }
-});
-new PouchDB('foobar').sayMyName(); // prints "My name is foobar"
-{% endhighlight %}

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,227 @@
+---
+layout: learn
+title: Write Plugins - PouchDB
+---
+
+# PouchDB Plugins
+
+Writing a plugin is easy! The API is:
+
+{% highlight js %}
+PouchDB.plugin({
+  methodName: myFunction
+  }
+});
+{% endhighlight %}
+
+This will add the function as a method of all databases with the given method name.  It will always be called in context, so that `this` always refers to the database object.
+
+#### Example Usage:
+{% highlight js %}
+PouchDB.plugin({
+  sayMyName : function () {
+    this.info().then(function (info)   {
+      console.log('My name is ' + info.db_name);
+    }).catch(function (err) { });
+  }
+});
+new PouchDB('foobar').sayMyName(); // prints "My name is foobar"
+{% endhighlight %}
+
+#### Index data
+
+Plugins also have access to a special `db.index()` API that gives developers the ability to store plugin-specific metadata in a database. This API has three main features:
+
+1. The stored data is unique per database
+2. It doesn't collide with user data.
+3. It supports pagination as well as a secondary index.
+
+##### Creating/fetching an index
+
+Example:
+
+{% highlight js %}
+PouchDB.plugin({
+  myPluginFunction : function () {
+    var index = this.index('myIndex');
+  }
+});
+{% endhighlight %}
+
+The `index()` function creates a new index or returns an existing index with the given name.
+
+All data stored in the index is bound to that particular index - i.e. indexes with different names do not share any data.
+
+However, the name of the index itself shares a global namespace, so it would be wise to prefix your index names with something like `'myAwesomePlugin-'` to avoid collisions.
+
+##### Putting data
+
+Example:
+
+{% highlight js %}
+PouchDB.plugin({
+  myPluginFunction : function () {
+    this.index('myIndex').put('groupId', {
+      'key1' : 'value1',
+      'key2' : 'value2',
+      'key3' : {
+        'fancy' : 'data',
+        'so' : 'the value can be anything!'
+      }
+    }, function (err) {});
+  }
+});
+{% endhighlight %}
+
+The `put()` function creates or overwrites data in the index.  The `groupId` and `key`s must be strings, but the values can be any valid JavaScript object.
+
+This is an all-or-nothing operation, so if you add new data to `groupId`, any data previously
+associated with `groupId` will be overwritten.  You may `put` an empty object or `null` to delete all associated data.
+
+##### Getting data
+
+Getting data from the index is as simple as specifying the `key`s from the aforementioned object.
+
+The basic method is to specify a simple string `key`:
+
+{% highlight js %}
+PouchDB.plugin({
+  myPluginFunction : function () {
+    this.index('myIndex').get('key1', function (err, result) {
+      /* handle err or result */
+    });
+  }
+});
+{% endhighlight %}
+
+Example response:
+
+{% highlight js %}
+[
+  {
+    "id"    : "groupId",
+    "key"   : "key1",
+    "value" : "value1"
+  }
+]
+{% endhighlight %}
+
+This method returns a list of stored objects that match the given key.  Note that keys are non-unique, and no ordering is guaranteed at the `value`/`groupId` level.
+
+Alternatively, you can specify an options object with the familiar Couch-style
+`startkey`/`endkey`/`descending`/`skip`/`limit`, which behave exactly like those parameters when used in `allDocs()` or `query()`:
+
+
+{% highlight js %}
+PouchDB.plugin({
+  myPluginFunction : function () {
+    this.index('myIndex').get({
+      startkey : 'key1',
+      endkey   : 'key2'
+    }, function (err, result) {
+      /* handle err or result */
+    });
+  }
+});
+{% endhighlight %}
+
+Example response:
+
+{% highlight js %}
+[
+  {
+    "id"    : "groupId",
+    "key"   : "key1",
+    "value" : "value1"
+  },
+  {
+    "id"    : "groupId",
+    "key"   : "key2",
+    "value" : "value2"
+  }
+]
+{% endhighlight %}
+
+Note that the `value`s are passed through `JSON.stringify()` before being stored, so `undefined`s will become `null`s, dates will become strings, etc.
+
+{% highlight js %}
+PouchDB.plugin({
+  myPluginFunction : function () {
+    var index = this.index('myIndex');
+    index.put('groupId', {
+      'key1' : undefined,
+      'key2' : {some : ['arbitrary', 'json', new Date(0)]}
+    });
+    index.get({}, function (err, result) {
+      /* handle err or result */
+    });
+  }
+});
+{% endhighlight %}
+
+Example response:
+
+{% highlight js %}
+[
+  {
+    "id"    : "groupId",
+    "key"   : "key1",
+    "value" : null
+  },
+  {
+    "id"    : "groupId",
+    "key"   : "key2",
+    "value" : {
+      "some" : [
+        "arbitrary",
+        "json",
+        "1970-01-01T00:00:00.000Z"
+      ]
+    }
+  }
+]
+{% endhighlight %}
+
+##### Counting the items in an index
+
+The `count()` function counts the number of items in an index, i.e. the number of rows you would get if you called `get({})`. This corresponds to the `total_rows` count, in CouchDB vocabulary.
+
+{% highlight js %}
+PouchDB.plugin({
+  myPluginFunction : function () {
+    var index = this.index('myIndex');
+    index.count(function (err, result) {
+      /* handle err or result */
+    });
+  }
+});
+{% endhighlight %}
+
+In this case the `result` will be an nonnegative integer (assuming no error).
+
+##### Destroying an index
+
+{% highlight js %}
+PouchDB.plugin({
+  myPluginFunction : function () {
+    this.index('myIndex').destroy(function (err) {
+      /* handle err or success */
+    });
+  }
+});
+{% endhighlight %}
+
+The `destroy()` function removes all data associated with the index.
+
+
+##### Uses
+
+The most common use case for this API would be for storing document-specific data that requires range queries on the keys emitted by those documents.
+
+For instance, you could implement a search plugin where the `groupId`s are document IDs and the `key`s are terms found in that document.  When a user searches for a term, you page through all documents that match that term using `get()`.  When a document is deleted or updated, you remove or update all the document's associated terms using `put()`.
+
+Keep in mind that plugin data is only stored locally, so it doesn't apply to remote CouchDB databases.  See the [Map/Reduce plugin][mapreduce] for a more full-fledged example of how to use this API.
+
+  [mapreduce]: https://github.com/pouchdb/mapreduce
+
+

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -794,6 +794,13 @@ AbstractPouchDB.prototype.id = utils.adapterFun('id', function (callback) {
   return this._id(callback);
 });
 
+AbstractPouchDB.prototype.index = function (name) {
+  if (typeof name !== 'string') {
+    throw new Error('name must be a string');
+  }
+  return this._index(name);
+};
+
 AbstractPouchDB.prototype.type = function () {
   return (typeof this._type === 'function') ? this._type() : this.adapter;
 };

--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -4,10 +4,45 @@ var utils = require('../utils');
 var merge = require('../merge');
 var errors = require('../deps/errors');
 
+// IndexedDB requires a versioned database structure, so we use the
+// version here to manage migrations.
+var ADAPTER_VERSION = 3;
+
+// The object stores created for each database
+// DOC_STORE stores the document meta data, its revision history and state
+var DOC_STORE = 'document-store';
+// BY_SEQ_STORE stores a particular version of a document, keyed by its
+// sequence id
+var BY_SEQ_STORE = 'by-sequence';
+// Where we store attachments
+var ATTACH_STORE = 'attach-store';
+// Where we store meta data
+var META_STORE = 'meta-store';
+// Where we detect blob support
+var DETECT_BLOB_SUPPORT_STORE = 'detect-blob-support';
+// Where we store plugin data
+var PLUGIN_DATA_STORE = 'plugin-data';
+
 function idbError(callback) {
   return function (event) {
     callback(errors.error(errors.IDB_ERROR, event.target, event.type));
   };
+}
+
+function createComplexKey(arr) {
+  // to support IE, use strings instead of complex keys
+  arr = arr.map(function (key) {
+    // We've to be sure that key does not contain \u0000
+    // Do order-preserving replacements:
+    // 0 -> 1, 1
+    // 1 -> 1, 2
+    // 2 -> 2, 2
+    key = key.replace(/\u0002/g, '\u0002\u0002');
+    key = key.replace(/\u0001/g, '\u0001\u0002');
+    key = key.replace(/\u0000/g, '\u0001\u0001');
+    return key;
+  });
+  return arr.join('\u0000');
 }
 
 function isModernIdb() {
@@ -35,23 +70,6 @@ function isModernIdb() {
 }
 function IdbPouch(opts, callback) {
 
-  // IndexedDB requires a versioned database structure, so we use the
-  // version here to manage migrations.
-  var ADAPTER_VERSION = 2;
-
-  // The object stores created for each database
-  // DOC_STORE stores the document meta data, its revision history and state
-  var DOC_STORE = 'document-store';
-  // BY_SEQ_STORE stores a particular version of a document, keyed by its
-  // sequence id
-  var BY_SEQ_STORE = 'by-sequence';
-  // Where we store attachments
-  var ATTACH_STORE = 'attach-store';
-  // Where we store meta data
-  var META_STORE = 'meta-store';
-  // Where we detect blob support
-  var DETECT_BLOB_SUPPORT_STORE = 'detect-blob-support';
-
   var name = opts.name;
   var req = global.indexedDB.open(name, ADAPTER_VERSION);
 
@@ -74,6 +92,9 @@ function IdbPouch(opts, callback) {
     if (e.oldVersion < 2) {
       // version 2 adds the deletedOrLocal index
       addDeletedOrLocalIndex(e);
+    }
+    if (e.oldVersion < 3) {
+      addPluginData(db);
     }
   };
 
@@ -103,6 +124,15 @@ function IdbPouch(opts, callback) {
         docStore.createIndex('deletedOrLocal', 'deletedOrLocal', {unique : false});
       }
     };
+  }
+
+  function addPluginData(db) {
+
+    var pluginStore = db.createObjectStore(PLUGIN_DATA_STORE, {keyPath : 'primaryKey'});
+    pluginStore.createIndex('name', 'name', {unique : false});
+
+    pluginStore.createIndex('nameAndId', 'nameAndId', {unique : false});
+    pluginStore.createIndex('nameAndKey', 'nameAndKey', {unique : false});
   }
 
   req.onsuccess = function (e) {
@@ -927,6 +957,10 @@ function IdbPouch(opts, callback) {
     };
   };
 
+  api._index = function (indexName) {
+    return new Index(idb, indexName);
+  };
+
 }
 
 IdbPouch.valid = function () {
@@ -957,5 +991,216 @@ IdbPouch.destroy = utils.toPromise(function (name, opts, callback) {
 });
 
 IdbPouch.Changes = new utils.Changes();
+
+
+function Index(idb, indexName) {
+  this.idb = idb;
+  this.name = indexName;
+}
+
+Index.prototype.put = utils.toPromise(function (id, keyValues, callback) {
+  var self = this;
+
+  if (typeof id !== 'string') {
+    return callback(errors.error(errors.IDB_ERROR, 'id must be a string', 'id-must-be-string'));
+  }
+
+  var txn = self.idb.transaction([PLUGIN_DATA_STORE], 'readwrite');
+
+  var store = txn.objectStore(PLUGIN_DATA_STORE);
+  var index = store.index('nameAndId');
+
+  function putNewKeyValues() {
+    if (!keyValues) {
+      // delete all the mappings
+      return;
+    }
+    Object.keys(keyValues).forEach(function (key) {
+      var value = keyValues[key];
+      value = (typeof value === 'undefined') ? null : value;
+      store.put({
+        primaryKey : utils.uuid(),
+        name : self.name,
+        id : id,
+        key : key,
+        value : JSON.parse(JSON.stringify(value)), // convert undefined to null
+        nameAndId : createComplexKey([self.name, id]),
+        nameAndKey : createComplexKey([self.name, key])
+      });
+    });
+  }
+
+  var oCursor = index.openCursor(global.IDBKeyRange.only(
+    createComplexKey([self.name, id])));
+  oCursor.onsuccess = function (event) {
+    var cursor = event.target.result;
+
+    if (!cursor) {
+      putNewKeyValues();
+      return;
+    }
+
+    var doc = cursor.value;
+    store.delete(doc.primaryKey);
+
+    cursor['continue']();
+  };
+
+  txn.onerror = idbError(callback);
+  txn.oncomplete = function () {
+    callback();
+  };
+});
+
+Index.prototype.count = utils.toPromise(function (callback) {
+  var self = this;
+
+  var count;
+
+  var txn = self.idb.transaction([PLUGIN_DATA_STORE], 'readonly');
+  var index = txn.objectStore(PLUGIN_DATA_STORE).index('name');
+  index.count(global.IDBKeyRange.only(self.name)).onsuccess = function (e) {
+    count = e.target.result;
+  };
+
+  txn.onerror = idbError(callback);
+  txn.oncomplete = function () {
+    callback(null, count);
+  };
+});
+
+Index.prototype.get = utils.toPromise(function (opts, callback) {
+  var self = this;
+
+  var key;
+  var start;
+  var end;
+  var descending;
+  var skip;
+  var limit;
+
+  if (typeof opts === 'string') {
+    key = opts;
+  } else if (typeof opts === 'object' && !Array.isArray(opts)) {
+    start = opts.startkey;
+    end = opts.endkey;
+    descending = opts.descending ? 'prev' : null;
+    skip = opts.skip;
+    limit = opts.limit;
+  } else {
+    return callback(new Error('opts must be a string or an object'));
+  }
+  var hasStart = typeof start !== 'undefined' && start !== null;
+  var hasEnd = typeof end !== 'undefined' && end !== null;
+  var hasKey = typeof key !== 'undefined' && key !== null;
+  var hasLimit = typeof limit === 'number';
+  var hasSkip = typeof skip === 'number';
+
+  var hasManualDescEnd;
+  var manualDescEnd;
+  if (descending && hasStart && hasEnd) {
+    // unfortunately IDB has a quirk where IDBKeyRange.bound is invalid if the
+    // start is less than the end, even in descending mode.  Best bet
+    // is just to handle it manually in that case.
+    hasManualDescEnd = true;
+    manualDescEnd = end;
+    hasEnd = false;
+  }
+
+  var startIdbKey = hasStart && createComplexKey([self.name, start]);
+  var endIdbKey = hasEnd && createComplexKey([self.name, end]);
+  var idbKey = hasKey && createComplexKey([self.name, key]);
+  var keyRange;
+  try {
+    keyRange = hasStart && hasEnd ? global.IDBKeyRange.bound(
+        startIdbKey, endIdbKey)
+      : hasStart ? (descending ?
+          global.IDBKeyRange.upperBound(startIdbKey)
+        : global.IDBKeyRange.lowerBound(startIdbKey))
+      : hasEnd ? (descending ?
+          global.IDBKeyRange.lowerBound(endIdbKey)
+        : global.IDBKeyRange.upperBound(endIdbKey))
+      : hasKey ? global.IDBKeyRange.only(idbKey)
+        : global.IDBKeyRange.only(self.name);
+  } catch (e) {
+    if (e.name === "DataError" && e.code === 0) {
+      // data error, start is less than end
+      return callback(null, []); // no docs possible
+    } else {
+      return callback(errors.error(errors.IDB_ERROR, e.name, e.message));
+    }
+  }
+
+  var skipped = 0;
+  var results = [];
+  var txn = self.idb.transaction([PLUGIN_DATA_STORE], 'readonly');
+  var store = txn.objectStore(PLUGIN_DATA_STORE);
+  var index = store.index((hasStart || hasEnd || hasKey) ? 'nameAndKey' : 'name');
+
+  var oCursor = descending ? index.openCursor(keyRange, descending)
+    : index.openCursor(keyRange);
+
+  oCursor.onsuccess = function (e) {
+    var cursor = e.target.result;
+
+    if (!cursor) {
+      return;
+    }
+
+    if (hasSkip && skipped < skip) {
+      skipped++;
+      cursor['continue']();
+    } else if (hasManualDescEnd && manualDescEnd &&
+        cursor.value.key < manualDescEnd) {
+      return;
+    } else if (!hasLimit || results.length < limit) {
+      var doc = cursor.value;
+
+      results.push({
+        id : doc.id,
+        key : doc.key,
+        value : doc.value
+      });
+      cursor['continue']();
+    }
+  };
+
+  txn.onerror = idbError(callback);
+  txn.oncomplete = function () {
+    if (!hasStart && !hasEnd) {
+      // sorting by keys not guaranteed
+      results = results.sort(function (a, b) {
+        return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
+      });
+    }
+    callback(null, results);
+  };
+});
+
+Index.prototype.destroy = utils.toPromise(function (callback) {
+  var self = this;
+
+  var txn = self.idb.transaction([PLUGIN_DATA_STORE], 'readwrite');
+  var store = txn.objectStore(PLUGIN_DATA_STORE);
+  var index = store.index('name');
+  index.openCursor(global.IDBKeyRange.only(self.name)).onsuccess = function (e) {
+    var cursor = e.target.result;
+
+    if (!cursor) {
+      return;
+    }
+
+    var doc = cursor.value;
+    store.delete(doc.primaryKey);
+
+    cursor['continue']();
+  };
+
+  txn.onerror = idbError(callback);
+  txn.oncomplete = function () {
+    callback();
+  };
+});
+
 
 module.exports = IdbPouch;

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -6,6 +6,7 @@ var EventEmitter = require('events').EventEmitter;
 var levelup = require('levelup');
 var leveldown = require("leveldown");
 var sublevel = require('level-sublevel');
+var deleteStream = require('level-delete-stream');
 
 var errors = require('../deps/errors');
 var merge = require('../merge');
@@ -692,6 +693,9 @@ function LevelPouch(opts, callback) {
       });
     }
   });
+  api._index = function (name) {
+    return new Index(db.sublevel('index-' + name, {valueEncoding: 'json'}));
+  };
 }
 
 LevelPouch.valid = function () {
@@ -713,4 +717,148 @@ LevelPouch.destroy = utils.toPromise(function (name, opts, callback) {
 
 LevelPouch.use_prefix = false;
 
+function Index(db) {
+  this.db = db;
+  this.byDoc = db.sublevel('bydoc', {valueEncoding: 'json'});
+  this.byKey = db.sublevel('bykey', {valueEncoding: 'json'});
+  this._count = 0;
+  this._offset = false;
+}
+
+Index.prototype.destroy = utils.toPromise(function (callback) {
+  var self = this;
+  this.byDoc.createKeyStream().pipe(deleteStream(this.byDoc, function (err) {
+    if (err) {
+      return callback(err);
+    }
+    self.byKey.createKeyStream().pipe(deleteStream(self.byKey, callback));
+  }));
+});
+
+Index.prototype.sep = '\x00';
+Index.prototype.endsep = '\xff';
+
+Index.prototype.put = utils.toPromise(function (id, map, callback) {
+  var self = this;
+  self.byDoc.get(id, function (err, resp) {
+    var batch = [];
+    if (!err) {
+      resp.forEach(function (item) {
+        batch.push({
+          key: item,
+          type: 'del',
+          prefix: self.byKey
+        });
+        self._count--;
+      });
+    }
+    var keys = Object.keys(map);
+    
+    if (!keys.length) {
+      if (!err) {
+        batch.push({
+          key: id,
+          type: 'del',
+          prefix: self.byDoc
+        });
+      }
+      return self.db.batch(batch, callback);
+    }
+    var payload = keys.map(function (key) {
+      batch.push({
+        key: key + self.sep + id,
+        value: {
+          key: key,
+          value: typeof map[key] === 'undefined' ? null : map[key],
+          id: id
+        },
+        type: 'put',
+        prefix: self.byKey
+      });
+      self._count++;
+      return key + self.sep + id;
+    });
+    batch.push({
+      key: id,
+      value: payload,
+      type: 'put',
+      prefix: self.byDoc
+    });
+    self.db.batch(batch, callback);
+  });
+});
+
+Index.prototype.get = utils.toPromise(function (opts, callback) {
+  var self = this;
+  var streamOpts = {};
+  var skip;
+  if (typeof opts === 'string') {
+    opts = {
+      startkey : opts,
+      endkey : opts
+    };
+  }
+  if ('descending' in opts) {
+    streamOpts.reverse = opts.descending;
+  }
+  if (streamOpts.reverse) {
+    if ('startkey' in opts) {
+      streamOpts.end = opts.startkey + self.sep + self.endsep;
+    }
+    if ('endkey' in opts) {
+      streamOpts.start = opts.endkey + self.sep;
+    }
+  } else {
+    if ('startkey' in opts) {
+      streamOpts.start = opts.startkey + self.sep;
+    }
+    if ('endkey' in opts) {
+      streamOpts.end = opts.endkey + self.sep + self.endsep;
+    }
+  }
+  skip = opts.skip;
+  if ('limit' in opts) {
+    streamOpts.limit = opts.limit;
+  } else {
+    streamOpts.limit = -1;
+  }
+  if (skip && streamOpts.limit !== -1) {
+    streamOpts.limit += skip;
+  }
+  if (typeof streamOpts.start !== 'undefined' && typeof streamOpts.end !== 'undefined') {
+    if (streamOpts.start > streamOpts.end) {
+      return callback(null, []);
+    }
+  }
+  streamOpts.valueEncoding = 'json';
+  var stream = this.byKey.createReadStream(streamOpts);
+
+  var output = [];
+  stream.on('data', function (item) {
+    if (skip) {
+      skip--;
+    } else {
+      output.push(item.value);
+    }
+  });
+  stream.on('error', callback);
+  stream.on('end', function () {
+    callback(null, output);
+  });
+});
+
+Index.prototype.count = utils.toPromise(function (callback) {
+  var self = this;
+  var total = 0;
+  if (this._offset === false) {
+    return self.byKey.createReadStream().on('data', function () {
+      total++;
+    }).on('end', function () {
+      this._offset = true;
+      self._count = total;
+      callback(null, total);
+    }).on('error', callback);
+  }
+  callback(null, self._count);
+});
 module.exports = LevelPouch;

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -24,7 +24,7 @@ var openDB = utils.getArguments(function (args) {
 
 var POUCH_VERSION = 1;
 var POUCH_SIZE = 5 * 1024 * 1024;
-var ADAPTER_VERSION = 2; // used to manage migrations
+var ADAPTER_VERSION = 3; // used to manage migrations
 
 // The object stores created for each database
 // DOC_STORE stores the document meta data, its revision history and state
@@ -35,6 +35,15 @@ var BY_SEQ_STORE = quote('by-sequence');
 // Where we store attachments
 var ATTACH_STORE = quote('attach-store');
 var META_STORE = quote('metadata-store');
+var PLUGIN_DATA_STORE = quote('plugin-data');
+
+var CREATE_PLUGIN_DATA_STORE_SQL = 'CREATE TABLE IF NOT EXISTS ' + PLUGIN_DATA_STORE +
+  ' (name, id, key, value)';
+var PLUGIN_DATA_NAME_ID_INDEX_SQL = 'CREATE INDEX IF NOT EXISTS \'plugin-data-key-idx\' ON ' +
+  PLUGIN_DATA_STORE + '(name, id)';
+var PLUGIN_DATA_NAME_KEY_INDEX_SQL = 'CREATE INDEX IF NOT EXISTS \'plugin-data-key-idx\' ON ' +
+  PLUGIN_DATA_STORE + '(name, key)';
+
 
 // these indexes cover the ground for most allDocs queries
 var BY_SEQ_STORE_DELETED_INDEX_SQL = 'CREATE INDEX IF NOT EXISTS \'by-seq-deleted-idx\' ON ' +
@@ -167,6 +176,13 @@ function WebSqlPouch(opts, callback) {
     });
   }
 
+  function runMigration3(tx) {
+    tx.executeSql(CREATE_PLUGIN_DATA_STORE_SQL, [], function () {
+      tx.executeSql(PLUGIN_DATA_NAME_ID_INDEX_SQL);
+      tx.executeSql(PLUGIN_DATA_NAME_KEY_INDEX_SQL);
+    });
+  }
+
   function onGetInstanceId() {
     while (idRequests.length > 0) {
       var idCallback = idRequests.pop();
@@ -203,14 +219,18 @@ function WebSqlPouch(opts, callback) {
         tx.executeSql(initSeq, [0, ADAPTER_VERSION, instanceId]);
         onGetInstanceId();
       });
+      runMigration3(tx);
     } else { // version > 0
-
-      if (dbVersion === 1) {
+      if (dbVersion < 2) {
         runMigration2(tx);
+      }
+      if (dbVersion < 3) {
+        runMigration3(tx);
+      }
+      if (dbVersion < ADAPTER_VERSION) {
         // mark the db version within this transaction
         tx.executeSql('UPDATE ' + META_STORE + ' SET db_version = ' + ADAPTER_VERSION);
-      } // in the future, add more migrations here
-
+      }
       // notify db.id() callers
       tx.executeSql('SELECT dbid FROM ' + META_STORE, [], function (tx, result) {
         instanceId = result.rows.item(0).dbid;
@@ -872,6 +892,10 @@ function WebSqlPouch(opts, callback) {
       });
     });
   };
+
+  api._index = function (indexName) {
+    return new Index(db, indexName);
+  };
 }
 
 WebSqlPouch.valid = function () {
@@ -894,6 +918,7 @@ WebSqlPouch.destroy = utils.toPromise(function (name, opts, callback) {
     tx.executeSql('DROP TABLE IF EXISTS ' + BY_SEQ_STORE, []);
     tx.executeSql('DROP TABLE IF EXISTS ' + ATTACH_STORE, []);
     tx.executeSql('DROP TABLE IF EXISTS ' + META_STORE, []);
+    tx.executeSql('DROP TABLE IF EXISTS ' + PLUGIN_DATA_STORE, []);
   }, unknownError(callback), function () {
     if (utils.hasLocalStorage()) {
       delete global.localStorage['_pouch__websqldb_' + name];
@@ -903,5 +928,129 @@ WebSqlPouch.destroy = utils.toPromise(function (name, opts, callback) {
 });
 
 WebSqlPouch.Changes = new utils.Changes();
+
+function Index(db, indexName) {
+  this.db = db;
+  this.name = indexName;
+}
+
+Index.prototype.put = utils.toPromise(function (id, keyValues, callback) {
+  var self = this;
+
+  if (typeof id !== 'string') {
+    return callback(errors.error(errors.WSQ_ERROR, 'id must be a string', 'id-must-be-string'));
+  }
+
+  self.db.transaction(function (tx) {
+    var deleteSql = 'DELETE FROM ' + PLUGIN_DATA_STORE + ' WHERE name = ? AND id = ?';
+    tx.executeSql(deleteSql, [self.name, id], function () {
+      if (!keyValues) { // delete all
+        return;
+      }
+      var insertSql = 'INSERT INTO ' + PLUGIN_DATA_STORE +
+        ' (name, id, key, value) VALUES (?,?,?,?)';
+
+      Object.keys(keyValues).forEach(function (key) {
+        var value = keyValues[key];
+        value = typeof value === 'undefined' ? null : value;
+        tx.executeSql(insertSql, [self.name, id, key, JSON.stringify(value)]);
+      });
+    });
+  }, unknownError(callback), function () {
+    callback();
+  });
+});
+
+Index.prototype.count = utils.toPromise(function (callback) {
+  var self = this;
+
+  var count;
+  self.db.transaction(function (tx) {
+    var sql = 'SELECT COUNT(*) AS count FROM ' + PLUGIN_DATA_STORE + ' WHERE name = ?';
+    tx.executeSql(sql, [self.name], function (tx, result) {
+      count = result.rows.item(0).count;
+    });
+  }, unknownError(callback), function () {
+    callback(null, count);
+  });
+});
+
+Index.prototype.get = utils.toPromise(function (opts, callback) {
+  var self = this;
+
+  var start;
+  var end;
+  var skip = 0;
+  var limit = -1;
+  var descending;
+
+  if (typeof opts === 'string') {
+    start = end = opts;
+  } else if (typeof opts === 'object' && !Array.isArray(opts)) {
+    start = opts.startkey;
+    end = opts.endkey;
+    if (typeof opts.skip !== 'undefined' && opts.skip !== null) {
+      skip = opts.skip;
+    }
+    if (typeof opts.limit !== 'undefined' && opts.limit !== null) {
+      limit = opts.limit;
+    }
+    descending = opts.descending;
+  } else {
+    return callback(new Error('opts must be a string or an object'));
+  }
+
+  if (descending) {
+    var tmp = start;
+    start = end;
+    end = tmp;
+  }
+
+  var hasStart = typeof start !== 'undefined' && start !== null;
+  var hasEnd = typeof end !== 'undefined' && end !== null;
+
+  var results = [];
+  self.db.transaction(function (tx) {
+
+    var criteria = ['name = ?'];
+    var sqlArgs = [self.name];
+
+    if (hasStart) {
+      criteria.push('key >= ?');
+      sqlArgs.push(start);
+    }
+    if (hasEnd) {
+      criteria.push('key <= ?');
+      sqlArgs.push(end);
+    }
+
+    var sql = 'SELECT id, key, value FROM ' + PLUGIN_DATA_STORE + ' WHERE ' +
+      (criteria.join(' AND ')) +
+      ' ORDER BY key ' + (descending ? 'DESC' : 'ASC') +
+      ' LIMIT ' + limit + ' OFFSET ' + skip;
+    tx.executeSql(sql, sqlArgs, function (tx, result) {
+      for (var i = 0; i < result.rows.length; i++) {
+        var item = result.rows.item(i);
+        results.push({
+          id : item.id,
+          key : item.key,
+          value : JSON.parse(item.value)
+        });
+      }
+    });
+  }, unknownError(callback), function () {
+    callback(null, results);
+  });
+});
+
+Index.prototype.destroy = utils.toPromise(function (callback) {
+  var self = this;
+
+  self.db.transaction(function (tx) {
+    tx.executeSql('DELETE FROM ' + PLUGIN_DATA_STORE + ' WHERE name = ?', [self.name]);
+  }, unknownError(callback), function () {
+    callback();
+  });
+});
 
 module.exports = WebSqlPouch;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "bluebird": "~1.0.0",
     "inherits": "~2.0.1",
+    "level-delete-stream": "0.0.1",
     "level-sublevel": "~5.2.0",
     "leveldown": "~0.10.2",
     "levelup": "~0.18.2",

--- a/tests/test.html
+++ b/tests/test.html
@@ -39,6 +39,7 @@
     <script src='test.revs_diff.js'></script>
     <script src='test.replication.js'></script>
     <script src='test.views.js'></script>
+    <script src='test.indexes.js'></script>
     <script src='test.taskqueue.js'></script>
     <script src='test.design_docs.js'></script>
     <script src='test.issue221.js'></script>

--- a/tests/test.indexes.js
+++ b/tests/test.indexes.js
@@ -1,0 +1,627 @@
+/*jshint expr:true */
+'use strict';
+
+describe('plugin indexes', function () {
+
+  var dbs = {};
+
+  beforeEach(function (done) {
+    dbs.name = testUtils.adapterUrl('local', 'test_indexes');
+    dbs.indexName = 'fooIndex';
+    testUtils.cleanup([dbs.name], done);
+  });
+
+  afterEach(function (done) {
+    new PouchDB(dbs.name).then(function (db) {
+      return db.index(dbs.indexName).destroy();
+    }).then(function () {
+      testUtils.cleanup([dbs.name], done);
+    }, done);
+  });
+
+  it('Test basic index', function (done) {
+    new PouchDB(dbs.name).then(function (db) {
+
+      var index = db.index(dbs.indexName);
+
+      var map = {
+        '1' : 'one',
+        '2' : 'two',
+        '3' : 'three'
+      };
+
+      index.put('fooDoc', map).then(function () {
+        return index.get({});
+      }).then(function (results) {
+        results.should.deep.equal([
+          {
+            id: 'fooDoc',
+            key: '1',
+            value: 'one'
+          }, {
+            id: 'fooDoc',
+            key: '2',
+            value: 'two'
+          }, {
+            id: 'fooDoc',
+            key: '3',
+            value: 'three'
+          }
+        ]);
+        return index.get({startkey : '1'});
+      }).then(function (results) {
+        results.should.have.length(3);
+        return index.get({startkey : '2'});
+      }).then(function (results) {
+        results.should.have.length(2);
+        return index.get({startkey : '3'});
+      }).then(function (results) {
+        results.should.have.length(1);
+        return index.get({startkey : '0'});
+      }).then(function (results) {
+        results.should.have.length(3);
+        return index.get({startkey : '4'});
+      }).then(function (results) {
+        results.should.have.length(0);
+        done();
+      }, done);
+    }, done);
+  });
+
+  it('Test simple get', function (done) {
+    new PouchDB(dbs.name).then(function (db) {
+
+      var index = db.index(dbs.indexName);
+
+      var map = {
+        '1' : 'one',
+        '2' : 'two',
+        '3' : 'three'
+      };
+
+      index.put('fooDoc', map).then(function () {
+        return index.get('1');
+      }).then(function (result) {
+        result.should.deep.equal([{
+          id: 'fooDoc',
+          key: '1',
+          value: 'one'
+        }]);
+        return index.get('2');
+      }).then(function (result) {
+        result.should.deep.equal([{
+          id: 'fooDoc',
+          key: '2',
+          value: 'two'
+        }]);
+        return index.get('3');
+      }).then(function (result) {
+        result.should.deep.equal([{
+          id: 'fooDoc',
+          key: '3',
+          value: 'three'
+        }]);
+        done();
+      }, done);
+    }, done);
+  });
+
+  it('Test start and end', function (done) {
+    new PouchDB(dbs.name).then(function (db) {
+
+      var index = db.index(dbs.indexName);
+
+      var map = {
+        '1' : 'one',
+        '2' : 'two',
+        '3' : 'three'
+      };
+
+      index.put('fooDoc', map).then(function () {
+        return index.get({startkey : '1', endkey : '3'});
+      }).then(function (results) {
+        results.should.deep.equal([
+          {
+            id: 'fooDoc',
+            key: '1',
+            value: 'one'
+          }, {
+            id: 'fooDoc',
+            key: '2',
+            value: 'two'
+          }, {
+            id: 'fooDoc',
+            key: '3',
+            value: 'three'
+          }
+        ], '1-3');
+
+        return index.get({startkey: '1', endkey : '2'});
+      }).then(function (results) {
+        results.should.have.length(2, '1-2');
+        return index.get({startkey: '2', endkey : '3'});
+      }).then(function (results) {
+        results.should.have.length(2, '2-3');
+        return index.get({startkey: '3', endkey : '4'});
+      }).then(function (results) {
+        results.should.have.length(1, '3-4');
+        return index.get({startkey: '4', endkey : '5'});
+      }).then(function (results) {
+        results.should.have.length(0, '4-5');
+        return index.get({endkey : '1'});
+      }).then(function (results) {
+        results.should.have.length(1, 'null-1');
+        return index.get({startkey: '2'});
+      }).then(function (results) {
+        results.should.have.length(2, '2-null');
+        return index.get({startkey: '2', endkey : '1'});
+      }).then(function (results) {
+        results.should.have.length(0, '2-1');
+        return index.get({startkey: '0', endkey : '5'});
+      }).then(function (results) {
+        results.should.have.length(3, '0-3');
+        return index.get({startkey: '0', endkey : '1'});
+      }).then(function (results) {
+        results.should.have.length(1, '0-1');
+        done();
+      }, done);
+    }, done);
+  });
+
+  it('Test limit and skip', function (done) {
+    new PouchDB(dbs.name).then(function (db) {
+
+      var index = db.index(dbs.indexName);
+
+      var map = {
+        '1' : 'one',
+        '2' : 'two',
+        '3' : 'three'
+      };
+
+      index.put('fooDoc', map).then(function () {
+        return index.get({startkey : '1', endkey : '3', limit : 2});
+      }).then(function (results) {
+        results.should.deep.equal([
+          {
+            id: 'fooDoc',
+            key: '1',
+            value: 'one'
+          }, {
+            id: 'fooDoc',
+            key: '2',
+            value: 'two'
+          }
+        ]);
+        return index.get({startkey: '1', endkey : '2', limit : 0});
+      }).then(function (results) {
+        results.should.have.length(0, '1,2,0');
+        return index.get({startkey: '2', endkey : '3', limit : 1});
+      }).then(function (results) {
+        results.should.deep.equal([
+          {
+            id: 'fooDoc',
+            key: '2',
+            value: 'two'
+          }
+        ]);
+        return index.get({startkey: '3', endkey : '4', skip : 2});
+      }).then(function (results) {
+        results.should.have.length(0, '3,4,2');
+        return index.get({startkey: '4', endkey : '5', skip : 1});
+      }).then(function (results) {
+        results.should.have.length(0, '4,5,1');
+        return index.get({endkey : '1', limit : 2});
+      }).then(function (results) {
+        results.should.have.length(1, 'null,1,2');
+        return index.get({startkey: '2', skip : 1});
+      }).then(function (results) {
+        results.should.deep.equal([
+          {
+            id: 'fooDoc',
+            key: '3',
+            value: 'three'
+          }
+        ]);
+        return index.get({startkey: '2', endkey : '1', skip : 10, limit : 2});
+      }).then(function (results) {
+        results.should.have.length(0, '2,1,10,2');
+        return index.get({startkey: '0', endkey : '5', skip : 1, limit : 1});
+      }).then(function (results) {
+        results.should.deep.equal([
+          {
+            id: 'fooDoc',
+            key: '2',
+            value: 'two'
+          }
+        ]);
+        return index.get({startkey: '0', endkey : '1', skip : 1, limit : 1});
+      }).then(function (results) {
+        results.should.have.length(0, '0,1,1,1');
+        done();
+      }, done);
+    }, done);
+  });
+
+  it('Test descending', function (done) {
+    new PouchDB(dbs.name).then(function (db) {
+
+      var index = db.index(dbs.indexName);
+
+      var map = {
+        '1' : 'one',
+        '2' : 'two',
+        '3' : 'three'
+      };
+
+      index.put('fooDoc', map).then(function () {
+        return index.get({startkey: '3', endkey : '1', descending : true});
+      }).then(function (results) {
+        results.should.deep.equal([
+          {
+            id: 'fooDoc',
+            key: '3',
+            value: 'three'
+          }, {
+            id: 'fooDoc',
+            key: '2',
+            value: 'two'
+          }, {
+            id: 'fooDoc',
+            key: '1',
+            value: 'one'
+          }
+        ]);
+        return index.get({startkey: '4', endkey : '0', descending : true});
+      }).then(function (results) {
+        results.should.have.length(3);
+        return index.get({startkey: '0', endkey : '3', descending : true});
+      }).then(function (results) {
+        results.should.have.length(0);
+        return index.get({startkey: '5', endkey : '3', skip : 1,
+          descending : true});
+      }).then(function (results) {
+        results.should.have.length(0);
+        return index.get({startkey: '3', endkey : '1', limit : 1, skip : 1,
+          descending : true});
+      }).then(function (results) {
+        results.should.deep.equal([
+          {
+            id: 'fooDoc',
+            key: '2',
+            value: 'two'
+          }
+        ]);
+        return index.get({startkey: '1', descending : true});
+      }).then(function (results) {
+        results.should.have.length(1, '1a');
+        return index.get({endkey: '3', descending : true});
+      }).then(function (results) {
+        results.should.have.length(1, '3');
+        return index.get({endkey: '3', descending : true, skip : 1});
+      }).then(function (results) {
+        results.should.have.length(0);
+        return index.get({endkey: '3', descending : true, limit : 1});
+      }).then(function (results) {
+        results.should.have.length(1, '3, limit');
+        done();
+      }, done);
+    }, done);
+  });
+
+  it('Test empty map', function (done) {
+    new PouchDB(dbs.name).then(function (db) {
+
+      var index = db.index(dbs.indexName);
+
+      var map = {
+      };
+
+      index.put('fooDoc', map).then(function () {
+        return index.get({});
+      }).then(function (results) {
+        results.should.have.length(0);
+        return index.get({startkey: '1'});
+      }).then(function (results) {
+        results.should.have.length(0);
+        done();
+      }, done);
+    }, done);
+  });
+
+  it('Test deleted map', function (done) {
+    new PouchDB(dbs.name).then(function (db) {
+
+      var index = db.index(dbs.indexName);
+
+      var map = {
+        '1' : 'one',
+        '2' : 'two',
+        '3' : 'three'
+      };
+
+      index.put('fooDoc', map).then(function () {
+        return index.put('fooDoc', {});
+      }).then(function () {
+        return index.get({});
+      }).then(function (results) {
+        results.should.have.length(0);
+        return index.get({startkey: '1'});
+      }).then(function (results) {
+        results.should.have.length(0);
+        done();
+      }, done);
+    }, done);
+  });
+
+  it('Test replaced map', function (done) {
+    new PouchDB(dbs.name).then(function (db) {
+
+      var index = db.index(dbs.indexName);
+
+      var map = {
+        '4' : 'four',
+        '5' : 'five',
+        '6' : 'six'
+      };
+
+      index.put('fooDoc', map).then(function () {
+        var newMap = {
+          '1' : 'one',
+          '2' : 'two',
+          '3' : 'three'
+        };
+        return index.put('fooDoc', newMap);
+      }).then(function () {
+        return index.get({startkey: '1', endkey : '3'});
+      }).then(function (results) {
+        results.should.have.length(3);
+        return index.get({startkey : '4'});
+      }).then(function (results) {
+        results.should.have.length(0);
+        done();
+      }, done);
+    }, done);
+  });
+
+  it('Test multiple maps', function (done) {
+    new PouchDB(dbs.name).then(function (db) {
+
+      var index = db.index(dbs.indexName);
+
+      var fooMap = {
+        '1' : 'one',
+        '2' : 'two',
+        '3' : 'three'
+      };
+
+      var barMap = {
+        '4' : 'four',
+        '5' : 'five',
+        '6' : 'six'
+      };
+
+      index.put('fooDoc', fooMap).then(function () {
+        return index.put('barDoc', barMap);
+      }).then(function () {
+        return index.get({startkey: '1', endkey : '3'});
+      }).then(function (results) {
+        results.should.have.length(3);
+        return index.get({startkey: '1', endkey : '6'});
+      }).then(function (results) {
+        results.should.have.length(6);
+        return index.get({startkey: '4', endkey : '6'});
+      }).then(function (results) {
+        results.should.have.length(3);
+        return index.get({});
+      }).then(function (results) {
+        results.should.have.length(6);
+        return index.put('barDoc', {});
+      }).then(function () {
+        return index.get({});
+      }).then(function (results) {
+        results.should.have.length(3);
+        done();
+      }, done);
+    }, done);
+  });
+
+  it('Test count', function (done) {
+    new PouchDB(dbs.name).then(function (db) {
+
+      var index = db.index(dbs.indexName);
+
+      var map = {
+        '1' : 'one',
+        '2' : 'two',
+        '3' : 'three'
+      };
+
+      index.put('fooDoc', map).then(function () {
+        return index.count();
+      }).then(function (count) {
+        count.should.equal(3);
+        done();
+      }, done);
+    }, done);
+  });
+
+  it('Test destroy', function (done) {
+    new PouchDB(dbs.name).then(function (db) {
+
+      var index = db.index(dbs.indexName);
+
+      var map = {
+        '1' : 'one',
+        '2' : 'two',
+        '3' : 'three'
+      };
+
+      index.put('fooDoc', map).then(function () {
+        return index.get({});
+      }).then(function (results) {
+        results.should.have.length(3);
+        return index.destroy();
+      }).then(function () {
+        var index2 = db.index(dbs.indexName);
+
+        return index2.get({}).then(function (results) {
+          results.should.have.length(0);
+          done();
+        });
+      }, done);
+    }, done);
+  });
+
+  it('Test empty string keys', function (done) {
+    new PouchDB(dbs.name).then(function (db) {
+      var index = db.index(dbs.indexName);
+
+      var map = {
+        '' : 'empty'
+      };
+
+      index.put('fooDoc', map).then(function () {
+        return index.get({});
+      }).then(function (results) {
+        results.should.deep.equal([{
+          key : '',
+          value : 'empty',
+          id : 'fooDoc'
+        }]);
+        return index.get('');
+      }).then(function (result) {
+        result.should.deep.equal([{
+          key : '',
+          value : 'empty',
+          id : 'fooDoc'
+        }]);
+        done();
+      }, done);
+    }, done);
+  });
+  it('Test values with multiple types', function (done) {
+    new PouchDB(dbs.name).then(function (db) {
+      var index = db.index(dbs.indexName);
+
+      var map = {
+        '1' : '1',
+        '2' : 2,
+        '3' : 3.3,
+        '4' : true,
+        '5' : false,
+        '6' : undefined,
+        '7' : null,
+        '8' : ['1', 2, 3.3, true, false, undefined, null, '0', null, ''],
+        '9' : {
+          '9' : {
+            '9' : null
+          },
+          'a' : [null, 3, undefined, Number.MAX_VALUE]
+        },
+        'a' : '',
+        'b' : '0',
+        'c' : 0,
+        'd' : new Date(0)
+      };
+
+      var getValues = function (obj) {
+        return obj.value;
+      };
+
+      index.put('fooDoc', map).then(function () {
+        return index.get({});
+      }).then(function (results) {
+          results.map(getValues).should.deep.equal([
+            '1', 2, 3.3, true, false, null, null,
+            [ '1', 2, 3.3, true, false, null, null, '0', null, ''],
+            { '9': { '9': null }, 'a': [ null, 3, null, Number.MAX_VALUE ] },
+            '', '0', 0, '1970-01-01T00:00:00.000Z'
+          ]);
+          done();
+        }, done);
+    }, done);
+  });
+
+  it('Test duplicate keys', function (done) {
+    new PouchDB(dbs.name).then(function (db) {
+      var index = db.index(dbs.indexName);
+
+      var map = {
+        '1'   : '1',
+        '2'   : '2',
+        '10'  : '10',
+        '100' : '100'
+      };
+
+      var sortByDoc = function (a, b) {
+        return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+      };
+
+      index.put('doc1', map).then(function () {
+        return index.put('doc2', map);
+      }).then(function () {
+        return index.put('doc3', {'1' : '1'});
+      }).then(function () {
+        return index.get('1');
+      }).then(function (res) {
+        res.sort(sortByDoc).should.deep.equal([
+          {
+            key : '1',
+            value: '1',
+            id : 'doc1'
+          },
+          {
+            key : '1',
+            value: '1',
+            id : 'doc2'
+          },
+          {
+            key : '1',
+            value: '1',
+            id : 'doc3'
+          }
+        ], 'get-1');
+        return index.get({startkey : '1', endkey : '1'});
+      }).then(function (res) {
+        res.sort(sortByDoc).should.deep.equal([
+          {
+            key : '1',
+            value: '1',
+            id : 'doc1'
+          },
+          {
+            key : '1',
+            value: '1',
+            id : 'doc2'
+          },
+          {
+            key : '1',
+            value: '1',
+            id : 'doc3'
+          }
+        ], 'start-1,end-1');
+        return index.get({startkey : '1', endkey : '10'});
+      }).then(function (res) {
+        res.should.have.length(5, '1-10');
+        return index.get({startkey : '10', endkey : '2'});
+      }).then(function (res) {
+        res.should.have.length(6, '10-2');
+        return index.get({startkey : '10', endkey : '1',
+          descending : true});
+      }).then(function (res) {
+        res.should.have.length(5, '10-1');
+        return index.get({startkey : '1'});
+      }).then(function (res) {
+        res.should.have.length(9, '1-');
+        return index.get({endkey : '10'});
+      }).then(function (res) {
+        res.should.have.length(5, '-10');
+        return index.get({startkey : '1', limit : 2});
+      }).then(function (res) {
+        res.should.have.length(2, '1-limit2');
+        done();
+      }, done);
+    }, done);
+  });
+});


### PR DESCRIPTION
Adds a new index() API for plugins to access
in order to store additional metadata.

This API was designed with Map/Reduce in mind,
since in order to persist its data it requires
a secondary index not normally exposed by the
adapter API.  However, the new API is
generic enough that it could be useful for
other plugins.
