### PR TITLE
(#2035) - make the CORS proxy optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,9 @@ env:
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome COMMAND=test
   - CLIENT=saucelabs:chrome ADAPTERS=websql COMMAND=test
-  - CLIENT=saucelabs:safari:6 COMMAND=test
-  - CLIENT="saucelabs:iphone:7.1:OS X 10.9" COMMAND=test
-  - CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
+  - CLIENT=saucelabs:safari:6 CORS_PROXY=true COMMAND=test
+  - CLIENT="saucelabs:iphone:7.1:OS X 10.9" CORS_PROXY=true COMMAND=test
+  - CLIENT="saucelabs:internet explorer:10:Windows 8" CORS_PROXY=true COMMAND=test
 
   - CLIENT=selenium:firefox ADAPTERS=memory COMMAND=test
   - CLIENT=selenium:firefox ADAPTERS=idb-alt COMMAND=test
@@ -64,9 +64,9 @@ matrix:
   allow_failures:
   - env: CLIENT=saucelabs:chrome COMMAND=test
   - env: CLIENT=saucelabs:chrome ADAPTERS=websql COMMAND=test
-  - env: CLIENT=saucelabs:safari:6 COMMAND=test
-  - env: CLIENT="saucelabs:iphone:7.1:OS X 10.9" COMMAND=test
-  - env: CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
+  - env: CLIENT=saucelabs:safari:6 CORS_PROXY=true COMMAND=test
+  - env: CLIENT="saucelabs:iphone:7.1:OS X 10.9" CORS_PROXY=true COMMAND=test
+  - env: CLIENT="saucelabs:internet explorer:10:Windows 8" CORS_PROXY=true COMMAND=test
   - env: SERVER_ADAPTER=memory LEVEL_ADAPTER=memdown SERVER=pouchdb-server COMMAND=test
 
 branches:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,23 +116,29 @@ or e.g.:
 
 or you can append it as `?es5shim=true` if you manually opened a browser window.
 
+#### Test with the CORS proxy
+
+For many cases we need to set with the CORS proxy running at localhost:2020 instead of directly accessing CouchDB at 5984.  You can start up the proxy using:
+
+    $ CORS_PROXY=true CLIENT=selenium:firefox npm run test
+    $ CORS_PROXY=true npm run dev
+
+The CORS proxy is only used in the browser, not in the Node tests.
+
 ### Cordova tests
 
 You may need to install `ant` in order for the Android tests to run (e.g. `brew install ant`).
 
-You will also need to run the dev test `npm run dev` simultaneously, so that
-the CORS server is available on port 2020.
-
     $ CLIENT=ios npm run cordova
     $ CLIENT=android DEVICE=true npm run cordova. Also available: `CLIENT=firefoxos`.
-    $ COUCH_HOST=http://myurl:2020 npm run cordova
+    $ COUCH_HOST=http://myurl:5984 npm run cordova
     $ GREP=basics npm run cordova
     $ SQLITE_PLUGIN=true npm run cordova
 
 * `CLIENT=ios` will run on iOS, default is `CLIENT=android`
 * `DEVICE=true` will run on a device connected via USB, else on an emulator
 * `SQLITE_PLUGIN=true` will use the [SQLite Plugin](https://github.com/brodysoft/Cordova-SQLitePlugin)
-* `COUCH_HOST` should be the full URL; you can only omit this is in the Android emulator
+* `COUCH_HOST` should be the full URL; you can only omit this is in the Android emulator because the magic route 10.0.2.2 routes to localhost
 
 You can also debug with Weinre by doing:
 

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -11,6 +11,7 @@ var browserify = require('browserify');
 var cors_proxy = require('corsproxy');
 var http_proxy = require('http-proxy');
 var http_server = require('http-server');
+var request = require('request');
 
 var queryParams = {};
 
@@ -19,6 +20,9 @@ if (process.env.ES5_SHIM || process.env.ES5_SHIMS) {
 }
 if (process.env.ADAPTERS) {
   queryParams.adapters = process.env.ADAPTERS;
+}
+if (process.env.CORS_PROXY) {
+  queryParams.corsProxy = process.env.CORS_PROXY;
 }
 
 var indexfile = "./lib/index.js";
@@ -76,25 +80,77 @@ var CORS_PORT = 2020;
 var serversStarted;
 var readyCallback;
 
-function startServers(callback) {
-  readyCallback = callback;
+function printServerInfo() {
+  var testRoot = 'http://127.0.0.1:' + HTTP_PORT;
+  var query = '';
+  Object.keys(queryParams).forEach(function (key) {
+    query += (query ? '&' : '?');
+    query += key + '=' + encodeURIComponent(queryParams[key]);
+  });
+  console.log('Integration tests: ' + testRoot +
+    '/tests/test.html' + query);
+  console.log('Performance tests: ' + testRoot +
+    '/tests/performance/test.html');
+}
+
+function setUpCors() {
+  // enable CORS globally, because it's easier this way
+
+  var corsValues = {
+    '/_config/httpd/enable_cors': 'true',
+    '/_config/cors/origins': '*',
+    '/_config/cors/credentials': 'true',
+    '/_config/cors/methods': 'PROPFIND, PROPPATCH, COPY, MOVE, DELETE, ' +
+      'MKCOL, LOCK, UNLOCK, PUT, GETLIB, VERSION-CONTROL, CHECKIN, ' +
+      'CHECKOUT, UNCHECKOUT, REPORT, UPDATE, CANCELUPLOAD, HEAD, ' +
+      'OPTIONS, GET, POST',
+    '/_config/cors/headers':
+      'Cache-Control, Content-Type, Depth, Destination, ' +
+        'If-Modified-Since, Overwrite, User-Agent, X-File-Name, ' +
+        'X-File-Size, X-Requested-With, accept, accept-encoding, ' +
+        'accept-language, authorization, content-type, origin, referer'
+  };
+
+  Promise.all(Object.keys(corsValues).map(function (key) {
+      var value = corsValues[key];
+      return request({
+        method: 'put',
+        url: COUCH_HOST + key,
+        body: JSON.stringify(value)
+      });
+    })).then(function () {
+      http_server.createServer().listen(HTTP_PORT, function () {
+        serversStarted = true;
+        printServerInfo();
+        checkReady();
+      });
+    }).catch(function (err) {
+      if (err) {
+        console.log(err);
+        process.exit(1);
+      }
+    });
+}
+
+function startCorsProxy() {
+  console.log('Starting up CORS proxy at localhost:2020');
   http_server.createServer().listen(HTTP_PORT, function () {
     cors_proxy.options = {target: COUCH_HOST};
     http_proxy.createServer(cors_proxy).listen(CORS_PORT, function () {
-      var testRoot = 'http://127.0.0.1:' + HTTP_PORT;
-      var query = '';
-      Object.keys(queryParams).forEach(function (key) {
-        query += (query ? '&' : '?');
-        query += key + '=' + encodeURIComponent(queryParams[key]);
-      });
-      console.log('Integration tests: ' + testRoot +
-        '/tests/test.html' + query);
-      console.log('Performance tests: ' + testRoot +
-        '/tests/performance/test.html');
       serversStarted = true;
+      printServerInfo();
       checkReady();
     });
   });
+}
+
+function startServers(callback) {
+  readyCallback = callback;
+  if (process.env.CORS_PROXY === 'true') {
+    startCorsProxy();
+  } else {
+    setUpCors();
+  }
 }
 
 function checkReady() {

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -50,6 +50,9 @@ if (process.env.ADAPTERS) {
 if (process.env.ES5_SHIM || process.env.ES5_SHIMS) {
   qs.es5shim = true;
 }
+if (process.env.CORS_PROXY) {
+  qs.corsProxy = process.env.CORS_PROXY;
+}
 testUrl += '?';
 testUrl += querystring.stringify(qs);
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "rimraf": "2.2.8",
     "pouchdb-server": "^0.3.0",
+    "request": "^2.28.0",
     "commander": "~2.1.0",
     "watchify": "~0.8.2",
     "uglify-js": "~2.4.6",

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -34,10 +34,12 @@ testUtils.couchHost = function () {
     return window.COUCH_HOST;
   } else if (window && window.cordova) {
     // magic route to localhost on android emulator
-    return 'http://10.0.2.2:2020';
+    return 'http://10.0.2.2:5984';
+  } else if (window && window.location.search.match(/[?&]corsProxy=true/)) {
+    // use the CORS proxy
+    return 'http://localhost:2020';
   }
-  // In the browser we default to the CORS server, in future will change
-  return 'http://localhost:2020';
+  return 'http://localhost:5984';
 };
 
 testUtils.makeBlob = function (data, type) {


### PR DESCRIPTION
The CORS proxy is really flakey, and it contributes to
our intermittent errors.  However, for reasons that
are mysterious to me, Saucelabs gives us an error
without it, on iPhone, Safari, and IE.

This adds an optional flag, CORS_PROXY=true, which
can be used to enable the proxy.  Otherwise we
set the CORS config on CouchDB and use 5984 directly.
