### PR TITLE
(#2492) - fast fail in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ matrix:
   - env: CLIENT="saucelabs:iphone:7.1:OS X 10.9" COMMAND=test
   - env: CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
   - env: SERVER_ADAPTER=memory LEVEL_ADAPTER=memdown SERVER=pouchdb-server COMMAND=test
+  fast_finish: true
 
 branches:
   only:


### PR DESCRIPTION
This will ensure that our "allowed failures" don't run
if any of the non-"allowed failures" fails.

So e.g. if PhantomJS fails, we won't bother running
the Safari/iPhone builds.
