### PR TITLE
bulkdocs response may not contain .ok property

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -180,7 +180,7 @@ function replicate(repId, src, target, opts, returnValue) {
       }
       var errors = [];
       res.forEach(function (res) {
-        if (!res.ok) {
+        if (!res.ok || !(res.id && res.rev)) {
           result.doc_write_failures++;
           errors.push(new Error(res.reason || res.message || 'Unknown reason'));
         }


### PR DESCRIPTION
I hit this case when syncing against Sync Gateway. First I thought it was a SG issue, but according to CouchDB docs SG is conformant.

See https://wiki.apache.org/couchdb/HTTP_Bulk_Document_API under 'Modify Multiple Documents With a Single Request' they have a sample response.

Another approach could be checking for `res.error`
