### PR TITLE
(#1860) - Fix info.doc_count for websql/idb

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -723,23 +723,26 @@ function IdbPouch(opts, callback) {
     };
   }
 
+  function countDocs(callback) {
+    var totalRows;
+    var txn = idb.transaction([DOC_STORE], 'readonly');
+    var index = txn.objectStore(DOC_STORE).index('deletedOrLocal');
+    index.count(global.IDBKeyRange.only("0")).onsuccess = function (e) {
+      totalRows = e.target.result;
+    };
+    txn.onerror = idbError(callback);
+    txn.oncomplete = function () {
+      callback(null, totalRows);
+    };
+  }
+
   api._allDocs = function idb_allDocs(opts, callback) {
 
-    // first count the total_rows using the undeleted/non-local count
-    var txn = idb.transaction([DOC_STORE], 'readonly');
-
-    var totalRows;
-    function countUndeletedNonlocalDocs(e) {
-      totalRows = e.target.result;
-    }
-
-    var index = txn.objectStore(DOC_STORE).index('deletedOrLocal');
-    index.count(global.IDBKeyRange.only("0")).onsuccess =
-      countUndeletedNonlocalDocs;
-
-    txn.onerror = idbError(callback);
-
-    txn.oncomplete = function () {
+    // first count the total_rows
+    countDocs(function (err, totalRows) {
+      if (err) {
+        return callback(err);
+      }
       if (opts.limit === 0) {
         return callback(null, {
           total_rows : totalRows,
@@ -751,39 +754,30 @@ function IdbPouch(opts, callback) {
       } else {
         allDocsNormalQuery(totalRows, opts, callback);
       }
-    };
+    });
   };
 
   api._info = function idb_info(callback) {
-    var count = 0;
-    var update_seq = 0;
-    var txn = idb.transaction([DOC_STORE, META_STORE], 'readonly');
 
-    function fetchUpdateSeq(e) {
-      update_seq = e.target.result && e.target.result.updateSeq || 0;
-    }
-
-    function countDocs(e) {
-      var cursor = e.target.result;
-      if (!cursor) {
-        txn.objectStore(META_STORE).get(META_STORE).onsuccess = fetchUpdateSeq;
-        return;
+    countDocs(function (err, count) {
+      if (err) {
+        return callback(err);
       }
-      if (cursor.value.deleted !== true) {
-        count++;
-      }
-      cursor['continue']();
-    }
+      var updateSeq = 0;
+      var txn = idb.transaction([META_STORE], 'readonly');
 
-    txn.oncomplete = function () {
-      callback(null, {
-        db_name: name,
-        doc_count: count,
-        update_seq: update_seq
-      });
-    };
+      txn.objectStore(META_STORE).get(META_STORE).onsuccess = function (e) {
+        updateSeq = e.target.result && e.target.result.updateSeq || 0;
+      };
 
-    txn.objectStore(DOC_STORE).openCursor().onsuccess = countDocs;
+      txn.oncomplete = function () {
+        callback(null, {
+          db_name: name,
+          doc_count: count,
+          update_seq: updateSeq
+        });
+      };
+    });
   };
 
   api._changes = function idb_changes(opts) {

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -54,6 +54,9 @@ var DOC_STORE_WINNINGSEQ_INDEX_SQL =
   'CREATE INDEX IF NOT EXISTS \'doc-winningseq-idx\' ON ' +
   DOC_STORE + ' (winningseq)';
 
+var DOC_STORE_AND_BY_SEQ = BY_SEQ_STORE + ' JOIN ' + DOC_STORE +
+  ' ON ' + BY_SEQ_STORE + '.seq = ' + DOC_STORE + '.winningseq';
+
 
 function unknownError(callback) {
   return function (event) {
@@ -258,7 +261,6 @@ function WebSqlPouch(opts, callback) {
     setup();
   }
 
-
   api.type = function () {
     return 'websql';
   };
@@ -269,16 +271,14 @@ function WebSqlPouch(opts, callback) {
 
   api._info = function (callback) {
     db.transaction(function (tx) {
-      var sql = 'SELECT COUNT(id) AS count FROM ' + DOC_STORE;
-      tx.executeSql(sql, [], function (tx, result) {
-        var doc_count = result.rows.item(0).count;
-        var updateseq = 'SELECT update_seq FROM ' + META_STORE;
-        tx.executeSql(updateseq, [], function (tx, result) {
-          var update_seq = result.rows.item(0).update_seq;
+      countDocs(tx, function (docCount) {
+        var sql = 'SELECT update_seq FROM ' + META_STORE;
+        tx.executeSql(sql, [], function (tx, result) {
+          var updateSeq = result.rows.item(0).update_seq;
           callback(null, {
             db_name: name,
-            doc_count: doc_count,
-            update_seq: update_seq
+            doc_count: docCount,
+            update_seq: updateSeq
           });
         });
       });
@@ -654,13 +654,23 @@ function WebSqlPouch(opts, callback) {
     });
   };
 
+  function countDocs(tx, callback) {
+    // count the total rows
+    var sql = 'SELECT COUNT(' + DOC_STORE + '.id) AS \'num\' FROM ' +
+      DOC_STORE_AND_BY_SEQ + ' WHERE ' + BY_SEQ_STORE + '.deleted = 0 AND ' +
+      // local docs are e.g. '_local_foo'
+      DOC_STORE + '.local = 0';
+
+    tx.executeSql(sql, [], function (tx, result) {
+      var count = result.rows.item(0).num;
+      callback(count);
+    });
+  }
+
   api._allDocs = function (opts, callback) {
     var results = [];
     var resultsMap = {};
     var totalRows;
-
-    var from = BY_SEQ_STORE + ' JOIN ' + DOC_STORE + ' ON ' + BY_SEQ_STORE +
-      '.seq = ' + DOC_STORE + '.winningseq';
 
     var start = 'startkey' in opts ? opts.startkey : false;
     var end = 'endkey' in opts ? opts.endkey : false;
@@ -704,13 +714,8 @@ function WebSqlPouch(opts, callback) {
     db.transaction(function (tx) {
 
       // first count up the total rows
-      var sql = 'SELECT COUNT(' + DOC_STORE + '.id) AS \'num\' FROM ' +
-        from + ' WHERE ' + BY_SEQ_STORE + '.deleted = 0 AND ' +
-        // local docs are e.g. '_local_foo'
-        DOC_STORE + '.local = 0';
-
-      tx.executeSql(sql, [], function (tx, result) {
-        totalRows = result.rows.item(0).num;
+      countDocs(tx, function (count) {
+        totalRows = count;
 
         if (limit === 0) {
           return;
@@ -720,7 +725,7 @@ function WebSqlPouch(opts, callback) {
 
         var sql = 'SELECT ' + DOC_STORE + '.id, ' + BY_SEQ_STORE + '.seq, ' +
           BY_SEQ_STORE + '.json AS data, ' + DOC_STORE +
-          '.json AS metadata FROM ' + from;
+          '.json AS metadata FROM ' + DOC_STORE_AND_BY_SEQ;
 
         if (criteria.length) {
           sql += ' WHERE ' + criteria.join(' AND ');

--- a/tests/test.basics.js
+++ b/tests/test.basics.js
@@ -595,6 +595,28 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    // unskip when leveldb is fixed (#1860)
+    it.skip('db.info should give correct doc_count', function (done) {
+      new PouchDB(dbs.name).then(function (db) {
+        db.info().then(function (info) {
+          info.doc_count.should.equal(0);
+          return db.bulkDocs({docs : [{_id : '1'}, {_id : '2'}, {_id : '3'}]});
+        }).then(function () {
+          return db.info();
+        }).then(function (info) {
+          info.doc_count.should.equal(3);
+          return db.get('1');
+        }).then(function (doc) {
+          return db.remove(doc);
+        }).then(function () {
+          return db.info();
+        }).then(function (info) {
+          info.doc_count.should.equal(2);
+          done();
+        }, done);
+      }, done);
+    });
+
     if (adapter === 'local') {
       // TODO: this test fails in the http adapter in Chrome
       it('should allow unicode doc ids', function (done) {


### PR DESCRIPTION
Same as #1860, but for WebSQL and IDB only.  The test is skipped in anticipation of getting unskipped once LevelDB is fixed.
