### PR TITLE
(#2062) - Update alt

### DIFF
--- a/alt/build-js.sh
+++ b/alt/build-js.sh
@@ -6,6 +6,7 @@ if [ -z "$LEVEL_BACKEND" ]; then
 fi
 
 ../node_modules/.bin/browserify . \
+    -r ./index-alt:./index \
     -r $LEVEL_BACKEND:levelalt \
     -s PouchDB \
     -o ../dist/pouchdb-$LEVEL_BACKEND.js

--- a/alt/index-alt.js
+++ b/alt/index-alt.js
@@ -5,11 +5,11 @@ var PouchDB = require('../lib/setup');
 module.exports = PouchDB;
 
 PouchDB.ajax = require('../lib/deps/ajax');
+PouchDB.extend = require('extend');
 PouchDB.utils = require('../lib/utils');
 PouchDB.Errors = require('../lib/deps/errors');
-var replicate = require('../lib/replicate');
-PouchDB.replicate = replicate.replicate;
-PouchDB.sync = replicate.sync;
+PouchDB.replicate = require('../lib/replicate').replicate;
+PouchDB.sync = require('../lib/sync');
 PouchDB.version = require('../lib/version');
 var httpAdapter = require('../lib/adapters/http');
 PouchDB.adapter('http', httpAdapter);

--- a/alt/package.json
+++ b/alt/package.json
@@ -2,7 +2,7 @@
   "name": "levelalt",
   "version": "0.0.0",
   "description": "alt pouchdb",
-  "main": "index.js",
+  "main": "index-alt.js",
   "scripts": {
     "build": "./build-js.sh",
     "build-perf": "browserify tests/performance/*.js > ../dist/performance-bundle.js"
@@ -10,11 +10,11 @@
   "author": "",
   "license": "Apache",
   "browser": {
+    "../lib/deps/ajax.js": "../lib/deps/ajax-browser.js",
     "./deps/buffer": false,
     "request": false,
     "leveldown": "level-js",
-    "bluebird": "lie",
-    "./index": "../lib/index"
+    "bluebird": "lie"
   },
   "dependencies": {
     "level-js": "^2.1.2",

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -19,7 +19,7 @@ var query = "";
 var perfRoot;
 if (process.env.LEVEL_BACKEND) {
   query = "?sourceFile=pouchdb-" + level_backend + ".js";
-  indexfile = "./alt/index.js";
+  indexfile = "./alt/index-alt.js";
   outfile = "./dist/pouchdb-" + level_backend + ".js";
   perfRoot = './alt/performance/*.js';
 } else {
@@ -45,6 +45,7 @@ function writeFile(file) {
 function bundle() {
   if (level_backend) {
     w.require(level_backend, {expose: 'levelalt'});
+    w.require('./alt/index-alt', {expose: './index'});
   }
   w.bundle({standalone: "PouchDB"}, writeFile(outfile));
 }
@@ -54,6 +55,7 @@ function bundlePerfTests() {
     var b = browserify(files);
     if (level_backend) {
       b.require(level_backend, {expose: 'levelalt'});
+      b.require('./alt/index-alt', {expose: './index'});
     }
     b.bundle({}, writeFile(performanceBundle));
   });

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "commander": "~2.1.0",
-    "watchify": "~0.4.1",
+    "watchify": "~0.8.2",
     "uglify-js": "~2.4.6",
     "jshint": "~2.3.0",
     "http-proxy": "~0.10.3",


### PR DESCRIPTION
Alt has been missed in various updates and as a result produced several offending failures and such. 
(Watchify update needed to allow multiple b.requires() from browserify 3.0^)
