### PR TITLE
(#1797) - fix websql compaction

### DIFF
--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -860,6 +860,9 @@ function WebSqlPouch(opts, callback) {
   };
 
   api._doCompaction = function (docId, rev_tree, revs, callback) {
+    if (!revs.length) {
+      return callback();
+    }
     db.transaction(function (tx) {
       var sql = 'SELECT json AS metadata FROM ' + DOC_STORE + ' WHERE id = ?';
       tx.executeSql(sql, [docId], function (tx, result) {
@@ -869,15 +872,18 @@ function WebSqlPouch(opts, callback) {
         var metadata = JSON.parse(result.rows.item(0).metadata);
         metadata.rev_tree = rev_tree;
 
-        var sql = 'DELETE FROM ' + BY_SEQ_STORE + ' WHERE doc_id_rev IN (' +
-          revs.map(function () { return '?'; }).join(',') + ')';
-
-        var docIdRevs = revs.map(function (rev) {return docId + '::' + rev; });
-        tx.executeSql(sql, [docIdRevs], function (tx) {
-          var sql = 'UPDATE ' + DOC_STORE + ' SET json = ? WHERE id = ?';
-
-          tx.executeSql(sql, [JSON.stringify(metadata), docId], function () {
-            callback();
+        // websql never calls callback if we do WHERE doc_id_rev IN (...)
+        var numDone = 0;
+        revs.forEach(function (rev) {
+          var docIdRev = docId + '::' + rev;
+          var sql = 'DELETE FROM ' + BY_SEQ_STORE + ' WHERE doc_id_rev = ?';
+          tx.executeSql(sql, [docIdRev], function (tx) {
+            if (++numDone === revs.length) {
+              var sql = 'UPDATE ' + DOC_STORE + ' SET json = ? WHERE id = ?';
+              tx.executeSql(sql, [JSON.stringify(metadata), docId], function () {
+                callback();
+              });
+            }
           });
         });
       });


### PR DESCRIPTION
Somehow #1743 introduced a regression to WebSQL
where the "compact a complicated tree" test fails.
The fix is to rephrase the query to avoid param
lists (`WHERE foo in (?,?,?)`).

Reproduced in both Safari 7 and Chrome.
