### PR TITLE
(#2519) - increase selenium timeout

### DIFF
--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -5,6 +5,7 @@ var path = require('path');
 var spawn = require('child_process').spawn;
 
 var wd = require('wd');
+wd.configureHttp({timeout: 180000}); // 3 minutes
 var sauceConnectLauncher = require('sauce-connect-launcher');
 var querystring = require("querystring");
 var request = require('request').defaults({json: true});


### PR DESCRIPTION
Default is 60 seconds; maybe 180 will give us more breathing room, especially with Saucelabs.
