### PR TITLE
(#2447) - link pouchdb-server's pouchdb to us in travis

### DIFF
--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -4,6 +4,11 @@
 
 if [[ ! -z $SERVER ]]; then
   if [ "$SERVER" == "pouchdb-server" ]; then
+    if [[ "$TRAVIS_REPO_SLUG" == "pouchdb/pouchdb" ]]; then
+      # for pouchdb-server to link to pouchdb, only in travis
+      rm -fr ./node_modules/pouchdb-server/node_modules/pouchdb
+      ln -s ../../.. ./node_modules/pouchdb-server/node_modules/pouchdb
+    fi
     export COUCH_HOST='http://127.0.0.1:6984'
     echo -e "Starting up pouchdb-server\n"
     TESTDIR=./tests/pouchdb_server


### PR DESCRIPTION
Travis seems to be an unusual environment where the
immediate dependents of a module that depend on that module
are not automatically symlinked to it.  So this fix is to
only do it in Travis.

This is required to unblock #2442.
