### PR TITLE
 (#2192) longpoll ajax timeout issue

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -697,10 +697,11 @@ function HttpPouch(opts, callback) {
     var CHANGES_LIMIT = 25;
 
     opts = utils.clone(opts);
-    opts.timeout = opts.timeout || 0;
+    opts.timeout = opts.timeout || 30 * 1000;
 
-    // set timeout to 20s to prevent aborting via Ajax timeout
-    var params = { timeout: 20 * 1000 };
+    // the _change response may arrive between 0s ---> opts.timeout, and need give ajax timeout a gap time 5s to 
+    //avoid ajax timeout happened before the response arrive.
+    var params = { timeout: opts.timeout - 5 * 1000 };
     var limit = (typeof opts.limit !== 'undefined') ? opts.limit : false;
     if (limit === 0) {
       limit = 1;


### PR DESCRIPTION
the _change response may arrive between 0s ---> opts.timeout, and need give ajax timeout a gap time 5s to avoid ajax timeout happened before the response arrive.
