### PR TITLE
(#2006) - remove continue/catch keywords

### DIFF
--- a/bin/de-keywordify.sh
+++ b/bin/de-keywordify.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+REPLACE=./node_modules/replace/bin/replace.js
+
+$REPLACE "\.continue\(" "['continue'](" dist/pouchdb-nightly.js
+$REPLACE "\.catch\(" "['catch'](" dist/pouchdb-nightly.js

--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -100,7 +100,7 @@ function IdbPouch(opts, callback) {
         var local = utils.isLocalId(metadata.id);
         metadata.deletedOrLocal = (deleted || local) ? "1" : "0";
         docStore.put(metadata);
-        cursor['continue']();
+        cursor.continue();
       } else {
         docStore.createIndex('deletedOrLocal',
                              'deletedOrLocal', {unique : false});
@@ -679,7 +679,7 @@ function IdbPouch(opts, callback) {
 
       function allDocsInner(metadata, data) {
         if (utils.isLocalId(metadata.id)) {
-          return cursor['continue']();
+          return cursor.continue();
         }
         var doc = {
           id: metadata.id,
@@ -720,7 +720,7 @@ function IdbPouch(opts, callback) {
             return;
           }
         }
-        cursor['continue']();
+        cursor.continue();
       }
 
       if (!opts.include_docs) {
@@ -871,7 +871,7 @@ function IdbPouch(opts, callback) {
 
       if (utils.isLocalId(doc._id) ||
           (opts.doc_ids && opts.doc_ids.indexOf(doc._id) === -1)) {
-        return cursor['continue']();
+        return cursor.continue();
       }
 
       var index = txn.objectStore(DOC_STORE);
@@ -884,7 +884,7 @@ function IdbPouch(opts, callback) {
         // metadata.winningRev was only added later
         var winningRev = metadata.winningRev || merge.winningRev(metadata);
         if (doc._rev !== winningRev) {
-          return cursor['continue']();
+          return cursor.continue();
         }
 
         delete doc['_doc_id_rev'];
@@ -899,7 +899,7 @@ function IdbPouch(opts, callback) {
           opts.onChange(change);
         }
         if (numResults !== limit) {
-          cursor['continue']();
+          cursor.continue();
         }
       };
     }

--- a/package.json
+++ b/package.json
@@ -51,14 +51,16 @@
     "glob": "~3.2.9",
     "watch-glob": "~0.1.1",
     "mkdirp": "~0.3.5",
-    "exec-sync": "~0.1.6"
+    "exec-sync": "~0.1.6",
+    "replace": "~0.2.9"
   },
   "scripts": {
     "build-js": "browserify . -s PouchDB > dist/pouchdb-nightly.js",
+    "de-keywordify": "./bin/de-keywordify.sh",
     "min": "uglifyjs dist/pouchdb-nightly.js -mc > dist/pouchdb-nightly.min.js",
-    "build": "npm run version && mkdir -p dist && npm run build-js && npm run min",
+    "build": "npm run version && mkdir -p dist && npm run build-js && npm run de-keywordify && npm run min",
     "build-alt": "./bin/build-alt.sh",
-    "version":"echo \"module.exports = $(./bin/get-version.js);\" > lib/.version.js",
+    "version": "echo \"module.exports = $(./bin/get-version.js);\" > lib/.version.js",
     "test-node": "./bin/run-mocha.sh",
     "test-browser": "mkdir -p dist && npm run build-js && ./bin/test-browser.js",
     "test-browser-alt": "mkdir -p dist && npm run build-alt && ./bin/test-browser.js",


### PR DESCRIPTION
Automatically removes the continue and catch
keywords when they're used as methods, since
older versions of Android don't like this.
