### PR TITLE
Adds Python-PouchDB as an external project

### DIFF
--- a/docs/external.md
+++ b/docs/external.md
@@ -62,3 +62,10 @@ A tool drawing revision tree of a couchdb document. You can see what is a confli
 A plugin to let PouchDB talk streams.
 
 [Github](https://github.com/calvinmetcalf/PouchStream)
+
+### Python-PouchDB
+A Python interface to PouchDB, with both a synchronous and an asynchronous API. Uses QtWebKit internally (via either PySide, PyQt4 or PyQt5). The geopouch, GQL, search, validation, show and list PouchDB plugins are also wrapped.
+
+[Website](http://python-pouchdb.marten-de-vries.nl/)
+[Documentation](http://pythonhosted.org/Python-PouchDB/)
+[Launchpad](https://launchpad.net/python-pouchdb)


### PR DESCRIPTION
Like PouchDroid, but for another dev environment. Disclaimer: my project, so I'm biased. Feel free to alter description/not add it.
