### PR TITLE
Small fix for IE versions where `addEventListener()` is not defined.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -276,9 +276,15 @@ exports.Changes = function () {
       }
     });
   } else if (hasLocal) {
-    global.addEventListener("storage", function (e) {
-      eventEmitter.emit(e.key);
-    });
+    if (global.addEventListener) {
+      global.addEventListener("storage", function (e) {
+        eventEmitter.emit(e.key);
+      });
+    } else {
+      global.attachEvent("storage", function (e) {
+        eventEmitter.emit(e.key);
+      });
+    }
   }
 
   api.addListener = function (dbName, id, db, opts) {


### PR DESCRIPTION
Use `attachEvent()` instead.
