### PR TITLE
(#1820) - add docs for persisted mapreduce

### DIFF
--- a/docs/_includes/api.html
+++ b/docs/_includes/api.html
@@ -12,6 +12,8 @@
 <li><a href="#get_attachment">Get attachment</a></li>
 <li><a href="#delete_attachment">Delete attachment</a></li>
 <li><a href="#query_database">Query database</a></li>
+<li><a href="#create_view">Create view</a></li>
+<li><a href="#view_cleanup">View cleanup</a></li>
 <li><a href="#database_information">Database info</a></li>
 <li><a href="#compaction">Compaction</a></li>
 <li><a href="#revisions_diff">Revision diff</a></li>


### PR DESCRIPTION
This includes updated documentation for db.query(),
plus new documentation for two new API methods:
db.putView(), and db.viewCleanup().
