### PR TITLE
(#1515) - Add authentication headers on destroy

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -979,7 +979,8 @@ function HttpPouch(opts, callback) {
   api.destroy = utils.adapterFun('destroy', function (callback) {
     ajax({
       url: genDBUrl(host, ''),
-      method: 'DELETE'
+      method: 'DELETE',
+      headers: host.headers
     }, function (err, resp) {
       if (err) {
         api.emit('error', err);


### PR DESCRIPTION
"Remove a pouch" tests were previously failing against Cloudant databases. The root cause appears to be due to authentication headers not being added to the DELETE request correctly.

This patch adds the default headers (including authentication) to the request and the test now passes.
