### PR TITLE
(#2342) - harmonize update_seq across all 3 adapters

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -211,10 +211,6 @@ function init(api, opts, callback) {
           id: metadata.id,
           rev: rev
         });
-
-        if (utils.isLocalId(metadata.id)) {
-          return;
-        }
       });
       IdbPouch.Changes.notify(name);
       docCount = -1; // invalidate
@@ -298,7 +294,9 @@ function init(api, opts, callback) {
       docInfo.data._id = docInfo.metadata.id;
       docInfo.data._rev = docInfo.metadata.rev;
 
-      docsWritten++;
+      if (!utils.isLocalId(docInfo.metadata.id)) {
+        docsWritten++;
+      }
 
       if (deleted) {
         docInfo.data._deleted = true;

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -21,7 +21,13 @@ var dbStores = {};
 
 // store the value of update_seq in the by-sequence store the key name will
 // never conflict, since the keys in the by-sequence store are integers
+// this corresponds to the non-local documents added to by_seq
 var UPDATE_SEQ_KEY = '_local_last_update_seq';
+// the seq count is the equivalent of row_id in websql or "key" in idb, i.e.
+// it's the count of all documents ever added to the by_seq store
+var SEQ_COUNT_KEY = '_local_seq_count';
+// corresponds to the total number of non-deleted non-local docs, aka
+// total_rows or doc_count
 var DOC_COUNT_KEY = '_local_doc_count';
 var UUID_KEY = '_local_uuid';
 
@@ -72,21 +78,32 @@ function LevelPouch(opts, callback) {
     stores.attachmentStore =
       db.sublevel(ATTACHMENT_STORE, {valueEncoding: 'json'});
     stores.binaryStore = db.sublevel(BINARY_STORE, {valueEncoding: 'binary'});
-    stores.bySeqStore.get(UPDATE_SEQ_KEY, function (err, value) {
-      if (typeof db._updateSeq === 'undefined') {
-        db._updateSeq = value || 0;
+    stores.bySeqStore.get(SEQ_COUNT_KEY, function (err, value) {
+      if (typeof db._seqCount === 'undefined') {
+        db._seqCount = value || 0;
       }
-      stores.bySeqStore.get(DOC_COUNT_KEY, function (err, value) {
-        db._docCountQueue.docCount = !err ? value : 0;
-        countDocs(function (err) { // notify queue that the docCount is ready
-          if (err) {
-            api.emit('error', err);
-          }
-          stores.bySeqStore.get(UUID_KEY, function (err, value) {
-            instanceId = !err ? value : utils.uuid();
-            stores.bySeqStore.put(UUID_KEY, instanceId, function (err, value) {
-              process.nextTick(function () {
-                callback(null, api);
+      stores.bySeqStore.get(UPDATE_SEQ_KEY, function (err, value) {
+        if (typeof db._updateSeq === 'undefined') {
+          db._updateSeq = value || 0;
+        }
+        if (db._seqCount < db._updateSeq) {
+          // implicit database migration due to #2342
+          // the seqCount cannot be less than the updateSeq
+          db._seqCount = db._updateSeq;
+        }
+        stores.bySeqStore.get(DOC_COUNT_KEY, function (err, value) {
+          db._docCountQueue.docCount = !err ? value : 0;
+          countDocs(function (err) { // notify queue that the docCount is ready
+            if (err) {
+              api.emit('error', err);
+            }
+            stores.bySeqStore.get(UUID_KEY, function (err, value) {
+              instanceId = !err ? value : utils.uuid();
+              stores.bySeqStore.put(UUID_KEY, instanceId,
+                    function (err, value) {
+                process.nextTick(function () {
+                  callback(null, api);
+                });
               });
             });
           });
@@ -149,16 +166,10 @@ function LevelPouch(opts, callback) {
       if (err) {
         return callback(err);
       }
-      stores.bySeqStore.get(UPDATE_SEQ_KEY, function (err, otherUpdateSeq) {
-        if (err) {
-          otherUpdateSeq = db._updateSeq;
-        }
-
-        return callback(null, {
-          db_name: opts.name,
-          doc_count: docCount,
-          update_seq: otherUpdateSeq
-        });
+      return callback(null, {
+        db_name: opts.name,
+        doc_count: docCount,
+        update_seq: db._updateSeq
       });
     });
   };
@@ -419,6 +430,11 @@ function LevelPouch(opts, callback) {
       doc.data._id = doc.metadata.id;
       doc.data._rev = doc.metadata.rev;
 
+      if (!utils.isLocalId(doc.metadata.id)) {
+        db._updateSeq++;
+      }
+      db._seqCount++;
+
       if (utils.isDeleted(doc.metadata)) {
         doc.data._deleted = true;
       }
@@ -486,8 +502,7 @@ function LevelPouch(opts, callback) {
       }
 
       function finish() {
-        db._updateSeq++;
-        doc.metadata.seq = doc.metadata.seq || db._updateSeq;
+        doc.metadata.seq = doc.metadata.seq || db._seqCount;
         doc.metadata.rev_map[doc.metadata.rev] = doc.metadata.seq;
         var seq = formatSeq(doc.metadata.seq);
         db.emit('pouchdb-id-' + doc.metadata.id, doc);
@@ -580,10 +595,6 @@ function LevelPouch(opts, callback) {
           id: metadata.id,
           rev: rev
         });
-
-        if (utils.isLocalId(metadata.id)) {
-          return;
-        }
       });
       LevelPouch.Changes.notify(name);
       process.nextTick(function () { callback(null, aresults); });

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -356,13 +356,6 @@ function WebSqlPouch(opts, callback) {
           id: metadata.id,
           rev: rev
         });
-
-        if (utils.isLocalId(metadata.id)) {
-          return;
-        }
-
-        docsWritten++;
-
       });
       WebSqlPouch.Changes.notify(name);
 
@@ -484,6 +477,10 @@ function WebSqlPouch(opts, callback) {
 
       docInfo.data._id = docInfo.metadata.id;
       docInfo.data._rev = docInfo.metadata.rev;
+
+      if (!utils.isLocalId(docInfo.metadata.id)) {
+        docsWritten++;
+      }
 
       if (deleted) {
         docInfo.data._deleted = true;

--- a/tests/test.replication.js
+++ b/tests/test.replication.js
@@ -43,7 +43,11 @@ adapters.forEach(function (adapters) {
         db.replicate.from(dbs.remote, function (err, result) {
           result.ok.should.equal(true);
           result.docs_written.should.equal(docs.length);
-          done();
+          db.info(function (err, info) {
+            info.update_seq.should.equal(3, 'update_seq');
+            info.doc_count.should.equal(3, 'doc_count');
+            done();
+          });
         });
       });
     });
@@ -54,7 +58,11 @@ adapters.forEach(function (adapters) {
         PouchDB.replicate(dbs.remote, dbs.name, {}, function (err, result) {
           result.ok.should.equal(true);
           result.docs_written.should.equal(docs.length);
-          done();
+          new PouchDB(dbs.name).info(function (err, info) {
+            info.update_seq.should.equal(3, 'update_seq');
+            info.doc_count.should.equal(3, 'doc_count');
+            done();
+          });
         });
       });
     });
@@ -66,7 +74,11 @@ adapters.forEach(function (adapters) {
           complete: function (err, result) {
             result.ok.should.equal(true);
             result.docs_written.should.equal(docs.length);
-            done();
+            new PouchDB(dbs.name).info(function (err, info) {
+              info.update_seq.should.equal(3, 'update_seq');
+              info.doc_count.should.equal(3, 'doc_count');
+              done();
+            });
           }
         });
       });
@@ -80,7 +92,15 @@ adapters.forEach(function (adapters) {
           db.replicate.from(dbs.remote, function (err, _) {
             db.allDocs(function (err, result) {
               result.rows.length.should.equal(docs.length);
-              done();
+              db.info(function (err, info) {
+                info.update_seq.should.be.above(2, 'update_seq local');
+                info.doc_count.should.equal(3, 'doc_count local');
+                remote.info(function (err, info) {
+                  info.update_seq.should.be.above(2, 'update_seq remote');
+                  info.doc_count.should.equal(3, 'doc_count remote');
+                  done();
+                });
+              });
             });
           });
         });
@@ -93,7 +113,11 @@ adapters.forEach(function (adapters) {
         db.replicate.to(dbs.remote, function (err, result) {
           result.ok.should.equal(true);
           result.docs_written.should.equal(docs.length);
-          done();
+          db.info(function (err, info) {
+            info.update_seq.should.equal(3);
+            info.doc_count.should.equal(3);
+            done();
+          });
         });
       });
     });
@@ -105,7 +129,11 @@ adapters.forEach(function (adapters) {
         db.replicate.to(dbs.remote, function (err, _) {
           remote.allDocs(function (err, result) {
             result.rows.length.should.equal(docs.length);
-            done();
+            db.info(function (err, info) {
+              info.update_seq.should.equal(3);
+              info.doc_count.should.equal(3);
+              done();
+            });
           });
         });
       });
@@ -121,7 +149,11 @@ adapters.forEach(function (adapters) {
             result.docs_read.should.equal(0);
             db.replicate.to(dbs.remote, function (err, result) {
               result.docs_read.should.equal(0);
-              done();
+              db.info(function (err, info) {
+                info.update_seq.should.equal(1);
+                info.doc_count.should.equal(1);
+                done();
+              });
             });
           });
         });
@@ -139,7 +171,11 @@ adapters.forEach(function (adapters) {
             result.ok.should.equal(true);
             result.docs_written.should.equal(0);
             result.docs_read.should.equal(0);
-            done();
+            db.info(function (err, info) {
+              info.update_seq.should.equal(3);
+              info.doc_count.should.equal(3);
+              done();
+            });
           });
         });
       });
@@ -163,7 +199,11 @@ adapters.forEach(function (adapters) {
             db.replicate.from(dbs.remote, {
               complete: function (err, details) {
                 details.docs_read.should.equal(0);
-                done();
+                db.info(function (err, info) {
+                  info.update_seq.should.equal(3);
+                  info.doc_count.should.equal(3);
+                  done();
+                });
               }
             });
           }
@@ -185,7 +225,11 @@ adapters.forEach(function (adapters) {
           db.replicate.to(dbs.remote, {
             complete: function (err, details) {
               details.docs_read.should.equal(0);
-              done();
+              db.info(function (err, info) {
+                info.update_seq.should.equal(3);
+                info.doc_count.should.equal(3);
+                done();
+              });
             }
           });
         };
@@ -223,7 +267,11 @@ adapters.forEach(function (adapters) {
               db.replicate.from(dbs.remote, function (err, result) {
                 result.ok.should.equal(true);
                 result.docs_written.should.equal(1);
-                done();
+                db.info(function (err, info) {
+                  info.update_seq.should.equal(2);
+                  info.doc_count.should.equal(1);
+                  done();
+                });
               });
             });
           });
@@ -247,7 +295,11 @@ adapters.forEach(function (adapters) {
               PouchDB.replicate(db, remote, {}, function (err, result) {
                 result.ok.should.equal(true);
                 result.docs_written.should.equal(1);
-                done();
+                db.info(function (err, info) {
+                  info.update_seq.should.equal(3);
+                  info.doc_count.should.equal(1);
+                  done();
+                });
               });
             });
           });
@@ -292,7 +344,11 @@ adapters.forEach(function (adapters) {
       }).then(function (result) {
         result.ok.should.equal(true);
         result.docs_written.should.equal(1);
-        done();
+        db.info(function (err, info) {
+          info.update_seq.should.equal(3);
+          info.doc_count.should.equal(1);
+          done();
+        });
       }, function (a) {
         done(JSON.stringify(a, false, 4));
       });
@@ -339,7 +395,15 @@ adapters.forEach(function (adapters) {
                                 function (err, res) {
                                 res.rows.should.have.length.above(0, 'second');
                                 res.rows[0].doc.value.should.equal('db1');
-                                done();
+                                db1.info(function (err, info) {
+                                  info.update_seq.should.equal(4);
+                                  info.doc_count.should.equal(1);
+                                  db2.info(function (err, info2) {
+                                    info2.update_seq.should.equal(3);
+                                    info2.doc_count.should.equal(1);
+                                    done();
+                                  });
+                                });
                               });
                             });
                           });
@@ -368,7 +432,11 @@ adapters.forEach(function (adapters) {
           db.replicate.to(dbs.remote, function (err, _) {
             remote.get('adoc', { conflicts: true }, function (err, result) {
               result.should.have.property('_conflicts');
-              done();
+              db.info(function (err, info) {
+                info.update_seq.should.equal(1);
+                info.doc_count.should.equal(1);
+                done();
+              });
             });
           });
         });
@@ -395,7 +463,11 @@ adapters.forEach(function (adapters) {
               conflicts: true
             }, function (_, res) {
               res.rows.length.should.equal(1);
-              done();
+              db.info(function (err, info) {
+                info.update_seq.should.equal(1);
+                info.doc_count.should.equal(1);
+                done();
+              });
             });
           });
         });
