### PR TITLE
(pouchdb/mapreduce#76) - ddocs destroyed in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "leveldown": "~0.10.2",
     "levelup": "~0.18.2",
     "lie": "^2.6.0",
-    "pouchdb-mapreduce": "1.0.0",
+    "pouchdb-mapreduce": "^2.0.0",
     "request": "~2.28.0"
   },
   "devDependencies": {

--- a/tests/test.design_docs.js
+++ b/tests/test.design_docs.js
@@ -13,7 +13,15 @@ adapters.map(function (adapter) {
     });
 
     afterEach(function (done) {
-      testUtils.cleanup([dbs.name], done);
+
+      var db = new PouchDB(dbs.name);
+      db.get('_design/foo').then(function (ddoc) {
+        db.remove(ddoc).then(function () {
+          db.viewCleanup(done);
+        }).catch(done);
+      }).catch(function () {
+        testUtils.cleanup([dbs.name], done);
+      });
     });
 
 

--- a/tests/test.views.js
+++ b/tests/test.views.js
@@ -508,6 +508,7 @@ adapters.map(function (adapters) {
         views: { scores: { map: 'function (doc) { if (doc.score) { emit(null, doc.score); } }' } }
       };
       db.post(doc, function (err, info) {
+        doc._rev = info.rev;
         db.query('barbar/dontExist', { key: 'bar' }, function (err, res) {
           if (!err.name) {
             err.name = err.error;
@@ -515,7 +516,12 @@ adapters.map(function (adapters) {
           }
           err.name.should.equal('not_found');
           err.message.should.equal('missing_named_view');
-          done();
+
+          db.remove(doc, function (err, res) {
+            db.viewCleanup(function (err) {
+              done();
+            });
+          });
         });
       });
     });


### PR DESCRIPTION
The new persisted mapreduce code is causing some
tests to fail because the indexes aren't correctly
cleaned up between tests.
