### PR TITLE
(#1795) better contrast for code colors

### DIFF
--- a/docs/static/less/pouchdb/variables.less
+++ b/docs/static/less/pouchdb/variables.less
@@ -18,13 +18,12 @@
 @body-bg: #f6f6f6;
 @text-color: @gray;
 
-
 // Container sizes
 @container-large-desktop: ((950px + @grid-gutter-width));
 
 // Code
-@code-color: darken(@brand-primary, 20%);
-@code-bg: lighten(@code-color, 50%);
+@code-color: #6eca97;
+@code-bg: #3F3F39;
 
 // Type
 @font-family-sans-serif: "Open Sans", Helvetica, Arial, sans-serif;


### PR DESCRIPTION
this would use the same color scheme for the inline code that the blocks use
![screen shot 2014-04-01 at 3 41 00 pm](https://cloud.githubusercontent.com/assets/1128607/2583769/9906a302-b9d5-11e3-82d7-828b0f294e04.png)
