### PR TITLE
(#2028) - one change per replicate batch

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -74,7 +74,7 @@ function getCheckpoint(src, target, id) {
       }
       return 0;
     });
-  }).then(null, function (err) {
+  }).catch(function (err) {
     if (err.status !== 404) {
       throw err;
     }
@@ -85,7 +85,7 @@ function getCheckpoint(src, target, id) {
 
 function writeCheckpoint(src, target, id, checkpoint, callback) {
   function updateCheckpoint(db) {
-    return db.get(id).then(null, function (err) {
+    return db.get(id).catch(function (err) {
       if (err.status === 404) {
         return ({_id: id});
       }
@@ -245,13 +245,11 @@ function replicate(repId, src, target, opts, returnValue) {
         throw new Error('cancelled');
       }
       result.last_seq = last_seq = currentBatch.seq;
-      currentBatch.docs.forEach(function () {
-        result.docs_written++;
-        returnValue.emit('change', utils.clone(result));
-      });
+      result.docs_written += currentBatch.docs.length;
+      returnValue.emit('change', utils.clone(result));
       currentBatch = undefined;
       getChanges();
-    }).then(null, function (err) {
+    }).catch(function (err) {
       writingCheckpoint = false;
       abortReplication('writeCheckpoint completed with error', err);
       throw err;
@@ -292,7 +290,7 @@ function replicate(repId, src, target, opts, returnValue) {
     .then(writeDocs)
     .then(finishBatch)
     .then(startNextBatch)
-    .then(null, function (err) {
+    .catch(function (err) {
       abortReplication('batch processing terminated with error', err);
     });
   }
@@ -419,7 +417,7 @@ function replicate(repId, src, target, opts, returnValue) {
       src.changes(changesOpts)
       .on('change', onChange)
       .then(onChangesComplete)
-      .then(null, onChangesError);
+      .catch(onChangesError);
     }
   }
 
@@ -441,7 +439,7 @@ function replicate(repId, src, target, opts, returnValue) {
         changesOpts.query_params = opts.query_params;
       }
       getChanges();
-    }).then(null, function (err) {
+    }).catch(function (err) {
       abortReplication('getCheckpoint rejected with ', err);
     });
   }
@@ -472,7 +470,7 @@ function replicate(repId, src, target, opts, returnValue) {
       }
       last_seq = opts.since;
       startChanges();
-    }).then(null, function (err) {
+    }).catch(function (err) {
       writingCheckpoint = false;
       abortReplication('writeCheckpoint completed with error', err);
       throw err;


### PR DESCRIPTION
didn't actually need to modify any tests, also since #2008 landed, was reveted and landed again while this one was in being done I went ahead and fixed all the `.then(null,`'s
