### PR TITLE
(#1671) - Document adapter usage in constructor

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -26,13 +26,13 @@ This method creates a database or opens an existing one. If you use a URL like `
 * `options.name`: You can omit the `name` argument and specify it via `options` instead. Note that the name is required.
 * `options.auto_compaction`: This turns on auto compaction (experimental). Defaults to `false`.
 * `options.cache`: Appends a random string to the end of all HTTP GET requests to avoid them being cached on IE. Set this to `true` to prevent this happening (can also be set per request). Defaults to `false`.
-* `options.adapter` One of `'idb'`, `'leveldb'`, `'websql'`, or `'http'`. If unspecified, PouchDB will infer this automatically, preferring IndexedDB to WebSQL in browsers that support both (e.g. Chrome).
+* `options.adapter`: One of `'idb'`, `'leveldb'`, `'websql'`, or `'http'`. If unspecified, PouchDB will infer this automatically, preferring IndexedDB to WebSQL in browsers that support both (i.e. Chrome, Opera and Android 4.4+).
 
 **Notes:** 
 
 1. In IndexedDB and WebSQL, PouchDB will use `_pouch_` to prefix the internal database names. Do not manually create databases with the same prefix.
 2. When acting as a client on Node, any other options given will be passed to [request][].
-3. When using the `'leveldb'` adapter (the default on Node), any other options given will be passed to [levelup][]. The storage layer of leveldb can be replaced by passing a level backend factory (such as [MemDOWN][]) as `options.db`. The rest of the supported options are [documented here][levelup_options], .
+3. When using the `'leveldb'` adapter (the default on Node), any other options given will be passed to [levelup][]. The storage layer of leveldb can be replaced by passing a level backend factory (such as [MemDOWN][]) as `options.db`. The rest of the supported options are [documented here][levelup_options].
 
   [request]: https://github.com/mikeal/request
   [levelup]: https://github.com/rvagg/node-levelup
@@ -44,6 +44,20 @@ This method creates a database or opens an existing one. If you use a URL like `
 var db = new PouchDB('dbname');
 // or
 var db = new PouchDB('http://localhost:5984/dbname');
+{% endhighlight %}
+
+Create a WebSQL-only Pouch (e.g. when using the [SQLite Plugin][] for Cordova/PhoneGap):
+
+  [sqlite plugin]: https://github.com/lite4cordova/Cordova-SQLitePlugin
+
+{% highlight js %}
+var db = new PouchDB('dbname', {adapter : 'websql'});
+{% endhighlight %}
+
+Create an in-memory Pouch (in Node):
+
+{% highlight js %}
+var db = new PouchDB('dbname', {db : require('memdown')});
 {% endhighlight %}
 
 {% include anchor.html title="Delete database" %}

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -11,15 +11,20 @@ PouchDB is a free open-source project, written in JavaScript by these [wonderful
 
 # Browser Support
 
-PouchDB uses various backends so it can work across various browsers and in Node.js. It uses IndexedDB in Firefox/Chrome/Opera, WebSQL in Safari, and LevelDB in Node.js. It is currently tested in:
+PouchDB uses various backends so it can work across different browsers and in Node.js. It uses IndexedDB in Firefox/Chrome/Opera/IE, WebSQL in Safari, and LevelDB in Node.js. It is currently tested in:
 
  * Firefox 12+
  * Chrome 19+
  * Opera 12+
  * Safari 5+
+ * Internet Explorer 10+
  * [Node.js 0.10+](http://nodejs.org/)
  * [Apache Cordova](http://cordova.apache.org/)
- * Internet Explorer 10+
+
+For details on supported browsers, see ["Can I use IndexedDB?"][caniuse-idb] and ["Can I use Web SQL Database?"][caniuse-websql].
+
+  [caniuse-idb]: http://caniuse.com/indexeddb
+  [caniuse-websql]: http://caniuse.com/sql-storage
 
 If your application requires support for Internet Explorer below version 10, it is possible to use an online CouchDB as a fallback, however it will not work offline.
 


### PR DESCRIPTION
It's not very clear how to restrict PouchDB to
websql-only or memdown. This adds some more
details and examples.
