### PR TITLE
(#2428) - fix args for remove()

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -293,21 +293,32 @@ AbstractPouchDB.prototype.removeAttachment =
 });
 
 AbstractPouchDB.prototype.remove =
-  utils.adapterFun('remove', function (doc, opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  } else if (typeof opts === 'string') {
+  utils.adapterFun('remove', function (docOrId, optsOrRev, opts, callback) {
+  var doc;
+  if (typeof optsOrRev === 'string') {
+    // id, rev, opts, callback style
     doc = {
-      _id: doc,
-      _rev: opts
+      _id: docOrId,
+      _rev: optsOrRev
     };
-  } else if (opts === undefined) {
-    opts = {};
+    if (typeof opts === 'function') {
+      callback = opts;
+      opts = {};
+    }
+  } else {
+    // doc, opts, callback style
+    doc = docOrId;
+    if (typeof optsOrRev === 'function') {
+      callback = optsOrRev;
+      opts = {};
+    } else {
+      callback = opts;
+      opts = optsOrRev;
+    }
   }
-  opts = utils.clone(opts);
+  opts = utils.clone(opts || {});
   opts.was_delete = true;
-  var newDoc = {_id: doc._id, _rev: doc._rev};
+  var newDoc = {_id: doc._id, _rev: (doc._rev || opts.rev)};
   newDoc._deleted = true;
   if (utils.isLocalId(newDoc._id) && typeof this._removeLocal === 'function') {
     return this._removeLocal(doc, callback);

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -362,24 +362,37 @@ function HttpPouch(opts, callback) {
   });
 
   // Delete the document given by doc from the database given by host.
-  api.remove = utils.adapterFun('remove', function (doc, opts, callback) {
-    // If no options were given, set the callback to be the second parameter
-    if (typeof opts === 'function') {
-      callback = opts;
-      opts = {};
-    }  else if (typeof opts === 'string') {
+  api.remove = utils.adapterFun('remove', function (docOrId, optsOrRev, opts, callback) {
+    var doc;
+    if (typeof optsOrRev === 'string') {
+      // id, rev, opts, callback style
       doc = {
-        _id: doc,
-        _rev: opts
+        _id: docOrId,
+        _rev: optsOrRev
       };
-    } else if (opts === undefined) {
-      opts = {};
+      if (typeof opts === 'function') {
+        callback = opts;
+        opts = {};
+      }
+    } else {
+      // doc, opts, callback style
+      doc = docOrId;
+      if (typeof optsOrRev === 'function') {
+        callback = optsOrRev;
+        opts = {};
+      } else {
+        callback = opts;
+        opts = optsOrRev;
+      }
     }
+
+    var rev = (doc._rev || opts.rev);
+
     // Delete the document
     ajax({
       headers: host.headers,
       method: 'DELETE',
-      url: genDBUrl(host, encodeDocId(doc._id)) + '?rev=' + doc._rev
+      url: genDBUrl(host, encodeDocId(doc._id)) + '?rev=' + rev
     }, callback);
   });
 

--- a/tests/test.basics.js
+++ b/tests/test.basics.js
@@ -343,6 +343,76 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('Delete document with many args', function () {
+      var db = new PouchDB(dbs.name);
+      var doc = {_id: 'foo'};
+      return db.put(doc).then(function (info) {
+        return db.remove(doc._id, info.rev, {});
+      });
+    });
+
+    it('Delete document with many args, callback style', function (done) {
+      var db = new PouchDB(dbs.name);
+      var doc = {_id: 'foo'};
+      db.put(doc, function (err, info) {
+        should.not.exist(err);
+        db.remove(doc._id, info.rev, {}, function (err) {
+          should.not.exist(err);
+          done();
+        });
+      });
+    });
+
+    it('Delete doc with id + rev + no opts', function () {
+      var db = new PouchDB(dbs.name);
+      var doc = {_id: 'foo'};
+      return db.put(doc).then(function (info) {
+        return db.remove(doc._id, info.rev);
+      });
+    });
+
+    it('Delete doc with id + rev + no opts, callback style', function (done) {
+      var db = new PouchDB(dbs.name);
+      var doc = {_id: 'foo'};
+      db.put(doc, function (err, info) {
+        should.not.exist(err);
+        db.remove(doc._id, info.rev, function (err) {
+          should.not.exist(err);
+          done();
+        });
+      });
+    });
+
+    it('Delete doc with doc + opts', function () {
+      var db = new PouchDB(dbs.name);
+      var doc = {_id: 'foo'};
+      return db.put(doc).then(function (info) {
+        doc._rev = info.rev;
+        return db.remove(doc, {});
+      });
+    });
+
+    it('Delete doc with doc + opts, callback style', function (done) {
+      var db = new PouchDB(dbs.name);
+      var doc = {_id: 'foo'};
+      db.put(doc, function (err, info) {
+        should.not.exist(err);
+        doc._rev = info.rev;
+        db.remove(doc, {}, function (err) {
+          should.not.exist(err);
+          done();
+        });
+      });
+    });
+
+    it('Delete doc with rev in opts', function () {
+      var db = new PouchDB(dbs.name);
+      var doc = {_id: 'foo'};
+      return db.put(doc).then(function (info) {
+        return db.remove(doc, {rev: info.rev});
+      });
+    });
+
     it('Bulk docs', function (done) {
       var db = new PouchDB(dbs.name);
       db.bulkDocs({


### PR DESCRIPTION
It turned out there were a lot of argument
combinations that we weren't checking in the
tests, which is probably why this one slipped
through.

In addition, I added a fix to make it so you can
specify the rev in the options, and it'll use that
if the _rev isn't defined in the document. This is
not something I want to advertise in the docs (since
the usage is complicated enough as it is), but I think
it may help folks who are used to the CouchDB style
where we think of the Pouch options as being equivalent
to the Couch HTTP params.
