### PR TITLE
(#2283) - 'destroyed' event has correct db name

### DIFF
--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -127,10 +127,10 @@ function PouchDB(name, opts, callback) {
       function destructionListener(event) {
         if (event === 'destroyed') {
           self.emit('destroyed');
-          PouchDB.removeListener(opts.name, destructionListener);
+          PouchDB.removeListener(originalName, destructionListener);
         }
       }
-      PouchDB.on(opts.name, destructionListener);
+      PouchDB.on(originalName, destructionListener);
       self.emit('created', self);
       PouchDB.emit('created', opts.originalName);
       self.taskqueue.ready(self);

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -93,9 +93,9 @@ PouchDB.destroy = utils.toPromise(function (name, opts, callback) {
       if (err) {
         callback(err);
       } else {
-        PouchDB.emit('destroyed', dbName);
+        PouchDB.emit('destroyed', name);
         //so we don't have to sift through all dbnames
-        PouchDB.emit(dbName, 'destroyed');
+        PouchDB.emit(name, 'destroyed');
         callback(null, resp || { 'ok': true });
       }
     });

--- a/tests/test.events.js
+++ b/tests/test.events.js
@@ -34,6 +34,18 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('PouchDB emits destruction event on PouchDB object', function (done) {
+      PouchDB.once('destroyed', function (name) {
+        name.should.equal(dbs.name, 'should have the same name');
+        new PouchDB(dbs.name, function () {
+          done();
+        });
+      });
+      new PouchDB(dbs.name, function () {
+        PouchDB.destroy(dbs.name);
+      });
+    });
+
     it('emit creation event', function (done) {
       var db = new PouchDB(dbs.name).on('created', function (newDB) {
         db.should.equal(newDB, 'should be same thing');


### PR DESCRIPTION
Incidentally this was also broken in Node due to the `./tmp` prefix.  When https://github.com/pouchdb/pouchdb/pull/2322 gets merged, it'd be nice to verify that the prefix is not emitted on the created or destroyed events, but looking at the code, it seems it shouldn't be.
