### PR TITLE
(#1871) - WebSQL total_rows/get performance boosts

### DIFF
--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -90,6 +90,7 @@ function WebSqlPouch(opts, callback) {
   var instanceId = null;
   var name = opts.name;
   var idRequests = [];
+  var docCount = -1; // cache sqlite count(*) for performance
   var encoding;
 
   var db = openDB(name, POUCH_VERSION, name, POUCH_SIZE);
@@ -270,7 +271,7 @@ function WebSqlPouch(opts, callback) {
   });
 
   api._info = function (callback) {
-    db.transaction(function (tx) {
+    db.readTransaction(function (tx) {
       countDocs(tx, function (docCount) {
         var sql = 'SELECT update_seq FROM ' + META_STORE;
         tx.executeSql(sql, [], function (tx, result) {
@@ -282,7 +283,7 @@ function WebSqlPouch(opts, callback) {
           });
         });
       });
-    });
+    }, unknownError(callback));
   };
 
   api._bulkDocs = function (req, opts, callback) {
@@ -604,7 +605,9 @@ function WebSqlPouch(opts, callback) {
           docInfos.map(function () {return '?'; }).join(',') + ')';
         var queryArgs = docInfos.map(function (d) { return d.metadata.id; });
         tx.executeSql(sql, queryArgs, metadataFetched);
-      }, unknownError(callback));
+      }, unknownError(callback), function () {
+        docCount = -1;
+      });
     });
   };
 
@@ -614,7 +617,7 @@ function WebSqlPouch(opts, callback) {
     var metadata;
     var err;
     if (!opts.ctx) {
-      db.transaction(function (txn) {
+      db.readTransaction(function (txn) {
         opts.ctx = txn;
         api._get(id, opts, callback);
       });
@@ -655,6 +658,11 @@ function WebSqlPouch(opts, callback) {
   };
 
   function countDocs(tx, callback) {
+
+    if (docCount !== -1) {
+      return callback(docCount);
+    }
+
     // count the total rows
     var sql = 'SELECT COUNT(' + DOC_STORE + '.id) AS \'num\' FROM ' +
       DOC_STORE_AND_BY_SEQ + ' WHERE ' + BY_SEQ_STORE + '.deleted = 0 AND ' +
@@ -662,8 +670,8 @@ function WebSqlPouch(opts, callback) {
       DOC_STORE + '.local = 0';
 
     tx.executeSql(sql, [], function (tx, result) {
-      var count = result.rows.item(0).num;
-      callback(count);
+      docCount = result.rows.item(0).num;
+      callback(docCount);
     });
   }
 
@@ -711,7 +719,7 @@ function WebSqlPouch(opts, callback) {
       criteria.push(BY_SEQ_STORE + '.deleted = 0');
     }
 
-    db.transaction(function (tx) {
+    db.readTransaction(function (tx) {
 
       // first count up the total rows
       countDocs(tx, function (count) {
@@ -748,14 +756,15 @@ function WebSqlPouch(opts, callback) {
             var doc = result.rows.item(i);
             var metadata = JSON.parse(doc.metadata);
             var data = JSON.parse(doc.data);
+            var winningRev = merge.winningRev(metadata);
             doc = {
               id: metadata.id,
               key: metadata.id,
-              value: {rev: merge.winningRev(metadata)}
+              value: {rev: winningRev}
             };
             if (opts.include_docs) {
               doc.doc = data;
-              doc.doc._rev = merge.winningRev(metadata);
+              doc.doc._rev = winningRev;
               if (opts.conflicts) {
                 doc.doc._conflicts = merge.collectConflicts(metadata);
               }
@@ -766,13 +775,11 @@ function WebSqlPouch(opts, callback) {
               }
             }
             if ('keys' in opts) {
-              if (opts.keys.indexOf(metadata.id) > -1) {
-                if (utils.isDeleted(metadata)) {
-                  doc.value.deleted = true;
-                  doc.doc = null;
-                }
-                resultsMap[doc.id] = doc;
+              if (utils.isDeleted(metadata, winningRev)) {
+                doc.value.deleted = true;
+                doc.doc = null;
               }
+              resultsMap[doc.id] = doc;
             } else {
               results.push(doc);
             }
@@ -785,7 +792,7 @@ function WebSqlPouch(opts, callback) {
           if (key in resultsMap) {
             results.push(resultsMap[key]);
           } else {
-            results.push({"key": key, "error": "not_found"});
+            results.push({key: key, error: 'not_found'});
           }
         });
         if (opts.descending) {
@@ -829,7 +836,7 @@ function WebSqlPouch(opts, callback) {
         DOC_STORE + '.seq > ' + opts.since + ' ORDER BY ' + DOC_STORE +
         '.seq ' + (descending ? 'DESC' : 'ASC');
 
-      db.transaction(function (tx) {
+      db.readTransaction(function (tx) {
         tx.executeSql(sql, [], function (tx, result) {
           var last_seq = 0;
           for (var i = 0, l = result.rows.length; i < l; i++) {
@@ -882,7 +889,7 @@ function WebSqlPouch(opts, callback) {
   };
 
   api._getRevisionTree = function (docId, callback) {
-    db.transaction(function (tx) {
+    db.readTransaction(function (tx) {
       var sql = 'SELECT json AS metadata FROM ' + DOC_STORE + ' WHERE id = ?';
       tx.executeSql(sql, [docId], function (tx, result) {
         if (!result.rows.length) {


### PR DESCRIPTION
This is more on the order of a micro-optimization, but the changes were pretty simple and pretty obviously correct, so I don't see the harm.

If you're curious about why I'm caching `docCount`, it's because a performance analysis in the Chrome dev tools confirmed that `count(*)` was one of the costliest functions.  Apparently `count()` is never stored in SQLite, and a full table scan is always performed ([source](https://www.mail-archive.com/sqlite-users@sqlite.org/msg10279.html)).
