### PR TITLE
(#2167) - add docs for viewCleanup()

### DIFF
--- a/docs/_includes/api.html
+++ b/docs/_includes/api.html
@@ -12,6 +12,7 @@
 <li><a href="#get_attachment">Get attachment</a></li>
 <li><a href="#delete_attachment">Delete attachment</a></li>
 <li><a href="#query_database">Query database</a></li>
+<li><a href="#view_cleanup">View cleanup</a></li>
 <li><a href="#database_information">Database info</a></li>
 <li><a href="#compaction">Compaction</a></li>
 <li><a href="#revisions_diff">Revision diff</a></li>

--- a/docs/api.md
+++ b/docs/api.md
@@ -887,6 +887,30 @@ db.query(function(thisIs, awesome) {
 
 Note that closures are only supported by local databases with temporary views.
 
+{% include anchor.html title="View cleanup" hash="view_cleanup" %}
+
+{% highlight js %}
+db.viewCleanup([options], [callback])
+{% endhighlight %}
+
+Cleans up any stale map/reduce indexes.
+
+As design docs are deleted or modified, their associated index files (in CouchDB) or companion databases (in local PouchDBs) continue to take up space on disk. `viewCleanup()` removes these unnecessary index files.
+
+See [the CouchDB documentation on view cleanup](http://couchdb.readthedocs.org/en/latest/maintenance/compaction.html#views-cleanup) for details.
+
+#### Example Usage:
+{% highlight js %}
+db.viewCleanup([options], [callback])
+{% endhighlight %}
+
+#### Example Response:
+{% highlight js %}
+{
+  "ok" : "true"
+}
+{% endhighlight %}
+
 {% include anchor.html title="Get database information" hash="database_information" %}
 
 {% highlight js %}


### PR DESCRIPTION
Unlike `putView()` or whatever we choose for the index API, this is uncontroversial since it's already part of the CouchDB API, so we should add it.
