### PR TITLE
(#44) - Fix worker tests for alt backends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,6 @@ env:
 
 matrix:
   allow_failures:
-  - env: CLIENT=selenium:firefox LEVEL_BACKEND=level-js COMMAND=test
-  - env: CLIENT=selenium:firefox LEVEL_BACKEND=localstorage-down COMMAND=test
   - env: CLIENT="saucelabs:iphone:7.1:OS X 10.9" COMMAND=test
 
 branches:

--- a/tests/browser.migration.js
+++ b/tests/browser.migration.js
@@ -174,6 +174,7 @@ describe('migration', function () {
 
       if (scenario === 'PouchDB v2.2.0' && !skip) {
         it("Test persistent views don't require update", function (done) {
+          if (scenario !== 'PouchDB v2.2.0' || skip) { return done(); }
           var oldPouch =
             new dbs.first.pouch(dbs.first.local, dbs.first.localOpts,
               function (err) {

--- a/tests/browser.worker.js
+++ b/tests/browser.worker.js
@@ -1,5 +1,13 @@
 'use strict';
 
+var sourceFile = window.location.search.match(/[?&]sourceFile=([^&]+)/);
+
+if (!sourceFile) {
+  sourceFile = '../dist/pouchdb-nightly.js';
+} else {
+  sourceFile = '../dist/' + sourceFile[1];
+}
+
 if (typeof window.Worker === 'function') {
   runTests();
 }
@@ -27,6 +35,7 @@ function runTests() {
         worker.terminate();
         done();
       });
+      worker.postMessage(sourceFile);
       worker.postMessage('ping');
     });
 
@@ -37,6 +46,7 @@ function runTests() {
         worker.terminate();
         done();
       });
+      worker.postMessage(sourceFile);
       worker.postMessage('version');
     });
 
@@ -50,6 +60,7 @@ function runTests() {
         worker.terminate();
         done();
       });
+      worker.postMessage(sourceFile);
       worker.postMessage(['create', dbs.remote]);
     });
 
@@ -64,6 +75,7 @@ function runTests() {
           worker.terminate();
           done();
         });
+        worker.postMessage(sourceFile);
         worker.postMessage(['create', dbs.name]);
       });
     }

--- a/tests/worker.js
+++ b/tests/worker.js
@@ -1,8 +1,6 @@
 /* jshint worker: true */
 'use strict';
 
-importScripts('../dist/pouchdb-nightly.js');
-
 function bigTest(name) {
   new PouchDB(name, function (err, db) {
     if (err) {
@@ -27,6 +25,9 @@ function bigTest(name) {
 }
 
 self.addEventListener('message', function (e) {
+  if (typeof e.data === 'string' && e.data.indexOf('/dist/') > -1) {
+    importScripts(e.data);
+  }
   if (e.data === 'ping') {
     self.postMessage('pong');
   }


### PR DESCRIPTION
Fixes the issue found in #2179. Allows workers to import appropriate distribution, but the tests all must post the appropriate message beforehand.
