### PR TITLE
(#2458) - explicitly mark idb changes as readonly

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -835,7 +835,7 @@ function init(api, opts, callback) {
     var txn;
 
     function fetchChanges() {
-      txn = idb.transaction([DOC_STORE, BY_SEQ_STORE]);
+      txn = idb.transaction([DOC_STORE, BY_SEQ_STORE], 'readonly');
       txn.oncomplete = onTxnComplete;
 
       var req;


### PR DESCRIPTION
I had to Google for awhile before I figured out that
the default is readonly. This is the only case where
we're not being explicit.
