### PR TITLE
(#1739) - lower continuous changes feed timeout

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -694,7 +694,8 @@ function HttpPouch(opts, callback) {
     opts = utils.extend(true, {}, opts);
     opts.timeout = opts.timeout || 0;
 
-    var params = {};
+    // set timeout to 20s to prevent aborting via Ajax timeout
+    var params = { timeout: 20 * 1000 };
     var limit = (typeof opts.limit !== 'undefined') ? opts.limit : false;
     if (limit === 0) {
       limit = 1;


### PR DESCRIPTION
to prevent from being aborted via ajax timeout
