### PR TITLE
(pouchdb/express-pouchdb#61) - {ok:true} for put

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -506,7 +506,13 @@ function HttpPouch(opts, callback) {
       method: 'PUT',
       url: genDBUrl(host, encodeDocId(doc._id)) + params,
       body: doc
-    }, callback);
+    }, function (err, res) {
+      if (err) {
+        return callback(err);
+      }
+      res.ok = true;
+      callback(null, res);
+    });
   }));
 
   // Add the document given by doc (in JSON string format) to the database
@@ -525,8 +531,13 @@ function HttpPouch(opts, callback) {
     if (! ("_id" in doc)) {
       doc._id = utils.uuid();
     }
-    api.put(doc, opts, callback);
-    
+    api.put(doc, opts, function (err, res) {
+      if (err) {
+        return callback(err);
+      }
+      res.ok = true;
+      callback(null, res);
+    });
   });
 
   // Update/create multiple documents given by req in the database
@@ -547,7 +558,15 @@ function HttpPouch(opts, callback) {
       method: 'POST',
       url: genDBUrl(host, '_bulk_docs'),
       body: req
-    }, callback);
+    }, function (err, results) {
+      if (err) {
+        return callback(err);
+      }
+      results.forEach(function (result) {
+        result.ok = true; // smooths out cloudant not adding this
+      });
+      callback(null, results);
+    });
   };
 
   // Get a listing of the documents in the database given

--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -1009,7 +1009,7 @@ function init(api, opts, callback) {
           var req = oStore.put(doc);
 
           req.onsuccess = function () {
-            callback();
+            callback(null, {ok: true});
           };
         }
       };
@@ -1021,7 +1021,7 @@ function init(api, opts, callback) {
         } else { // insert
           var req = oStore.put(doc);
           req.onsuccess = function () {
-            callback();
+            callback(null, {ok: true});
           };
         }
       };

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -929,7 +929,12 @@ function LevelPouch(opts, callback) {
       } else {
         doc._rev = '0-' + (parseInt(oldRev.split('-')[1], 10) + 1);
       }
-      stores.localStore.put(id, doc, callback);
+      stores.localStore.put(id, doc, function (err) {
+        if (err) {
+          return callback(err);
+        }
+        callback(null, {ok: true});
+      });
     });
   };
 

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -180,7 +180,7 @@ function replicate(repId, src, target, opts, returnValue) {
       }
       var errors = [];
       res.forEach(function (res) {
-        if (!res.ok || !(res.id && res.rev)) {
+        if (!res.ok) {
           result.doc_write_failures++;
           errors.push(new Error(res.reason || res.message || 'Unknown reason'));
         }

--- a/tests/test.attachments.js
+++ b/tests/test.attachments.js
@@ -95,7 +95,8 @@ adapters.forEach(function (adapter) {
       function moreTests(rev) {
         var blob = testUtils.makeBlob('This is no base64 encoded text');
         db.putAttachment('bin_doc2', 'foo2.txt', rev, blob, 'text/plain',
-                         function (err, wtf) {
+                         function (err, info) {
+          info.ok.should.equal(true);
           db.getAttachment('bin_doc2', 'foo2.txt', function (err, res, xhr) {
             testUtils.readBlob(res, function (data) {
               should.exist(data);

--- a/tests/test.basics.js
+++ b/tests/test.basics.js
@@ -653,6 +653,27 @@ adapters.forEach(function (adapter) {
       }, done);
     });
 
+    it('putting returns {ok: true}', function () {
+      // in couch, it's {ok: true} and in cloudant it's {},
+      // but the http adapter smooths this out
+      return new PouchDB(dbs.name).then(function (db) {
+        return db.put({_id: '_local/foo'}).then(function (info) {
+          true.should.equal(info.ok, 'putting local returns ok=true');
+          return db.put({_id: 'quux'});
+        }).then(function (info) {
+          true.should.equal(info.ok, 'putting returns ok=true');
+          return db.bulkDocs([ {_id: '_local/bar'}, {_id: 'baz'} ]);
+        }).then(function (info) {
+          info.should.have.length(2, 'correct num bulk docs');
+          true.should.equal(info[0].ok, 'bulk docs says ok=true #1');
+          true.should.equal(info[1].ok, 'bulk docs says ok=true #2');
+          return db.post({});
+        }).then(function (info) {
+          true.should.equal(info.ok, 'posting returns ok=true');
+        });
+      });
+    });
+
     if (adapter === 'local') {
       // TODO: this test fails in the http adapter in Chrome
       it('should allow unicode doc ids', function (done) {


### PR DESCRIPTION
This ensures that all adapters (even Cloudant)
return `ok:true` for put/post/bulkDocs/putLocal.
Also it essentially reverts 54e5224 and instead
follows @calvinmetcalf's advice in that thread
to smooth out whatever the server sends us.
