### PR TITLE
(#2180) - add fetchedDocs optimization to idb

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -189,6 +189,7 @@ function IdbPouch(opts, callback) {
     }
 
     var results = [];
+    var fetchedDocs = {};
     var docsWritten = 0;
 
     function writeMetaData(e) {
@@ -203,7 +204,14 @@ function IdbPouch(opts, callback) {
         return;
       }
       var currentDoc = docInfos.shift();
-      var req = txn.objectStore(DOC_STORE).get(currentDoc.metadata.id);
+      var id = currentDoc.metadata.id;
+
+      if (id in fetchedDocs) {
+        // if newEdits=false, can re-use the same id from this batch
+        return updateDoc(fetchedDocs[id], currentDoc);
+      }
+
+      var req = txn.objectStore(DOC_STORE).get(id);
       req.onsuccess = function process_docRead(event) {
         var oldDoc = event.target.result;
         if (!oldDoc) {
@@ -381,6 +389,7 @@ function IdbPouch(opts, callback) {
               delete metadata.deletedOrLocal;
               delete metadata.winningRev;
               results.push(docInfo);
+              fetchedDocs[docInfo.metadata.id] = docInfo.metadata;
               utils.call(callback);
             };
           };


### PR DESCRIPTION
Follow-up to #2178.  If it's good enough for
websql, then it's good enough for idb.
