### PR TITLE
(#2104) - fix readTransaction on sqlite plugin

### DIFF
--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -109,6 +109,9 @@ function WebSqlPouch(opts, callback) {
   var db = openDB(name, POUCH_VERSION, name, POUCH_SIZE);
   if (!db) {
     return callback(errors.UNKNOWN_ERROR);
+  } else if (typeof db.readTransaction !== 'function') {
+    // doesn't exist in sqlite plugin
+    db.readTransaction = db.transaction;
   }
 
   function dbCreated() {


### PR DESCRIPTION
This fixes a ton of tests on Cordova using the SQLite plugin, and `readTransaction` was added recently, so I think this is worth sneaking in to 2.2.0.
