### PR TITLE
(#2540) - add referer to recommended cors headers

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -23,7 +23,7 @@ curl -X POST $HOST/_config/httpd/enable_cors -d '"true"'
 curl -X PUT $HOST/_config/cors/origins -d '"*"'
 curl -X PUT $HOST/_config/cors/credentials -d '"true"'
 curl -X PUT $HOST/_config/cors/methods -d '"GET, PUT, POST, HEAD, DELETE"'
-curl -X PUT $HOST/_config/cors/headers -d '"accept, content-type, origin"'
+curl -X PUT $HOST/_config/cors/headers -d '"accept, content-type, origin, referer"'
 ```
 
 {% include anchor.html class="h3" title="iOS/Safari: \"there was not enough remaining storage space\"" hash="not_enough_space" %}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -163,7 +163,7 @@ $ curl -X PUT $HOST/_config/cors/origins -d '"*"'
 $ curl -X PUT $HOST/_config/cors/credentials -d '"true"'
 $ curl -X PUT $HOST/_config/cors/methods -d '"GET, PUT, POST, HEAD, DELETE"'
 $ curl -X PUT $HOST/_config/cors/headers -d \
-  '"accept, authorization, content-type, origin"'
+  '"accept, authorization, content-type, origin, referer"'
 {% endhighlight %}
 
 {% include anchor.html class="h3" title="Implement basic two way sync" hash="basic_two_way_sync" %}


### PR DESCRIPTION
You actually need it for Chrome in web workers.
(I confirmed while testing PouchDB Server.)
