### PR TITLE
(#2484) - fix readOnly replication for CORS/40*

### DIFF
--- a/lib/deps/ajax-browser.js
+++ b/lib/deps/ajax-browser.js
@@ -119,6 +119,12 @@ function ajax(options, adapterCallback) {
       }
       errObj = errors.error(errType);
     }
+    if (err.withCredentials && err.status === 0) {
+      // apparently this is what we get when the method
+      // is reported as not allowed by CORS. so fudge it
+      errObj.status = 405;
+      errObj.statusText = "Method Not Allowed";
+    }
     cb(errObj);
   }
 

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -94,7 +94,9 @@ Checkpointer.prototype.updateSource = function (checkpoint) {
     return utils.Promise.resolve(true);
   }
   return updateCheckpoint(this.src, this.id, checkpoint).catch(function (err) {
-    if (err.status === 401) {
+    var isForbidden = typeof err.status === 'number' &&
+      Math.floor(err.status / 100) === 4;
+    if (isForbidden) {
       self.readOnlySource = true;
       return true;
     }


### PR DESCRIPTION
Currently we only mark a source database as
read-only if it returns a 401. Really we should
do it for any 40*, and also in the case of CORS
the error status is a deceptive 0, so this doesn't
help.

Ugly hack, but I verified manually that using a
CouchDB that only accepts CORS methods GET and HEAD,
I can now replicate in Safari 7, IE 11, Chrome 36, and Firefox 30.
