### PR TITLE
(#44) Create separate distribution for levelalt and add query param for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ env:
   - CLIENT=node npm test
   - NATIVEPROMISE=1 CLIENT=firefox npm test
   - CLIENT=chrome npm test
-  - CLIENT=firefox INDEX_FILE=index-levelalt.js npm test
+  - CLIENT=firefox LEVEL_BACKEND=leveljs npm test
 
 matrix:
   allow_failures:
   - env: CLIENT=chrome npm test
-  - env: CLIENT=firefox INDEX_FILE=index-levelalt.js npm test
+  - env: CLIENT=firefox LEVEL_BACKEND=leveljs npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,9 @@ For quick debugging, you can run an interactive Node shell with the `PouchDB` va
 
 Alternative Backends
 --------------------------------------
-PouchDB is looking to support alternative backends that comply with the [LevelDOWN API](https://github.com/rvagg/abstract-leveldown). Simply include `INDEX_FILE=index-levelalt.js` in your `npm run build` and `npm run dev` commands to experiment with this feature!
+PouchDB is looking to support alternative backends that comply with the [LevelDOWN API](https://github.com/rvagg/abstract-leveldown). For example, simply include `LEVEL_BACKEND=leveljs` in your `npm run build` and `npm run dev` commands to experiment with this feature!
+
+Doing so will also create a separate distribution, for example, `pouchdb-leveljs.js` rather than `pouchdb-nightly.js`. In order to test a different distribution from `pouchdb-nightly.js`, you must specify in the testing URL: http://127.0.0.1:8000/tests/test.html?sourceFile=pouchdb-leveljs.js. `LEVEL_BACKEND=leveljs npm run test` will accomplish the same thing.
 
 Git Essentials
 --------------------------------------

--- a/bin/build-js.sh
+++ b/bin/build-js.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-: ${INDEX_FILE:="index.js"}
-
-if [ "$INDEX_FILE" == "index-levelalt.js" ]; then
+if [ "$LEVEL_BACKEND" == "leveljs" ]; then
     node_modules/.bin/browserify lib/index-levelalt.js \
       --require ./lib/index:./lib/index-levelalt.js \
       --standalone PouchDB \
-      --outfile dist/pouchdb-nightly.js
+      --outfile dist/pouchdb-$LEVEL_BACKEND.js
+
+    node_modules/.bin/uglifyjs dist/pouchdb-$LEVEL_BACKEND.js -mc \
+      > dist/pouchdb-$LEVEL_BACKEND.min.js
 else
     node_modules/.bin/browserify lib/index.js \
       --exclude ./adapters/leveldb \
@@ -16,4 +17,7 @@ else
       --ignore level-sublevel \
       --standalone PouchDB \
       --outfile dist/pouchdb-nightly.js
+    
+    node_modules/.bin/uglifyjs dist/pouchdb-nightly.js -mc \
+      > dist/pouchdb-nightly.min.js
 fi

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -13,17 +13,19 @@ fs.mkdir('dist', function (e) {
   }
 });
 
-var indexfile;
-if (process.env.INDEX_FILE) {
-  indexfile = "./lib/" + process.env.INDEX_FILE;
+var indexfile, dotfile, outfile;
+if (process.env.LEVEL_BACKEND) {
+  indexfile = "./lib/index-levelalt.js";
+  dotfile = "./dist/.pouchdb-" + process.env.LEVEL_BACKEND + ".js";
+  outfile = "./dist/pouchdb-" + process.env.LEVEL_BACKEND + ".js";
 } else {
   indexfile = "./lib/index.js";
+  dotfile = "./dist/.pouchdb-nightly.js";
+  outfile = "./dist/pouchdb-nightly.js";
 }
 
 var watchify = require("watchify");
 var w = watchify(indexfile);
-var dotfile = "./dist/.pouchdb-nightly.js";
-var outfile = "./dist/pouchdb-nightly.js";
 
 w.on('update', bundle);
 bundle();

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -26,6 +26,9 @@ if (process.env.GREP) {
 if (process.env.NATIVEPROMISE) {
   qs.noBluebird = 1;
 }
+if (process.env.LEVEL_BACKEND) {
+  qs.sourceFile = "pouchdb-" + process.env.LEVEL_BACKEND + ".js";
+}
 testUrl += '?';
 testUrl += querystring.stringify(qs);
 

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
   "scripts": {
     "jshint": "jshint -c .jshintrc bin/ lib/ tests/*.js",
     "build-js": "./bin/build-js.sh",
-    "uglify": "uglifyjs dist/pouchdb-nightly.js -mc > dist/pouchdb-nightly.min.js",
-    "build": "mkdir -p dist && npm run build-js && npm run uglify",
+    "build": "mkdir -p dist && npm run build-js",
     "test-node": "./bin/run-mocha.sh",
     "test-browser": "mkdir -p dist && npm run build-js && ./bin/test-browser.js",
     "dev": "./bin/dev-server.js",

--- a/tests/test.html
+++ b/tests/test.html
@@ -24,7 +24,6 @@
       });
       var should = chai.should();
     </script>
-    <script src='../dist/pouchdb-nightly.js'></script>
     <script src='deps/pouchdb-1.1.0-postfixed.js'></script>
     <script src='deps/pouchdb-2.0.0-postfixed.js'></script>
     <script src='utils.js'></script>

--- a/tests/webrunner.js
+++ b/tests/webrunner.js
@@ -2,29 +2,70 @@
 
 'use strict';
 
-var runner = mocha.run();
+// use query parameter sourceFile if present,
+// eg: test.html?sourceFile=pouchdb-leveljs.js
+var sourceFile = window.location.search.match(/[?&]sourceFile=([^&]+)/);
 
-window.results = {
-  lastPassed: '',
-  passed: 0,
-  failed: 0,
-  failures: []
-};
+if (!sourceFile) {
+  sourceFile = '../dist/pouchdb-nightly.js';
+} else {
+  sourceFile = '../dist/' + sourceFile[1];
+}
 
-runner.on('pass', function (e) {
-  window.results.lastPassed = e.title;
-  window.results.passed++;
-});
+// Thanks to http://engineeredweb.com/blog/simple-async-javascript-loader/
+function asyncLoadScript(url, callback) {
 
-runner.on('fail', function (e) {
-  window.results.failed++;
-  window.results.failures.push({
-    title: e.title,
-    err: e.err
+  // Create a new script and setup the basics.
+  var script = document.createElement("script"),
+  firstScript = document.getElementsByTagName('script')[0];
+
+  script.async = true;
+  script.src = url;
+
+  // Handle the case where an optional callback was passed in.
+  if ("function" === typeof(callback)) {
+    script.onload = function () {
+      callback();
+
+      // Clear it out to avoid getting called more than once or any memory leaks.
+      script.onload = script.onreadystatechange = undefined;
+    };
+    script.onreadystatechange = function () {
+      if ("loaded" === script.readyState || "complete" === script.readyState) {
+        script.onload();
+      }
+    };
+  }
+
+  // Attach the script tag to the page (before the first script) so the
+  //magic can happen.
+  firstScript.parentNode.insertBefore(script, firstScript);
+}
+
+asyncLoadScript(sourceFile, function () {
+  var runner = mocha.run();
+  window.results = {
+    lastPassed: '',
+    passed: 0,
+    failed: 0,
+    failures: []
+  };
+
+  runner.on('pass', function (e) {
+    window.results.lastPassed = e.title;
+    window.results.passed++;
   });
-});
 
-runner.on('end', function () {
-  window.results.completed = true;
-  window.results.passed++;
+  runner.on('fail', function (e) {
+    window.results.failed++;
+    window.results.failures.push({
+      title: e.title,
+      err: e.err
+    });
+  });
+
+  runner.on('end', function () {
+    window.results.completed = true;
+    window.results.passed++;
+  });
 });


### PR DESCRIPTION
Extension of #1690 and #44. I moved some of the uglify code into the bash script since that is the easiest way to differentiate the two cases, but I left npm run uglify just in case. Most of the webrunner loader was taken from an older version of webrunner.js and slightly modified for this and to pass Travis tests.
