### PR TITLE
(#1732) Use allDocs to batch generation 1 docs in replication

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -178,7 +178,7 @@ function replicate(repId, src, target, opts, promise) {
         // * is no longer generation 1
         // * has attachments
         var needsSingleFetch = !row.doc ||
-          parseInt(row.value.rev, 10) > 1 ||
+          row.value.rev.slice(0, 2) !== '1-' ||
           row.doc._attachments && Object.keys(row.doc._attachments).length;
 
         if (needsSingleFetch) {
@@ -197,14 +197,10 @@ function replicate(repId, src, target, opts, promise) {
     });
   }
 
-  function fetchSingleRev(id, revs) {
-    src.get(id, {revs: true, open_revs: revs, attachments: true}, onGet);
-  }
-
   function fetchRev() {
     if (fetchAgain.length) {
       var doc = fetchAgain.shift();
-      return fetchSingleRev(doc.id, [doc.rev]);
+      return fetchSingleRev(src, onGet, doc.id, [doc.rev]);
     }
 
     var diffs = batches[0].diffs;
@@ -215,7 +211,7 @@ function replicate(repId, src, target, opts, promise) {
     }
 
     var generationOne = Object.keys(diffs).reduce(function (memo, id) {
-      if (diffs[id].missing.length === 1 && parseInt(diffs[id].missing[0], 10) === 1) {
+      if (diffs[id].missing.length === 1 && diffs[id].missing[0].slice(0, 2) === '1-') {
         memo.ids.push(id);
         memo.revs.push(diffs[id].missing[0]);
         delete diffs[id];
@@ -235,7 +231,7 @@ function replicate(repId, src, target, opts, promise) {
     var revs = diffs[id].missing;
     delete diffs[id];
 
-    fetchSingleRev(id, revs);
+    fetchSingleRev(src, onGet, id, revs);
   }
 
 
@@ -455,6 +451,10 @@ function replicate(repId, src, target, opts, promise) {
       getChanges();
     });
   }
+}
+
+function fetchSingleRev(src, callback, id, revs) {
+  src.get(id, {revs: true, open_revs: revs, attachments: true}, callback);
 }
 
 function toPouch(db, callback) {


### PR DESCRIPTION
This is a tweak of the original fix for #993 by @jo.  I updated it to pouchdb master and fix few things related to open_revs call.

All tests passes.  

It speed up the replicate a lot when most docs are one revision "old".  
