### PR TITLE
(#2216) - remove mistaken usage of this

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -311,6 +311,7 @@ AbstractPouchDB.prototype.remove =
 
 AbstractPouchDB.prototype.revsDiff =
   utils.adapterFun('revsDiff', function (req, opts, callback) {
+  var self = this;
   if (typeof opts === 'function') {
     callback = opts;
     opts = {};
@@ -352,7 +353,7 @@ AbstractPouchDB.prototype.revsDiff =
   }
 
   ids.map(function (id) {
-    this._getRevisionTree(id, function (err, rev_tree) {
+    self._getRevisionTree(id, function (err, rev_tree) {
       if (err && err.name === 'not_found' && err.message === 'missing') {
         missing[id] = {missing: req[id]};
       } else if (err) {
@@ -560,7 +561,7 @@ AbstractPouchDB.prototype.get =
         return callback(null, doc);
       }
       Object.keys(attachments).forEach(function (key) {
-        this._getAttachment(attachments[key],
+        self._getAttachment(attachments[key],
                             {encode: true, ctx: ctx}, function (err, data) {
           doc._attachments[key].data = data;
           if (!--count) {


### PR DESCRIPTION
It's not safe to use 'this' in the context
of a closure. It's mostly a fluke that this
even works as-is.
