### PR TITLE
(#1734) - WIP - simultaneous writes

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -469,6 +469,10 @@ AbstractPouchDB.prototype.get =
     }
 
     var doc = result.doc;
+    if (!doc) {
+      // a smoke test for something being very wrong
+      return callback(new Error('no doc!'));
+    }
     var metadata = result.metadata;
     var ctx = result.ctx;
 

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -61,6 +61,7 @@ function LevelPouch(opts, callback) {
         return callback(err);
       }
       db = dbStore[name];
+      db._locks = db._locks || {};
       if (opts.db || opts.noMigrate) {
         afterDBCreated();
       } else {
@@ -124,9 +125,19 @@ function LevelPouch(opts, callback) {
   function parseSeq(s) {
     return parseInt(s, 10);
   }
-
+  function makeDoc(rawDoc) {
+    var doc = rawDoc.data;
+    doc._id = rawDoc.metadata.id;
+    doc._rev = rawDoc.metadata.rev;
+    return {doc: doc, metadata: rawDoc.metadata};
+  }
   api._get = function (id, opts, callback) {
     opts = utils.clone(opts);
+    var docChanged = [];
+    function didDocChange(doc) {
+      docChanged.push(doc);
+    }
+    db.on('pouchdb-id-' + id, didDocChange);
     stores.docStore.get(id, function (err, metadata) {
       if (err || !metadata) {
         return callback(errors.MISSING_DOC);
@@ -134,12 +145,27 @@ function LevelPouch(opts, callback) {
       if (utils.isDeleted(metadata) && !opts.rev) {
         return callback(errors.error(errors.MISSING_DOC, "deleted"));
       }
-
+      var updated;
+      function ifUpdate(doc) {
+        updated = doc;
+      }
       var rev = merge.winningRev(metadata);
       rev = opts.rev ? opts.rev : rev;
       var seq = metadata.rev_map[rev];
-
+      db.removeListener('pouchdb-id-' + id, didDocChange);
+      var anyChanged = docChanged.filter(function (doc) {
+        return doc.metadata.seq === seq;
+      });
+      if (anyChanged.length) {
+        return callback(null, makeDoc(anyChanged.pop()));
+      }
+      db.on('pouchdb-' + seq, ifUpdate);
       stores.bySeqStore.get(formatSeq(seq), function (err, doc) {
+        db.removeListener('pouchdb-' + seq, ifUpdate);
+        if (updated) {
+          return callback(null, makeDoc(updated));
+
+        }
         if (!doc) {
           return callback(errors.MISSING_DOC);
         }
@@ -174,17 +200,16 @@ function LevelPouch(opts, callback) {
       callback(null, data);
     });
   };
-  api._locks = {};
   api.lock = function (id) {
-    if (id in api._locks) {
+    if (id in db._locks) {
       return false;
     } else {
-      api._locks[id] = true;
+      db._locks[id] = true;
       return true;
     }
   };
   api.unlock = function (id) {
-    delete api._locks[id];
+    delete db._locks[id];
     return true;
   };
   api._bulkDocs = function (req, opts, callback) {
@@ -218,7 +243,8 @@ function LevelPouch(opts, callback) {
       var currentDoc = info.shift();
       stores.docStore.get(currentDoc.metadata.id, function (err, oldDoc) {
         if (!api.lock(currentDoc.metadata.id)) {
-          results.push(makeErr(errors.REV_CONFLICT, 'someobody else is accessing this'));
+          results.push(makeErr(errors.REV_CONFLICT,
+            'someobody else is accessing this'));
           return processDocs();
         }
         if (err && err.name === 'NotFoundError') {
@@ -226,8 +252,7 @@ function LevelPouch(opts, callback) {
             api.unlock(currentDoc.metadata.id);
             processDocs();
           });
-        }
-        else {
+        } else {
           updateDoc(oldDoc, currentDoc, function () {
             api.unlock(currentDoc.metadata.id);
             processDocs();
@@ -332,7 +357,9 @@ function LevelPouch(opts, callback) {
         updateSeq++;
         doc.metadata.seq = doc.metadata.seq || updateSeq;
         doc.metadata.rev_map[doc.metadata.rev] = doc.metadata.seq;
-
+        var seq = formatSeq(doc.metadata.seq);
+        db.emit('pouchdb-id-' + doc.metadata.id, doc);
+        db.emit('pouchdb-' + seq, doc);
         db.batch([{
           key: formatSeq(doc.metadata.seq),
           value: doc.data,
@@ -346,6 +373,10 @@ function LevelPouch(opts, callback) {
           type: 'put',
           valueEncoding: 'json'
         }], function (err) {
+          if (!err) {
+            db.emit('pouchdb-id-' + doc.metadata.id, doc);
+            db.emit('pouchdb-' + seq, doc);
+          }
           return stores.bySeqStore.put(UPDATE_SEQ_KEY, updateSeq,
             function (err) {
             if (err) {

--- a/tests/test.bulk_docs.js
+++ b/tests/test.bulk_docs.js
@@ -319,7 +319,6 @@ adapters.forEach(function (adapter) {
         } else {
           ids.push(res[0].id);
         }
-        console.log(res);
         if (++numDone === 2) {
           errorNames.should.deep.equal(['conflict']);
           ids.should.deep.equal([id]);


### PR DESCRIPTION
Sadly this test fails in Node.  Without transactions, I'm guessing the only solution is task queues, which will unfortunately not work unless we tie them to db names rather than PouchDB instances.

``` js
it('handles simultaneous writes', function (done) {
  var db = new PouchDB(dbs.name);
  var id = 'fooId';
  var errorNames = [];
  var ids = [];
  var numDone = 0;
  function callback(err, res) {
    should.not.exist(err);
    if (res[0].error) {
      errorNames.push(res[0].name);
    } else {
      ids.push(res[0].id);
    }
    console.log(res);
    if (++numDone === 2) {
      errorNames.should.deep.equal(['conflict']);
      ids.should.deep.equal([id]);
      done();
    }
  }
  db.bulkDocs({docs : [{_id : id}]}, callback);
  db.bulkDocs({docs : [{_id : id}]}, callback);
});
```
