### PR TITLE
(pouchdb/express-pouchdb#43) - add replication id event

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -566,6 +566,7 @@ function replicateWrapper(src, target, opts, callback) {
         src.replicateOnServer(target, opts, replicateRet);
       } else {
         return genReplicationId(src, target, opts).then(function (repId) {
+          replicateRet.emit('id', repId);
           replicate(repId, src, target, opts, replicateRet);
         });
       }


### PR DESCRIPTION
This PR along with https://github.com/pouchdb/express-pouchdb/pull/44 fixes pouchdb/express-pouchdb#43.  This combined with my other PRs (including one on levelup), gives us fully passing tests against pouchdb-server in both Node and Chrome.

Basically all we need is an event to tell us when the replication id has been generated.  That way, we can stash it for later, so that the user can cancel based off of that id.
