### PR TITLE
can't react on connection issues if using options.complete instead of callback for db.replicate.[to|from]

### DIFF
--- a/tests/test.replication.js
+++ b/tests/test.replication.js
@@ -1517,14 +1517,22 @@ downAdapters.map(function (adapter) {
       testUtils.cleanup([dbs.name], done);
     });
 
-    it('replicate from down server test', function (done) {
+    it('replicate to down server test callback', function (done) {
       var db = new PouchDB(dbs.name);
       db.replicate.to('http://infiniterequest.com', function (err, changes) {
         should.exist(err);
         done();
       });
     });
-
+    it('replicate to down server test options.complete', function (done) {
+      var db = new PouchDB(dbs.name);
+      db.replicate.to('http://infiniterequest.com', {
+        complete: function (err, result) {
+          should.exist(err);
+          done();
+        }
+      })
+    });
   });
 });
 


### PR DESCRIPTION
Test fails with: "TypeError: undefined is not a function"
callback at 
https://github.com/pouchdb/pouchdb/blob/master/lib/replicate.js#L492
is undefined.
