### PR TITLE
(#1997) - parse user agent for the perf tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,14 +51,15 @@
     "glob": "~3.2.9",
     "watch-glob": "~0.1.1",
     "mkdirp": "~0.3.5",
-    "exec-sync": "~0.1.6"
+    "exec-sync": "~0.1.6",
+    "ua-parser-js": "^0.6.2"
   },
   "scripts": {
     "build-js": "browserify . -s PouchDB > dist/pouchdb-nightly.js",
     "min": "uglifyjs dist/pouchdb-nightly.js -mc > dist/pouchdb-nightly.min.js",
     "build": "npm run version && mkdir -p dist && npm run build-js && npm run min",
     "build-alt": "./bin/build-alt.sh",
-    "version":"echo \"module.exports = $(./bin/get-version.js);\" > lib/.version.js",
+    "version": "echo \"module.exports = $(./bin/get-version.js);\" > lib/.version.js",
     "test-node": "./bin/run-mocha.sh",
     "test-browser": "mkdir -p dist && npm run build-js && ./bin/test-browser.js",
     "test-browser-alt": "mkdir -p dist && npm run build-alt && ./bin/test-browser.js",

--- a/tests/performance/perf.reporter.js
+++ b/tests/performance/perf.reporter.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var UAParser = require('ua-parser-js');
+var ua = new UAParser(navigator.userAgent);
 global.results = {};
 
 var pre = document && document.getElementById('output');
@@ -35,7 +37,14 @@ exports.end = function (testCase) {
 
 exports.complete = function (suiteName) {
   global.results.completed = true;
-  global.results.client = navigator.userAgent;
+  global.results.client = {
+    browser: ua.getBrowser(),
+    device: ua.getDevice(),
+    engine: ua.getEngine(),
+    cpu: ua.getCPU(),
+    os : ua.getOS(),
+    userAgent: navigator.userAgent
+  };
   console.log(global.results);
   log('\nTests Complete!\n\n');
 };


### PR DESCRIPTION
This gives us something like e.g.

``` js
{ browser: 
   { name: 'Chrome',
     version: '34.0.1847.116',
     major: '34' },
  device: {},
  engine: { name: 'WebKit', version: '537.36' },
  cpu: {},
  os: { name: 'Mac OS X', version: '10.8.5' },
  userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.116 Safari/537.36' }
```
