### PR TITLE
(#1068) - cache websql dbs

### DIFF
--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -7,6 +7,8 @@ function quote(str) {
   return "'" + str + "'";
 }
 
+var cachedDatabases = {};
+
 var openDB = utils.getArguments(function (args) {
   if (typeof global !== 'undefined') {
     if (global.navigator && global.navigator.sqlitePlugin &&
@@ -17,7 +19,11 @@ var openDB = utils.getArguments(function (args) {
       return global.sqlitePlugin.openDatabase
         .apply(global.sqlitePlugin, args);
     } else {
-      return global.openDatabase.apply(global, args);
+      var db = cachedDatabases[args[0]];
+      if (!db) {
+        db = cachedDatabases[args[0]] = global.openDatabase.apply(global, args);
+      }
+      return db;
     }
   }
 });
@@ -46,7 +52,6 @@ var DOC_STORE_WINNINGSEQ_INDEX_SQL = 'CREATE INDEX IF NOT EXISTS \'doc-winningse
 
 
 var idRequests = [];
-var cachedDatabases = {};
 
 function unknownError(callback) {
   return function (event) {
@@ -106,10 +111,7 @@ function WebSqlPouch(opts, callback) {
   var instanceId = null;
   var name = opts.name;
 
-  var db = cachedDatabases[name];
-  if (!db) {
-    cachedDatabases[name] = db = openDB(name, POUCH_VERSION, name, POUCH_SIZE);
-  }
+  var db = openDB(name, POUCH_VERSION, name, POUCH_SIZE);
   if (!db) {
     return callback(errors.UNKNOWN_ERROR);
   }


### PR DESCRIPTION
Safari 7 starts throwing DOM Exception 11 if
we open up too many db handles, which crashes
our unit tests. Caching them fixes that.

We actually already tried this once before in
6575e8d490fbc745242edf72090598a72df6f120, but
we forgot to put the cachedDatabases outside
the constructor method.
