### PR TITLE
(#2132) - fix remote pouch worker test on IE

### DIFF
--- a/lib/deps/ajax-browser.js
+++ b/lib/deps/ajax-browser.js
@@ -3,6 +3,7 @@
 var createBlob = require('./blob.js');
 var errors = require('./errors');
 var utils = require("../utils");
+var hasUpload;
 
 function ajax(options, adapterCallback) {
 
@@ -203,7 +204,11 @@ function ajax(options, adapterCallback) {
       clearTimeout(timer);
       timer = setTimeout(abortReq, options.timeout);
     };
-    if (xhr.upload) { // does not exist in ie9
+    if (typeof hasUpload === 'undefined') {
+      // IE throws an error if you try to access it directly
+      hasUpload = Object.keys(xhr).indexOf('upload') !== -1;
+    }
+    if (hasUpload) { // does not exist in ie9
       xhr.upload.onprogress = xhr.onprogress;
     }
   }


### PR DESCRIPTION
This fully fixes the 'create remote db' worker test in IE.  Apparently you just can't call `xhr.upload` at all.
