### PR TITLE
Defer replication termination on changes error

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -442,7 +442,10 @@ function replicate(repId, src, target, opts, returnValue) {
     if (returnValue.cancelled) {
       return completeReplication();
     }
-    abortReplication('changes rejected', err);
+    result.push(new utils.Error('changes terminated with error'));
+    result.push(err);
+    changesCompleted = true;
+    processPendingBatch(true);
   }
 
 


### PR DESCRIPTION
This is a small optimization to replication: if changes terminates with an error, all changes preceding the error are processed before replication terminates. This has significant benefit where there is high cost to the changes feed.