@@ -413,7 +485,11 @@ adapters.forEach(function (adapters) {
           if (++finished !== 2) {
             return;
           }
-          done();
+          db.info(function (err, info) {
+            info.update_seq.should.equal(4);
+            info.doc_count.should.equal(4);
+            done();
+          });
         };
         var rep = db.replicate.from(dbs.remote, {
           live: true,
@@ -447,7 +523,11 @@ adapters.forEach(function (adapters) {
           if (++finished !== 2) {
             return;
           }
-          done();
+          db.info(function (err, info) {
+            info.update_seq.should.equal(4);
+            info.doc_count.should.equal(4);
+            done();
+          });
         };
         var rep = remote.replicate.from(db, {
           live: true,
@@ -495,7 +575,11 @@ adapters.forEach(function (adapters) {
             live: true,
             complete: function (err, reason) {
               count.should.equal(4);
-              done();
+              db.info(function (err, info) {
+                info.update_seq.should.equal(4);
+                info.doc_count.should.equal(4);
+                done();
+              });
             },
             onChange: function (change) {
               ++count;
@@ -544,7 +628,11 @@ adapters.forEach(function (adapters) {
             db.allDocs(function (err, docs) {
               if (err) { done(err); }
               docs.rows.length.should.equal(2);
-              done();
+              db.info(function (err, info) {
+                info.update_seq.should.equal(2);
+                info.doc_count.should.equal(2);
+                done();
+              });
             });
           },
           filter: function (doc) {
@@ -570,7 +658,11 @@ adapters.forEach(function (adapters) {
           remote.bulkDocs({ docs: more_docs }, function (err, info) {
             db.replicate.from(remote, {}, function (err, response) {
               response.docs_written.should.equal(3);
-              done();
+              db.info(function (err, info) {
+                info.update_seq.should.equal(5);
+                info.doc_count.should.equal(5);
+                done();
+              });
             });
           });
         });
@@ -590,7 +682,11 @@ adapters.forEach(function (adapters) {
           doc_ids: ['3', '4']
         }, function (err, response) {
           response.docs_written.should.equal(2);
-          done();
+          db.info(function (err, info) {
+            info.update_seq.should.equal(2);
+            info.doc_count.should.equal(2);
+            done();
+          });
         });
       });
     });
@@ -616,7 +712,11 @@ adapters.forEach(function (adapters) {
               complete: function (err, result) {
                 should.not.exist(err);
                 result.docs_written.should.equal(3);
-                done();
+                db.info(function (err, info) {
+                  info.update_seq.should.equal(5);
+                  info.doc_count.should.equal(5);
+                  done();
+                });
               }
             });
           }
@@ -644,7 +744,11 @@ adapters.forEach(function (adapters) {
               }
             }, function (err, response) {
               response.docs_written.should.equal(1);
-              done();
+              db.info(function (err, info) {
+                info.update_seq.should.equal(3);
+                info.doc_count.should.equal(3);
+                done();
+              });
             });
           });
         });
@@ -665,7 +769,11 @@ adapters.forEach(function (adapters) {
         db.replicate.from(remote, function () {
           db.allDocs(function (err, res) {
             res.total_rows.should.equal(4);
-            done();
+            db.info(function (err, info) {
+              info.update_seq.should.equal(5);
+              info.doc_count.should.equal(4);
+              done();
+            });
           });
         });
       });
@@ -707,7 +815,11 @@ adapters.forEach(function (adapters) {
         return db.allDocs();
       }).then(function (res) {
         res.total_rows.should.equal(2);
-        done();
+        db.info(function (err, info) {
+          info.update_seq.should.equal(4);
+          info.doc_count.should.equal(2);
+          done();
+        });
       }).catch(function (err) {
         done(JSON.stringify(err, false, 4));
       });
@@ -720,7 +832,11 @@ adapters.forEach(function (adapters) {
       var onChange = function (c) {
         changes++;
         if (changes === 3) {
-          done();
+          db.info(function (err, info) {
+            info.update_seq.should.equal(3);
+            info.doc_count.should.equal(3);
+            done();
+          });
         }
       };
       remote.bulkDocs({ docs: docs }, {}, function (err, results) {
@@ -751,7 +867,11 @@ adapters.forEach(function (adapters) {
                         function (err, localdoc) {
                         localdoc._rev.should.equal(winningRev);
                         remotedoc._rev.should.equal(winningRev);
-                        done();
+                        db.info(function (err, info) {
+                          info.update_seq.should.equal(3);
+                          info.doc_count.should.equal(1);
+                          done();
+                        });
                       });
                     });
                   });
@@ -797,7 +917,11 @@ adapters.forEach(function (adapters) {
           // written to the target database (this is consistent with CouchDB)
           result.docs_written.should.equal(3);
           result.docs_read.should.equal(3);
-          done();
+          db.info(function (err, info) {
+            info.update_seq.should.be.above(0);
+            info.doc_count.should.equal(1);
+            done();
+          });
         });
       });
     });
