### PR TITLE
Allow id to fail if no uuid (  custom couch setup or rewrites )

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -218,7 +218,7 @@ function HttpPouch(opts, callback) {
       method: 'GET',
       url: genUrl(host, '')
     }, function (err, result) {
-      if (err) {
+      if (err && err !== 404) {
         callback(err);
       } else {
         var uuid = (result && result.uuid) ?


### PR DESCRIPTION
So replication takes place even if we cannot pull uuid of DB.
