### PR TITLE
(#2054) - implement PouchDB.defaults

### DIFF
--- a/docs/_includes/api.html
+++ b/docs/_includes/api.html
@@ -17,4 +17,5 @@
 <li><a href="#compaction">Compaction</a></li>
 <li><a href="#revisions_diff">Revision diff</a></li>
 <li><a href="#events">Events</a></li>
+<li><a href="#defaults">Default settings</a></li>
 <li><a href="#plugins">Plugins</a></li>

--- a/docs/api.md
+++ b/docs/api.md
@@ -1024,6 +1024,40 @@ PouchDB.on('destroyed', function (dbName) {
 });
 {% endhighlight %}
 
+{% include anchor.html title="Default settings" hash="defaults"%}
+
+If you find yourself using the same constructor options repeatedly,
+you can simplify your code with `PouchDB.defaults()`:
+
+{% highlight js %}
+PouchDB.defaults({
+  option1: 'foo',
+  option2: 'value'
+});
+{% endhighlight %}
+
+The returned object is a constructor function that works the same as `PouchDB`, except that whenever you invoke it (e.g. with `new`), the given options will be passed in by default.
+
+#### Example Usage:
+{% highlight js %}
+var MyMemPouch = PouchDB.defaults({
+  db: require('memdown')
+});
+// MemDOWN-backed Pouch (in Node)
+var MyMemPouch = new MyMemPouch('dbname');
+
+var MyPrefixedPouch = PouchDB.defaults({
+  prefix: '/path/to/my/db/'
+});
+// db will be named '/path/to/my/db/dbname', useful for LevelDB
+var myPrefixedPouch = new MyPrefixedPouch('dbname');
+{% endhighlight %}
+
+Note the special constructor option `prefix`, which appends a prefix to the database name
+and can be helpful for URL-based or file-based LevelDOWN path names.
+
+All [constructor options](#create_database) are supported. Default options can still be overriden individually.
+
 {% include anchor.html title="Plugins" hash="plugins"%}
 
 Writing a plugin is easy! The API is:

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var levelup = require('levelup');
-var leveldown = require('leveldown');
+var originalLeveldown = require('leveldown');
 var sublevel = require('level-sublevel');
 var through = require('through2').obj;
 
@@ -17,7 +17,7 @@ var BINARY_STORE = 'attach-binary-store';
 
 // leveldb barks if we try to open a db multiple times
 // so we cache opened connections here for initstore()
-var dbStore = {};
+var dbStores = {};
 
 // store the value of update_seq in the by-sequence store the key name will
 // never conflict, since the keys in the by-sequence store are integers
@@ -36,13 +36,12 @@ function LevelPouch(opts, callback) {
     opts.createIfMissing = true;
   }
 
-  if (process.browser) {
-    leveldown = opts.db || leveldown;
-  }
+  var leveldown = opts.db || originalLeveldown;
   if (typeof leveldown.destroy !== 'function') {
     leveldown.destroy = function (name, cb) { cb(); };
   }
 
+  var dbStore = dbStores[leveldown.name] = dbStores[leveldown.name] || {};
   if (dbStore[name]) {
     db = dbStore[name];
     afterDBCreated();
@@ -901,9 +900,13 @@ LevelPouch.valid = function () {
 LevelPouch.destroy = utils.toPromise(function (name, opts, callback) {
   opts = utils.clone(opts);
 
-  if (process.browser) {
-    leveldown = opts.db || leveldown;
+  var leveldown = opts.db || originalLeveldown;
+  if (typeof leveldown.destroy !== 'function') {
+    leveldown.destroy = function (name, cb) { cb(); };
   }
+
+  var dbStore = dbStores[leveldown.name] || {};
+
   if (dbStore[name]) {
 
     LevelPouch.Changes.removeAllListeners(name);

--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -24,7 +24,7 @@ function PouchDB(name, opts, callback) {
     opts = {};
   }
 
-  if (typeof name === 'object') {
+  if (name && typeof name === 'object') {
     opts = name;
     name = undefined;
   }
@@ -62,6 +62,9 @@ function PouchDB(name, opts, callback) {
         
         opts.originalName = originalName;
         opts.name = backend.name;
+        if (opts.prefix) {
+          opts.name = opts.prefix + opts.name;
+        }
         opts.adapter = opts.adapter || backend.adapter;
         self._adapter = opts.adapter;
         if (!PouchDB.adapters[opts.adapter]) {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -77,7 +77,7 @@ PouchDB.destroy = utils.toPromise(function (name, opts, callback) {
     opts = {};
   }
 
-  if (typeof name === 'object') {
+  if (name && typeof name === 'object') {
     opts = name;
     name = undefined;
   }
@@ -145,6 +145,47 @@ PouchDB.plugin = function (obj) {
   Object.keys(obj).forEach(function (id) {
     PouchDB.prototype[id] = obj[id];
   });
+};
+
+PouchDB.defaults = function (defaultOpts) {
+  defaultOpts = utils.clone(defaultOpts);
+
+  function PouchAlt(name, opts, callback) {
+    if (typeof opts === 'function' || typeof opts === 'undefined') {
+      callback = opts;
+      opts = {};
+    }
+    if (name && typeof name === 'object') {
+      opts = name;
+      name = undefined;
+    }
+
+    opts = utils.extend(true, defaultOpts, opts);
+    PouchDB.call(this, name, opts, callback);
+  }
+
+  utils.inherits(PouchAlt, PouchDB);
+
+  PouchAlt.destroy = utils.toPromise(function (name, opts, callback) {
+    if (typeof opts === 'function' || typeof opts === 'undefined') {
+      callback = opts;
+      opts = {};
+    }
+
+    if (name && typeof name === 'object') {
+      opts = name;
+      name = undefined;
+    }
+
+    opts = utils.extend(true, defaultOpts, opts);
+    return PouchDB.destroy(name, opts, callback);
+  });
+
+  eventEmitterMethods.forEach(function (method) {
+    PouchAlt[method] = eventEmitter[method].bind(eventEmitter);
+  });
+  PouchAlt.setMaxListeners(0);
+  return PouchAlt;
 };
 
 module.exports = PouchDB;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "pouchdb-extend": "^0.1.0"
   },
   "devDependencies": {
+    "rimraf": "2.2.8",
     "pouchdb-server": "^0.2.1",
     "commander": "~2.1.0",
     "watchify": "~0.8.2",

--- a/tests/test.defaults.js
+++ b/tests/test.defaults.js
@@ -1,0 +1,94 @@
+'use strict';
+
+var path = require('path');
+var mkdirp = require('mkdirp');
+var rimraf = require('rimraf');
+
+describe('defaults', function () {
+
+  beforeEach(function () {
+    return PouchDB.destroy('mydb').then(function () {
+      return PouchDB.destroy('mydb', {db: require('memdown')});
+    });
+  });
+
+  afterEach(function (done) {
+    rimraf.sync('./tmp/_pouch_.');
+    rimraf.sync('./tmp/path');
+    done();
+  });
+
+  it('should allow prefixes', function () {
+    var prefix = './tmp/path/to/db/1/';
+    var dir = path.join(prefix, '/tmp/');
+    var dir2 = path.join('./tmp/_pouch_./', prefix);
+    var dir3 = path.join(dir2, './tmp/_pouch_mydb');
+    mkdirp.sync(dir);
+    mkdirp.sync(dir2);
+    mkdirp.sync(dir3);
+
+    return new PouchDB('mydb', {
+      prefix: prefix
+    }).then(function (db) {
+      return db.info().then(function (info1) {
+        info1.db_name.should.equal(prefix + './tmp/_pouch_mydb');
+        return db.destroy();
+      });
+    });
+  });
+
+  it('should allow us to set a prefix by default', function () {
+    var prefix = './tmp/path/to/db/2/';
+    var dir = path.join(prefix, '/tmp/');
+    var dir2 = path.join('./tmp/_pouch_./', prefix);
+    var dir3 = path.join(dir2, './tmp/_pouch_mydb');
+    mkdirp.sync(dir);
+    mkdirp.sync(dir2);
+    mkdirp.sync(dir3);
+
+    var CustomPouch = PouchDB.defaults({
+      prefix: prefix
+    });
+    return new CustomPouch('mydb').then(function (db) {
+      return db.info().then(function (info1) {
+        info1.db_name.should.equal(prefix + './tmp/_pouch_mydb');
+        return db.destroy();
+      });
+    });
+  });
+
+  it('should allow us to use memdown', function () {
+    var opts = { name: 'mydb', db: require('memdown') };
+    return new PouchDB(opts).then(function (db) {
+      return db.put({_id: 'foo'}).then(function () {
+        return new PouchDB('mydb').then(function (otherDB) {
+          return db.info().then(function (info1) {
+            return otherDB.info().then(function (info2) {
+              info1.doc_count.should.not.equal(info2.doc_count);
+              return otherDB.destroy();
+            }).then(function () {
+              return db.destroy();
+            });
+          });
+        });
+      });
+    });
+  });
+  it('should allow us to use memdown by default', function () {
+    var CustomPouch = PouchDB.defaults({db: require('memdown')});
+    return new CustomPouch('mydb').then(function (db) {
+      return db.put({_id: 'foo'}).then(function () {
+        return new PouchDB('mydb').then(function (otherDB) {
+          return db.info().then(function (info1) {
+            return otherDB.info().then(function (info2) {
+              info1.doc_count.should.not.equal(info2.doc_count);
+              return otherDB.destroy();
+            }).then(function () {
+              return db.destroy();
+            });
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This also fixes several bugs in how opts.db
is used in leveldb.js, namely:

~~1. opts.db only worked in the browser, not Node~~ corrected in the commit msg
2. the leveldown object was overriden globally
3. databases with the same names but different backends collided
