### PR TITLE
(#2143) Make npm run build work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "min": "uglifyjs dist/pouchdb-nightly.js -mc > dist/pouchdb-nightly.min.js",
     "build": "npm run version && mkdir -p dist && npm run build-js && npm run min",
     "build-alt": "./bin/build-alt.sh",
-    "version": "./bin/get-version.js",
+    "version": "node ./bin/get-version.js",
     "test-node": "./bin/run-mocha.sh",
     "test-browser": "mkdir -p dist && npm run build-js && ./bin/test-browser.js",
     "test-browser-alt": "mkdir -p dist && npm run build-alt && ./bin/test-browser.js",


### PR DESCRIPTION
Just add 'node' to version and npm run build will work on Linux/OS X and Windows. Although I only tested it on Linux and Windows.

Note that tests still fail so this isn't a fix for all of #2143.
