### PR TITLE
(#1860) - info.doc_count is wrong

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -723,23 +723,26 @@ function IdbPouch(opts, callback) {
     };
   }
 
+  function countDocs(callback) {
+    var totalRows;
+    var txn = idb.transaction([DOC_STORE], 'readonly');
+    var index = txn.objectStore(DOC_STORE).index('deletedOrLocal');
+    index.count(global.IDBKeyRange.only("0")).onsuccess = function (e) {
+      totalRows = e.target.result;
+    };
+    txn.onerror = idbError(callback);
+    txn.oncomplete = function () {
+      callback(null, totalRows);
+    };
+  }
+
   api._allDocs = function idb_allDocs(opts, callback) {
 
-    // first count the total_rows using the undeleted/non-local count
-    var txn = idb.transaction([DOC_STORE], 'readonly');
-
-    var totalRows;
-    function countUndeletedNonlocalDocs(e) {
-      totalRows = e.target.result;
-    }
-
-    var index = txn.objectStore(DOC_STORE).index('deletedOrLocal');
-    index.count(global.IDBKeyRange.only("0")).onsuccess =
-      countUndeletedNonlocalDocs;
-
-    txn.onerror = idbError(callback);
-
-    txn.oncomplete = function () {
+    // first count the total_rows
+    countDocs(function (err, totalRows) {
+      if (err) {
+        return callback(err);
+      }
       if (opts.limit === 0) {
         return callback(null, {
           total_rows : totalRows,
@@ -751,39 +754,30 @@ function IdbPouch(opts, callback) {
       } else {
         allDocsNormalQuery(totalRows, opts, callback);
       }
-    };
+    });
   };
 
   api._info = function idb_info(callback) {
-    var count = 0;
-    var update_seq = 0;
-    var txn = idb.transaction([DOC_STORE, META_STORE], 'readonly');
 
-    function fetchUpdateSeq(e) {
-      update_seq = e.target.result && e.target.result.updateSeq || 0;
-    }
-
-    function countDocs(e) {
-      var cursor = e.target.result;
-      if (!cursor) {
-        txn.objectStore(META_STORE).get(META_STORE).onsuccess = fetchUpdateSeq;
-        return;
+    countDocs(function (err, count) {
+      if (err) {
+        return callback(err);
       }
-      if (cursor.value.deleted !== true) {
-        count++;
-      }
-      cursor['continue']();
-    }
+      var updateSeq = 0;
+      var txn = idb.transaction([META_STORE], 'readonly');
 
-    txn.oncomplete = function () {
-      callback(null, {
-        db_name: name,
-        doc_count: count,
-        update_seq: update_seq
-      });
-    };
+      txn.objectStore(META_STORE).get(META_STORE).onsuccess = function (e) {
+        updateSeq = e.target.result && e.target.result.updateSeq || 0;
+      };
 
-    txn.objectStore(DOC_STORE).openCursor().onsuccess = countDocs;
+      txn.oncomplete = function () {
+        callback(null, {
+          db_name: name,
+          doc_count: count,
+          update_seq: updateSeq
+        });
+      };
+    });
   };
 
   api._changes = function idb_changes(opts) {

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -29,7 +29,6 @@ var changeEmitters = {};
 // store the value of update_seq in the by-sequence store the key name will
 // never conflict, since the keys in the by-sequence store are integers
 var UPDATE_SEQ_KEY = '_local_last_update_seq';
-var DOC_COUNT_KEY = '_local_doc_count';
 var UUID_KEY = '_local_uuid';
 
 function LevelPouch(opts, callback) {
@@ -37,7 +36,6 @@ function LevelPouch(opts, callback) {
   var api = this;
   var instanceId;
   var updateSeq = 0;
-  var docCount = 0;
   var stores = {};
   var db;
   var name = opts.name;
@@ -70,7 +68,7 @@ function LevelPouch(opts, callback) {
   }
 
   function afterDBCreated() {
-    updateSeq = docCount = -1;
+    updateSeq = -1;
     stores.docStore = db.sublevel(DOC_STORE, {valueEncoding: 'json'});
     stores.bySeqStore = db.sublevel(BY_SEQ_STORE, {valueEncoding: 'json'});
     stores.attachmentStore =
@@ -78,14 +76,11 @@ function LevelPouch(opts, callback) {
     stores.binaryStore = db.sublevel(BINARY_STORE, {valueEncoding: 'binary'});
     stores.bySeqStore.get(UPDATE_SEQ_KEY, function (err, value) {
       updateSeq = !err ? value : 0;
-      stores.bySeqStore.get(DOC_COUNT_KEY, function (err, value) {
-        docCount = !err ? value : 0;
-        stores.bySeqStore.get(UUID_KEY, function (err, value) {
-          instanceId = !err ? value : utils.uuid();
-          stores.bySeqStore.put(UUID_KEY, instanceId, function (err, value) {
-            process.nextTick(function () {
-              callback(null, api);
-            });
+      stores.bySeqStore.get(UUID_KEY, function (err, value) {
+        instanceId = !err ? value : utils.uuid();
+        stores.bySeqStore.put(UUID_KEY, instanceId, function (err, value) {
+          process.nextTick(function () {
+            callback(null, api);
           });
         });
       });
@@ -101,16 +96,16 @@ function LevelPouch(opts, callback) {
   };
 
   api._info = function (callback) {
-
-    stores.bySeqStore.get(DOC_COUNT_KEY, function (err, otherDocCount) {
-      if (err) { otherDocCount = docCount; }
-
+    countDocs(function (err, docCount) {
+      if (err) {
+        return callback(err);
+      }
       stores.bySeqStore.get(UPDATE_SEQ_KEY, function (err, otherUpdateSeq) {
         if (err) { otherUpdateSeq = updateSeq; }
 
         return callback(null, {
           db_name: opts.name,
-          doc_count: otherDocCount,
+          doc_count: docCount,
           update_seq: otherUpdateSeq
         });
       });
@@ -220,15 +215,7 @@ function LevelPouch(opts, callback) {
         results.push(makeErr(errors.MISSING_DOC, doc._bulk_seq));
         return callback();
       }
-      docCount++;
-      writeDoc(doc, function () {
-        stores.bySeqStore.put(DOC_COUNT_KEY, docCount, function (err) {
-          if (err) {
-            // TODO: handle error
-          }
-          return callback();
-        });
-      });
+      writeDoc(doc, callback);
     }
 
     function updateDoc(oldDoc, docInfo, callback) {
@@ -420,7 +407,7 @@ function LevelPouch(opts, callback) {
     processDocs();
   };
 
-  api.countDocs = function (callback) {
+  function countDocs(callback) {
     // get the total_rows count, then do allDocs
     var totalRows = 0;
     var totalRowsStream = stores.docStore.readStream();
@@ -437,10 +424,13 @@ function LevelPouch(opts, callback) {
     totalRowsStream.on('end', function () {
       callback(null, totalRows);
     });
-  };
+  }
 
   api._allDocs = function (opts, callback) {
-    this.countDocs(function (err, totalRows) {
+    countDocs(function (err, totalRows) {
+      if (err) {
+        return callback(err);
+      }
       var readstreamOpts = {};
       var skip = opts.skip || 0;
       if (opts.startkey) {

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -54,6 +54,9 @@ var DOC_STORE_WINNINGSEQ_INDEX_SQL =
   'CREATE INDEX IF NOT EXISTS \'doc-winningseq-idx\' ON ' +
   DOC_STORE + ' (winningseq)';
 
+var DOC_STORE_AND_BY_SEQ = BY_SEQ_STORE + ' JOIN ' + DOC_STORE +
+  ' ON ' + BY_SEQ_STORE + '.seq = ' + DOC_STORE + '.winningseq';
+
 
 function unknownError(callback) {
   return function (event) {
@@ -258,7 +261,6 @@ function WebSqlPouch(opts, callback) {
     setup();
   }
 
-
   api.type = function () {
     return 'websql';
   };
@@ -269,16 +271,14 @@ function WebSqlPouch(opts, callback) {
 
   api._info = function (callback) {
     db.transaction(function (tx) {
-      var sql = 'SELECT COUNT(id) AS count FROM ' + DOC_STORE;
-      tx.executeSql(sql, [], function (tx, result) {
-        var doc_count = result.rows.item(0).count;
-        var updateseq = 'SELECT update_seq FROM ' + META_STORE;
-        tx.executeSql(updateseq, [], function (tx, result) {
-          var update_seq = result.rows.item(0).update_seq;
+      countDocs(tx, function (docCount) {
+        var sql = 'SELECT update_seq FROM ' + META_STORE;
+        tx.executeSql(sql, [], function (tx, result) {
+          var updateSeq = result.rows.item(0).update_seq;
           callback(null, {
             db_name: name,
-            doc_count: doc_count,
-            update_seq: update_seq
+            doc_count: docCount,
+            update_seq: updateSeq
           });
         });
       });
@@ -654,13 +654,23 @@ function WebSqlPouch(opts, callback) {
     });
   };
 
+  function countDocs(tx, callback) {
+    // count the total rows
+    var sql = 'SELECT COUNT(' + DOC_STORE + '.id) AS \'num\' FROM ' +
+      DOC_STORE_AND_BY_SEQ + ' WHERE ' + BY_SEQ_STORE + '.deleted = 0 AND ' +
+      // local docs are e.g. '_local_foo'
+      DOC_STORE + '.local = 0';
+
+    tx.executeSql(sql, [], function (tx, result) {
+      var count = result.rows.item(0).num;
+      callback(count);
+    });
+  }
+
   api._allDocs = function (opts, callback) {
     var results = [];
     var resultsMap = {};
     var totalRows;
-
-    var from = BY_SEQ_STORE + ' JOIN ' + DOC_STORE + ' ON ' + BY_SEQ_STORE +
-      '.seq = ' + DOC_STORE + '.winningseq';
 
     var start = 'startkey' in opts ? opts.startkey : false;
     var end = 'endkey' in opts ? opts.endkey : false;
@@ -704,13 +714,8 @@ function WebSqlPouch(opts, callback) {
     db.transaction(function (tx) {
 
       // first count up the total rows
-      var sql = 'SELECT COUNT(' + DOC_STORE + '.id) AS \'num\' FROM ' +
-        from + ' WHERE ' + BY_SEQ_STORE + '.deleted = 0 AND ' +
-        // local docs are e.g. '_local_foo'
-        DOC_STORE + '.local = 0';
-
-      tx.executeSql(sql, [], function (tx, result) {
-        totalRows = result.rows.item(0).num;
+      countDocs(tx, function (count) {
+        totalRows = count;
 
         if (limit === 0) {
           return;
@@ -720,7 +725,7 @@ function WebSqlPouch(opts, callback) {
 
         var sql = 'SELECT ' + DOC_STORE + '.id, ' + BY_SEQ_STORE + '.seq, ' +
           BY_SEQ_STORE + '.json AS data, ' + DOC_STORE +
-          '.json AS metadata FROM ' + from;
+          '.json AS metadata FROM ' + DOC_STORE_AND_BY_SEQ;
 
         if (criteria.length) {
           sql += ' WHERE ' + criteria.join(' AND ');

--- a/tests/test.basics.js
+++ b/tests/test.basics.js
@@ -595,6 +595,27 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('db.info should give correct doc_count', function (done) {
+      new PouchDB(dbs.name).then(function (db) {
+        db.info().then(function (info) {
+          info.doc_count.should.equal(0);
+          return db.bulkDocs({docs : [{_id : '1'}, {_id : '2'}, {_id : '3'}]});
+        }).then(function () {
+          return db.info();
+        }).then(function (info) {
+          info.doc_count.should.equal(3);
+          return db.get('1');
+        }).then(function (doc) {
+          return db.remove(doc);
+        }).then(function () {
+          return db.info();
+        }).then(function (info) {
+          info.doc_count.should.equal(2);
+          done();
+        }, done);
+      }, done);
+    });
+
     if (adapter === 'local') {
       // TODO: this test fails in the http adapter in Chrome
       it('should allow unicode doc ids', function (done) {


### PR DESCRIPTION
This is a less ambitious version of #1860 that does not attempt to make leveldb any faster.  In fact we just stop using the `_local_doc_count` entirely, because it doesn't take deleted docs into consideration. Instead we just iterate through all the docs to give us `total_rows`/`doc_count`.

This does make IDB faster, and it makes both IDB and WebSQL correct.
