### PR TITLE
(#1859) - Performance tests for map/reduce

### DIFF
--- a/tests/performance/index.js
+++ b/tests/performance/index.js
@@ -1,2 +1,2 @@
-var PouchDB = require('../..');
-require('./perf.basics')(PouchDB);
+require('./perf.basics');
+require('./perf.views');

--- a/tests/performance/perf.basics.js
+++ b/tests/performance/perf.basics.js
@@ -1,9 +1,8 @@
 'use strict';
 
 var PouchDB = require('../..');
-var test = require('tape');
-var reporter = require('./perf.reporter');
 var Promise = PouchDB.utils.Promise;
+var utils = require('./utils');
 
 function createDocId(i) {
   var intString = i.toString();
@@ -102,48 +101,4 @@ var testCases = [
   }
 ];
 
-testCases.forEach(function (testCase, i) {
-  test('benchmarking', function (t) {
-
-    var db;
-    var setupObj;
-
-    t.test('setup', function (t) {
-      new PouchDB('test').then(function (d) {
-        db = d;
-        testCase.setup(db, function (err, res) {
-          setupObj = res;
-          reporter.start(testCase);
-          t.end();
-        });
-      });
-    });
-
-    t.test(testCase.name, function (t) {
-      t.plan(testCase.assertions);
-      var num = 0;
-      function after(err) {
-        if (err) {
-          t.error(err);
-        }
-        if (++num < testCase.iterations) {
-          process.nextTick(function () {
-            testCase.test(db, num, setupObj, after);
-          });
-        } else {
-          t.ok(testCase.name + ' completed');
-        }
-      }
-      testCase.test(db, num, setupObj, after);
-    });
-    t.test('teardown', function (t) {
-      reporter.end(testCase);
-      db.destroy(function () {
-        t.end();
-        if (i === testCases.length - 1) {
-          reporter.complete();
-        }
-      });
-    });
-  });
-});
+utils.runTests('basics', testCases);

--- a/tests/performance/perf.reporter.js
+++ b/tests/performance/perf.reporter.js
@@ -10,6 +10,10 @@ function log(msg) {
   }
 }
 
