### PR TITLE
(#2178) - fix websql newEdits=false optimization

### DIFF
--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -523,7 +523,7 @@ function WebSqlPouch(opts, callback) {
           [docInfo.metadata.id, seq, metadataStr, local];
         tx.executeSql(sql, params, function () {
           results.push(docInfo);
-          fetchedDocs = docInfo.metadata;
+          fetchedDocs[docInfo.metadata.id] = docInfo.metadata;
           callback();
         });
       }


### PR DESCRIPTION
Follow-up to #2072.  I realized the fetchedDocs
optimization wasn't actually being used.  Stepped
through in a debugger and verified that it is now.
