### PR TITLE
(#2391) - improve idb bulkDocs perf

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -211,6 +211,7 @@ function init(api, opts, callback) {
     var results = [];
     var fetchedDocs = {};
     var docsWritten = 0;
+    var currentDocId = -1;
 
     function writeMetaData(e) {
       var meta = e.target.result;
@@ -219,11 +220,11 @@ function init(api, opts, callback) {
     }
 
     function processDocs() {
-      if (!docInfos.length) {
+      if (++currentDocId === docInfos.length) {
         txn.objectStore(META_STORE).get(META_STORE).onsuccess = writeMetaData;
         return;
       }
-      var currentDoc = docInfos.shift();
+      var currentDoc = docInfos[currentDocId];
 
       if (currentDoc._id && utils.isLocalId(currentDoc._id)) {
         api._putLocal(currentDoc, {ctx: txn}, function (err, resp) {
@@ -397,29 +398,37 @@ function init(api, opts, callback) {
       function finish() {
         docsWritten++;
         docInfo.data._doc_id_rev = docInfo.data._id + "::" + docInfo.data._rev;
-        var index = txn.objectStore(BY_SEQ_STORE).index('_doc_id_rev');
+        var seqStore = txn.objectStore(BY_SEQ_STORE);
+        var index = seqStore.index('_doc_id_rev');
 
-        index.getKey(docInfo.data._doc_id_rev).onsuccess = function (e) {
+        function afterPut(e) {
+          var metadata = docInfo.metadata;
+          metadata.seq = e.target.result;
+          // Current _rev is calculated from _rev_tree on read
+          delete metadata.rev;
+          metadata.deletedOrLocal = deleted ? "1" : "0";
+          metadata.winningRev = winningRev;
+          var metaDataReq = txn.objectStore(DOC_STORE).put(metadata);
+          metaDataReq.onsuccess = function () {
+            delete metadata.deletedOrLocal;
+            delete metadata.winningRev;
+            results.push(docInfo);
+            fetchedDocs[docInfo.metadata.id] = docInfo.metadata;
+            utils.call(callback);
+          };
+        }
 
-          var dataReq = e.target.result ?
-            txn.objectStore(BY_SEQ_STORE).put(docInfo.data, e.target.result) :
-            txn.objectStore(BY_SEQ_STORE).put(docInfo.data);
+        var putReq = seqStore.put(docInfo.data);
 
-          dataReq.onsuccess = function (e) {
-            var metadata = docInfo.metadata;
-            metadata.seq = e.target.result;
-            // Current _rev is calculated from _rev_tree on read
-            delete metadata.rev;
-            metadata.deletedOrLocal = deleted ? "1" : "0";
-            metadata.winningRev = winningRev;
-            var metaDataReq = txn.objectStore(DOC_STORE).put(metadata);
-            metaDataReq.onsuccess = function () {
-              delete metadata.deletedOrLocal;
-              delete metadata.winningRev;
-              results.push(docInfo);
-              fetchedDocs[docInfo.metadata.id] = docInfo.metadata;
-              utils.call(callback);
-            };
+        putReq.onsuccess = afterPut;
+        putReq.onerror = function (e) {
+          // ConstraintError, need to update, not put (see #1638 for details)
+          e.preventDefault(); // avoid transaction abort
+          e.stopPropagation(); // avoid transaction onerror
+          var getKeyReq = index.getKey(docInfo.data._doc_id_rev);
+          getKeyReq.onsuccess = function (e) {
+            var putReq = seqStore.put(docInfo.data, e.target.result);
+            putReq.onsuccess = afterPut;
           };
         };
       }
@@ -961,7 +970,7 @@ function init(api, opts, callback) {
 
 
   api._getLocal = function (id, callback) {
-    var tx = opts.ctx || idb.transaction([LOCAL_STORE], 'readonly');
+    var tx = idb.transaction([LOCAL_STORE], 'readonly');
     var req = tx.objectStore(LOCAL_STORE).get(id);
 
     req.onerror = idbError(callback);
@@ -1029,7 +1038,7 @@ function init(api, opts, callback) {
   };
 
   api._removeLocal = function (doc, callback) {
-    var tx = opts.ctx || idb.transaction([LOCAL_STORE], 'readwrite');
+    var tx = idb.transaction([LOCAL_STORE], 'readwrite');
     var docIdRev = doc._id + '::' + doc._rev;
     var oStore = tx.objectStore(LOCAL_STORE);
     var index = oStore.index('_doc_id_rev');


### PR DESCRIPTION
Improve the performance of bulkDocs in idb
by optimistically inserting into the by-seq
store and then recovering from the
rare error only when necessary.
