### PR TITLE
Intermittent allDocs error

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -183,7 +183,7 @@ function replicate(repId, src, target, opts, promise) {
 
         if (needsSingleFetch) {
           return fetchAgain.push({
-            id: row.id,
+            id: row.error === 'not_found' ? row.key : row.id,
             rev: revs[i]
           });
         }


### PR DESCRIPTION
This 'fixes' intermittent failures in several replication tests.
There may be an underlying error in allDocs. It returns error not_found intermittently and probably should not. None the less, there may be (very rare) cases where allDocs correctly returns error not_found for a document that recently appeared in the changes feed, so this case should be handled. 