@@ -821,7 +945,11 @@ adapters.forEach(function (adapters) {
         db.replicate.from(remote, {}, function () {
           db.allDocs(function (err, res) {
             res.total_rows.should.equal(num);
-            done();
+            db.info(function (err, info) {
+              info.update_seq.should.equal(30);
+              info.doc_count.should.equal(30);
+              done();
+            });
           });
         });
       });
@@ -868,7 +996,11 @@ adapters.forEach(function (adapters) {
           should.exist(err);
           doc_count.should.equal(result.docs_read);
           remote.changes = changes;
-          done();
+          db.info(function (err, info) {
+            info.update_seq.should.equal(3);
+            info.doc_count.should.equal(3);
+            done();
+          });
         });
       });
     });
@@ -957,7 +1089,11 @@ adapters.forEach(function (adapters) {
           doc_ids: docList
         }, function (err, result) {
           result.docs_written.should.equal(docList.length);
-          done();
+          db.info(function (err, info) {
+            info.update_seq.should.equal(3);
+            info.doc_count.should.equal(3);
+            done();
+          });
         });
       });
     });
@@ -1062,7 +1198,11 @@ adapters.forEach(function (adapters) {
             result.docs_written.should.equal(6);
             function check_docs(id, exists) {
               if (!id) {
-                done();
+                db.info(function (err, info) {
+                  info.update_seq.should.equal(6);
+                  info.doc_count.should.equal(6);
+                  done();
+                });
                 return;
               }
               db.get(id, function (err, result) {
@@ -1235,7 +1375,11 @@ adapters.forEach(function (adapters) {
             result.docs_written.should.equal(6);
             function check_docs(id, exists) {
               if (!id) {
-                done();
+                db.info(function (err, info) {
+                  info.update_seq.should.equal(6);
+                  info.doc_count.should.equal(6);
+                  done();
+                });
                 return;
               }
               db.get(id, function (err, result) {
@@ -1325,7 +1469,11 @@ adapters.forEach(function (adapters) {
         db.replicate.from(remote, {
           complete: function (err, result) {
             should.exist(err);
-            done();
+            db.info(function (err, info) {
+              info.update_seq.should.equal(2);
+              info.doc_count.should.equal(2);
+              done();
+            });
           }
         });
       });
@@ -1338,7 +1486,11 @@ adapters.forEach(function (adapters) {
         should.not.exist(err);
         should.exist(result);
         result.docs_written.should.equal(0);
-        done();
+        db.info(function (err, info) {
+          info.update_seq.should.equal(0);
+          info.doc_count.should.equal(0);
+          done();
+        });
       });
     });
 
@@ -1421,7 +1573,11 @@ adapters.forEach(function (adapters) {
               .equal(1, 'second replication, docs_written');
             result.doc_write_failures.should
               .equal(0, 'second replication, doc_write_failures');
-            done();
+            db.info(function (err, info) {
+              info.update_seq.should.equal(2);
+              info.doc_count.should.equal(2);
+              done();
+            });
           });
         });
       });
@@ -1555,7 +1711,11 @@ adapters.forEach(function (adapters) {
               doc_ids: ['5']
             }, function (err, result) {
               result.docs_written.should.equal(0);
-              done();
+              db.info(function (err, info) {
+                info.update_seq.should.equal(5);
+                info.doc_count.should.equal(5);
+                done();
+              });
             });
           });
         });
