### PR TITLE
(#1926) - More efficient changes() for idb/websql

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -801,7 +801,7 @@ function IdbPouch(opts, callback) {
     });
   };
 
-  api._changes = function idb_changes(opts) {
+  api._changes = function (opts) {
     opts = utils.clone(opts);
 
     if (opts.continuous) {
@@ -816,12 +816,19 @@ function IdbPouch(opts, callback) {
     }
 
     var descending = opts.descending ? 'prev' : null;
-    var last_seq = 0;
+    var lastSeq = 0;
 
     // Ignore the `since` parameter when `descending` is true
     opts.since = opts.since && !descending ? opts.since : 0;
 
-    var results = [], resultIndices = {}, dedupResults = [];
+    var limit = 'limit' in opts ? opts.limit : -1;
+    if (limit === 0) {
+      limit = 1; // per CouchDB _changes spec
+    }
+
+    var results = [];
+    var filter = utils.filterChange(opts);
+
     var txn;
 
     function fetchChanges() {
@@ -846,67 +853,53 @@ function IdbPouch(opts, callback) {
     fetchChanges();
 
     function onsuccess(event) {
-      if (!event.target.result) {
-        // Filter out null results casued by deduping
-        for (var i = 0, l = results.length; i < l; i++) {
-          var result = results[i];
-          if (result) {
-            dedupResults.push(result);
-          }
-        }
-        return false;
-      }
-
       var cursor = event.target.result;
 
-      // Try to pre-emptively dedup to save us a bunch of idb calls
-      var changeId = cursor.value._id;
-      var changeIdIndex = resultIndices[changeId];
-      if (changeIdIndex !== undefined) {
-        results[changeIdIndex].seq = cursor.key;
-        // update so it has the later sequence number
-        results.push(results[changeIdIndex]);
-        results[changeIdIndex] = null;
-        resultIndices[changeId] = results.length - 1;
+      if (!cursor) {
+        return;
+      }
+
+      var doc = cursor.value;
+
+      if (utils.isLocalId(doc._id) ||
+          (opts.doc_ids && opts.doc_ids.indexOf(doc._id) === -1)) {
         return cursor['continue']();
       }
 
       var index = txn.objectStore(DOC_STORE);
-      index.get(cursor.value._id).onsuccess = function (event) {
+      index.get(doc._id).onsuccess = function (event) {
         var metadata = event.target.result;
-        if (utils.isLocalId(metadata.id)) {
+
+        if (lastSeq < metadata.seq) {
+          lastSeq = metadata.seq;
+        }
+        // metadata.winningRev was only added later
+        var winningRev = metadata.winningRev || merge.winningRev(metadata);
+        if (doc._rev !== winningRev) {
           return cursor['continue']();
         }
 
-        if (last_seq < metadata.seq) {
-          last_seq = metadata.seq;
-        }
+        delete doc['_doc_id_rev'];
 
-        var mainRev = merge.winningRev(metadata);
-        var key = metadata.id + "::" + mainRev;
-        var index = txn.objectStore(BY_SEQ_STORE).index('_doc_id_rev');
-        index.get(key).onsuccess = function (docevent) {
-          var doc = docevent.target.result;
-          delete doc['_doc_id_rev'];
-
-          doc._rev = mainRev;
-          var change = opts.processChange(doc, metadata, opts);
-          change.seq = cursor.key;
-
-          // Dedupe the changes feed
-          var changeId = change.id, changeIdIndex = resultIndices[changeId];
-          if (changeIdIndex !== undefined) {
-            results[changeIdIndex] = null;
-          }
+        var change = opts.processChange(doc, metadata, opts);
+        change.seq = cursor.key;
+        if (filter(change)) {
           results.push(change);
-          resultIndices[changeId] = results.length - 1;
+          utils.call(opts.onChange, change);
+        }
+        if (results.length !== limit) {
           cursor['continue']();
-        };
+        }
       };
     }
 
     function onTxnComplete() {
-      utils.processChanges(opts, dedupResults, last_seq);
+      if (!opts.continuous) {
+        utils.call(opts.complete, null, {
+          results: results,
+          last_seq: lastSeq
+        });
+      }
     }
   };
 

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -57,8 +57,7 @@ var DOC_STORE_WINNINGSEQ_INDEX_SQL =
 var DOC_STORE_AND_BY_SEQ_JOINER = BY_SEQ_STORE +
   '.seq = ' + DOC_STORE + '.winningseq';
 
-var SELECT_DOCS = BY_SEQ_STORE + '.doc_id_rev AS rev, ' +
-  BY_SEQ_STORE + '.seq AS seq, ' +
+var SELECT_DOCS = BY_SEQ_STORE + '.seq AS seq, ' +
   BY_SEQ_STORE + '.deleted AS deleted, ' +
   BY_SEQ_STORE + '.json AS data, ' +
   DOC_STORE + '.json AS metadata';
@@ -671,7 +670,6 @@ function WebSqlPouch(opts, callback) {
         return finish();
       }
       doc = JSON.parse(item.data);
-      doc._rev = opts.rev || item.rev.split('::')[1];
       finish();
     });
   };
@@ -764,7 +762,7 @@ function WebSqlPouch(opts, callback) {
             var item = result.rows.item(i);
             var metadata = JSON.parse(item.metadata);
             var data = JSON.parse(item.data);
-            var winningRev = item.rev.split('::')[1];
+            var winningRev = data._rev;
             var doc = {
               id: metadata.id,
               key: metadata.id,
@@ -815,7 +813,7 @@ function WebSqlPouch(opts, callback) {
     });
   };
 
-  api._changes = function idb_changes(opts) {
+  api._changes = function (opts) {
     opts = utils.clone(opts);
 
     if (opts.continuous) {
@@ -834,31 +832,63 @@ function WebSqlPouch(opts, callback) {
     // Ignore the `since` parameter when `descending` is true
     opts.since = opts.since && !descending ? opts.since : 0;
 
+    var limit = 'limit' in opts ? opts.limit : -1;
+    if (limit === 0) {
+      limit = 1; // per CouchDB _changes spec
+    }
+
     var results = [];
 
     function fetchChanges() {
+
+      var criteria = [
+        DOC_STORE + '.seq > ' + opts.since,
+        DOC_STORE + '.local = 0'
+      ];
+      var sqlArgs = [];
+      if (opts.doc_ids) {
+        criteria.push(DOC_STORE + '.id IN (' + opts.doc_ids.map(function () {
+          return '?';
+        }).join(',') + ')');
+        sqlArgs = opts.doc_ids;
+      }
+
       var sql = select(SELECT_DOCS, [DOC_STORE, BY_SEQ_STORE],
-      DOC_STORE_AND_BY_SEQ_JOINER, DOC_STORE + '.seq > ' + opts.since,
+        DOC_STORE_AND_BY_SEQ_JOINER, criteria,
         DOC_STORE + '.seq ' + (descending ? 'DESC' : 'ASC'));
 
+      var filter = utils.filterChange(opts);
+      if (!opts.view && !opts.filter) {
+        // we can just limit in the query
+        sql += ' LIMIT ' + limit;
+      }
+
       db.readTransaction(function (tx) {
-        tx.executeSql(sql, [], function (tx, result) {
-          var last_seq = 0;
+        tx.executeSql(sql, sqlArgs, function (tx, result) {
+          var lastSeq = 0;
           for (var i = 0, l = result.rows.length; i < l; i++) {
             var res = result.rows.item(i);
             var metadata = JSON.parse(res.metadata);
-            if (!utils.isLocalId(metadata.id)) {
-              if (last_seq < res.seq) {
-                last_seq = res.seq;
-              }
-              var doc = JSON.parse(res.data);
-              var change = opts.processChange(doc, metadata, opts);
-              change.seq = res.seq;
-
+            if (lastSeq < res.seq) {
+              lastSeq = res.seq;
+            }
+            var doc = JSON.parse(res.data);
+            var change = opts.processChange(doc, metadata, opts);
+            change.seq = res.seq;
+            if (filter(change)) {
               results.push(change);
+              utils.call(opts.onChange, change);
+            }
+            if (results.length === limit) {
+              break;
             }
           }
-          utils.processChanges(opts, results, last_seq);
+          if (!opts.continuous) {
+            utils.call(opts.complete, null, {
+              results: results,
+              last_seq: lastSeq
+            });
+          }
         });
       });
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -144,22 +144,6 @@ exports.filterChange = function (opts) {
   };
 };
 
-exports.processChanges = function (opts, changes, last_seq) {
-  // TODO: we should try to filter and limit as soon as possible
-  changes = changes.filter(exports.filterChange(opts));
-  if (opts.limit) {
-    if (opts.limit < changes.length) {
-      changes.length = opts.limit;
-    }
-  }
-  changes.forEach(function (change) {
-    exports.call(opts.onChange, change);
-  });
-  if (!opts.continuous) {
-    exports.call(opts.complete, null, {results: changes, last_seq: last_seq});
-  }
-};
-
 // Preprocess documents, parse their revisions, assign an id and a
 // revision for new writes that are missing them, etc
 exports.parseDoc = function (doc, newEdits) {

--- a/tests/test.all_docs.js
+++ b/tests/test.all_docs.js
@@ -497,5 +497,24 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    if (adapter === 'local') { // chrome doesn't like \u0000 in URLs
+      it('test unicode ids and revs', function (done) {
+        var db = new PouchDB(dbs.name);
+        var id = 'baz\u0000';
+        var rev;
+        return db.put({_id: id}).then(function (res) {
+          rev = res.rev;
+        }).then(function () {
+            return db.get(id);
+          }).then(function (doc) {
+            doc._id.should.equal(id);
+            doc._rev.should.equal(rev);
+            return db.allDocs({keys: [id]});
+          }).then(function (res) {
+            res.rows.should.have.length(1);
+            res.rows[0].value.rev.should.equal(rev);
+          }).then(done, done);
+      });
+    }
   });
 });


### PR DESCRIPTION
This moves more of the limit/doc_ids filtering logic
up-front, so that we don't have to read the entire
changes stream into memory and then filter at the end.
