### PR TITLE
(#1775) - add getUrl() to http adapter

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -125,7 +125,9 @@ function HttpPouch(opts, callback) {
   var host = api.getHost(opts.name, opts);
 
   // Generate the database URL based on the host
-  var db_url = genDBUrl(host, '');
+  var dbUrl = genDBUrl(host, '');
+
+  api.getUrl = function () {return dbUrl; };
 
   var ajaxOpts = opts.ajax || {};
   opts = utils.extend(true, {}, opts);
@@ -158,11 +160,11 @@ function HttpPouch(opts, callback) {
 
   // Create a new CouchDB database based on the given opts
   var createDB = function () {
-    ajax({headers: host.headers, method: 'PUT', url: db_url}, function (err, ret) {
+    ajax({headers: host.headers, method: 'PUT', url: dbUrl}, function (err, ret) {
       // If we get an "Unauthorized" error
       if (err && err.status === 401) {
         // Test if the database already exists
-        ajax({headers: host.headers, method: 'HEAD', url: db_url}, function (err, ret) {
+        ajax({headers: host.headers, method: 'HEAD', url: dbUrl}, function (err, ret) {
           // If there is still an error
           if (err) {
             // Give the error to the callback to deal with
@@ -184,7 +186,7 @@ function HttpPouch(opts, callback) {
     });
   };
   if (!opts.skipSetup) {
-    ajax({headers: host.headers, method: 'GET', url: db_url}, function (err, ret) {
+    ajax({headers: host.headers, method: 'GET', url: dbUrl}, function (err, ret) {
       //check if the db exists
       if (err) {
         if (err.status === 404) {


### PR DESCRIPTION
I'm probably going to need this function for a new plugin I'm working on : https://github.com/nolanlawson/pouchdb-authentication.  The plugin accesses the `_users` and `_security` databases, and for that it needs to know what the root URL of the Pouch is.
