### PR TITLE
(#1987) - improve idb compaction performance

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -963,14 +963,6 @@ function IdbPouch(opts, callback) {
 
           count--;
           if (!count) {
-            if (metadata) {
-              var deleted = utils.isDeleted(metadata);
-              var local = utils.isLocalId(metadata.id);
-              metadata = utils.extend(true, {
-                deletedOrLocal: (deleted || local) ? "1" : "0",
-                winningRev : merge.winningRev(metadata)
-              }, metadata);
-            }
             txn.objectStore(DOC_STORE).put(metadata);
           }
         };


### PR DESCRIPTION
There's no need to recalculate the winningRev or
deletedOrLocal values on the metadata, because
neither one has changed.
