### PR TITLE
(#1981) - more reliable, greppable perf tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,10 @@ You can specify a particular version of PouchDB or a particular adapter by doing
     http://localhost:8000/tests/performance/test.html?adapter=websql
     http://localhost:8000/tests/performance/test.html?adapter=idb&src=//site.com/pouchdb.js
 
+You can specify particular tests by using `grep=`, e.g.:
+
+    http://127.0.0.1:8000/tests/performance/test.html?grep=basics
+    http://127.0.0.1:8000/tests/performance/test.html?grep=basic-inserts
 
 Alternative Backends
 --------------------------------------

--- a/tests/performance/perf.basics.js
+++ b/tests/performance/perf.basics.js
@@ -20,17 +20,17 @@ module.exports = function (PouchDB, opts) {
     {
       name: 'basic-inserts',
       assertions: 1,
-      iterations: 100,
+      iterations: 1000,
       setup: function (db, callback) {
-        callback(null, {'yo': 'dawg', _id : 'doc-' + Math.random()});
+        callback(null, {'yo': 'dawg'});
       },
       test: function (db, itr, doc, done) {
-        db.put(doc, done);
+        db.post(doc, done);
       }
     }, {
       name: 'bulk-inserts',
       assertions: 1,
-      iterations: 10,
+      iterations: 100,
       setup: function (db, callback) {
         var docs = [];
         for (var i = 0; i < 100; i++) {
@@ -44,10 +44,10 @@ module.exports = function (PouchDB, opts) {
     }, {
       name: 'basic-gets',
       assertions: 1,
-      iterations: 1000,
+      iterations: 10000,
       setup: function (db, callback) {
         var docs = [];
-        for (var i = 0; i < 1000; i++) {
+        for (var i = 0; i < 10000; i++) {
           docs.push({_id : createDocId(i), foo : 'bar', baz : 'quux'});
         }
         db.bulkDocs({docs : docs}, callback);
@@ -58,7 +58,7 @@ module.exports = function (PouchDB, opts) {
     }, {
       name: 'all-docs-skip-limit',
       assertions: 1,
-      iterations: 5,
+      iterations: 50,
       setup: function (db, callback) {
         var docs = [];
         for (var i = 0; i < 1000; i++) {
@@ -80,7 +80,7 @@ module.exports = function (PouchDB, opts) {
     }, {
       name: 'all-docs-startkey-endkey',
       assertions: 1,
-      iterations: 5,
+      iterations: 50,
       setup: function (db, callback) {
         var docs = [];
         for (var i = 0; i < 1000; i++) {

--- a/tests/performance/utils.js
+++ b/tests/performance/utils.js
@@ -3,8 +3,18 @@
 var reporter = require('./perf.reporter');
 var test = require('tape');
 
+var grep;
+if (global.window && global.window.location && global.window.location.search) {
+  grep = global.window.location.search.match(/[&?]grep=([^&]+)/);
+  grep = grep && grep[1];
+}
+
 exports.runTests = function (PouchDB, suiteName, testCases, opts) {
   testCases.forEach(function (testCase, i) {
+    if (grep && suiteName.indexOf(grep) === -1 &&
+        testCase.name.indexOf(grep) === -1) {
+      return;
+    }
     test('benchmarking', function (t) {
 
       var db;
@@ -30,6 +40,7 @@ exports.runTests = function (PouchDB, suiteName, testCases, opts) {
         function after(err) {
           if (err) {
             t.error(err);
+            reporter.log(testCase.name + ' errored: ' + err.message + '\n');
           }
           if (++num < testCase.iterations) {
             process.nextTick(function () {


### PR DESCRIPTION
Added the ability to specify ?grep=foo to limit
the perf tests to a single test/suite. Logged
errors to the document, so we know to disregard
the results.

Increased the iterations to a point where the tests
still complete in a reasonable amount of time even
in a slow browser, but aren't so fast that we can't
tell different browsers apart.  Still based on gut
feelings, not statistical measures of significance.
