### PR TITLE
(#1638) - Overwrite previous by_seq docs with new_edits

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -33,6 +33,7 @@ function isModernIdb() {
   }
   return result;
 }
+
 function IdbPouch(opts, callback) {
 
   // IndexedDB requires a versioned database structure, so we use the
@@ -80,7 +81,7 @@ function IdbPouch(opts, callback) {
   function createSchema(db) {
     db.createObjectStore(DOC_STORE, {keyPath : 'id'})
       .createIndex('seq', 'seq', {unique: true});
-    db.createObjectStore(BY_SEQ_STORE, {autoIncrement : true})
+    db.createObjectStore(BY_SEQ_STORE, {autoIncrement: true})
       .createIndex('_doc_id_rev', '_doc_id_rev', {unique: true});
     db.createObjectStore(ATTACH_STORE, {keyPath: 'digest'});
     db.createObjectStore(META_STORE, {keyPath: 'id', autoIncrement: false});
@@ -350,19 +351,30 @@ function IdbPouch(opts, callback) {
       }
 
       function finish() {
+
         docInfo.data._doc_id_rev = docInfo.data._id + "::" + docInfo.data._rev;
-        var dataReq = txn.objectStore(BY_SEQ_STORE).put(docInfo.data);
-        dataReq.onsuccess = function (e) {
-          docInfo.metadata.seq = e.target.result;
-          // Current _rev is calculated from _rev_tree on read
-          delete docInfo.metadata.rev;
-          var deleted = utils.isDeleted(docInfo.metadata);
-          var local = utils.isLocalId(docInfo.metadata.id);
-          var metadata = utils.extend(true, {deletedOrLocal : (deleted || local) ? "1" : "0"}, docInfo.metadata);
-          var metaDataReq = txn.objectStore(DOC_STORE).put(metadata);
-          metaDataReq.onsuccess = function () {
-            results.push(docInfo);
-            utils.call(callback);
+        var index = txn.objectStore(BY_SEQ_STORE).index('_doc_id_rev');
+
+        index.getKey(docInfo.data._doc_id_rev).onsuccess = function (e) {
+
+          var dataReq = e.target.result ?
+            txn.objectStore(BY_SEQ_STORE).put(docInfo.data, e.target.result) :
+            txn.objectStore(BY_SEQ_STORE).put(docInfo.data);
+
+          dataReq.onsuccess = function (e) {
+            docInfo.metadata.seq = e.target.result;
+            // Current _rev is calculated from _rev_tree on read
+            delete docInfo.metadata.rev;
+            var deleted = utils.isDeleted(docInfo.metadata);
+            var local = utils.isLocalId(docInfo.metadata.id);
+            var metadata = utils.extend(true, {
+              deletedOrLocal : (deleted || local) ? "1" : "0"
+            }, docInfo.metadata);
+            var metaDataReq = txn.objectStore(DOC_STORE).put(metadata);
+            metaDataReq.onsuccess = function () {
+              results.push(docInfo);
+              utils.call(callback);
+            };
           };
         };
       }

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -412,13 +412,28 @@ function WebSqlPouch(opts, callback) {
 
       function finish() {
         var data = docInfo.data;
-        var sql = 'INSERT INTO ' + BY_SEQ_STORE + ' (doc_id_rev, json, deleted) VALUES (?, ?, ?);';
-        var sqlArgs = [
-          data._id + "::" + data._rev,
-          JSON.stringify(data),
-          utils.isDeleted(docInfo.metadata, docInfo.metadata.rev) ? 1 : 0
-        ];
-        tx.executeSql(sql, sqlArgs, dataWritten);
+        var doc_id_rev = data._id + "::" + data._rev;
+        var deleted = utils.isDeleted(docInfo.metadata, docInfo.metadata.rev) ? 1 : 0;
+        var fetchSql = 'SELECT * FROM ' + BY_SEQ_STORE + ' WHERE doc_id_rev=?;';
+
+        tx.executeSql(fetchSql, [doc_id_rev], function (err, res) {
+          var sql, sqlArgs;
+          if (res.rows.length) {
+            sql = 'UPDATE ' + BY_SEQ_STORE +
+              ' SET json=?, deleted=? WHERE doc_id_rev=?;';
+            sqlArgs = [JSON.stringify(data), deleted, doc_id_rev];
+            tx.executeSql(sql, sqlArgs, function (tx) {
+              dataWritten(tx, res.rows.item(0).seq);
+            });
+          } else {
+            sql = 'INSERT INTO ' + BY_SEQ_STORE +
+              ' (doc_id_rev, json, deleted) VALUES (?, ?, ?);';
+            sqlArgs = [doc_id_rev, JSON.stringify(data), deleted];
+            tx.executeSql(sql, sqlArgs, function (tx, result) {
+              dataWritten(tx, result.insertId);
+            });
+          }
+        });
       }
 
       function collectResults(attachmentErr) {
@@ -466,8 +481,8 @@ function WebSqlPouch(opts, callback) {
         finish();
       }
 
-      function dataWritten(tx, result) {
-        var seq = docInfo.metadata.seq = result.insertId;
+      function dataWritten(tx, seq) {
+        docInfo.metadata.seq = seq;
         delete docInfo.metadata.rev;
 
         var mainRev = merge.winningRev(docInfo.metadata);

--- a/tests/test.bulk_docs.js
+++ b/tests/test.bulk_docs.js
@@ -216,6 +216,28 @@ adapters.map(function (adapter) {
       });
     });
 
+    it('Testing successive new_edits to the same doc', function (done) {
+
+      var db = new PouchDB(dbs.name);
+      var docs = [{
+        '_id': 'foo',
+        '_rev': '1-x',
+        '_revisions': {
+          'start': 1,
+          'ids': ['x']
+        }
+      }];
+
+      db.bulkDocs({docs: docs, new_edits: false}, function (err, result) {
+        should.not.exist(err);
+        db.bulkDocs({docs: docs, new_edits: false}, function (err, result) {
+          should.not.exist(err);
+          done();
+        });
+      });
+    });
+
+
     it('Bulk with new_edits=false in req body', function (done) {
       var db = new PouchDB(dbs.name);
       var docs = [{


### PR DESCRIPTION
This works, it should just need a migration which is annoying, it should solve all the constraint error problems

The problem was this code never worked as assumed, but was never being hit, during replication we should expect to miss checkpoints and rewrite previously written documents, but we also do a revsDiff during replication so we never actually ever try to write over old documents, theres a timing issue somewhere in replications in which we can (and we should expect to be able to) which was causing this to show
