### PR TITLE
(#2085) Fix replicate sequence 'number' comparison

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -424,7 +424,6 @@ function replicate(repId, src, target, opts, returnValue) {
     if (returnValue.cancelled) {
       return completeReplication();
     }
-    // Compare sequence numbers as strings
     if (changesCount > 0) {
       changesOpts.since = changes.last_seq;
       getChanges();


### PR DESCRIPTION
On cloudant, sequence 'numbers' are strings. This change allows replicate to succeed where the source is on cloudant.
