### PR TITLE
(#2276) - fix non-standard splice() usage

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -525,8 +525,10 @@ AbstractPouchDB.prototype.get =
           .indexOf(doc._rev.split('-')[1]) !== -1;
       });
 
-      path.ids.splice(path.ids.map(function (x) {return x.id; })
-                      .indexOf(doc._rev.split('-')[1]) + 1);
+      var indexOfRev = path.ids.map(function (x) {return x.id; })
+        .indexOf(doc._rev.split('-')[1]) + 1;
+      var howMany = path.ids.length - indexOfRev;
+      path.ids.splice(indexOfRev, howMany);
       path.ids.reverse();
 
       if (opts.revs) {


### PR DESCRIPTION
This will fix the issue in PhantomJS.  In order for this to be fully green, though, we're gonna have to wait for #2278 to get merged.

My thought is that we should merge #2278 when everything's passing but Phantom, then merge this PR.
