### PR TITLE
(#2165) Alldocs compatible with couchdb.

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -657,24 +657,12 @@ function HttpPouch(opts, callback) {
     }
 
     if (typeof opts.keys !== 'undefined') {
-
-      var MAX_URL_LENGTH = 2000;
-      // according to http://stackoverflow.com/a/417184/680742,
-      // the de factor URL length limit is 2000 characters
-
-      var keysAsString =
-        'keys=' + encodeURIComponent(JSON.stringify(opts.keys));
-      if (keysAsString.length + params.length + 1 <= MAX_URL_LENGTH) {
-        // If the keys are short enough, do a GET. we do this to work around
-        // Safari not understanding 304s on POSTs (see issue #1239)
-        params += (params.indexOf('?') !== -1 ? '&' : '?') + keysAsString;
-      } else {
-        // If keys are too long, issue a POST request to circumvent GET
+       // This workaround patch damage the basic flow of get alldocs, some couchdb version does not support keys 
+       //in its http request, so it will cause download all the docs of database again and again. Delete those workaround codes to follow couchdb's querying options.
         // query string limits
         // see http://wiki.apache.org/couchdb/HTTP_view_API#Querying_Options
         method = 'POST';
         body = JSON.stringify({keys: opts.keys});
-      }
     }
 
     // Get the document listing


### PR DESCRIPTION
This workaround does damage the basic flow of get all docs, some couchdb does not support the keys in its http get request, so this will cause download the all the docs of db again and again. So follow the couchdb querying options delete those workaround codes. 
