### PR TITLE
(#44) Initial support for alternative level backends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,9 @@ env:
   - CLIENT=node npm test
   - NATIVEPROMISE=1 CLIENT=firefox npm test
   - CLIENT=chrome npm test
+  - CLIENT=firefox INDEX_FILE=index-levelalt.js npm test
 
 matrix:
   allow_failures:
   - env: CLIENT=chrome npm test
+  - env: CLIENT=firefox INDEX_FILE=index-levelalt.js npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,9 @@ For quick debugging, you can run an interactive Node shell with the `PouchDB` va
 
     npm run shell
 
+Alternative Backends
+--------------------------------------
+PouchDB is looking to support alternative backends that comply with the [LevelDOWN API](https://github.com/rvagg/abstract-leveldown). Simply include `INDEX_FILE=index-levelalt.js` in your `npm run build` and `npm run dev` commands to experiment with this feature!
 
 Git Essentials
 --------------------------------------

--- a/bin/build-js.sh
+++ b/bin/build-js.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+: ${INDEX_FILE:="index.js"}
+
+if [ "$INDEX_FILE" == "index-levelalt.js" ]; then
+    node_modules/.bin/browserify lib/index-levelalt.js \
+      --require ./lib/index:./lib/index-levelalt.js \
+      --standalone PouchDB \
+      --outfile dist/pouchdb-nightly.js
+else
+    node_modules/.bin/browserify lib/index.js \
+      --exclude ./adapters/leveldb \
+      --exclude ./adapters/levelalt \
+      --ignore levelup \
+      --ignore crypto \
+      --ignore level-sublevel \
+      --standalone PouchDB \
+      --outfile dist/pouchdb-nightly.js
+fi

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -13,8 +13,15 @@ fs.mkdir('dist', function (e) {
   }
 });
 
+var indexfile;
+if (process.env.INDEX_FILE) {
+  indexfile = "./lib/" + process.env.INDEX_FILE;
+} else {
+  indexfile = "./lib/index.js";
+}
+
 var watchify = require("watchify");
-var w = watchify("./lib/index.js");
+var w = watchify(indexfile);
 var dotfile = "./dist/.pouchdb-nightly.js";
 var outfile = "./dist/pouchdb-nightly.js";
 

--- a/lib/adapters/levelalt.js
+++ b/lib/adapters/levelalt.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var LevelPouch = require('./leveldb');
+var levelalt = require('level-js');
+var utils = require('../utils');
+
+function LevelPouchAlt(opts, callback) {
+  var _opts = utils.extend({
+    db: levelalt
+  }, opts);
+
+  LevelPouch.call(this, _opts, callback);
+}
+
+LevelPouchAlt.valid = function () {
+  return LevelPouch.valid();
+};
+
+LevelPouchAlt.destroy = utils.toPromise(function (name, opts, callback) {
+  if (typeof opts === 'function') {
+    callback = opts;
+    opts = {};
+  }
+
+  var _opts = utils.extend({
+    db: levelalt
+  }, opts);
+
+  return LevelPouch.destroy(name, _opts, callback);
+});
+
+module.exports = LevelPouchAlt;

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -4,13 +4,14 @@ var crypto = require('crypto');
 var EventEmitter = require('events').EventEmitter;
 
 var levelup = require('levelup');
-var leveldown = require("leveldown");
+var leveldown = require('leveldown');
 var sublevel = require('level-sublevel');
 
 var errors = require('../deps/errors');
 var merge = require('../merge');
 var utils = require('../utils');
 var migrate = require('../deps/migrate');
+var indexDB = require('./idb');
 
 var DOC_STORE = 'document-store';
 var BY_SEQ_STORE = 'by-sequence';
@@ -46,7 +47,10 @@ function LevelPouch(opts, callback) {
   }
   changeEmitters[name] = change_emitter;
 
-  
+  if (process.browser) {
+    leveldown = opts.db || leveldown;
+  }
+
   if (dbStore[name]) {
     db = dbStore[name];
     afterDBCreated();
@@ -703,12 +707,15 @@ function LevelPouch(opts, callback) {
 }
 
 LevelPouch.valid = function () {
-  return process && !process.browser;
+  return (process && !process.browser) || indexDB.valid();
 };
 
 // close and delete open leveldb stores
 LevelPouch.destroy = utils.toPromise(function (name, opts, callback) {
   opts = utils.extend(true, {}, opts);
+  if (process.browser) {
+    leveldown = opts.db || leveldown;
+  }
   if (dbStore[name]) {
     dbStore[name].close(function () {
       delete dbStore[name];

--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -60,7 +60,7 @@ function PouchDB(name, opts, callback) {
           throw error;
         }
 
-        backend = PouchDB.parseAdapter(originalName);
+        backend = PouchDB.parseAdapter(originalName, opts);
         
         opts.originalName = originalName;
         opts.name = backend.name;

--- a/lib/index-levelalt.js
+++ b/lib/index-levelalt.js
@@ -1,0 +1,28 @@
+"use strict";
+
+require('./deps/es5_shims');
+
+var PouchDB = require('./setup');
+
+module.exports = PouchDB;
+
+PouchDB.ajax = require('./deps/ajax');
+PouchDB.extend = require('./deps/extend');
+PouchDB.utils = require('./utils');
+PouchDB.Errors = require('./deps/errors');
+var replicate = require('./replicate');
+PouchDB.replicate = replicate.replicate;
+PouchDB.sync = replicate.sync;
+PouchDB.version = require('./version');
+var httpAdapter = require('./adapters/http');
+PouchDB.adapter('http', httpAdapter);
+PouchDB.adapter('https', httpAdapter);
+
+PouchDB.adapter('idb', require('./adapters/idb'));
+PouchDB.adapter('websql', require('./adapters/websql'));
+PouchDB.plugin(require('pouchdb-mapreduce'));
+
+var ldbAdapter = require('./adapters/leveldb');
+PouchDB.adapter('ldb', ldbAdapter);
+PouchDB.adapter('leveldb', ldbAdapter);
+PouchDB.adapter('levelalt', require('./adapters/levelalt'));

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -20,15 +20,15 @@ var eventEmitterMethods = [
   'setMaxListeners'
 ];
 
-var preferredAdapters = ['idb', 'leveldb', 'websql'];
+var preferredAdapters = ['levelalt', 'idb', 'leveldb', 'websql'];
 
 eventEmitterMethods.forEach(function (method) {
   PouchDB[method] = eventEmitter[method].bind(eventEmitter);
 });
 PouchDB.setMaxListeners(0);
-PouchDB.parseAdapter = function (name) {
+PouchDB.parseAdapter = function (name, opts) {
   var match = name.match(/([a-z\-]*):\/\/(.*)/);
-  var adapter;
+  var adapter, adapterName;
   if (match) {
     // the http adapter expects the fully qualified name
     name = /http(s?)/.test(match[1]) ? match[1] + '://' + match[2] : match[2];
@@ -44,20 +44,28 @@ PouchDB.parseAdapter = function (name) {
     utils.hasLocalStorage() &&
     global.localStorage['_pouch__websqldb_' + PouchDB.prefix + name];
 
-  for (var i = 0; i < preferredAdapters.length; ++i) {
-    var adapterName = preferredAdapters[i];
-    if (adapterName in PouchDB.adapters) {
-      if (skipIdb && adapterName === 'idb') {
-        continue; // keep using websql to avoid user data loss
+  if (typeof opts !== 'undefined' && opts.db) {
+    adapterName = 'leveldb';
+  } else {
+    for (var i = 0; i < preferredAdapters.length; ++i) {
+      adapterName = preferredAdapters[i];
+      if (adapterName in PouchDB.adapters) {
+        if (skipIdb && adapterName === 'idb') {
+          continue; // keep using websql to avoid user data loss
+        }
+        break;
       }
-      adapter = PouchDB.adapters[adapterName];
-      var use_prefix = 'use_prefix' in adapter ? adapter.use_prefix : true;
-
-      return {
-        name: use_prefix ? PouchDB.prefix + name : name,
-        adapter: adapterName
-      };
     }
+  }
+
+  if (adapterName) {
+    adapter = PouchDB.adapters[adapterName];
+    var use_prefix = 'use_prefix' in adapter ? adapter.use_prefix : true;
+
+    return {
+      name: use_prefix ? PouchDB.prefix + name : name,
+      adapter: adapterName
+    };
   }
 
   throw 'No valid adapter found';
@@ -74,7 +82,7 @@ PouchDB.destroy = utils.toPromise(function (name, opts, callback) {
     name = undefined;
   }
 
-  var backend = PouchDB.parseAdapter(opts.name || name);
+  var backend = PouchDB.parseAdapter(opts.name || name, opts);
   var dbName = backend.name;
 
   // call destroy method of the particular adaptor

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "bluebird": "~1.0.0",
     "inherits": "~2.0.1",
+    "level-js": "~2.0.0",
     "level-sublevel": "~5.2.0",
     "leveldown": "~0.10.2",
     "levelup": "~0.18.2",
@@ -47,7 +48,7 @@
   },
   "scripts": {
     "jshint": "jshint -c .jshintrc bin/ lib/ tests/*.js",
-    "build-js": "browserify lib/index.js -s PouchDB -o dist/pouchdb-nightly.js",
+    "build-js": "./bin/build-js.sh",
     "uglify": "uglifyjs dist/pouchdb-nightly.js -mc > dist/pouchdb-nightly.min.js",
     "build": "mkdir -p dist && npm run build-js && npm run uglify",
     "test-node": "./bin/run-mocha.sh",
@@ -60,13 +61,9 @@
     "shell": "./bin/repl.js"
   },
   "browser": {
-    "./adapters/leveldb": false,
     "./deps/buffer": false,
     "request": false,
-    "levelup": false,
-    "leveldown": false,
-    "crypto": false,
-    "bluebird": "lie",
-    "level-sublevel": false
+    "leveldown": "level-js",
+    "bluebird": "lie"
   }
 }


### PR DESCRIPTION
Adds first draft support to use alternative backends via "levelalt", an adapter that wraps leveldb and includes level-js as a db option, as per #44.

To use, <code>INDEX=index-level.js npm run build</code> to build a distribution over pouchdb-nightly.js and <code>INDEX=index-level.js npm run dev</code> to test in browser. 
Note: <code>npm run build</code> and <code>npm run dev</code> build and test the standard distribution.
