### PR TITLE
(#2462) - Fix API documentation for cache constructor option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -24,8 +24,9 @@ This method creates a database or opens an existing one. If you use a URL like `
 
 * `options.name`: You can omit the `name` argument and specify it via `options` instead. Note that the name is required.
 * `options.auto_compaction`: This turns on auto compaction (experimental). Defaults to `false`.
-* `options.cache`: Appends a random string to the end of all HTTP GET requests to avoid them being cached on IE. Set this to `true` to prevent this happening (can also be set per request). Defaults to `false`.
 * `options.adapter`: One of `'idb'`, `'leveldb'`, `'websql'`, or `'http'`. If unspecified, PouchDB will infer this automatically, preferring IndexedDB to WebSQL in browsers that support both (i.e. Chrome, Opera and Android 4.4+).
+* `options.ajax`: An object of options to be sent to the ajax requester. In Node they are sent verbatim to [request][] with the exception of:
+    * `options.ajax.cache`: Appends a random string to the end of all HTTP GET requests to avoid them being cached on IE. Set this to `true` to prevent this happening.
 
 **Notes:** 
 
@@ -192,7 +193,7 @@ All options default to `false` unless otherwise specified.
 * `options.conflicts`: If specified, conflicting leaf revisions will be attached in `_conflicts` array.
 * `options.attachments`: Include attachment data.
 * `options.local_seq`: Include sequence number of the revision in the database.
-* `options.ajax`: An object of options to be sent to the ajax requester. In Node they are sent ver batim to [request][] with the exception of:
+* `options.ajax`: An object of options to be sent to the ajax requester. In Node they are sent verbatim to [request][] with the exception of:
     * `options.ajax.cache`: Appends a random string to the end of all HTTP GET requests to avoid them being cached on IE. Set this to `true` to prevent this happening.
 
 


### PR DESCRIPTION
Updated the documentation for new PouchDB's cache option.
The flag is a sub property of the ajax option, not a top
level option.
