### PR TITLE
(#1658) - fix tests for persisted map/reduce

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -4,6 +4,7 @@ var utils = require('./utils');
 var merge = require('./merge');
 var errors = require('./deps/errors');
 var EventEmitter = require('events').EventEmitter;
+var upsert = require('./deps/upsert');
 
 /*
  * A generic pouch adapter
@@ -782,4 +783,19 @@ AbstractPouchDB.prototype.bulkDocs = utils.adapterFun('bulkDocs', function (req,
   }
 
   return this._bulkDocs(req, opts, this.autoCompact(callback));
+});
+
+AbstractPouchDB.prototype.registerDependentDatabase = utils.adapterFun('registerDependentDatabase', function (dependentDb, callback) {
+  var depDB = new this.constructor(dependentDb, {adapter: this._adapter});
+  function diffFun(doc) {
+    doc.dependentDbs = doc.dependentDbs || {};
+    doc.dependentDbs[dependentDb] = true;
+    return doc;
+  }
+  upsert(this, '_local/_pouch_dependentDbs', diffFun, function (err) {
+    if (err) {
+      return callback(err);
+    }
+    return callback(null, {db: depDB});
+  });
 });

--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -63,7 +63,7 @@ function PouchDB(name, opts, callback) {
         opts.originalName = originalName;
         opts.name = backend.name;
         opts.adapter = opts.adapter || backend.adapter;
-
+        self._adapter = opts.adapter;
         if (!PouchDB.adapters[opts.adapter]) {
           error = new Error('Adapter is missing');
           error.code = 404;

--- a/lib/deps/upsert.js
+++ b/lib/deps/upsert.js
@@ -1,0 +1,44 @@
+'use strict';
+var Promise = require('../utils').Promise;
+
+// this is essentially the "update sugar" function from daleharvey/pouchdb#1388
+function upsert(db, docId, diffFun) {
+  return new Promise(function (fullfil, reject) {
+    if (docId && typeof docId === 'object') {
+      docId = docId._id;
+    }
+    if (typeof docId !== 'string') {
+      return reject(new Error('doc id is required'));
+    }
+
+    db.get(docId, function (err, doc) {
+      if (err) {
+        if (err.name !== 'not_found') {
+          return reject(err);
+        }
+        return fullfil(tryAndPut(db, diffFun({_id : docId}), diffFun));
+      }
+      doc = diffFun(doc);
+      fullfil(tryAndPut(db, doc, diffFun));
+    });
+  });
+}
+
+function tryAndPut(db, doc, diffFun) {
+  return db.put(doc).then(null, function (err) {
+    if (err.name !== 'conflict') {
+      throw err;
+    }
+    return upsert(db, doc, diffFun);
+  });
+}
+
+module.exports = function (db, docId, diffFun, cb) {
+  if (typeof cb === 'function') {
+    upsert(db, docId, diffFun).then(function (resp) {
+      cb(null, resp);
+    }, cb);
+  } else {
+    return upsert(db, docId, diffFun);
+  }
+};

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -2,6 +2,7 @@
 
 var PouchDB = require("./constructor");
 var utils = require('./utils');
+var Promise = utils.Promise;
 var EventEmitter = require('events').EventEmitter;
 PouchDB.adapters = {};
 
@@ -85,18 +86,51 @@ PouchDB.destroy = utils.toPromise(function (name, opts, callback) {
   var backend = PouchDB.parseAdapter(opts.name || name, opts);
   var dbName = backend.name;
 
-  // call destroy method of the particular adaptor
-  PouchDB.adapters[backend.adapter].destroy(dbName, opts, function (err, resp) {
+  var adapter = PouchDB.adapters[backend.adapter];
+
+  function destroyDb() {
+    // call destroy method of the particular adaptor
+    adapter.destroy(dbName, opts, function (err, resp) {
+      if (err) {
+        callback(err);
+      } else {
+        PouchDB.emit('destroyed', dbName);
+        //so we don't have to sift through all dbnames
+        PouchDB.emit(dbName, 'destroyed');
+        callback(null, resp);
+      }
+    });
+  }
+
+  var usePrefix = 'use_prefix' in adapter ? adapter.use_prefix : true;
+
+  var trueDbName = usePrefix ?
+    dbName.replace(new RegExp('^' + PouchDB.prefix), '') : dbName;
+  new PouchDB(trueDbName, {adapter : backend.adapter}, function (err, db) {
     if (err) {
-      callback(err);
-    } else {
-      PouchDB.emit('destroyed', dbName);
-      //so we don't have to sift through all dbnames
-      PouchDB.emit(dbName, 'destroyed');
-      callback(null, resp);
+      return callback(err);
     }
+    db.get('_local/_pouch_dependentDbs', function (err, localDoc) {
+      if (err) {
+        if (err.name !== 'not_found') {
+          return callback(err);
+        } else { // no dependencies
+          return destroyDb();
+        }
+      }
+      var dependentDbs = localDoc.dependentDbs;
+      var deletedMap = Object.keys(dependentDbs).map(function (name) {
+        var trueName = usePrefix ?
+          name.replace(new RegExp('^' + PouchDB.prefix), '') : name;
+        return PouchDB.destroy(trueName, {adapter: backend.adapter});
+      });
+      Promise.all(deletedMap).then(destroyDb, function (error) {
+        callback(error);
+      });
+    });
   });
 });
+
 PouchDB.allDbs = utils.toPromise(function (callback) {
   var err = new Error('allDbs method removed');
   err.stats = '400';

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "leveldown": "~0.10.2",
     "levelup": "~0.18.2",
     "lie": "^2.6.0",
-    "pouchdb-mapreduce": "1.0.0",
+    "pouchdb-mapreduce": "2.1.0",
     "request": "~2.28.0"
   },
   "devDependencies": {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -4,6 +4,14 @@
 
 var testUtils = {};
 
+function uniq(list) {
+  var map = {};
+  list.forEach(function (item) {
+    map[item] = true;
+  });
+  return Object.keys(map);
+}
+
 testUtils.couchHost = function () {
   if (typeof module !== 'undefined' && module.exports) {
     return process.env.COUCH_HOST || 'http://localhost:5984';
@@ -65,6 +73,8 @@ testUtils.adapterUrl = function (adapter, name) {
 
 // Delete specified databases
 testUtils.cleanup = function (dbs, done) {
+
+  dbs = uniq(dbs);
 
   var deleted = 0;
   var num = dbs.length;


### PR DESCRIPTION
This commit ensures that the persisted map/reduce
indexes are destroyed when their parent database
is destroyed.
