### PR TITLE
(1655) - Make genDBUrl and replicateOnServer both use genUrl

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -98,7 +98,7 @@ function getHost(name, opts) {
 
 // Generate a URL with the host data given by opts and the given path
 function genDBUrl(opts, path) {
-    return genUrl(opts, opts.db + '/' + path);
+  return genUrl(opts, opts.db + '/' + path);
 }
 
 // Generate a URL with the host data given by opts and the given path


### PR DESCRIPTION
A very straight forward cleanup to get rid of duplicate code in genDBUrl and to make replicateOnServer's URL be consistent with the behavior everywhere else.
