### PR TITLE
(#942) - Fix replicate: detecton of errors from bulkDocs

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -97,6 +97,7 @@ function replicate(repId, src, target, opts, promise) {
     start_time: new Date(),
     docs_read: 0,
     docs_written: 0,
+    doc_write_failures: 0,
     errors: []
   };
 
@@ -113,7 +114,24 @@ function replicate(repId, src, target, opts, promise) {
     var docs = batches[0].docs;
     target.bulkDocs({docs: docs}, {new_edits: false}, function (err, res) {
       if (err) {
+        result.doc_write_failures += docs.length;
         return abortReplication('target.bulkDocs completed with error', err);
+      }
+
+      var errors = [];
+      res.forEach(function (res) {
+        if (!res.ok) {
+          result.doc_write_failures++;
+          errors.push({
+            status: 500,
+            error: res.error || 'Unknown document write error',
+            reason: res.reason || 'Unknown reason',
+          });
+        }
+      });
+
+      if (errors.length > 0) {
+        return abortReplication('target.bulkDocs failed to write docs', errors);
       }
 
       result.docs_written += docs.length;

--- a/tests/test.replication.js
+++ b/tests/test.replication.js
@@ -1191,52 +1191,60 @@ adapters.map(function (adapters) {
       });
     });
 
-    it.skip("Reporting write failures (#942)", function (done) {
+    it("Reporting write failures (#942)", function (done) {
       var docs = [{_id: 'a', _rev: '1-a'}, {_id: 'b', _rev: '1-b'}];
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
       db.bulkDocs({docs: docs}, {new_edits: false}, function (err, _) {
+        var bulkDocs = remote.bulkDocs;
         remote.bulkDocs = function (content, opts, callback) {
-          var response = [];
           var ids = content.docs.map(function (doc) { return doc._id; });
           if (ids.indexOf('a') >= 0) {
-            response.push({id: 'a', rev: '1-a'});
+            callback(null, [{ok: true, id: 'a', rev: '1-a'}]);
+          } else if (ids.indexOf('b') >= 0) {
+            callback(null, [{id: 'b', error: 'internal server error'}]);
+          } else {
+            bulkDocs.apply(this, arguments);
           }
-          if (ids.indexOf('b') >= 0) {
-            response.push({id: 'b', error: 'internal server error'});
-          }
-          callback(null, response);
         };
 
-        db.replicate.to(remote, function (err, result) {
-          result.docs_read.should.equal(2);
-          result.docs_written.should.equal(1);
-          result.doc_write_failures.should.equal(1);
-          db.replicate.to(remote, function (err, result) {
-            // checkpoint should not be moved and subsequent replications
-            // should continue from this some point
-            result.docs_read.should.equal(2);
+        db.replicate.to(remote, { batch_size: 1 }, function (err, result) {
+          result.docs_read.should.equal(2, 'docs_read');
+          result.docs_written.should.equal(1, 'docs_written');
+          result.doc_write_failures.should.equal(1, 'doc_write_failures');
+          remote.bulkDocs = bulkDocs;
+          db.replicate.to(remote, { batch_size: 1 }, function (err, result) {
+            // checkpoint should not be moved past first doc
+            // should continue from this point and retry second doc
+            result.docs_read.should.equal(1, 'second replication, docs_read');
+            result.docs_written.should.equal(1, 'second replication, docs_written');
+            result.doc_write_failures.should.equal(0, 'second replication, doc_write_failures');
             done();
           });
         });
       });
     });
 
-    it.skip("Reporting write failures if whole saving fails (#942)", function (done) {
+    it("Reporting write failures if whole saving fails (#942)", function (done) {
       var docs = [{_id: 'a', _rev: '1-a'}, {_id: 'b', _rev: '1-b'}];
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
       db.bulkDocs({docs: docs}, {new_edits: false}, function (err, _) {
+        var bulkDocs = remote.bulkDocs;
         remote.bulkDocs = function (docs, opts, callback) {
           callback(new Error());
         };
 
-        db.replicate.to(remote, function (err, result) {
-          result.docs_read.should.equal(2);
-          result.docs_written.should.equal(0);
-          result.doc_write_failures.equal(2);
-          db.replicate.to(remote, function (err, result) {
-            result.docs_read.should.equal(2);
+        db.replicate.to(remote, { batch_size: 1 }, function (err, result) {
+          result.docs_read.should.equal(1, 'docs_read');
+          result.docs_written.should.equal(0, 'docs_written');
+          result.doc_write_failures.should.equal(1, 'doc_write_failures');
+          result.last_seq.should.equal(0, 'last_seq');
+          remote.bulkDocs = bulkDocs;
+          db.replicate.to(remote, { batch_size: 1 }, function (err, result) {
+            result.doc_write_failures.should.equal(0, 'second replication, doc_write_failures');
+            result.docs_written.should.equal(2, 'second replication, docs_written');
+            result.last_seq.should.equal(2, 'second replication, last_seq');
             done();
           });
         });


### PR DESCRIPTION
This fixes replicate to detect and report errors from bulkDocs, per the tests in PR #1713 and changes and enables those tests.

In the first test, the mock of bulkDocs broke put, so replicate could not update checkpoint.

Some of the expectations in the tests seemed wrong to me, so I have amended them.
