### PR TITLE
(nick-thompson/express-pouchdb#42) - WIP - fix metadata.id

### DIFF
--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -783,7 +783,7 @@ function LevelPouch(opts, callback) {
       }
 
       stores.docStore.get(data.value._id, function (err, metadata) {
-        if (opts.cancelled || opts.done || db.isClosed() ||
+        if (err || opts.cancelled || opts.done || db.isClosed() ||
             utils.isLocalId(metadata.id)) {
           return next();
         }


### PR DESCRIPTION
So don't ask me why, but occasionally metadata
is undefined here, so this throws an error in
PouchDB server when you run npm test against it.
Related to #2282.
