### PR TITLE
(#1809) - Defer allDocs callback until processing is complete

### DIFF
--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -436,6 +436,8 @@ function LevelPouch(opts, callback) {
 
   api._allDocs = function (opts, callback) {
     this.countDocs(function (err, totalRows) {
+      var callbacks = 0;            // count of oustanding callbacks
+      var readstreamClosed = false; // flag set when readstream is closed
       var readstreamOpts = {};
       var skip = opts.skip || 0;
       if (opts.startkey) {
@@ -525,8 +527,13 @@ function LevelPouch(opts, callback) {
         var metadata = entry.value;
         if (opts.include_docs) {
           var seq = metadata.rev_map[merge.winningRev(metadata)];
+          callbacks++;
           stores.bySeqStore.get(formatSeq(seq), function (err, data) {
+            callbacks--;
             allDocsInner(metadata, data);
+            if (readstreamClosed && callbacks === 0) {
+              returnResults();
+            }
           });
         }
         else {
@@ -538,6 +545,13 @@ function LevelPouch(opts, callback) {
       docstream.on('end', function () {
       });
       docstream.on('close', function () {
+        readstreamClosed = true;
+        if (callbacks === 0) {
+          returnResults();
+        }
+      });
+
+      function returnResults() {
         if ('keys' in opts) {
           opts.keys.forEach(function (key) {
             if (key in resultsMap) {
@@ -550,12 +564,14 @@ function LevelPouch(opts, callback) {
             results.reverse();
           }
         }
+
         return callback(null, {
           total_rows: totalRows,
           offset: opts.skip,
           rows: results
         });
-      });
+      }
+
     });
   };
 


### PR DESCRIPTION
This fixes a race in leveldb.js _allDocs.
