### PR TITLE
(pouchdb/mapreduce#145) - fix es3ify path

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   },
   "browserify": {
     "transform": [
-      "node_modules/es3ify"
+      "./node_modules/es3ify"
     ]
   }
 }


### PR DESCRIPTION
Apparently mapreduce can find es3ify now.
