### PR TITLE
(#2534) - use fewer test names

### DIFF
--- a/tests/test.all_docs.js
+++ b/tests/test.all_docs.js
@@ -7,7 +7,7 @@ adapters.forEach(function (adapter) {
 
     var dbs = {};
     beforeEach(function (done) {
-      dbs = {name: testUtils.adapterUrl(adapter, 'test_all_docs')};
+      dbs = {name: testUtils.adapterUrl(adapter, 'testdb')};
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/test.attachments.js
+++ b/tests/test.attachments.js
@@ -14,7 +14,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'test_attach');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
       testUtils.cleanup([dbs.name], done);
     });
 
@@ -596,7 +596,7 @@ repl_adapters.forEach(function (adapters) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'test_attach');
+      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
       dbs.remote = testUtils.adapterUrl(adapters[1], 'test_attach_remote');
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });

--- a/tests/test.basics.js
+++ b/tests/test.basics.js
@@ -8,7 +8,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'test_basics');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
       testUtils.cleanup([dbs.name], done);
     });
 
@@ -711,7 +711,7 @@ adapters.forEach(function (adapter) {
     it('db.info should give correct name', function (done) {
       var db = new PouchDB(dbs.name);
       db.info().then(function (info) {
-        info.db_name.should.equal('test_basics');
+        info.db_name.should.equal('testdb');
         done();
       });
     });

--- a/tests/test.bulk_docs.js
+++ b/tests/test.bulk_docs.js
@@ -26,7 +26,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'test_bulk_docs');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/test.changes.js
+++ b/tests/test.changes.js
@@ -10,7 +10,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'test_changes');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
       dbs.remote = testUtils.adapterUrl(adapter, 'test_changes_remote');
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });

--- a/tests/test.compaction.js
+++ b/tests/test.compaction.js
@@ -9,7 +9,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'test_compaction');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/test.conflicts.js
+++ b/tests/test.conflicts.js
@@ -8,7 +8,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'test_conflicts');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/test.design_docs.js
+++ b/tests/test.design_docs.js
@@ -8,7 +8,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'test_design_docs');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/test.events.js
+++ b/tests/test.events.js
@@ -7,7 +7,7 @@ adapters.forEach(function (adapter) {
 
     var dbs = {};
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'events_tests');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/test.get.js
+++ b/tests/test.get.js
@@ -8,7 +8,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'test_get');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/test.issue221.js
+++ b/tests/test.issue221.js
@@ -13,7 +13,7 @@ adapters.forEach(function (adapters) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'test_221');
+      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
       dbs.remote = testUtils.adapterUrl(adapters[1], 'test_221_remote');
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });

--- a/tests/test.local_docs.js
+++ b/tests/test.local_docs.js
@@ -8,7 +8,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'test_local');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/test.replication.js
+++ b/tests/test.replication.js
@@ -20,7 +20,7 @@ adapters.forEach(function (adapters) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'test_repl');
+      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
       dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote');
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });

--- a/tests/test.reserved.js
+++ b/tests/test.reserved.js
@@ -13,7 +13,7 @@ adapters.forEach(function (adapters) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'test_repl');
+      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
       dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote');
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });

--- a/tests/test.revs_diff.js
+++ b/tests/test.revs_diff.js
@@ -8,7 +8,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'test_revs_diff');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/test.slash_id.js
+++ b/tests/test.slash_id.js
@@ -14,7 +14,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'test_slash_ids');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/test.sync.js
+++ b/tests/test.sync.js
@@ -17,7 +17,7 @@ adapters.forEach(function (adapters) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'test_repl');
+      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
       dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote');
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });

--- a/tests/test.taskqueue.js
+++ b/tests/test.taskqueue.js
@@ -8,7 +8,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'test_taskqueue');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/test.views.js
+++ b/tests/test.views.js
@@ -11,7 +11,7 @@ adapters.forEach(function (adapters) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'test_views');
+      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
       dbs.remote = testUtils.adapterUrl(adapters[1], 'test_views_remote');
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });


### PR DESCRIPTION
There's really no need to have a different
testdb name for every single test suite,
so I consolidated the big ones down to
only using the name 'testdb'.

With this fix, I can actually get #2472
to pass without the storage popup.
