### PR TITLE
(#2249) - switch es3ify back to standard path

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   },
   "browserify": {
     "transform": [
-      "./node_modules/es3ify"
+      "es3ify"
     ]
   }
 }


### PR DESCRIPTION
original issue was likely a bug with browserify, it had some issues with relative paths that got fixed
