### PR TITLE
(#1988) - smarter upsert, only updates doc when necessary

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -679,6 +679,9 @@ AbstractPouchDB.prototype.registerDependentDatabase =
   var depDB = new this.constructor(dependentDb, {adapter: this._adapter});
   function diffFun(doc) {
     doc.dependentDbs = doc.dependentDbs || {};
+    if (doc.dependentDbs[dependentDb]) {
+      return false; // no update required
+    }
     doc.dependentDbs[dependentDb] = true;
     return doc;
   }

--- a/lib/deps/upsert.js
+++ b/lib/deps/upsert.js
@@ -2,8 +2,10 @@
 var Promise = require('../utils').Promise;
 
 // this is essentially the "update sugar" function from daleharvey/pouchdb#1388
+// the diffFun tells us what delta to apply to the doc.  it either returns
+// the doc, or false if it doesn't need to do an update after all
 function upsert(db, docId, diffFun) {
-  return new Promise(function (fullfil, reject) {
+  return new Promise(function (fulfill, reject) {
     if (docId && typeof docId === 'object') {
       docId = docId._id;
     }
@@ -16,10 +18,13 @@ function upsert(db, docId, diffFun) {
         if (err.name !== 'not_found') {
           return reject(err);
         }
-        return fullfil(tryAndPut(db, diffFun({_id : docId}), diffFun));
+        return fulfill(tryAndPut(db, diffFun({_id : docId}), diffFun));
       }
-      doc = diffFun(doc);
-      fullfil(tryAndPut(db, doc, diffFun));
+      var newDoc = diffFun(doc);
+      if (!newDoc) {
+        return fulfill(doc);
+      }
+      fulfill(tryAndPut(db, newDoc, diffFun));
     });
   });
 }


### PR DESCRIPTION
You guys were right to say that upsert() had
code smell.  One of the dumb things it does
is update the document whether we need to
or not.

So in the case of persisted mapreduce,
every time you do query(), a new change is
written to the _local/dependentDbs doc,
which is pure waste. This fixes that.
