### PR TITLE
WIP - change batching for replication

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -10,11 +10,37 @@ utils.inherits(Replication, EE);
 function Replication(opts) {
   EE.call(this);
   this.cancelled = false;
+  var self = this;
+  var promise = new utils.Promise(function (fulfill, reject) {
+    self.once('complete', fulfill);
+    self.once('error', reject);
+  });
+  self.then = function (resolve, reject) {
+    return promise.then(resolve, reject);
+  };
+  self.catch = function (reject) {
+    return promise.catch(reject);
+  };
 }
 
 Replication.prototype.cancel = function () {
   this.cancelled = true;
   this.emit('cancel');
+};
+
+Replication.prototype.ready = function (src, target) {
+  var self = this;
+  function onDestroy() {
+    self.cancel();
+  }
+  src.once('destroyed', onDestroy);
+  target.once('destroyed', onDestroy);
+  function cleanup() {
+    self.removeAllListeners();
+    src.removeListener('destroyed', onDestroy);
+    target.removeListener('destroyed', onDestroy);
+  }
+  this.then(cleanup, cleanup);
 };
 
 // A batch of changes to be processed as a unit
@@ -40,46 +66,37 @@ function genReplicationId(src, target, opts, callback) {
 
 
 // A checkpoint lets us restart replications from when they were last cancelled
-function fetchCheckpoint(src, target, id, callback) {
-  target.get(id, function (err, targetDoc) {
-    if (err && err.status === 404) {
-      callback(null, 0);
-    } else if (err) {
-      callback(err);
-    } else {
-      src.get(id, function (err, sourceDoc) {
-        if (err && err.status === 404 ||
-            (!err && (targetDoc.last_seq !== sourceDoc.last_seq))) {
-          callback(null, 0);
-        } else if (err) {
-          callback(err);
-        } else {
-          callback(null, sourceDoc.last_seq);
-        }
-      });
+function getCheckpoint(src, target, id) {
+  return target.get(id).then(function (targetDoc) {
+    return src.get(id).then(function (sourceDoc) {
+      if (targetDoc.last_seq === sourceDoc.last_seq) {
+        return (sourceDoc.last_seq);
+      }
+      return 0;
+    });
+  }).then(null, function (err) {
+    if (err.status !== 404) {
+      throw err;
     }
+    return 0;
   });
 }
 
 
 function writeCheckpoint(src, target, id, checkpoint, callback) {
-  function updateCheckpoint(db, callback) {
-    db.get(id, function (err, doc) {
-      if (err && err.status === 404) {
-        doc = {_id: id};
-      } else if (err) {
-        return callback(err);
+  function updateCheckpoint(db) {
+    return db.get(id).then(null, function (err) {
+      if (err.status === 404) {
+        return ({_id: id});
       }
+      throw err;
+    }).then(function (doc) {
       doc.last_seq = checkpoint;
-      db.put(doc, callback);
+      return db.put(doc);
     });
   }
-  updateCheckpoint(target, function (err, doc) {
-    if (err) { return callback(err); }
-    updateCheckpoint(src, function (err, doc) {
-      if (err) { return callback(err); }
-      callback();
-    });
+  return updateCheckpoint(target).then(function (res) {
+    return updateCheckpoint(src);
   });
 }
 
@@ -88,13 +105,14 @@ function replicate(repId, src, target, opts, returnValue) {
   var batches = [];               // list of batches to be processed
   var currentBatch;               // the batch currently being processed
   var pendingBatch = new Batch(); // next batch, not yet ready to be processed
-  var fetchAgain = [];  // queue of documents to be fetched again with api.get
-  var writingCheckpoint = false;
-  var changesCompleted = false;
-  var completeCalled = false;
+  var writingCheckpoint = false;  // true while checkpoint is being written
+  var changesCompleted = false;   // true when all changes received
+  var replicationCompleted = false; // true when replication has completed
   var last_seq = 0;
   var continuous = opts.continuous || opts.live || false;
-  var batch_size = opts.batch_size || 1;
+  var batch_size = opts.batch_size || 100;
+  var batches_limit = opts.batches_limit || 10;
+  var changesPending = false;     // true while src.changes is running
   var doc_ids = opts.doc_ids;
   var result = {
     ok: true,
@@ -104,234 +122,199 @@ function replicate(repId, src, target, opts, returnValue) {
     doc_write_failures: 0,
     errors: []
   };
+  var changesOpts = {};
+  returnValue.ready(src, target);
 
 
   function writeDocs() {
     if (currentBatch.docs.length === 0) {
-      // This should never happen:
-      // batch processing continues past onRevsDiff only if there are diffs
-      // and replication is aborted if a get fails.
-      // TODO: throw or log the error
-      return finishBatch();
+      return;
     }
-
     var docs = currentBatch.docs;
-    target.bulkDocs({docs: docs}, {new_edits: false}, function (err, res) {
-      if (err) {
-        result.doc_write_failures += docs.length;
-        return abortReplication('target.bulkDocs completed with error', err);
+    return target.bulkDocs({
+      docs: docs
+    }, {
+      new_edits: false
+    }).then(function (res) {
+      if (returnValue.cancelled) {
+        completeReplication();
+        throw new Error('cancelled');
       }
-
       var errors = [];
       res.forEach(function (res) {
         if (!res.ok) {
           result.doc_write_failures++;
-          errors.push(new Error(res.reason || 'Unknown reason'));
+          errors.push(new Error(res.reason || res.message || 'Unknown reason'));
         }
       });
-
       if (errors.length > 0) {
-        return abortReplication('target.bulkDocs failed to write docs', errors);
+        var error = new Error('bulkDocs error');
+        error.other_errors = errors;
+        abortReplication('target.bulkDocs failed to write docs', error);
+        throw new Error('bulkWrite partial failure');
       }
-
-      result.docs_written += docs.length;
-      finishBatch();
+    }, function (err) {
+      result.doc_write_failures += docs.length;
+      throw err;
     });
   }
 
-  function onGetError(err) {
-    if (returnValue.cancelled) {
-      return replicationComplete();
-    }
-    return abortReplication('src.get completed with error', err);
-  }
 
-  function onGet(docs) {
-    if (returnValue.cancelled) {
-      return replicationComplete();
-    }
-
-    Object.keys(docs).forEach(function (revpos) {
-      var doc = docs[revpos].ok;
-
-      if (doc) {
-        result.docs_read++;
-        currentBatch.pendingRevs++;
-        currentBatch.docs.push(doc);
-      }
-    });
-
-    fetchRev();
-  }
-
-  function fetchGenerationOneRevs(ids, revs) {
-    src.allDocs({
-      keys: ids,
-      include_docs: true
-    }, function (err, res) {
-      if (returnValue.cancelled) {
-        return replicationComplete();
-      }
-      if (err) {
-        return abortReplication('src.get completed with error', err);
-      }
-
-      res.rows.forEach(function (row, i) {
-        // fetch document again via api.get when doc
-        // * is deleted document (could have data)
-        // * is no longer generation 1
-        // * has attachments
-        var needsSingleFetch = !row.doc ||
-          row.value.rev.slice(0, 2) !== '1-' ||
-          row.doc._attachments && Object.keys(row.doc._attachments).length;
-
-        if (needsSingleFetch) {
-          return fetchAgain.push({
-            id: row.error === 'not_found' ? row.key : row.id,
-            rev: revs[i]
-          });
-        }
-
-        result.docs_read++;
-        currentBatch.pendingRevs++;
-        currentBatch.docs.push(row.doc);
-      });
-
-      fetchRev();
-    });
-  }
-
-  
-  function fetchRev() {
-    if (fetchAgain.length) {
-      var doc = fetchAgain.shift();
-      return fetchSingleRev(src, doc.id, [doc.rev]).then(onGet, onGetError);
-    }
-
+  function getNextDoc() {
     var diffs = currentBatch.diffs;
-
-    if (Object.keys(diffs).length === 0) {
-      writeDocs();
-      return;
-    }
-
-    var generationOne = Object.keys(diffs).reduce(function (memo, id) {
-      if (diffs[id].missing.length === 1 &&
-          diffs[id].missing[0].slice(0, 2) === '1-') {
-        memo.ids.push(id);
-        memo.revs.push(diffs[id].missing[0]);
-        delete diffs[id];
-      }
-
-      return memo;
-    }, {
-      ids: [],
-      revs: []
-    });
-
-    if (generationOne.ids.length) {
-      return fetchGenerationOneRevs(generationOne.ids, generationOne.revs);
-    }
-
     var id = Object.keys(diffs)[0];
     var revs = diffs[id].missing;
-    delete diffs[id];
-
-    fetchSingleRev(src, id, revs).then(onGet, onGetError);
+    return src.get(id, {revs: true, open_revs: revs, attachments: true})
+    .then(function (docs) {
+      docs.forEach(function (doc) {
+        if (returnValue.cancelled) {
+          return completeReplication();
+        }
+        if (doc.ok) {
+          result.docs_read++;
+          currentBatch.pendingRevs++;
+          currentBatch.docs.push(doc.ok);
+          delete diffs[doc.ok._id];
+        }
+      });
+    });
   }
 
-  function abortReplication(reason, err) {
-    if (completeCalled) {
-      return;
+
+  function getAllDocs() {
+    if (Object.keys(currentBatch.diffs).length > 0) {
+      return getNextDoc().then(getAllDocs);
+    } else {
+      return utils.Promise.resolve();
     }
-    result.ok = false;
-    result.status = 'aborted';
-    result.errors.push(err);
-    result.end_time = new Date();
-    result.last_seq = last_seq;
-    batches = [];
-    pendingBatch = new Batch();
-    err.message = reason;
-    completeCalled = true;
-    opts.complete(err, result);
-    returnValue.cancel();
+  }
+
+
+  function getRevisionOneDocs() {
+    // filter out the generation 1 docs and get them
+    // leaving the non-generation one docs to be got otherwise
+    var ids = Object.keys(currentBatch.diffs).filter(function (id) {
+      var missing = currentBatch.diffs[id].missing;
+      return missing.length === 1 && missing[0].slice(0, 2) === '1-';
+    });
+    return src.allDocs({
+      keys: ids,
+      include_docs: true
+    }).then(function (res) {
+      if (returnValue.cancelled) {
+        completeReplication();
+        throw (new Error('cancelled'));
+      }
+      res.rows.forEach(function (row, i) {
+        if (row.doc && !row.deleted &&
+          row.value.rev.slice(0, 2) === '1-' && (
+            !row.doc._attachments ||
+            Object.keys(row.doc._attachments).length === 0
+          )
+        ) {
+          result.docs_read++;
+          currentBatch.pendingRevs++;
+          currentBatch.docs.push(row.doc);
+          delete currentBatch.diffs[row.id];
+        }
+      });
+    });
+  }
+
+
+  function getDocs() {
+    if (src.type() === 'http') {
+      return getRevisionOneDocs().then(getAllDocs);
+    } else {
+      return getAllDocs();
+    }
   }
 
 
   function finishBatch() {
-    if (returnValue.cancelled) {
-      return;
-    }
     writingCheckpoint = true;
-    writeCheckpoint(src, target, repId, currentBatch.seq, function (err, res) {
+    return writeCheckpoint(
+      src,
+      target,
+      repId,
+      currentBatch.seq
+    ).then(function (res) {
       writingCheckpoint = false;
       if (returnValue.cancelled) {
-        return replicationComplete();
-      }
-      if (err) {
-        return abortReplication('writeCheckpoint completed with error', err);
+        completeReplication();
+        throw new Error('cancelled');
       }
       result.last_seq = last_seq = currentBatch.seq;
-      utils.call(opts.onChange, null, result);
+      currentBatch.docs.forEach(function () {
+        result.docs_written++;
+        returnValue.emit('change', utils.clone(result));
+      });
       currentBatch = undefined;
-      startNextBatch();
+      getChanges();
+    }).then(null, function (err) {
+      writingCheckpoint = false;
+      abortReplication('writeCheckpoint completed with error', err);
+      throw err;
     });
   }
 
-  function startNextBatch() {
-    if (returnValue.cancelled) {
-      return replicationComplete();
-    }
 
-    if (currentBatch) {
-      return;
-    }
-
-    if (batches.length === 0) {
-      processPendingBatch();
-      return;
-    }
-
-    currentBatch = batches.shift();
-
+  function getDiffs() {
     var diff = {};
     currentBatch.changes.forEach(function (change) {
       diff[change.id] = change.changes.map(function (x) {
         return x.rev;
       });
     });
-
-    target.revsDiff(diff, onRevsDiff);
+    return target.revsDiff(diff).then(function (diffs) {
+      if (returnValue.cancelled) {
+        completeReplication();
+        throw new Error('cancelled');
+      }
+      // currentBatch.diffs elements are deleted as the documents are written
+      currentBatch.diffs = diffs;
+      currentBatch.pendingRevs = 0;
+    });
   }
 
-  function onRevsDiff(err, diffs) {
-    if (returnValue.cancelled) {
-      return replicationComplete();
-    }
 
-    if (err) {
-      return abortReplication('target.revsDiff completed with error', err);
-    }
-
-    if (Object.keys(diffs).length === 0) {
-      finishBatch();
+  function startNextBatch() {
+    if (returnValue.cancelled || currentBatch) {
       return;
     }
-
-    currentBatch.diffs = diffs;
-    currentBatch.pendingRevs = 0;
-    fetchRev();
+    if (batches.length === 0) {
+      processPendingBatch(true);
+      return;
+    }
+    currentBatch = batches.shift();
+    getDiffs()
+    .then(getDocs)
+    .then(writeDocs)
+    .then(finishBatch)
+    .then(startNextBatch)
+    .then(null, function (err) {
+      abortReplication('batch processing terminated with error', err);
+    });
   }
 
-  function processPendingBatch() {
+
+  function processPendingBatch(immediate) {
     if (pendingBatch.changes.length === 0) {
-      if (changesCompleted && batches.length === 0 && !currentBatch) {
-        replicationComplete();
+      if (batches.length === 0 && !currentBatch) {
+        if ((continuous && changesOpts.live) || changesCompleted) {
+          returnValue.emit('uptodate', utils.clone(result));
+        }
+        if (changesCompleted) {
+          completeReplication();
+        }
       }
       return;
     }
-
-    if (changesCompleted || pendingBatch.changes.length >= batch_size) {
+    if (
+      immediate ||
+      changesCompleted ||
+      pendingBatch.changes.length >= batch_size
+    ) {
       batches.push(pendingBatch);
       pendingBatch = new Batch();
       startNextBatch();
@@ -339,8 +322,22 @@ function replicate(repId, src, target, opts, returnValue) {
   }
 
 
-  function replicationComplete() {
-    if (completeCalled) {
+  function abortReplication(reason, err) {
+    if (replicationCompleted) {
+      return;
+    }
+    result.ok = false;
+    result.status = 'aborted';
+    err.message = reason;
+    result.errors.push(err);
+    batches = [];
+    pendingBatch = new Batch();
+    completeReplication();
+  }
+
+
+  function completeReplication() {
+    if (replicationCompleted) {
       return;
     }
     if (returnValue.cancelled) {
@@ -352,112 +349,137 @@ function replicate(repId, src, target, opts, returnValue) {
     result.status = result.status || 'complete';
     result.end_time = new Date();
     result.last_seq = last_seq;
-    completeCalled = true;
+    replicationCompleted = returnValue.cancelled = true;
     if (result.errors.length > 0) {
-      return opts.complete(result.errors[0], result);
+      var error = result.errors.pop();
+      if (result.errors.length > 0) {
+        error.other_errors = result.errors;
+      }
+      error.result = result;
+      returnValue.emit('error', utils.clone(error));
     } else {
-      return opts.complete(null, result);
+      returnValue.emit('complete', utils.clone(result));
     }
   }
 
 
   function onChange(change) {
     if (returnValue.cancelled) {
-      return replicationComplete();
+      return completeReplication();
     }
-
-    if (completeCalled) {
-      // This should never happen
-      // The complete callback has already been called
-      // How to raise an exception in PouchDB?
-      return;
+    if (
+      pendingBatch.changes.length === 0 &&
+      batches.length === 0 &&
+      !currentBatch
+    ) {
+      returnValue.emit('outofdate', utils.clone(result));
     }
-
     pendingBatch.seq = change.seq;
     pendingBatch.changes.push(change);
-
-    processPendingBatch();
+    processPendingBatch(batches.length === 0);
   }
 
 
-  function complete(err, changes) {
-    changesCompleted = true;
+  function onChangesComplete(changes) {
+    changesPending = false;
     if (returnValue.cancelled) {
-      return replicationComplete();
+      return completeReplication();
     }
-
-    if (err) {
-      result.status = 'src.changes completed with error';
-      result.errors.push(err);
+    if (changes.last_seq > changesOpts.since) {
+      changesOpts.since = changes.last_seq;
+      getChanges();
+    } else {
+      if (continuous) {
+        changesOpts.live = true;
+        getChanges();
+      } else {
+        changesCompleted = true;
+      }
     }
+    processPendingBatch(true);
+  }
 
-    processPendingBatch();
+
+  function onChangesError(err) {
+    changesPending = false;
+    if (returnValue.cancelled) {
+      return completeReplication();
+    }
+    abortReplication('changes rejected', err);
   }
 
 
   function getChanges() {
-    fetchCheckpoint(src, target, repId, function (err, checkpoint) {
-      if (err) {
-        return abortReplication('fetchCheckpoint completed with error', err);
-      }
+    if (
+      !changesPending &&
+      !changesCompleted &&
+      batches.length < batches_limit
+    ) {
+      changesPending = true;
+      src.changes(changesOpts)
+      .on('change', onChange)
+      .then(onChangesComplete)
+      .then(null, onChangesError);
+    }
+  }
 
+
+  function startChanges() {
+    getCheckpoint(src, target, repId).then(function (checkpoint) {
       last_seq = checkpoint;
-
-      // Was the replication cancelled by the caller before it had a chance
-      // to start. Shouldnt we be calling complete?
-      if (returnValue.cancelled) {
-        return replicationComplete();
-      }
-
-      // Call changes on the source database, with callbacks to onChange for
-      // each change and complete when done.
-      var repOpts = {
-        continuous: continuous,
+      changesOpts = {
         since: last_seq,
+        limit: batch_size,
         style: 'all_docs',
-        onChange: onChange,
-        complete: complete,
         doc_ids: doc_ids,
         returnDocs: false
       };
-
       if (opts.filter) {
-        repOpts.filter = opts.filter;
+        changesOpts.filter = opts.filter;
       }
-
       if (opts.query_params) {
-        repOpts.query_params = opts.query_params;
+        changesOpts.query_params = opts.query_params;
       }
-
-      var changes = src.changes(repOpts);
-
-      returnValue.once('cancel', function () {
-        replicationComplete();
-        if (changes && typeof changes.cancel === 'function') {
-          changes.cancel();
-        }
-      });
-
+      getChanges();
+    }).then(null, function (err) {
+      abortReplication('getCheckpoint rejected with ', err);
     });
   }
 
-  // If opts.since is given, set the checkpoint to opts.since
+
+  returnValue.once('cancel', completeReplication);
+
+  if (typeof opts.onChange === 'function') {
+    returnValue.on('change', opts.onChange);
+  }
+
+  if (typeof opts.complete === 'function') {
+    returnValue.once('error', opts.complete);
+    returnValue.once('complete', function (result) {
+      opts.complete(null, result);
+    });
+  }
+
   if (typeof opts.since === 'undefined') {
-    getChanges();
+    startChanges();
   } else {
-    writeCheckpoint(src, target, repId, opts.since, function (err, res) {
-      if (err) {
-        return abortReplication('writeCheckpoint completed with error', err);
+    writingCheckpoint = true;
+    writeCheckpoint(src, target, repId, opts.since).then(function (res) {
+      writingCheckpoint = false;
+      if (returnValue.cancelled) {
+        completeReplication();
+        return;
       }
       last_seq = opts.since;
-      getChanges();
+      startChanges();
+    }).then(null, function (err) {
+      writingCheckpoint = false;
+      abortReplication('writeCheckpoint completed with error', err);
+      throw err;
     });
   }
 }
 
-function fetchSingleRev(src, id, revs) {
-  return src.get(id, {revs: true, open_revs: revs, attachments: true});
-}
 
 function toPouch(db) {
   if (typeof db === 'string') {
@@ -468,6 +490,7 @@ function toPouch(db) {
     return utils.Promise.resolve(db);
   }
 }
+
 
 function replicateWrapper(src, target, opts, callback) {
   if (typeof opts === 'function') {
@@ -511,4 +534,3 @@ function replicateWrapper(src, target, opts, callback) {
 }
 
 exports.replicate = replicateWrapper;
-

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -45,7 +45,9 @@ function complete(callback, direction, cancel) {
       // cancel both replications if either experiences problems
       cancel();
     }
-    res.direction = direction;
+    if (res) {
+      res.direction = direction;
+    }
     callback(err, res);
   };
 }

--- a/tests/test.sync.js
+++ b/tests/test.sync.js
@@ -255,7 +255,7 @@ adapters.forEach(function (adapters) {
           error: 'mock error',
           reason: 'mock changes failure'
         };
-        opts.complete(err, null);
+        return PouchDB.utils.Promise.reject(err);
       };
       function check_results() {
         db.allDocs(function (err, res) {


### PR DESCRIPTION
I still can't get a clean test run for this in node (haven't tried the browser yet). It is close to what I had intended, but I'm stymied by a surprising number of leveldb bugs. I'm taking a break now, but thought you might like to consider this.

With all the interference, I have lost track a bit, but I believe this puts bounds on memory for both changes and replicate (i.e. it should work even for very large changes feeds). It throttles changes to limit the queue of replicate batches. It signals uptodate, but a bit prematurely. The event should be deferred until the documents are written. I know what I want to do about this, but must get back to other work now. 

There is a new option for replication: opts.batchs_limit, which is an upper bound on the number of batches queued.

The algorithm is somewhat as Dale and Calvin have discussed, but different in some details.

npm test was running fairly reliably with batch_size = batches_limit = 1 (after fixing a few bugs elsewhere), but is not yet clean with batch_size = batches_limit = 100.

The latest problem appears to be a fault in allDocs on leveldb (#1961). It it can't be sorted soon I'll remove the revision-1 stuff pending a fix, to get this going and stable.

It may be just my bad luck, but at the moment I am feeling there may be a bit too much change and too little testing going on. It sure seems easy for me to find bugs... Anyway, time for a nap and I'll look at it with fresh eyes later.

Comments and suggestions welcome.
