### PR TITLE
(pouchdb/mapreduce#161) - migration test for viewCleanup fix

### DIFF
--- a/tests/browser.migration.js
+++ b/tests/browser.migration.js
@@ -226,6 +226,57 @@ describe('migration', function () {
             });
           });
         });
+
+        it('Returns ok for viewCleanup after modifying view', function (done) {
+          if (skip) { return done(); }
+          var oldPouch =
+            new dbs.first.pouch(dbs.first.local, dbs.first.localOpts,
+              function (err) {
+                should.not.exist(err, 'got error: ' + JSON.stringify(err));
+                if (err) {
+                  done();
+                }
+              });
+          var ddoc = {
+            _id: '_design/myview',
+            views: {
+              myview: {
+                map: function (doc) {
+                  emit(doc.firstName);
+                }.toString()
+              }
+            }
+          };
+          var doc = {
+            _id: 'foo',
+            firstName: 'Foobar',
+            lastName: 'Bazman'
+          };
+          oldPouch.bulkDocs({docs: [ddoc, doc]}).then(function (info) {
+            ddoc._rev = info[0].rev;
+            return oldPouch.query('myview');
+          }).then(function (res) {
+            res.rows.should.deep.equal([
+              {id: 'foo', key: 'Foobar', value: null}
+            ]);
+            ddoc.views.myview.map = function (doc) {
+              emit(doc.lastName);
+            }.toString();
+            return oldPouch.put(ddoc);
+          }).then(function () {
+            return oldPouch.query('myview');
+          }).then(function (res) {
+            res.rows.should.deep.equal([
+              {id: 'foo', key: 'Bazman', value: null}
+            ]);
+            return oldPouch.close();
+          }).then(function () {
+            var newPouch = new dbs.second.pouch(dbs.second.local);
+            newPouch.viewCleanup().then(function () {
+              done();
+            }, done);
+          }, done);
+        });
       }
     });
   });


### PR DESCRIPTION
This test will fail until https://github.com/pouchdb/mapreduce/pull/162 is merged and published.  Definitely worth a dot release for pouchdb, in my opinion.
