### PR TITLE
(#1743) - escape sql in websql's doCompaction

### DIFF
--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -882,12 +882,13 @@ function WebSqlPouch(opts, callback) {
         metadata.rev_tree = rev_tree;
 
         var sql = 'DELETE FROM ' + BY_SEQ_STORE + ' WHERE doc_id_rev IN (' +
-          revs.map(function (rev) {return quote(docId + '::' + rev); }).join(',') + ')';
+          revs.map(function () { return '?'; }).join(',') + ')';
 
-        tx.executeSql(sql, [], function (tx, result) {
+        var docIdRevs = revs.map(function (rev) {return docId + '::' + rev; });
+        tx.executeSql(sql, [docIdRevs], function (tx) {
           var sql = 'UPDATE ' + DOC_STORE + ' SET json = ? WHERE id = ?';
 
-          tx.executeSql(sql, [JSON.stringify(metadata), docId], function (tx, result) {
+          tx.executeSql(sql, [JSON.stringify(metadata), docId], function () {
             callback();
           });
         });

--- a/tests/test.compaction.js
+++ b/tests/test.compaction.js
@@ -192,6 +192,26 @@ adapters.map(function (adapter) {
       });
     });
 
+    it('Compact db with sql-injecty doc id', function (done) {
+      var db = new PouchDB(dbs.name);
+      var id = '\'sql_injection_here';
+      db.put({ _id: id }, function (err, res) {
+        var firstRev = res.rev;
+        db.remove({
+          _id: id,
+          _rev: firstRev
+        }, function (err, res) {
+          db.compact(function () {
+            db.get(id, { rev: firstRev }, function (err, res) {
+              should.exist(err, 'got error');
+              err.message.should.equal('missing', 'correct reason');
+              done();
+            });
+          });
+        });
+      });
+    });
+
     if (autoCompactionAdapters.indexOf(adapter) === -1) {
       return;
     }


### PR DESCRIPTION
This should be the final SQL injection fix. I don't
see quote() being used anywhere else, except for
static db names.
