### PR TITLE
(#1897) - idb perf improvements for get/allDocs

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -55,6 +55,7 @@ function IdbPouch(opts, callback) {
 
   var name = opts.name;
   var req = global.indexedDB.open(name, ADAPTER_VERSION);
+  var docCount = -1;
 
   if (!('openReqList' in IdbPouch)) {
     IdbPouch.openReqList = {};
@@ -236,6 +237,7 @@ function IdbPouch(opts, callback) {
         IdbPouch.Changes.notify(name);
         IdbPouch.Changes.notifyLocalWindows(name);
       });
+      docCount = -1; // invalidate
       callback(null, aresults);
     }
 
@@ -310,7 +312,7 @@ function IdbPouch(opts, callback) {
       }
     }
 
-    function writeDoc(docInfo, callback) {
+    function writeDoc(docInfo, winningRev, deleted, callback) {
       var err = null;
       var recv = 0;
       docInfo.data._id = docInfo.metadata.id;
@@ -318,7 +320,7 @@ function IdbPouch(opts, callback) {
 
       docsWritten++;
 
-      if (utils.isDeleted(docInfo.metadata, docInfo.metadata.rev)) {
+      if (deleted) {
         docInfo.data._deleted = true;
       }
 
@@ -368,10 +370,10 @@ function IdbPouch(opts, callback) {
             docInfo.metadata.seq = e.target.result;
             // Current _rev is calculated from _rev_tree on read
             delete docInfo.metadata.rev;
-            var deleted = utils.isDeleted(docInfo.metadata);
             var local = utils.isLocalId(docInfo.metadata.id);
             var metadata = utils.extend(true, {
-              deletedOrLocal : (deleted || local) ? "1" : "0"
+              deletedOrLocal : (deleted || local) ? "1" : "0",
+              winningRev : merge.winningRev(docInfo.metadata)
             }, docInfo.metadata);
             var metaDataReq = txn.objectStore(DOC_STORE).put(metadata);
             metaDataReq.onsuccess = function () {
@@ -388,11 +390,13 @@ function IdbPouch(opts, callback) {
     }
 
     function updateDoc(oldDoc, docInfo) {
+      var winningRev = merge.winningRev(docInfo.metadata);
+      var deleted = utils.isDeleted(docInfo.metadata, winningRev);
+
       var merged =
         merge.merge(oldDoc.rev_tree, docInfo.metadata.rev_tree[0], 1000);
       var wasPreviouslyDeleted = utils.isDeleted(oldDoc);
-      var inConflict = (wasPreviouslyDeleted &&
-                        utils.isDeleted(docInfo.metadata)) ||
+      var inConflict = (wasPreviouslyDeleted && deleted) ||
         (!wasPreviouslyDeleted && newEdits && merged.conflicts !== 'new_leaf');
 
       if (inConflict) {
@@ -401,16 +405,20 @@ function IdbPouch(opts, callback) {
       }
 
       docInfo.metadata.rev_tree = merged.tree;
-      writeDoc(docInfo, processDocs);
+
+      writeDoc(docInfo, winningRev, deleted, processDocs);
     }
 
     function insertDoc(docInfo) {
+      var winningRev = merge.winningRev(docInfo.metadata);
+      var deleted = utils.isDeleted(docInfo.metadata, winningRev);
       // Cant insert new deleted documents
-      if ('was_delete' in opts && utils.isDeleted(docInfo.metadata)) {
+      if ('was_delete' in opts && deleted) {
         results.push(errors.MISSING_DOC);
         return processDocs();
       }
-      writeDoc(docInfo, processDocs);
+
+      writeDoc(docInfo, winningRev, deleted, processDocs);
     }
 
     // Insert sequence number into the error so we can sort later
@@ -486,12 +494,13 @@ function IdbPouch(opts, callback) {
         err = errors.error(errors.MISSING_DOC, "deleted");
         return finish();
       }
+      var objectStore = txn.objectStore(BY_SEQ_STORE);
 
-      var rev = merge.winningRev(metadata);
-      var key = metadata.id + '::' + (opts.rev ? opts.rev : rev);
-      var index = txn.objectStore(BY_SEQ_STORE).index('_doc_id_rev');
+      // metadata.winningRev was added later, so older DBs might not have it
+      var rev = opts.rev || metadata.winningRev || merge.winningRev(metadata);
+      var key = metadata.id + '::' + rev;
 
-      index.get(key).onsuccess = function (e) {
+      objectStore.index('_doc_id_rev').get(key).onsuccess = function (e) {
         doc = e.target.result;
         if (doc && doc._doc_id_rev) {
           delete(doc._doc_id_rev);
@@ -664,12 +673,13 @@ function IdbPouch(opts, callback) {
       }
       var cursor = e.target.result;
       var metadata = cursor.value;
+      // metadata.winningRev added later, some dbs might be missing it
+      var winningRev = metadata.winningRev || merge.winningRev(metadata);
 
       function allDocsInner(metadata, data) {
         if (utils.isLocalId(metadata.id)) {
           return cursor['continue']();
         }
-        var winningRev = merge.winningRev(metadata);
         var doc = {
           id: metadata.id,
           key: metadata.id,
@@ -716,8 +726,7 @@ function IdbPouch(opts, callback) {
         allDocsInner(metadata);
       } else {
         var index = transaction.objectStore(BY_SEQ_STORE).index('_doc_id_rev');
-        var mainRev = merge.winningRev(metadata);
-        var key = metadata.id + "::" + mainRev;
+        var key = metadata.id + "::" + winningRev;
         index.get(key).onsuccess = function (event) {
           allDocsInner(cursor.value, event.target.result);
         };
@@ -726,15 +735,20 @@ function IdbPouch(opts, callback) {
   }
 
   function countDocs(callback) {
-    var totalRows;
+    if (docCount !== -1) {
+      return callback(null, docCount);
+    }
+
+    var count;
     var txn = idb.transaction([DOC_STORE], 'readonly');
     var index = txn.objectStore(DOC_STORE).index('deletedOrLocal');
     index.count(global.IDBKeyRange.only("0")).onsuccess = function (e) {
-      totalRows = e.target.result;
+      count = e.target.result;
     };
     txn.onerror = idbError(callback);
     txn.oncomplete = function () {
-      callback(null, totalRows);
+      docCount = count;
+      callback(null, docCount);
     };
   }
 
@@ -942,10 +956,12 @@ function IdbPouch(opts, callback) {
             if (metadata) {
               var deleted = utils.isDeleted(metadata);
               var local = utils.isLocalId(metadata.id);
-              metadata =
-                utils.extend(true,
-                             {deletedOrLocal : (deleted || local) ? "1" : "0"},
-                             metadata);
+              metadata = utils.extend(true,
+                {
+                  deletedOrLocal: (deleted || local) ? "1" : "0",
+                  winningRev : merge.winningRev(metadata)
+                },
+                metadata);
             }
             txn.objectStore(DOC_STORE).put(metadata);
           }


### PR DESCRIPTION
Similar to what was done for WebSQL, this caches
the docCount as well as minimizing the calls to
isDeleted and merge.winningRev. The winningRev
is also stored in the by-seq store, similar to how
the winningSeq is stored in websql.
