### PR TITLE
(#1990) - move allDocs keys query to adapter.js

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -6,6 +6,7 @@ var errors = require('./deps/errors');
 var EventEmitter = require('events').EventEmitter;
 var upsert = require('./deps/upsert');
 var Changes = require('./changes');
+var Promise = utils.Promise;
 
 /*
  * A generic pouch adapter
@@ -58,6 +59,42 @@ function computeHeight(revs) {
     }
   });
   return height;
+}
+
+function allDocsKeysQuery(api, opts, callback) {
+  var keys =  ('limit' in opts) ?
+      opts.keys.slice(opts.skip, opts.limit + opts.skip) :
+      (opts.skip > 0) ? opts.keys.slice(opts.skip) : opts.keys;
+  if (opts.descending) {
+    keys.reverse();
+  }
+  if (!keys.length) {
+    return api._allDocs({limit: 0}, callback);
+  }
+  var finalResults = {
+    rows: new Array(keys.length),
+    offset: opts.skip
+  };
+  Promise.all(keys.map(function (key, i) {
+    var subOpts = utils.extend(true, {key: key, deleted: 'ok'}, opts);
+    ['limit', 'skip', 'keys'].forEach(function (optKey) {
+      delete subOpts[optKey];
+    });
+    return new Promise(function (resolve, reject) {
+      api._allDocs(subOpts, function (err, res) {
+        if (err) {
+          return reject(err);
+        }
+        finalResults.rows[i] = res.rows[0] || {key: key, error: 'not_found'};
+        finalResults.total_rows = res.total_rows;
+        resolve();
+      });
+    });
+  })).then(function () {
+    callback(null, finalResults);
+  }).catch(function (err) {
+    callback(err);
+  });
 }
 
 utils.inherits(AbstractPouchDB, EventEmitter);
@@ -576,6 +613,7 @@ AbstractPouchDB.prototype.allDocs =
     opts = {};
   }
   opts = utils.clone(opts);
+  opts.skip = typeof opts.skip !== 'undefined' ? opts.skip : 0;
   if ('keys' in opts) {
     if (!Array.isArray(opts.keys)) {
       return callback(new TypeError('options.keys must be an array'));
@@ -591,9 +629,9 @@ AbstractPouchDB.prototype.allDocs =
       ));
       return;
     }
-  }
-  if (typeof opts.skip === 'undefined') {
-    opts.skip = 0;
+    if (this.type() !== 'http') {
+      return allDocsKeysQuery(this, opts, callback);
+    }
   }
 
   return this._allDocs(opts, callback);

--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -555,68 +555,7 @@ function IdbPouch(opts, callback) {
     };
   };
 
-  function allDocsKeysQuery(totalRows, opts, callback) {
-    var keys = opts.keys;
-    var descending = 'descending' in opts ? opts.descending : false;
-
-    if (!keys.length) { // empty list is okay
-      callback(null, {
-        offset : opts.skip,
-        rows : [],
-        total_rows : totalRows
-      });
-    } else {
-      // do a separate "key" query for each key in the keys array
-      var resultsToCollate = [];
-      keys.forEach(function (key) {
-        var subOpts = utils.clone(opts);
-        // internal param, says this is a "keys" request
-        subOpts.keys_request = true;
-        subOpts.key = key;
-        delete subOpts.keys;
-        delete subOpts.skip;
-        delete subOpts.limit;
-
-        allDocsNormalQuery(totalRows, subOpts, function (err, res) {
-          resultsToCollate.push({err : err, res : res, key : key});
-          if (resultsToCollate.length === keys.length) {
-            // all done, time to collate
-            var keysToResults = {};
-            for (var i = 0; i < resultsToCollate.length; i++) {
-              var result = resultsToCollate[i];
-              if (result.err) {
-                callback(err);
-                return;
-              } else {
-                keysToResults[result.key] = result;
-              }
-            }
-            var results = [];
-            keys.forEach(function (key) {
-              var result = keysToResults[key];
-              if (result.res.rows.length) {
-                results.push(result.res.rows[0]); // only one result ever
-              } else {
-                results.push({"key": key, "error": "not_found"});
-              }
-            });
-            if (descending) {
-              results = results.reverse();
-            }
-            callback(null, {
-              total_rows: totalRows,
-              offset: opts.skip,
-              rows: ('limit' in opts) ?
-                results.slice(opts.skip, opts.limit + opts.skip) :
-                (opts.skip > 0) ? results.slice(opts.skip) : results
-            });
-          }
-        });
-      });
-    }
-  }
-
-  function allDocsNormalQuery(totalRows, opts, callback) {
+  function allDocsQuery(totalRows, opts, callback) {
     var start = 'startkey' in opts ? opts.startkey : false;
     var end = 'endkey' in opts ? opts.endkey : false;
     var key = 'key' in opts ? opts.key : false;
@@ -704,7 +643,7 @@ function IdbPouch(opts, callback) {
           }
         }
         var deleted = utils.isDeleted(metadata, winningRev);
-        if (opts.keys_request) {
+        if (opts.deleted === 'ok') {
           // deleted docs are okay with keys_requests
           if (deleted) {
             doc.value.deleted = true;
@@ -766,11 +705,8 @@ function IdbPouch(opts, callback) {
           offset : opts.skip,
           rows : []
         });
-      } else if ('keys' in opts) {
-        allDocsKeysQuery(totalRows, opts, callback);
-      } else {
-        allDocsNormalQuery(totalRows, opts, callback);
       }
+      allDocsQuery(totalRows, opts, callback);
     });
   };
 

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -584,23 +584,6 @@ function LevelPouch(opts, callback) {
       if (opts.endkey) {
         readstreamOpts.end = opts.endkey;
       }
-      if (opts.keys) {
-        if (opts.keys.length === 0) {
-          return callback(null, {
-            total_rows: docCount,
-            offset: opts.skip,
-            rows: []
-          });
-        } else {
-          var sortedKeys = utils.extend(true, [], opts.keys);
-          sortedKeys.sort();
-          if (opts.descending) {
-            sortedKeys.reverse();
-          }
-          readstreamOpts.start = sortedKeys[0];
-          readstreamOpts.end = sortedKeys[sortedKeys.length - 1];
-        }
-      }
       if (opts.key) {
         readstreamOpts.start = readstreamOpts.end = opts.key;
       }
@@ -630,7 +613,6 @@ function LevelPouch(opts, callback) {
         });
       }
       var results = [];
-      var resultsMap = {};
       var docstream = stores.docStore.readStream(readstreamOpts);
 
       var throughStream = through(function (entry, _, next) {
@@ -644,7 +626,7 @@ function LevelPouch(opts, callback) {
             next();
             return;
           }
-        } else if (!('keys' in opts)) {
+        } else if (opts.deleted !== 'ok') {
           next();
           return;
         }
@@ -672,19 +654,15 @@ function LevelPouch(opts, callback) {
               }
             }
           }
-          if ('keys' in opts) {
-            if (opts.keys.indexOf(metadata.id) > -1) {
-              if (utils.isDeleted(metadata)) {
-                doc.value.deleted = true;
-                doc.doc = null;
-              }
-              resultsMap[doc.id] = doc;
-            }
-          } else {
-            if (!utils.isDeleted(metadata)) {
-              results.push(doc);
+          if (utils.isDeleted(metadata)) {
+            if (opts.deleted === 'ok') {
+              doc.value.deleted = true;
+              doc.doc = null;
+            } else {
+              return next();
             }
           }
+          results.push(doc);
           next();
         }
         var metadata = entry.value;
@@ -698,18 +676,6 @@ function LevelPouch(opts, callback) {
           allDocsInner(metadata);
         }
       }, function (next) {
-        if ('keys' in opts) {
-          opts.keys.forEach(function (key) {
-            if (key in resultsMap) {
-              results.push(resultsMap[key]);
-            } else {
-              results.push({"key": key, "error": "not_found"});
-            }
-          });
-          if (opts.descending) {
-            results.reverse();
-          }
-        }
         callback(null, {
           total_rows: docCount,
           offset: opts.skip,

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -695,14 +695,12 @@ function WebSqlPouch(opts, callback) {
 
   api._allDocs = function (opts, callback) {
     var results = [];
-    var resultsMap = {};
     var totalRows;
 
     var start = 'startkey' in opts ? opts.startkey : false;
     var end = 'endkey' in opts ? opts.endkey : false;
     var key = 'key' in opts ? opts.key : false;
     var descending = 'descending' in opts ? opts.descending : false;
-    var keys = 'keys' in opts ? opts.keys : false;
     var limit = 'limit' in opts ? opts.limit : -1;
     var offset = 'skip' in opts ? opts.skip : 0;
 
@@ -712,11 +710,6 @@ function WebSqlPouch(opts, callback) {
     if (key !== false) {
       criteria.push(DOC_STORE + '.id = ?');
       sqlArgs.push(key);
-    } else if (keys !== false) {
-      criteria.push(DOC_STORE + '.id in (' + keys.map(function () {
-        return '?';
-      }).join(',') + ')');
-      sqlArgs = sqlArgs.concat(keys);
     } else if (start !== false || end !== false) {
       if (start !== false) {
         criteria.push(DOC_STORE + '.id ' + (descending ? '<=' : '>=') + ' ?');
@@ -732,7 +725,7 @@ function WebSqlPouch(opts, callback) {
       }
     }
 
-    if (keys === false) {
+    if (opts.deleted !== 'ok') {
       // report deleted if keys are specified
       criteria.push(BY_SEQ_STORE + '.deleted = 0');
     }
@@ -780,31 +773,19 @@ function WebSqlPouch(opts, callback) {
                 }
               }
             }
-            if ('keys' in opts) {
-              if (item.deleted) {
+            if (item.deleted) {
+              if (opts.deleted === 'ok') {
                 doc.value.deleted = true;
                 doc.doc = null;
+              } else {
+                continue;
               }
-              resultsMap[doc.id] = doc;
-            } else {
-              results.push(doc);
             }
+            results.push(doc);
           }
         });
       });
     }, unknownError(callback), function () {
-      if (limit !== 0 && 'keys' in opts) {
-        opts.keys.forEach(function (key) {
-          if (key in resultsMap) {
-            results.push(resultsMap[key]);
-          } else {
-            results.push({key: key, error: 'not_found'});
-          }
-        });
-        if (opts.descending) {
-          results.reverse();
-        }
-      }
       callback(null, {
         total_rows: totalRows,
         offset: opts.skip,


### PR DESCRIPTION
This moves the allDocs() logic when opts.keys is
used to adapter.js, which allows us to just do a
simple multi-key fetch for each non-http adapter.

This improves the performance of leveldb.js and should
not have an impact on the performance of websql.js or
idb.js.  Plus it's less code.
