### PR TITLE
(#2318) - link pouchdb-server to us

### DIFF
--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -5,6 +5,10 @@
 if [[ ! -z $SERVER ]]; then
   if [ "$SERVER" == "pouchdb-server" ]; then
     export COUCH_HOST='http://127.0.0.1:6984'
+    # link pouchdb-server's pouchdb to us
+    cd ./node_modules/pouchdb-server
+    npm link ../..
+    cd -
     echo -e "Starting up pouchdb-server\n"
     ./node_modules/.bin/pouchdb-server -p 6984 &
     export POUCHDB_SERVER_PID=$!

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "rimraf": "2.2.8",
-    "pouchdb-server": "^0.2.1",
+    "pouchdb-server": "^0.3.0",
     "commander": "~2.1.0",
     "watchify": "~0.8.2",
     "uglify-js": "~2.4.6",


### PR DESCRIPTION
will have to change obviously, when pouchdb-server depends on us and passes pouch into express-pouchdb
