### PR TITLE
Update replication docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -488,7 +488,7 @@ db.changes()
 PouchDB.replicate(source, target, [options])
 {% endhighlight %}
 
-Replicate data from `source` to `target`.  Both the `source` and `target` can be a PouchDB instance or a string representing a CouchDB database url or the name a local PouchDB database. If `options.live` is `true`, then this will track future changes and also replicate them automatically.
+Replicate data from `source` to `target`.  Both the `source` and `target` can be a PouchDB instance or a string representing a CouchDB database url or the name a local PouchDB database. If `options.live` is `true`, then this will track future changes and also replicate them automatically. Note that ``complete`` will not be emitted when `options.live` is `true`.
 
 Replication is an event emiter like changes and emits the `complete`, `change`, and `error` events.
 


### PR DESCRIPTION
Mention that complete event is not emitted in live replication.
