### PR TITLE
(#2029) - read only replication

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -43,51 +43,25 @@ Replication.prototype.ready = function (src, target) {
   this.then(cleanup, cleanup);
 };
 
-// A batch of changes to be processed as a unit
-function Batch() {
-  this.seq = 0;
-  this.changes = [];
-  this.docs = [];
-}
-
 
 // TODO: check CouchDB's replication id generation
 // Generate a unique id particular to this replication
-function genReplicationId(src, target, opts, callback) {
+function genReplicationId(src, target, opts) {
   var filterFun = opts.filter ? opts.filter.toString() : '';
-  src.id(function (err, src_id) {
-    target.id(function (err, target_id) {
+  return src.id().then(function (src_id) {
+    return target.id().then(function (target_id) {
       var queryData = src_id + target_id + filterFun +
         JSON.stringify(opts.query_params) + opts.doc_ids;
-      callback('_local/' + utils.MD5(queryData));
+      return '_local/' + utils.MD5(queryData);
     });
   });
 }
 
 
-// A checkpoint lets us restart replications from when they were last cancelled
-function getCheckpoint(src, target, id) {
-  return target.get(id).then(function (targetDoc) {
-    return src.get(id).then(function (sourceDoc) {
-      if (targetDoc.last_seq === sourceDoc.last_seq) {
-        return (sourceDoc.last_seq);
-      }
-      return 0;
-    });
-  }).catch(function (err) {
-    if (err.status !== 404) {
-      throw err;
-    }
-    return 0;
-  });
-}
-
-
-function writeCheckpoint(src, target, id, checkpoint, callback) {
-  function updateCheckpoint(db) {
+function updateCheckpoint(db, id, checkpoint) {
     return db.get(id).catch(function (err) {
       if (err.status === 404) {
-        return ({_id: id});
+        return {_id: id};
       }
       throw err;
     }).then(function (doc) {
@@ -95,16 +69,75 @@ function writeCheckpoint(src, target, id, checkpoint, callback) {
       return db.put(doc);
     });
   }
-  return updateCheckpoint(target).then(function (res) {
-    return updateCheckpoint(src);
-  });
+
+function Checkpointer(src, target, id) {
+  this.src = src;
+  this.target = target;
+  this.id = id;
 }
 
-
+Checkpointer.prototype.writeCheckpoint = function (checkpoint) {
+  var self = this;
+  return this.updateTarget(checkpoint).then(function () {
+    return self.updateSource(checkpoint);
+  });
+};
+Checkpointer.prototype.updateTarget = function (checkpoint) {
+  return updateCheckpoint(this.target, this.id, checkpoint);
+};
+Checkpointer.prototype.updateSource = function (checkpoint) {
+  var self = this;
+  if (this.readOnlySource) {
+    return utils.Promise.resolve(true);
+  }
+  return updateCheckpoint(this.src, this.id, checkpoint).catch(function (err) {
+    if (err.status === 401) {
+      self.readOnlySource = true;
+      return true;
+    }
+    throw err;
+  });
+};
+Checkpointer.prototype.getCheckpoint = function () {
+  var self = this;
+  return self.target.get(self.id).then(function (targetDoc) {
+    return self.src.get(self.id).then(function (sourceDoc) {
+      if (targetDoc.last_seq === sourceDoc.last_seq) {
+        return sourceDoc.last_seq;
+      }
+      return 0;
+    }, function (err) {
+      if (err.status === 404 && targetDoc.last_seq) {
+        return self.target.put({
+          _id: self.id,
+          last_seq: 0
+        }).then(function () {
+          return 0;
+        }, function (err) {
+          if (err.status === 401) {
+            self.readOnlySource = true;
+            return targetDoc.last_seq;
+          }
+          return 0;
+        });
+      }
+      throw err;
+    });
+  }).catch(function (err) {
+    if (err.status !== 404) {
+      throw err;
+    }
+    return 0;
+  });
+};
 function replicate(repId, src, target, opts, returnValue) {
   var batches = [];               // list of batches to be processed
   var currentBatch;               // the batch currently being processed
-  var pendingBatch = new Batch(); // next batch, not yet ready to be processed
+  var pendingBatch = {
+    seq: 0,
+    changes: [],
+    docs: []
+  }; // next batch, not yet ready to be processed
   var writingCheckpoint = false;  // true while checkpoint is being written
   var changesCompleted = false;   // true when all changes received
   var replicationCompleted = false; // true when replication has completed
@@ -114,6 +147,7 @@ function replicate(repId, src, target, opts, returnValue) {
   var batches_limit = opts.batches_limit || 10;
   var changesPending = false;     // true while src.changes is running
   var doc_ids = opts.doc_ids;
+  var checkpointer = new Checkpointer(src, target, repId);
   var result = {
     ok: true,
     start_time: new Date(),
@@ -233,10 +267,7 @@ function replicate(repId, src, target, opts, returnValue) {
 
   function finishBatch() {
     writingCheckpoint = true;
-    return writeCheckpoint(
-      src,
-      target,
-      repId,
+    return checkpointer.writeCheckpoint(
       currentBatch.seq
     ).then(function (res) {
       writingCheckpoint = false;
@@ -314,7 +345,11 @@ function replicate(repId, src, target, opts, returnValue) {
       pendingBatch.changes.length >= batch_size
     ) {
       batches.push(pendingBatch);
-      pendingBatch = new Batch();
+      pendingBatch = {
+        seq: 0,
+        changes: [],
+        docs: []
+      };
       startNextBatch();
     }
   }
@@ -329,7 +364,11 @@ function replicate(repId, src, target, opts, returnValue) {
     err.message = reason;
     result.errors.push(err);
     batches = [];
-    pendingBatch = new Batch();
+    pendingBatch = {
+      seq: 0,
+      changes: [],
+      docs: []
+    };
     completeReplication();
   }
 
@@ -354,9 +393,9 @@ function replicate(repId, src, target, opts, returnValue) {
         error.other_errors = result.errors;
       }
       error.result = result;
-      returnValue.emit('error', utils.clone(error));
+      returnValue.emit('error', error);
     } else {
-      returnValue.emit('complete', utils.clone(result));
+      returnValue.emit('complete', result);
     }
   }
 
@@ -423,7 +462,7 @@ function replicate(repId, src, target, opts, returnValue) {
 
 
   function startChanges() {
-    getCheckpoint(src, target, repId).then(function (checkpoint) {
+    checkpointer.getCheckpoint().then(function (checkpoint) {
       last_seq = checkpoint;
       changesOpts = {
         since: last_seq,
@@ -462,7 +501,7 @@ function replicate(repId, src, target, opts, returnValue) {
     startChanges();
   } else {
     writingCheckpoint = true;
-    writeCheckpoint(src, target, repId, opts.since).then(function (res) {
+    checkpointer.writeCheckpoint(opts.since).then(function (res) {
       writingCheckpoint = false;
       if (returnValue.cancelled) {
         completeReplication();
@@ -520,7 +559,7 @@ function replicateWrapper(src, target, opts, callback) {
         }
         src.replicateOnServer(target, opts, replicateRet);
       } else {
-        genReplicationId(src, target, opts, function (repId) {
+        return genReplicationId(src, target, opts).then(function (repId) {
           replicate(repId, src, target, opts, replicateRet);
         });
       }

--- a/tests/test.issue1175.js
+++ b/tests/test.issue1175.js
@@ -3,7 +3,11 @@ function MockDatabase(statusCodeToReturn, dataToReturn) {
   this.once = this.removeListener = function () {};
   this.type = function () { return 'mock'; };
   this.id = function (callback) {
-    callback(123);
+    if (callback) {
+      callback(123);
+    } else {
+      return PouchDB.utils.Promise.resolve(123);
+    }
   };
   this.get = function (id, callback) {
     return new PouchDB.utils.Promise(function (fulfill, reject) {
@@ -23,6 +27,9 @@ function MockDatabase(statusCodeToReturn, dataToReturn) {
     var promise = PouchDB.utils.Promise.resolve({results: []});
     promise.on = function () { return this; };
     return promise;
+  };
+  this.put = function () {
+    return PouchDB.utils.Promise.resolve();
   };
 }
 function getCallback(expectError, done) {


### PR DESCRIPTION
this allows you to replicate from a readonly db by not crashing if it can't write to the source, it also will allow you to resume replicating from a read only database by using the targets checkpoint if the source does not have the checkpoint and it can't write one to the source.

also adds tests for both cases, though since validate_doc_update doesn't work with local docs we have to mock it.
