### PR TITLE
(#2418) - remove PouchDB Server from allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,6 @@ matrix:
   allow_failures:
   - env: CLIENT="saucelabs:iphone:7.1:OS X 10.9" COMMAND=test
   - env: CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
-  - env: CLIENT=node SERVER=pouchdb-server COMMAND=test
-  - env: CLIENT=selenium:firefox SERVER=pouchdb-server COMMAND=test
   - env: SERVER_ADAPTER=memory LEVEL_ADAPTER=memdown SERVER=pouchdb-server COMMAND=test
 
 branches:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "level-js": "^2.1.3",
     "level-sublevel": "~5.2.0",
     "leveldown": "~0.10.2",
-    "levelup": "~0.18.2",
+    "levelup": "~0.18.4",
     "lie": "^2.6.0",
     "localstorage-down": "^0.4.4",
     "pouchdb-mapreduce": "~2.2.4",


### PR DESCRIPTION
Now that [this fix](https://github.com/rvagg/node-levelup/commit/c1c2ae6b5dca143295ba7a847ec25853ff69f6a3) has been npm published to node-levelup, we can safely remove PouchDB Server from the allowed failures.  I've been keeping tabs on it in Travis (both Firefox and Node tests), and this seems to be the last intermittent failure.
