### PR TITLE
(#1921) - WIP - implement returnDocs for websql/idb

### DIFF
--- a/tests/test.changes.js
+++ b/tests/test.changes.js
@@ -1,6 +1,5 @@
 
 'use strict';
-
 var adapters = ['http', 'local'];
 
 adapters.forEach(function (adapter) {
@@ -1423,6 +1422,35 @@ adapters.forEach(function (adapter) {
         }, 'nextSong', rev2);
       });
     });
+
+    if (adapter === 'local') {
+      it('supports returnDocs=false', function (done) {
+        var db = new PouchDB(dbs.name);
+        var docs = [];
+        var num = 10;
+        for (var i = 0; i < num; i++) {
+          docs.push({ _id: 'doc_' + i, });
+        }
+        var changes = 0;
+        db.bulkDocs({ docs: docs }, function (err, info) {
+          if (err) {
+            return done(err);
+          }
+          db.changes({
+            descending: true,
+            returnDocs : false
+          }).on('change', function (change) {
+            changes++;
+          }).on('complete', function (results) {
+            results.results.should.have.length(0, '0 results returned');
+            changes.should.equal(num, 'correct number of changes');
+            done();
+          }).on('error', function (err) {
+            done(err);
+          });
+        });
+      });
+    }
   });
 });
 


### PR DESCRIPTION
This may be way harder than I thought, but it's going to be ace for improving performance in mapreduce, since mapreduce doesn't need all the changes to be stored in memory at once.
