### PR TITLE
Short-circuit if isChromeApp in localStorage check

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -249,6 +249,9 @@ exports.isCordova = function () {
 };
 
 exports.hasLocalStorage = function () {
+  if (isChromeApp()) {
+    return false;
+  }
   try {
     return global.localStorage;
   } catch (e) {


### PR DESCRIPTION
Any calls made to `localStorage` in Chrome Apps will return:

> window.localStorage is not available in packaged apps. Use
> chrome.storage.local instead.

Therefore, guard against it if we're in a Chrome App.

Closes #1727.
