### PR TITLE
(#2424) - add cors credentials to errors.md

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -21,6 +21,7 @@ HOST=http://adminname:password@localhost:5984 # or whatever you got
 
 curl -X POST $HOST/_config/httpd/enable_cors -d '"true"'
 curl -X PUT $HOST/_config/cors/origins -d '"*"'
+curl -X PUT $HOST/_config/cors/credentials -d '"true"'
 curl -X PUT $HOST/_config/cors/methods -d '"GET, PUT, POST, HEAD, DELETE"'
 curl -X PUT $HOST/_config/cors/headers -d '"accept, content-type, origin"'
 ```


### PR DESCRIPTION
Forgot to add this when I originally wrote this
error page. Not every user will use credentials,
but it's probably better to just have them enable
everything and then tweak it later after it works.
