### PR TITLE
(#2457) - don't set error.message

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -365,7 +365,6 @@ function replicate(repId, src, target, opts, returnValue) {
     }
     result.ok = false;
     result.status = 'aborted';
-    err.message = reason;
     result.errors.push(err);
     batches = [];
     pendingBatch = {


### PR DESCRIPTION
I checked; this is the only place where we're doing this.
