### PR TITLE
(#1869) - performance improvements for idb.get

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -669,16 +669,17 @@ function IdbPouch(opts, callback) {
         if (utils.isLocalId(metadata.id)) {
           return cursor['continue']();
         }
+        var winningRev = merge.winningRev(metadata);
         var doc = {
           id: metadata.id,
           key: metadata.id,
           value: {
-            rev: merge.winningRev(metadata)
+            rev: winningRev
           }
         };
         if (opts.include_docs) {
           doc.doc = data;
-          doc.doc._rev = merge.winningRev(metadata);
+          doc.doc._rev = winningRev;
           if (doc.doc._doc_id_rev) {
             delete(doc.doc._doc_id_rev);
           }
@@ -691,14 +692,15 @@ function IdbPouch(opts, callback) {
             }
           }
         }
+        var deleted = utils.isDeleted(metadata, winningRev);
         if (opts.keys_request) {
           // deleted docs are okay with keys_requests
-          if (utils.isDeleted(metadata)) {
+          if (deleted) {
             doc.value.deleted = true;
             doc.doc = null;
           }
           results.push(doc);
-        } else if (!utils.isDeleted(metadata) && skip-- <= 0) {
+        } else if (!deleted && skip-- <= 0) {
           if (manualDescEnd && doc.key < manualDescEnd) {
             return;
           }

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -213,21 +213,18 @@ PouchMerge.winningRev = function (metadata) {
 // The return value from the callback will be passed as context to all
 // children of that node
 PouchMerge.traverseRevTree = function (revs, callback) {
-  var toVisit = [];
+  var toVisit = revs.slice();
 
-  revs.forEach(function (tree) {
-    toVisit.push({pos: tree.pos, ids: tree.ids});
-  });
-  while (toVisit.length > 0) {
-    var node = toVisit.pop();
+  var node;
+  while ((node = toVisit.pop())) {
     var pos = node.pos;
     var tree = node.ids;
+    var branches = tree[2];
     var newCtx =
-      callback(tree[2].length === 0, pos, tree[0], node.ctx, tree[1]);
-    /*jshint loopfunc: true */
-    tree[2].forEach(function (branch) {
-      toVisit.push({pos: pos + 1, ids: branch, ctx: newCtx});
-    });
+      callback(branches.length === 0, pos, tree[0], node.ctx, tree[1]);
+    for (var i = 0, len = branches.length; i < len; i++) {
+      toVisit.push({pos: pos + 1, ids: branches[i], ctx: newCtx});
+    }
   }
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -104,8 +104,9 @@ exports.isDeleted = function (metadata, rev) {
   if (!rev) {
     rev = merge.winningRev(metadata);
   }
-  if (rev.indexOf('-') >= 0) {
-    rev = rev.split('-')[1];
+  var dashIndex = rev.indexOf('-');
+  if (dashIndex !== -1) {
+    rev = rev.substring(dashIndex + 1);
   }
   var deleted = false;
   merge.traverseRevTree(metadata.rev_tree,


### PR DESCRIPTION
Also includes some generic performance
improvements for merge.traverseRevTree and
utils.isDeleted.
