### PR TITLE
(#2097) - Escape unicode before leveldb binaryStore

### DIFF
--- a/alt/package.json
+++ b/alt/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "level-js": "^2.1.2",
     "lie": "^2.6.0",
-    "localstorage-down": "^0.4.2"
+    "localstorage-down": "^0.4.4"
   },
   "devDependencies": {
     "tape": "^2.12.3"

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -286,9 +286,9 @@ function LevelPouch(opts, callback) {
 
       if (process.browser) {
         if (opts.encode) {
-          data = utils.btoa(attach);
+          data = utils.btoa(global.unescape(attach));
         } else {
-          data = utils.createBlob([utils.fixBinary(attach)],
+          data = utils.createBlob([utils.fixBinary(global.unescape(attach))],
             {type: attachment.content_type});
         }
       } else {
@@ -445,7 +445,8 @@ function LevelPouch(opts, callback) {
       }
 
       function onLoadEnd(e) {
-        var myData = utils.arrayBufferToBinaryString(e.target.result);
+        var myData = global.escape(
+          utils.arrayBufferToBinaryString(e.target.result));
         var myDigest = 'md5-' + utils.MD5(myData);
         saveAttachment(doc, myDigest, key, myData, attachmentSaved);
       }
@@ -464,6 +465,9 @@ function LevelPouch(opts, callback) {
         if (typeof att.data === 'string') {
           try {
             data = utils.atob(att.data);
+            if (process.browser) {
+              data = global.escape(data);
+            }
           } catch (e) {
             callback(utils.extend({}, errors.BAD_ARG,
               {reason: "Attachments need to be base64 encoded"}));

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "leveldown": "~0.10.2",
     "levelup": "~0.18.2",
     "lie": "^2.6.0",
-    "localstorage-down": "~0.4.2",
+    "localstorage-down": "~0.4.4",
     "pouchdb-mapreduce": "2.1.0",
     "request": "~2.28.0",
     "extend": "^1.2.1",


### PR DESCRIPTION
Escape unicode before leveldb binaryStore to avoid png attachment test failures. 

This gets localstorage-down all green [locally] in Chrome with the exception of migration tests and 1 browser.worker.js test (create local db)!
