### PR TITLE
(#1673) - Make destroy honor opts.ajax

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -1016,6 +1016,8 @@ HttpPouch.destroy = utils.toPromise(function (name, opts, callback) {
   opts.headers = host.headers;
   opts.method = 'DELETE';
   opts.url = genDBUrl(host, '');
+  var ajaxOpts = opts.ajax || {};
+  opts = utils.extend({}, opts, ajaxOpts);
   utils.ajax(opts, callback);
 });
 


### PR DESCRIPTION
Right now the configuration of opts.ajax is used in the constructor for an adapter but not by destroy. This fixes that inconsistency.
