### PR TITLE
(#2534) - use less storage in websql

### DIFF
--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -30,7 +30,7 @@ var openDB = utils.getArguments(function (args) {
 });
 
 var POUCH_VERSION = 1;
-var ADAPTER_VERSION = 3; // used to manage migrations
+var ADAPTER_VERSION = 4; // used to manage migrations
 
 // The object stores created for each database
 // DOC_STORE stores the document meta data, its revision history and state
@@ -47,6 +47,9 @@ var META_STORE = quote('metadata-store');
 var BY_SEQ_STORE_DELETED_INDEX_SQL =
   'CREATE INDEX IF NOT EXISTS \'by-seq-deleted-idx\' ON ' +
   BY_SEQ_STORE + ' (seq, deleted)';
+var BY_SEQ_STORE_DOC_ID_REV_INDEX_SQL =
+  'CREATE UNIQUE INDEX IF NOT EXISTS \'by-seq-doc-id-rev\' ON ' +
+    BY_SEQ_STORE + ' (doc_id, rev)';
 var DOC_STORE_WINNINGSEQ_INDEX_SQL =
   'CREATE INDEX IF NOT EXISTS \'doc-winningseq-idx\' ON ' +
   DOC_STORE + ' (winningseq)';
@@ -57,6 +60,7 @@ var DOC_STORE_AND_BY_SEQ_JOINER = BY_SEQ_STORE +
 var SELECT_DOCS = BY_SEQ_STORE + '.seq AS seq, ' +
   BY_SEQ_STORE + '.deleted AS deleted, ' +
   BY_SEQ_STORE + '.json AS data, ' +
+  BY_SEQ_STORE + '.rev AS rev, ' +
   DOC_STORE + '.json AS metadata';
 
 function select(selector, table, joiner, where, orderBy) {
@@ -93,6 +97,21 @@ function parseHexString(str, encoding) {
   }
   result = encoding === 'UTF-8' ? decodeUtf8(result) : result;
   return result;
+}
+
+function stringifyDoc(doc) {
+  // don't bother storing the id/rev. it uses lots of space,
+  // in persistent map/reduce especially
+  delete doc._id;
+  delete doc._rev;
+  return JSON.stringify(doc);
+}
+
+function unstringifyDoc(doc, id, rev) {
+  doc = JSON.parse(doc);
+  doc._id = id;
+  doc._rev = rev;
+  return doc;
 }
 
 function getSize(opts) {
@@ -195,22 +214,75 @@ function WebSqlPouch(opts, callback) {
         for (var i = 0; i < res.rows.length; i++) {
           rows.push(res.rows.item(i));
         }
-        utils.Promise.all(rows.map(function (row) {
-          return new utils.Promise(function (resolve) {
-            var rev = JSON.parse(row.data)._rev;
-            tx.executeSql('INSERT INTO ' + LOCAL_STORE +
-                ' (id, rev, json) VALUES (?,?,?)',
-                [row.id, rev, row.data], function () {
-              tx.executeSql('DELETE FROM ' + DOC_STORE + ' WHERE id=?',
-                  [row.id], function () {
-                tx.executeSql('DELETE FROM ' + BY_SEQ_STORE + ' WHERE seq=?',
-                    [row.seq], function () {
-                  resolve();
-                });
+        function doNext() {
+          if (!rows.length) {
+            return callback();
+          }
+          var row = rows.shift();
+          var rev = JSON.parse(row.data)._rev;
+          tx.executeSql('INSERT INTO ' + LOCAL_STORE +
+              ' (id, rev, json) VALUES (?,?,?)',
+              [row.id, rev, row.data], function (tx) {
+            tx.executeSql('DELETE FROM ' + DOC_STORE + ' WHERE id=?',
+                [row.id], function (tx) {
+              tx.executeSql('DELETE FROM ' + BY_SEQ_STORE + ' WHERE seq=?',
+                  [row.seq], function () {
+                doNext();
               });
             });
           });
-        })).then(callback);
+        }
+        doNext();
+      });
+    });
+  }
+
+  // in this migration, we remove doc_id_rev and just use rev
+  function runMigration4(tx, callback) {
+
+    function updateRows(rows, encoding) {
+      function doNext() {
+        if (!rows.length) {
+          return callback();
+        }
+        var row = rows.shift();
+        var doc_id_rev = parseHexString(row.hex, encoding);
+        var idx = doc_id_rev.lastIndexOf('::');
+        var doc_id = doc_id_rev.substring(0, idx);
+        var rev = doc_id_rev.substring(idx + 2);
+        var sql = 'UPDATE ' + BY_SEQ_STORE +
+          ' SET doc_id=?, rev=? WHERE doc_id_rev=?';
+        tx.executeSql(sql, [doc_id, rev, doc_id_rev], function () {
+          doNext();
+        });
+      }
+      doNext();
+    }
+
+    var sql = 'ALTER TABLE ' + BY_SEQ_STORE + ' ADD COLUMN doc_id';
+    tx.executeSql(sql, [], function (tx) {
+      var sql = 'ALTER TABLE ' + BY_SEQ_STORE + ' ADD COLUMN rev';
+      tx.executeSql(sql, [], function (tx) {
+        tx.executeSql(BY_SEQ_STORE_DOC_ID_REV_INDEX_SQL, [], function (tx) {
+          var sql = 'SELECT hex(doc_id_rev) as hex FROM ' + BY_SEQ_STORE;
+          tx.executeSql(sql, [], function (tx, res) {
+            var rows = [];
+            for (var i = 0; i < res.rows.length; i++) {
+              rows.push(res.rows.item(i));
+            }
+            // it sucks, but we fetch the encoding twice
+            tx.executeSql(
+                'SELECT dbid, hex(dbid) AS hexId FROM ' + META_STORE, [],
+              function (tx, result) {
+                var id = result.rows.item(0).dbid;
+                var hexId = result.rows.item(0).hexId;
+                var encoding = (hexId.length === id.length * 2) ?
+                  'UTF-8' : 'UTF-16';
+                updateRows(rows, encoding);
+              }
+            );
+          });
+        });
       });
     });
   }
@@ -226,7 +298,7 @@ function WebSqlPouch(opts, callback) {
   function checkDbEncoding(tx) {
     // check db encoding - utf-8 (chrome, opera) or utf-16 (safari)?
     tx.executeSql('SELECT dbid, hex(dbid) AS hexId FROM ' + META_STORE, [],
-      function (err, result) {
+      function (tx, result) {
         var id = result.rows.item(0).dbid;
         var hexId = result.rows.item(0).hexId;
         encoding = (hexId.length === id.length * 2) ? 'UTF-8' : 'UTF-16';
@@ -246,30 +318,34 @@ function WebSqlPouch(opts, callback) {
         ' (id unique, json, winningseq)';
       var seq = 'CREATE TABLE IF NOT EXISTS ' + BY_SEQ_STORE +
         ' (seq INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, ' +
-        'doc_id_rev UNIQUE, json, deleted TINYINT(1))';
+        'json, deleted TINYINT(1), doc_id, rev)';
       var local = 'CREATE TABLE IF NOT EXISTS ' + LOCAL_STORE +
         ' (id UNIQUE, rev, json)';
 
       // creates
       tx.executeSql(attach);
+      tx.executeSql(local);
       tx.executeSql(doc, [], function () {
         tx.executeSql(DOC_STORE_WINNINGSEQ_INDEX_SQL);
+        tx.executeSql(seq, [], function () {
+          tx.executeSql(BY_SEQ_STORE_DELETED_INDEX_SQL);
+          tx.executeSql(BY_SEQ_STORE_DOC_ID_REV_INDEX_SQL);
+          tx.executeSql(meta, [], function () {
+            // mark the update_seq, db version, and new dbid
+            var initSeq = 'INSERT INTO ' + META_STORE +
+              ' (update_seq, db_version, dbid) VALUES (?, ?, ?)';
+            instanceId = utils.uuid();
+            var initSeqArgs = [0, ADAPTER_VERSION, instanceId];
+            tx.executeSql(initSeq, initSeqArgs, function (tx) {
+              onGetInstanceId(tx);
+            });
+          });
+        });
       });
-      tx.executeSql(seq, [], function () {
-        tx.executeSql(BY_SEQ_STORE_DELETED_INDEX_SQL);
-      });
-      tx.executeSql(meta, [], function () {
-        // mark the update_seq, db version, and new dbid
-        var initSeq = 'INSERT INTO ' + META_STORE +
-          ' (update_seq, db_version, dbid) VALUES (?, ?, ?)';
-        instanceId = utils.uuid();
-        tx.executeSql(initSeq, [0, ADAPTER_VERSION, instanceId]);
-        onGetInstanceId(tx);
-      });
-      tx.executeSql(local);
     } else { // version > 0
 
-      var setupDone = function (migrated) {
+      var setupDone = function () {
+        var migrated = dbVersion < ADAPTER_VERSION;
         if (migrated) {
           // update the db version within this transaction
           tx.executeSql('UPDATE ' + META_STORE + ' SET db_version = ' +
@@ -282,18 +358,28 @@ function WebSqlPouch(opts, callback) {
           onGetInstanceId(tx);
         });
       };
-      if (dbVersion === 1) {
-        runMigration2(tx, function () {
-          runMigration3(tx, function () {
-            setupDone(true);
+
+      // would love to use promises here, but then websql
+      // ends the transaction early
+      switch (dbVersion) {
+        case 1:
+          runMigration2(tx, function () {
+            runMigration3(tx, function () {
+              runMigration4(tx, setupDone);
+            });
           });
-        });
-      } else if (dbVersion === 2) {
-        runMigration3(tx, function () {
-          setupDone(true);
-        });
-      } else {
-        setupDone(false);
+          break;
+        case 2:
+          runMigration3(tx, function () {
+            runMigration4(tx, setupDone);
+          });
+          break;
+        case 3:
+          runMigration4(tx, setupDone);
+          break;
+        default:
+          setupDone();
+          break;
       }
     }
   }
@@ -492,24 +578,26 @@ function WebSqlPouch(opts, callback) {
       function finish() {
         updateSeq++;
         var data = docInfo.data;
-        var doc_id_rev = data._id + "::" + data._rev;
         var deletedInt = deleted ? 1 : 0;
 
-        var json = JSON.stringify(data);
+        var id = data._id;
+        var rev = data._rev;
+        var json = stringifyDoc(data);
         var sql = 'INSERT INTO ' + BY_SEQ_STORE +
-          ' (doc_id_rev, json, deleted) VALUES (?, ?, ?);';
-        var sqlArgs = [doc_id_rev, json, deletedInt];
+          ' (doc_id, rev, json, deleted) VALUES (?, ?, ?, ?);';
+        var sqlArgs = [id, rev, json, deletedInt];
 
         tx.executeSql(sql, sqlArgs, function (tx, result) {
           dataWritten(tx, result.insertId);
         }, function () {
           // constraint error, recover by updating instead (see #1638)
-          var fetchSql = select('seq', BY_SEQ_STORE, null, 'doc_id_rev=?');
-          tx.executeSql(fetchSql, [doc_id_rev], function (tx, res) {
+          var fetchSql = select('seq', BY_SEQ_STORE, null,
+            'doc_id=? AND rev=?');
+          tx.executeSql(fetchSql, [id, rev], function (tx, res) {
             var seq = res.rows.item(0).seq;
             var sql = 'UPDATE ' + BY_SEQ_STORE +
-              ' SET json=?, deleted=? WHERE doc_id_rev=?;';
-            var sqlArgs = [json, deletedInt, doc_id_rev];
+              ' SET json=?, deleted=? WHERE doc_id=? AND rev=?;';
+            var sqlArgs = [json, deletedInt, id, rev];
             tx.executeSql(sql, sqlArgs, function (tx) {
               updateSeq--; // discount, since it's an update, not a new seq
               dataWritten(tx, seq);
@@ -571,17 +659,17 @@ function WebSqlPouch(opts, callback) {
         var sql = isUpdate ?
           'UPDATE ' + DOC_STORE +
           ' SET json=?, winningseq=(SELECT seq FROM ' + BY_SEQ_STORE +
-          ' WHERE doc_id_rev=?) WHERE id=?'
+          ' WHERE doc_id=' + DOC_STORE + '.id AND rev=?) WHERE id=?'
           : 'INSERT INTO ' + DOC_STORE +
           ' (id, winningseq, json) VALUES (?, ?, ?);';
         var metadataStr = JSON.stringify(docInfo.metadata);
-        var key = docInfo.metadata.id + "::" + winningRev;
+        var id = docInfo.metadata.id;
         var params = isUpdate ?
-          [metadataStr, key, docInfo.metadata.id] :
-          [docInfo.metadata.id, seq, metadataStr];
+          [metadataStr, winningRev, id] :
+          [id, seq, metadataStr];
         tx.executeSql(sql, params, function () {
           results.push(docInfo);
-          fetchedDocs.set(docInfo.metadata.id, docInfo.metadata);
+          fetchedDocs.set(id, docInfo.metadata);
           callback();
         });
       }
@@ -722,9 +810,9 @@ function WebSqlPouch(opts, callback) {
       sql = select(
         SELECT_DOCS,
         [DOC_STORE, BY_SEQ_STORE],
-        null,
-        [BY_SEQ_STORE + '.doc_id_rev=?', DOC_STORE + '.id=?']);
-      sqlArgs = [id + '::' + opts.rev, id];
+        DOC_STORE + '.id=' + BY_SEQ_STORE + '.doc_id',
+        [BY_SEQ_STORE + '.doc_id=?', BY_SEQ_STORE + '.rev=?']);
+      sqlArgs = [id, opts.rev];
     } else {
       sql = select(
         SELECT_DOCS,
@@ -744,7 +832,7 @@ function WebSqlPouch(opts, callback) {
         err = errors.error(errors.MISSING_DOC, 'deleted');
         return finish();
       }
-      doc = JSON.parse(item.data);
+      doc = unstringifyDoc(item.data, metadata.id, item.rev);
       finish();
     });
   };
@@ -834,7 +922,7 @@ function WebSqlPouch(opts, callback) {
           for (var i = 0, l = result.rows.length; i < l; i++) {
             var item = result.rows.item(i);
             var metadata = JSON.parse(item.metadata);
-            var data = JSON.parse(item.data);
+            var data = unstringifyDoc(item.data, metadata.id, item.rev);
             var winningRev = data._rev;
             var doc = {
               id: metadata.id,
@@ -938,7 +1026,7 @@ function WebSqlPouch(opts, callback) {
             if (lastSeq < res.seq) {
               lastSeq = res.seq;
             }
-            var doc = JSON.parse(res.data);
+            var doc = unstringifyDoc(res.data, metadata.id, res.rev);
             var change = opts.processChange(doc, metadata, opts);
             change.seq = res.seq;
             if (filter(change)) {
@@ -1019,12 +1107,10 @@ function WebSqlPouch(opts, callback) {
         var metadata = JSON.parse(result.rows.item(0).metadata);
         metadata.rev_tree = rev_tree;
 
-        // websql never calls callback if we do WHERE doc_id_rev IN (...)
         var numDone = 0;
         revs.forEach(function (rev) {
-          var docIdRev = docId + '::' + rev;
-          var sql = 'DELETE FROM ' + BY_SEQ_STORE + ' WHERE doc_id_rev = ?';
-          tx.executeSql(sql, [docIdRev], function (tx) {
+          var sql = 'DELETE FROM ' + BY_SEQ_STORE + ' WHERE doc_id=? AND rev=?';
+          tx.executeSql(sql, [docId, rev], function (tx) {
             if (++numDone === revs.length) {
               var sql = 'UPDATE ' + DOC_STORE + ' SET json = ? WHERE id = ?';
               tx.executeSql(sql, [JSON.stringify(metadata), docId],
@@ -1040,10 +1126,12 @@ function WebSqlPouch(opts, callback) {
 
   api._getLocal = function (id, callback) {
     db.readTransaction(function (tx) {
-      var sql = 'SELECT json FROM ' + LOCAL_STORE + ' WHERE id=?';
+      var sql = 'SELECT json, rev FROM ' + LOCAL_STORE + ' WHERE id=?';
       tx.executeSql(sql, [id], function (tx, res) {
         if (res.rows.length) {
-          callback(null, JSON.parse(res.rows.item(0).json));
+          var item = res.rows.item(0);
+          var doc = unstringifyDoc(item.json, id, item.rev);
+          callback(null, doc);
         } else {
           callback(errors.MISSING_DOC);
         }
@@ -1058,12 +1146,13 @@ function WebSqlPouch(opts, callback) {
     }
     var oldRev = doc._rev;
     var id = doc._id;
+    var newRev;
     if (!oldRev) {
-      doc._rev = '0-0';
+      newRev = doc._rev = '0-0';
     } else {
-      doc._rev = '0-' + (parseInt(oldRev.split('-')[1], 10) + 1);
+      newRev = doc._rev = '0-' + (parseInt(oldRev.split('-')[1], 10) + 1);
     }
-    var json = JSON.stringify(doc);
+    var json = stringifyDoc(doc);
 
     var ret;
     function putLocal(tx) {
@@ -1072,14 +1161,14 @@ function WebSqlPouch(opts, callback) {
       if (oldRev) {
         sql = 'UPDATE ' + LOCAL_STORE + ' SET rev=?, json=? ' +
           'WHERE id=? AND rev=?';
-        values = [doc._rev, json, id, oldRev];
+        values = [newRev, json, id, oldRev];
       } else {
         sql = 'INSERT INTO ' + LOCAL_STORE + ' (id, rev, json) VALUES (?,?,?)';
-        values = [id, doc._rev, json];
+        values = [id, newRev, json];
       }
       tx.executeSql(sql, values, function (tx, res) {
         if (res.rowsAffected) {
-          ret = {ok: true, id: id, rev: doc._rev};
+          ret = {ok: true, id: id, rev: newRev};
           if (opts.ctx) { // return immediately
             callback(null, ret);
           }


### PR DESCRIPTION
This doesn't actually fix #2534 (in fact the popup still comes at exactly the same spot in the tests - around 97%), but it may have other benefits. I'll try to get some numbers on what kind of storage impact this actually has in the real world.

The idea here is if a doc only contains `{_id: "E0FC7135-9107-946B-AD68-FC67CEA4A8AE", _rev: "1-5d94ca8f4bd707979b5d13fb17ab93b4"}`, then we only really need to stringify `{}` in websql because the id/rev can be inferred.
