### PR TITLE
(#2281) - fix kill command at test end

### DIFF
--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -22,5 +22,7 @@ else
 fi
 
 EXIT_STATUS=$?
-kill $POUCHDB_SERVER_PID
+if [[ ! -z $POUCHDB_SERVER_PID ]]; then 
+  kill $POUCHDB_SERVER_PID
+fi
 exit $EXIT_STATUS


### PR DESCRIPTION
Dumb mistake I made here; you can't kill
pouchdb-server if it's not running.
