### PR TITLE
(#2158) - bring back custom extend

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ var PouchDB = require('./setup');
 module.exports = PouchDB;
 
 PouchDB.ajax = require('./deps/ajax');
-PouchDB.extend = require('extend');
+PouchDB.extend = require('pouchdb-extend');
 PouchDB.utils = require('./utils');
 PouchDB.Errors = require('./deps/errors');
 PouchDB.replicate = require('./replicate').replicate;

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,5 +1,5 @@
 'use strict';
-var extend = require('extend');
+var extend = require('pouchdb-extend');
 
 
 // for a better overview of what this is doing, read:

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@
 var crypto = require('crypto');
 var md5 = require('md5-jkmyers');
 var merge = require('./merge');
-exports.extend = require('extend');
+exports.extend = require('pouchdb-extend');
 exports.ajax = require('./deps/ajax');
 exports.createBlob = require('./deps/blob');
 exports.uuid = require('./deps/uuid');

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "localstorage-down": "^0.4.4",
     "pouchdb-mapreduce": "~2.2.2",
     "request": "~2.28.0",
-    "extend": "^1.2.1",
     "md5-jkmyers": "0.0.1",
     "through2": "^0.4.1",
     "es3ify": "^0.1.3",
-    "memdown": "^0.8.0"
+    "memdown": "^0.8.0",
+    "pouchdb-extend": "^0.1.0"
   },
   "devDependencies": {
     "commander": "~2.1.0",


### PR DESCRIPTION
OK, so I figured out that the Ember.js bug was caused by the change from using a custom extend method (ripped from jquery) to the one on npm. Proof here: http://bl.ocks.org/nolanlawson/7bb46ec8310196357217

I haven't figured out yet why the change caused the error, but I think the important thing is that we get Ember.js support back for the 2.3.0 release.  (Yes, users can always disable the prototype modification in Ember.js, but they won't.  Or they will, but only after some Googling and much frustration, at which point they will blame PouchDB for their troubles and we'll have lost a user.)
