### PR TITLE
(#2398) - add ADAPTERS option for cordova tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,20 +127,20 @@ the CORS server is available on port 2020.
     $ CLIENT=android DEVICE=true npm run cordova
     $ COUCH_HOST=http://myurl:2020 npm run cordova
     $ GREP=basics npm run cordova
-    $ SQLITE_PLUGIN=true npm run cordova
+    $ SQLITE_PLUGIN=true ADAPTERS=websql npm run cordova
 
 * `CLIENT=ios` will run on iOS, default is `CLIENT=android`
 * `DEVICE=true` will run on a device connected via USB, else on an emulator
-* `SQLITE_PLUGIN=true` will use the [SQLite Plugin](https://github.com/brodysoft/Cordova-SQLitePlugin)
-* `COUCH_HOST` should be the full URL; you can only omit this is in the Android emulator
+* `SQLITE_PLUGIN=true` will install and use the [SQLite Plugin](https://github.com/brodysoft/Cordova-SQLitePlugin) in lieu of the `'websql'` adapter.
+* `ADAPTERS=websql` should be used if you want to skip using IndexedDB on Android 4.4+ and iOS 8+.
+* `COUCH_HOST` should be the full URL; you can only omit this is in the Android emulator due to the magic `10.0.2.2` route to `localhost`.
+* `ES5_SHIM=true` should be used on devices that don't support ES5 (e.g. Android 2.x).
 
 You can also debug with Weinre by doing:
 
     $ npm install -g weinre
     $ weinre --boundHost=0.0.0.0
     $ WEINRE_HOST=http://route.to.my.weinre:8080
-
-The `ES5_SHIM=true` option is also available for Cordova.
 
 ### Testing against PouchDB server
 

--- a/bin/run-cordova.sh
+++ b/bin/run-cordova.sh
@@ -59,6 +59,16 @@ if [[ ! -z $COUCH_HOST ]]; then
     $TESTS_DIR/www/tests/test.html
 fi
 
+if [[ ! -z $ADAPTER ]]; then
+  ADAPTERS=$ADAPTER # I know I'm gonna mistype this
+fi
+
+if [[ ! -z $ADAPTERS ]]; then
+  ./node_modules/replace/bin/replace.js '<body>' \
+    "<body><script>window.ADAPTERS = ""'"$ADAPTERS"'"";</script>" \
+    $TESTS_DIR/www/tests/test.html
+fi
+
 if [[ ! -z $WEINRE_HOST ]]; then
   ./node_modules/replace/bin/replace.js '<body>' \
     "<body><script src=""'"$WEINRE_HOST"/target/target-script-min.js#anonymous""'""></script>" \

--- a/tests/webrunner.js
+++ b/tests/webrunner.js
@@ -99,17 +99,22 @@ function startTests() {
 
 if (window.cordova) {
   var hasGrep = window.GREP &&
-      window.location.search.indexOf('grep') === -1;
+      window.location.search.indexOf('grep=') === -1;
   var hasEs5Shim = window.ES5_SHIM &&
-      window.location.search.indexOf('es5Shim') === -1;
+      window.location.search.indexOf('es5Shim=') === -1;
+  var hasAdapters = window.ADAPTERS &&
+      window.location.search.indexOf('adapters=') === -1;
 
-  if (hasGrep || hasEs5Shim) {
+  if (hasGrep || hasEs5Shim || hasAdapters) {
     var params = [];
     if (hasGrep) {
       params.push('grep=' + encodeURIComponent(window.GREP));
     }
     if (hasEs5Shim) {
       params.push('es5Shim=' + encodeURIComponent(window.ES5_SHIM));
+    }
+    if (hasAdapters) {
+      params.push('adapters=' + encodeURIComponent(window.ADAPTERS));
     }
     window.location.search += (window.location.search ? '&' : '?') +
       params.join('&');


### PR DESCRIPTION
Confirmed manually that I can now use the SQLite
plugin on my Android 4.4 device, and the SQLite
plugin is indeed being used. (Sadly the tests fail.)
