### PR TITLE
(#2275) fix overflow-x in chrome

### DIFF
--- a/docs/static/less/pouchdb/scaffolding.less
+++ b/docs/static/less/pouchdb/scaffolding.less
@@ -2,6 +2,7 @@
 
 body {
   overflow-x: hidden;
+  position: relative;
 }
 
 // Temporary fix for Jekyll's P tags all over the place. :/


### PR DESCRIPTION
The github ribbon needs to be contained!!11
