### PR TITLE
(#2460) - websql: update_seq should be an INTEGER

### DIFF
--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -239,7 +239,7 @@ function WebSqlPouch(opts, callback) {
       // initial schema
 
       var meta = 'CREATE TABLE IF NOT EXISTS ' + META_STORE +
-        ' (update_seq, dbid, db_version INTEGER)';
+        ' (update_seq INTEGER, dbid, db_version INTEGER)';
       var attach = 'CREATE TABLE IF NOT EXISTS ' + ATTACH_STORE +
         ' (digest, json, body BLOB)';
       var doc = 'CREATE TABLE IF NOT EXISTS ' + DOC_STORE +


### PR DESCRIPTION
This fixes errors with the update_seq on
Android 2.x using the SQLite plugin, because we
need to know the type of the column in order to
bind it properly.
