### PR TITLE
(#2164) Long pull Ajax timeout issue

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -782,7 +782,10 @@ function HttpPouch(opts, callback) {
         method: 'GET',
         url: genDBUrl(host, '_changes' + paramStr),
         // _changes can take a long time to generate, especially when filtered
-        timeout: opts.timeout
+        //this long pull's timeout is 20s, so this request's timeout should be larger than 20s to avoid Ajax timeout      happened when the response finally arrive.
+        //but opt default timeout is 10s, so replace opts.timeout with 30000
+        
+        timeout: 30000
       };
       lastFetchedSeq = since;
 


### PR DESCRIPTION
This long pull's timeout is 20s, so this Ajax request timeout should be larger than 20s to avoid Ajax timeout happened when the response finally arrived. But the opt default timeout is 10s, so replace opts.timeout with 30000