@@ -1646,7 +1806,11 @@ adapters.forEach(function (adapters) {
               if (--x) {
                 workflow(name, remote, x);
               } else {
-                done();
+                db.info(function (err, info) {
+                  info.update_seq.should.equal(4);
+                  info.doc_count.should.equal(4);
+                  done();
+                });
               }
             });
           });
@@ -1666,7 +1830,11 @@ adapters.forEach(function (adapters) {
             result.rows.length.should.equal(2);
             result.rows[0].id.should.equal('a');
             result.rows[1].id.should.equal('b');
-            done();
+            db.info(function (err, info) {
+              info.update_seq.should.equal(2);
+              info.doc_count.should.equal(2);
+              done();
+            });
           });
         });
       });
@@ -1681,7 +1849,11 @@ adapters.forEach(function (adapters) {
           PouchDB.destroy(dbs.remote, function (err, result) {
             db.replicate.to(dbs.remote, function (err, result) {
               result.docs_written.should.equal(docs.length);
-              done();
+              db.info(function (err, info) {
+                info.update_seq.should.equal(2);
+                info.doc_count.should.equal(2);
+                done();
+              });
             });
           });
         });
@@ -1709,7 +1881,11 @@ adapters.forEach(function (adapters) {
         };
         return src.replicate.to(target);
       }).then(function () {
-        done();
+        target.info(function (err, info) {
+          info.update_seq.should.equal(3);
+          info.doc_count.should.equal(3);
+          done();
+        });
       }, function (a) {
         done(JSON.stringify(a, false, 4));
       });


### PR DESCRIPTION
An alternative version of #2361 where we actually try to get all 3 adapters to behave like the HTTP adapter.

In the end I was successful except for the very special case of conflicts.  It seems that CouchDB increments the update_seq for non-local documents based on the depth of the revision tree, not the number of revisions.  So conflicts at the same level in the tree only implement the count by one. That's where in the test you see me do `should.be.above` instead of `should.equal`.

The adapter that got clobbered the most was leveldb.  There's even an implicit migration in there, although if we assume that the update_seq doesn't matter as long as it gets incremented for every non-local revision written, then it shouldn't make a big difference.
