### PR TITLE
(#1998) - fix intermittent safari replication error

### DIFF
--- a/tests/test.replication.js
+++ b/tests/test.replication.js
@@ -1803,13 +1803,17 @@ interHTTPAdapters.map(function (adapters) {
             }
             if (count === 4) {
               replicate.cancel();
-              remote.put(doc2);
-              // This setTimeout is needed to ensure no further changes come
-              // through
+              // This setTimeout ensures that Safari fires the cancel
+              // event before the put event.
               setTimeout(function () {
-                count.should.equal(4);
-                changes.cancel();
-                done();
+                remote.put(doc2);
+                // This setTimeout is needed to ensure no further changes come
+                // through
+                setTimeout(function () {
+                  count.should.equal(4);
+                  changes.cancel();
+                  done();
+                }, 500);
               }, 500);
             }
           }


### PR DESCRIPTION
In Safari 6 I am occasionally (about 1/10 times) seeing an error in this test (expected 5 to equal 4), because sometimes Safari is sending the `cancel` XHR to `_replicate` after sending the `PUT`, even though in the code it looks like the `PUT` should go second.  I have screenshot evidence below to prove that this Sasquatch exists.

Since there doesn't seem to be any way to have the `promise.cancel` in `replicate.js` communicate with the `changes` object in `changes.js` (nor should there be, probably), tweaking the test seems like the best solution.

![screenshot 2014-04-20 21 02 13](https://cloud.githubusercontent.com/assets/283842/2752417/f3f31cac-c90a-11e3-8189-5229d63fdd07.png)
