### PR TITLE
(#44) - Add localstorage-down option to LevelAlt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,13 @@ env:
   - CLIENT=node COMMAND=test
   - NATIVEPROMISE=1 CLIENT=firefox COMMAND=test
   - CLIENT=chrome COMMAND=test
-  - CLIENT=firefox LEVEL_BACKEND=leveljs COMMAND=test
+  - CLIENT=firefox LEVEL_BACKEND=level-js COMMAND=test
   - CLIENT=firefox PERF=1 COMMAND=test
   - COMMAND=report-coverage
 
 matrix:
   allow_failures:
-  - env: CLIENT=firefox LEVEL_BACKEND=leveljs COMMAND=test
+  - env: CLIENT=firefox LEVEL_BACKEND=level-js COMMAND=test
 
 branches:
   only:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,9 +118,9 @@ To run the performance test suite in node.js or the automated browser runner.
 
 Alternative Backends
 --------------------------------------
-PouchDB is looking to support alternative backends that comply with the [LevelDOWN API](https://github.com/rvagg/abstract-leveldown). For example, simply include `LEVEL_BACKEND=leveljs` in your `npm run build` and `npm run dev` commands to experiment with this feature!
+PouchDB is looking to support alternative backends that comply with the [LevelDOWN API](https://github.com/rvagg/abstract-leveldown). For example, simply include `LEVEL_BACKEND=level-js` in your `npm run build-alt` and `npm run dev` commands to experiment with this feature!
 
-Doing so will also create a separate distribution, for example, `pouchdb-leveljs.js` rather than `pouchdb-nightly.js`. In order to test a different distribution from `pouchdb-nightly.js`, you must specify in the testing URL: http://127.0.0.1:8000/tests/test.html?sourceFile=pouchdb-leveljs.js. `LEVEL_BACKEND=leveljs npm run test` will accomplish the same thing.
+Doing so will also create a separate distribution, for example `pouchdb-level-js.js` rather than `pouchdb-nightly.js`. In order to test a different distribution from `pouchdb-nightly.js`, you must specify in the testing URL: http://127.0.0.1:8000/tests/test.html?sourceFile=pouchdb-level-js.js. `LEVEL_BACKEND=level-js npm run test` will accomplish the same thing.
 
 Git Essentials
 --------------------------------------

--- a/alt/build-js.sh
+++ b/alt/build-js.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ -z "$LEVEL_BACKEND" ]; then
+    echo "Error: must specify LEVEL_BACKEND parameter with build-alt."
+    exit 1
+fi
+
+node_modules/.bin/browserify . \
+    -r $LEVEL_BACKEND:levelalt \
+    -s PouchDB \
+    -o ../dist/pouchdb-$LEVEL_BACKEND.js

--- a/alt/levelalt.js
+++ b/alt/levelalt.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var LevelPouch = require('../lib/adapters/leveldb');
-var levelalt = require('level-js');
+var levelalt = require('levelalt');
 var utils = require('../lib/utils');
 
 function LevelPouchAlt(opts, callback) {

--- a/alt/package.json
+++ b/alt/package.json
@@ -4,7 +4,7 @@
   "description": "alt pouchdb",
   "main": "index.js",
   "scripts": {
-    "build": "browserify . -s PouchDB > ../dist/pouchdb-leveljs.js",
+    "build": "./build-js.sh",
     "build-perf": "browserify tests/performance/*.js > ../dist/performance-bundle.js"
   },
   "author": "",
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "level-js": "^2.1.2",
-    "lie": "^2.6.0"
+    "lie": "^2.6.0",
+    "localstorage-down": "^0.4.2"
   },
   "devDependencies": {
     "browserify": "^3.38.1",

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -13,13 +13,14 @@ var http_proxy = require('http-proxy');
 var http_server = require('http-server');
 
 var performanceBundle = './dist/performance-bundle.js';
+var level_backend = process.env.LEVEL_BACKEND;
 var indexfile, outfile;
 var query = "";
 var perfRoot;
 if (process.env.LEVEL_BACKEND) {
-  query = "?sourceFile=pouchdb-" + process.env.LEVEL_BACKEND + ".js";
+  query = "?sourceFile=pouchdb-" + level_backend + ".js";
   indexfile = "./alt/index.js";
-  outfile = "./dist/pouchdb-" + process.env.LEVEL_BACKEND + ".js";
+  outfile = "./dist/pouchdb-" + level_backend + ".js";
   perfRoot = './alt/performance/*.js';
 } else {
   indexfile = "./lib/index.js";
@@ -42,12 +43,19 @@ function writeFile(file) {
 }
 
 function bundle() {
+  if (level_backend) {
+    w.require(level_backend, {expose: 'levelalt'});
+  }
   w.bundle({standalone: "PouchDB"}, writeFile(outfile));
 }
 
 function bundlePerfTests() {
   glob(perfRoot, function (err, files) {
-    browserify(files).bundle({}, writeFile(performanceBundle));
+    var b = browserify(files);
+    if (level_backend) {
+      b.require(level_backend, {expose: 'levelalt'});
+    }
+    b.bundle({}, writeFile(performanceBundle));
   });
 }
 


### PR DESCRIPTION
So we can input <code>LEVEL_BACKEND=localstorage-down</code> and such with <code>build-alt</code> instead of hardcoding only level-js.
