### PR TITLE
(#2477) - WIP - fix reserved words in doc ids

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -239,10 +239,10 @@ function init(api, opts, callback) {
       }
 
       var id = currentDoc.metadata.id;
-
-      if (id in fetchedDocs) {
+      var idKey = '_' + id; // avoid js keywords
+      if (idKey in fetchedDocs) {
         // if newEdits=false, can re-use the same id from this batch
-        return updateDoc(fetchedDocs[id], currentDoc);
+        return updateDoc(fetchedDocs['_' + id], currentDoc);
       }
 
       var req = txn.objectStore(DOC_STORE).get(id);
@@ -413,7 +413,7 @@ function init(api, opts, callback) {
             delete metadata.deletedOrLocal;
             delete metadata.winningRev;
             results.push(docInfo);
-            fetchedDocs[docInfo.metadata.id] = docInfo.metadata;
+            fetchedDocs['_' + docInfo.metadata.id] = docInfo.metadata;
             utils.call(callback);
           };
         }

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -27,6 +27,10 @@ var UPDATE_SEQ_KEY = '_local_last_update_seq';
 var DOC_COUNT_KEY = '_local_doc_count';
 var UUID_KEY = '_local_uuid';
 
+function prefix(dbName) {
+  return '-' + dbName; // to avoid e.g. names like 'constructor'
+}
+
 function LevelPouch(opts, callback) {
   opts = utils.clone(opts);
   var api = this;
@@ -44,16 +48,16 @@ function LevelPouch(opts, callback) {
   }
 
   var dbStore = dbStores[leveldown.name] = dbStores[leveldown.name] || {};
-  if (dbStore[name]) {
-    db = dbStore[name];
+  if (dbStore[prefix(name)]) {
+    db = dbStore[prefix(name)];
     afterDBCreated();
   } else {
-    dbStore[name] = sublevel(levelup(name, opts, function (err) {
+    dbStore[prefix(name)] = sublevel(levelup(name, opts, function (err) {
       if (err) {
-        delete dbStore[name];
+        delete dbStore[prefix(name)];
         return callback(err);
       }
-      db = dbStore[name];
+      db = dbStore[prefix(name)];
       db._locks = db._locks || {};
       db._docCountQueue = {
         queue : [],
@@ -856,7 +860,7 @@ function LevelPouch(opts, callback) {
       if (err) {
         callback(err);
       } else {
-        delete dbStore[name];
+        delete dbStore[prefix(name)];
         callback();
       }
     });
@@ -969,12 +973,12 @@ LevelPouch.destroy = utils.toPromise(function (name, opts, callback) {
 
   var dbStore = dbStores[leveldown.name] || {};
 
-  if (dbStore[name]) {
+  if (dbStore[prefix(name)]) {
 
     LevelPouch.Changes.removeAllListeners(name);
 
-    dbStore[name].close(function () {
-      delete dbStore[name];
+    dbStore[prefix(name)].close(function () {
+      delete dbStore[prefix(name)];
       leveldown.destroy(name, callback);
     });
   } else {

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -579,7 +579,7 @@ function WebSqlPouch(opts, callback) {
           [docInfo.metadata.id, seq, metadataStr];
         tx.executeSql(sql, params, function () {
           results.push(docInfo);
-          fetchedDocs[docInfo.metadata.id] = docInfo.metadata;
+          fetchedDocs['_' + docInfo.metadata.id] = docInfo.metadata;
           callback();
         });
       }
@@ -636,10 +636,10 @@ function WebSqlPouch(opts, callback) {
       }
 
       var id = currentDoc.metadata.id;
-
-      if (id in fetchedDocs) {
+      var idKey = '_' + id; // avoid js keywords
+      if (idKey in fetchedDocs) {
         // if newEdits=false, can re-use the same id from this batch
-        return updateDoc(fetchedDocs[id], currentDoc);
+        return updateDoc(fetchedDocs[idKey], currentDoc);
       }
 
       tx.executeSql('SELECT json FROM ' + DOC_STORE +

--- a/tests/test.html
+++ b/tests/test.html
@@ -48,6 +48,7 @@
     <script src='browser.migration.js'></script>
     <script src='test.uuids.js'></script>
     <script src='test.slash_id.js'></script>
+    <script src='test.reserved.js'></script>
     <script src='browser.worker.js'></script>
     <script type="text/javascript" src="./webrunner.js"></script>
   </body>

--- a/tests/test.reserved.js
+++ b/tests/test.reserved.js
@@ -1,0 +1,67 @@
+'use strict';
+
+var adapters = [
+  ['local', 'http'],
+  ['http', 'http'],
+  ['http', 'local'],
+  ['local', 'local']
+];
+
+adapters.forEach(function (adapters) {
+  describe('test.reserved.js-' + adapters[0] + '-' + adapters[1], function () {
+
+    var dbs = {};
+
+    beforeEach(function (done) {
+      dbs.name = testUtils.adapterUrl(adapters[0], 'test_repl');
+      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote');
+      testUtils.cleanup([dbs.name, dbs.remote], done);
+    });
+
+    after(function (done) {
+      testUtils.cleanup([dbs.name, dbs.remote], done);
+    });
+
+    it('test docs with reserved javascript ids', function () {
+      this.timeout(5000);
+      var db = new PouchDB(dbs.name);
+      var remote = new PouchDB(dbs.remote);
+      return db.bulkDocs([
+        {_id: 'constructor'},
+        {_id: 'toString'},
+        {_id: 'valueOf'}
+      ]).then(function () {
+        return db.allDocs({key: 'constructor'});
+      }).then(function (res) {
+        res.rows.should.have.length(1, 'allDocs with key');
+        return db.allDocs({keys: ['constructor']});
+      }).then(function (res) {
+        res.rows.should.have.length(1, 'allDocs with keys');
+        return db.allDocs();
+      }).then(function (res) {
+        res.rows.should.have.length(3, 'allDocs empty opts');
+        return db.query(function (doc) {
+          emit(doc._id);
+        }, {key: 'constructor'});
+      }).then(function (res) {
+        res.rows.should.have.length(1, 'query with key');
+        return db.query(function (doc) {
+          emit(doc._id);
+        }, {keys: ['constructor']});
+      }).then(function (res) {
+        res.rows.should.have.length(1, 'query with keys');
+        return new PouchDB.utils.Promise(function (resolve, reject) {
+          db.replicate.to(remote).on('complete', resolve).on('error', reject);
+        });
+      });
+    });
+
+    it('can create db with reserved name', function () {
+      return new PouchDB('constructor').then(function (db) {
+        return db.info().then(function () {
+          return db.destroy();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Working in everything but LevelDB. There seems to be a bug somewhere in SubLevel or LevelUP, because the test fails in all three *DOWN adapters plus on Node. No failure if not using reserved words for doc ids.
