### PR TITLE
(#2293) - allDocs callback never called if database closed

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -646,6 +646,7 @@ AbstractPouchDB.prototype.changes = function (opts, callback) {
 
 AbstractPouchDB.prototype.close =
   utils.adapterFun('close', function (callback) {
+  this._closed = true;
   return this._close(callback);
 });
 

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -902,9 +902,9 @@ function HttpPouch(opts, callback) {
     });
   });
 
-  api.close = utils.adapterFun('close', function (callback) {
+  api._close = function (callback) {
     callback();
-  });
+  };
 
   function replicateOnServer(target, opts, promise, targetHostUrl) {
     opts = utils.clone(opts);

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -111,6 +111,9 @@ function LevelPouch(opts, callback) {
     }
     db._docCountQueue.running = true;
     var item = db._docCountQueue.queue.shift();
+    if (db.isClosed()) {
+      return item.callback(new Error('database is closed'));
+    }
     stores.bySeqStore.get(DOC_COUNT_KEY, function (err, docCount) {
       docCount = !err ? docCount : 0;
 
@@ -602,6 +605,9 @@ function LevelPouch(opts, callback) {
   api._allDocs = function (opts, callback) {
     opts = utils.clone(opts);
     countDocs(function (err, docCount) {
+      if (err) {
+        return callback(err);
+      }
       var readstreamOpts = {};
       var skip = opts.skip || 0;
       if (opts.startkey) {

--- a/lib/deps/errors.js
+++ b/lib/deps/errors.js
@@ -55,7 +55,7 @@ exports.RESERVED_ID = new PouchError({
 exports.NOT_OPEN = new PouchError({
   status: 412,
   error: 'precondition_failed',
-  reason: 'Database not open so cannot close'
+  reason: 'Database not open'
 });
 exports.UNKNOWN_ERROR = new PouchError({
   status: 500,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -424,6 +424,9 @@ exports.toPromise = function (func) {
 
 exports.adapterFun = function (name, callback) {
   return exports.toPromise(exports.getArguments(function (args) {
+    if (this._closed) {
+      return Promise.reject(new Error('database is closed'));
+    }
     var self = this;
     if (!this.taskqueue.isReady) {
       return new exports.Promise(function (fulfill, reject) {

--- a/tests/test.all_docs.js
+++ b/tests/test.all_docs.js
@@ -547,6 +547,27 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('test empty db', function (done) {
+      return new PouchDB(dbs.name).then(function (db) {
+        return db.allDocs().then(function (res) {
+          res.rows.should.have.length(0);
+          res.total_rows.should.equal(0);
+          done();
+        });
+      });
+    });
+
+    it('test after db close', function (done) {
+      return new PouchDB(dbs.name).then(function (db) {
+        return db.close().then(function () {
+          return db.allDocs().catch(function (err) {
+            err.message.should.equal('database is closed');
+            done();
+          });
+        });
+      });
+    });
+
     if (adapter === 'local') { // chrome doesn't like \u0000 in URLs
       it('test unicode ids and revs', function (done) {
         var db = new PouchDB(dbs.name);


### PR DESCRIPTION
Fixed by checking docCount for 0 and returning empty array.
Test closes the DB (actually a cached one). Without this fix,
the allDocs callback is never called!