+exports.startSuite = function (suiteName) {
+  log('Starting suite: ' + suiteName + '\n\n');
+};
+
 exports.start = function (testCase) {
   var key = testCase.name;
   log('Starting test: ' + key + ' with ' + testCase.assertions +
@@ -27,7 +31,7 @@ exports.end = function (testCase) {
   log('done in ' + obj.duration + 'ms\n');
 };
 
-exports.complete = function () {
+exports.complete = function (suiteName) {
   global.results.completed = true;
   console.log(global.results);
   log('\nTests Complete!\n\n');

--- a/tests/performance/perf.views.js
+++ b/tests/performance/perf.views.js
@@ -1,0 +1,148 @@
+'use strict';
+
+var PouchDB = require('../..');
+var Promise = PouchDB.utils.Promise;
+var utils = require('./utils');
+
+function makeTestDocs() {
+  return [
+    {key: null},
+    {key: true},
+    {key: false},
+    {key: -1},
+    {key: 0},
+    {key: 1},
+    {key: 2},
+    {key: 3},
+    {key: Math.random()},
+    {key: 'bar' + Math.random()},
+    {key: 'foo' + Math.random()},
+    {key: 'foobar' + Math.random()}
+  ];
+}
+
+var testCases = [
+  {
+    name: 'temp-views',
+    assertions: 1,
+    iterations: 10,
+    setup: function (db, callback) {
+      var tasks = [];
+      for (var i = 0; i < 100; i++) {
+        tasks.push(i);
+      }
+      Promise.all(tasks.map(function () {
+        return db.bulkDocs({docs : makeTestDocs()});
+      })).then(function () {
+        callback();
+      }, callback);
+    },
+    test: function (db, itr, doc, done) {
+      var tasks = [
+        {startkey: 'foo', limit: 5},
+        {startkey: 'foobar', limit: 5},
+        {startkey: 'foo', limit: 5},
+        {startkey: -1, limit: 5},
+        {startkey: null, limit: 5}
+      ];
+      Promise.all(tasks.map(function (task) {
+        return db.query(function (doc) {
+          emit(doc.key);
+        }, task);
+      })).then(function (res) {
+        console.log(res);
+        done();
+      }, done);
+    }
+  },
+  {
+    name: 'persisted-views',
+    assertions: 1,
+    iterations: 10,
+    setup: function (db, callback) {
+      var tasks = [];
+      for (var i = 0; i < 100; i++) {
+        tasks.push(i);
+      }
+      Promise.all(tasks.map(function () {
+        return db.bulkDocs({docs : makeTestDocs()});
+      })).then(function () {
+        return db.put({
+          _id : '_design/myview',
+          views : {
+            myview : {
+              map : function (doc) {
+                emit(doc.key);
+              }.toString()
+            }
+          }
+        });
+      }).then(function () {
+        return db.query('myview/myview');
+      }).then(function () {
+        callback();
+      }, callback);
+    },
+    test: function (db, itr, doc, done) {
+      var tasks = [
+        {startkey: 'foo', limit: 5},
+        {startkey: 'foobar', limit: 5},
+        {startkey: 'foo', limit: 5},
+        {startkey: -1, limit: 5},
+        {startkey: null, limit: 5}
+      ];
+      Promise.all(tasks.map(function (task) {
+          return db.query('myview/myview', task);
+        })).then(function (res) {
+          console.log(res);
+          done();
+        }, done);
+    }
+  },
+  {
+    name: 'persisted-views-stale-ok',
+    assertions: 1,
+    iterations: 10,
+    setup: function (db, callback) {
+      var tasks = [];
+      for (var i = 0; i < 100; i++) {
+        tasks.push(i);
+      }
+      Promise.all(tasks.map(function () {
+          return db.bulkDocs({docs : makeTestDocs()});
+        })).then(function () {
+          return db.put({
+            _id : '_design/myview',
+            views : {
+              myview : {
+                map : function (doc) {
+                  emit(doc.key);
+                }.toString()
+              }
+            }
+          });
+        }).then(function () {
+          return db.query('myview/myview');
+        }).then(function () {
+          callback();
+        }, callback);
+    },
+    test: function (db, itr, doc, done) {
+      var tasks = [
+        {startkey: 'foo', limit: 5, stale : 'ok'},
+        {startkey: 'foobar', limit: 5, stale : 'ok'},
+        {startkey: 'foo', limit: 5, stale : 'ok'},
+        {startkey: -1, limit: 5, stale : 'ok'},
+        {startkey: null, limit: 5, stale : 'ok'}
+      ];
+      Promise.all(tasks.map(function (task) {
+          return db.query('myview/myview', task);
+        })).then(function (res) {
+          console.log(res);
+          done();
+        }, done);
+    }
+  }
+];
+
+utils.runTests('views', testCases);

--- a/tests/performance/utils.js
+++ b/tests/performance/utils.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var PouchDB = require('../..');
+var reporter = require('./perf.reporter');
+var test = require('tape');
+
+exports.runTests = function (suiteName, testCases) {
+  testCases.forEach(function (testCase, i) {
+    test('benchmarking', function (t) {
+
+      var db;
+      var setupObj;
+
+      t.test('setup', function (t) {
+        new PouchDB('test').then(function (d) {
+          db = d;
+          testCase.setup(db, function (err, res) {
+            setupObj = res;
+            if (i === 0) {
+              reporter.startSuite(suiteName);
+            }
+            reporter.start(testCase);
+            t.end();
+          });
+        });
+      });
+
+      t.test(testCase.name, function (t) {
+        t.plan(testCase.assertions);
+        var num = 0;
+        function after(err) {
+          if (err) {
+            t.error(err);
+          }
+          if (++num < testCase.iterations) {
+            process.nextTick(function () {
+              testCase.test(db, num, setupObj, after);
+            });
+          } else {
+            t.ok(testCase.name + ' completed');
+          }
+        }
+        testCase.test(db, num, setupObj, after);
+      });
+      t.test('teardown', function (t) {
+        reporter.end(testCase);
+        db.destroy(function () {
+          t.end();
+          if (i === testCases.length - 1) {
+            reporter.complete(suiteName);
+          }
+        });
+      });
+    });
+  });
+};


### PR DESCRIPTION
So, the good news is that persistent mapreduce
is faster than the old temporary in-memory view.

The bad news is that it's not _much_ faster,
only about 1.5 or twice as fast, rather than
the order of magnitude difference we were expecting.
That's even with discounting the initial buildup
with the first query.

Luckily it seems there are some low-hanging fruit
we can grab to make it faster
