### PR TITLE
(#2360) - PouchDB.defaults() missing some fields

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -185,6 +185,14 @@ PouchDB.defaults = function (defaultOpts) {
     PouchAlt[method] = eventEmitter[method].bind(eventEmitter);
   });
   PouchAlt.setMaxListeners(0);
+
+  PouchAlt.preferredAdapters = PouchDB.preferredAdapters.slice();
+  Object.keys(PouchDB).forEach(function (key) {
+    if (!(key in PouchAlt)) {
+      PouchAlt[key] = PouchDB[key];
+    }
+  });
+
   return PouchAlt;
 };
 


### PR DESCRIPTION
Noticed by @commandoline, e.g. PouchDB.plugin is missing.
