### PR TITLE
(#1733) - fix unicode doc ids in websql

### DIFF
--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -51,8 +51,6 @@ var DOC_STORE_WINNINGSEQ_INDEX_SQL = 'CREATE INDEX IF NOT EXISTS \'doc-winningse
   DOC_STORE + ' (winningseq)';
 
 
-var idRequests = [];
-
 function unknownError(callback) {
   return function (event) {
     // event may actually be a SQLError object, so report is as such
@@ -63,53 +61,29 @@ function unknownError(callback) {
     callback(errors.error(errors.WSQ_ERROR, errorReason, errorName));
   };
 }
-
-function parseHexString(str) {
-  var result = '';
-  for (var i = 0, len = str.length; i < len; i += 2) {
-    result += String.fromCharCode(parseInt(str.substring(i, i + 2), 16));
-  }
-  return result;
-}
-
-// Safari is weird, it encodes everything with bonus \u0000 characters after
-// every character rather than user agent sniff, we test every odd
-// character for \u0000
-function isMangledUnicode(str) {
-  for (var i = 1, len = str.length; i < len; i += 2) {
-    if (str.charAt(i) !== '\u0000') {
-      return false;
-    }
-  }
-  return true;
-}
-
-// unmangle the aforementioned Safari atrocity
-function unmangleUnicode(str) {
-  var result = '';
-  for (var i = 0, len = str.length; i < len; i += 2) {
-    result += str.charAt(i);
-  }
-  return result;
-}
-
-// used to deal with utf8 encoding that occurs in most sqlite implementations
-// partially taken from
-// http://ecmanaut.blogspot.ca/2006/07/encoding-decoding-utf8-in-javascript.html
 function decodeUtf8(str) {
-  var result;
-  try {
-    result = decodeURIComponent(window.escape(str));
-  } catch (err) {
-    // URI error in safari, string is already escaped but still possibly mangled
-    result = str;
-  }
-  return isMangledUnicode(result) ? unmangleUnicode(result) : result;
+  return decodeURIComponent(window.escape(str));
 }
+function parseHexString(str, encoding) {
+  var result = '';
+  var charWidth = encoding === 'UTF-8' ? 2 : 4;
+  for (var i = 0, len = str.length; i < len; i += charWidth) {
+    var substring = str.substring(i, i + charWidth);
+    if (charWidth === 4) { // UTF-16, twiddle the bits
+      substring = substring.substring(2, 4) + substring.substring(0, 2);
+    }
+    result += String.fromCharCode(parseInt(substring, 16));
+  }
+  result = encoding === 'UTF-8' ? decodeUtf8(result) : result;
+  return result;
+}
+
 function WebSqlPouch(opts, callback) {
   var api = this;
   var instanceId = null;
   var name = opts.name;
+  var idRequests = [];
+  var encoding;
 
   var db = openDB(name, POUCH_VERSION, name, POUCH_SIZE);
   if (!db) {
@@ -169,11 +143,23 @@ function WebSqlPouch(opts, callback) {
     });
   }
 
-  function onGetInstanceId() {
+  function onGetInstanceId(tx) {
     while (idRequests.length > 0) {
       var idCallback = idRequests.pop();
       idCallback(null, instanceId);
     }
+    checkDbEncoding(tx);
+  }
+
+  function checkDbEncoding(tx) {
+    // check db encoding - utf-8 (chrome, opera) or utf-16 (safari)?
+    tx.executeSql('SELECT dbid, hex(dbid) AS hexId FROM ' + META_STORE, [],
+      function (err, result) {
+        var id = result.rows.item(0).dbid;
+        var hexId = result.rows.item(0).hexId;
+        encoding = (hexId.length === id.length * 2) ? 'UTF-8' : 'UTF-16';
+      }
+    );
   }
 
   function onGetVersion(tx, dbVersion) {
@@ -203,7 +189,7 @@ function WebSqlPouch(opts, callback) {
         var initSeq = 'INSERT INTO ' + META_STORE + ' (update_seq, db_version, dbid) VALUES (?, ?, ?)';
         instanceId = utils.uuid();
         tx.executeSql(initSeq, [0, ADAPTER_VERSION, instanceId]);
-        onGetInstanceId();
+        onGetInstanceId(tx);
       });
     } else { // version > 0
 
@@ -216,7 +202,7 @@ function WebSqlPouch(opts, callback) {
       // notify db.id() callers
       tx.executeSql('SELECT dbid FROM ' + META_STORE, [], function (tx, result) {
         instanceId = result.rows.item(0).dbid;
-        onGetInstanceId();
+        onGetInstanceId(tx);
       });
     }
   }
@@ -578,7 +564,8 @@ function WebSqlPouch(opts, callback) {
     function metadataFetched(tx, results) {
       for (var j = 0; j < results.rows.length; j++) {
         var row = results.rows.item(j);
-        fetchedDocs[row.id] = JSON.parse(row.json);
+        var id = parseHexString(row.hexId, encoding);
+        fetchedDocs[id] = JSON.parse(row.json);
       }
       processDocs();
     }
@@ -586,7 +573,7 @@ function WebSqlPouch(opts, callback) {
     preprocessAttachments(function () {
       db.transaction(function (txn) {
         tx = txn;
-        var sql = 'SELECT * FROM ' + DOC_STORE + ' WHERE id IN ' +
+        var sql = 'SELECT hex(id) AS hexId, json FROM ' + DOC_STORE + ' WHERE id IN ' +
           '(' + docInfos.map(function () {return '?'; }).join(',') + ')';
         var queryArgs = docInfos.map(function (d) { return d.metadata.id; });
         tx.executeSql(sql, queryArgs, metadataFetched);
@@ -844,9 +831,10 @@ function WebSqlPouch(opts, callback) {
     var type = attachment.content_type;
     var sql = 'SELECT hex(body) as body FROM ' + ATTACH_STORE + ' WHERE digest=?';
     tx.executeSql(sql, [digest], function (tx, result) {
-      // TODO: sqlite normally stores data as utf8, so even the hex() function "encodes" the binary
-      // data in utf8 before returning it, and yet hex() is the only way to get the full data. so we do this.
-      var data = decodeUtf8(parseHexString(result.rows.item(0).body));
+      // sqlite normally stores data as utf8, so even the hex() function
+      // "encodes" the binary data in utf8/16 before returning it. yet hex()
+      // is the only way to get the full data, so we do this.
+      var data = parseHexString(result.rows.item(0).body, encoding);
       if (opts.encode) {
         res = btoa(data);
       } else {


### PR DESCRIPTION
Working in Safari local, broken in Chrome http for the time being.
