### PR TITLE
(#2342) - align websql update_seq with idb

### DIFF
--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -352,8 +352,6 @@ function WebSqlPouch(opts, callback) {
           return;
         }
 
-        docsWritten++;
-
       });
       WebSqlPouch.Changes.notify(name);
 
@@ -475,6 +473,8 @@ function WebSqlPouch(opts, callback) {
 
       docInfo.data._id = docInfo.metadata.id;
       docInfo.data._rev = docInfo.metadata.rev;
+
+      docsWritten++;
 
       if (deleted) {
         docInfo.data._deleted = true;


### PR DESCRIPTION
After talking with @daleharvey on IRC it seems I overestimated the severity of this problem. We can over-increment the update_seq and that's fine. (And we do, relative to Couch.) However, websql does need to update to the same update_seq as idb.
