### PR TITLE
Update localstorage-down version

### DIFF
--- a/alt/package.json
+++ b/alt/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "level-js": "^2.1.2",
     "lie": "^2.6.0",
-    "localstorage-down": "^0.4.2"
+    "localstorage-down": "^0.4.3"
   },
   "devDependencies": {
     "tape": "^2.12.3"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "leveldown": "~0.10.2",
     "levelup": "~0.18.2",
     "lie": "^2.6.0",
-    "localstorage-down": "~0.4.2",
+    "localstorage-down": "~0.4.3",
     "pouchdb-mapreduce": "2.1.0",
     "request": "~2.28.0",
     "extend": "^1.2.1",


### PR DESCRIPTION
Update localstorage-down to 0.4.3, where a bug (https://github.com/No9/localstorage-down/pull/4) that was making a replication test fail for the alt backend was fixed.
