### PR TITLE
(nick-thompson/express-pouchdb#38) - WIP - fix changeStream.destroy()

### DIFF
--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -845,7 +845,11 @@ function LevelPouch(opts, callback) {
       cancel: function () {
         opts.cancelled = true;
         changeStream.unpipe(throughStream);
-        changeStream.destroy();
+        try {
+          changeStream.destroy();
+        } catch (err) {
+          // Occasional TypeError, ignore
+        }
         if (changeListener) {
           change_emitter.removeListener('change', changeListener);
         }


### PR DESCRIPTION
So again, don't ask me why this works, but this avoids
an occasional TypeError here and keeps the tests from
crashing.  We should probably investigate further,
or maybe this will get fixed automatically when #2252
is merged.  Not sure.
