### PR TITLE
Return better error when doc._id is not decodable with decodeURIComponent

### DIFF
--- a/lib/deps/errors.js
+++ b/lib/deps/errors.js
@@ -42,6 +42,11 @@ exports.INVALID_ID = new PouchError({
   error: 'invalid_id',
   reason: '_id field must contain a string'
 });
+exports.MALFORMED_ID = new PouchError({
+  status: 400,
+  error: 'malformed_id',
+  reason: '_id field cannot be decoded'
+});
 exports.MISSING_ID = new PouchError({
   status: 412,
   error: 'missing_id',

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -200,8 +200,12 @@ exports.parseDoc = function (doc, newEdits) {
   if (error) {
     return error;
   }
-
-  doc._id = decodeURIComponent(doc._id);
+  try {
+    doc._id = decodeURIComponent(doc._id);
+  }
+  catch (e) {
+    return errors.MALFORMED_ID;
+  }
   doc._rev = [nRevNum, newRevId].join('-');
 
   var result = {metadata : {}, data : {}};


### PR DESCRIPTION
I've had a case where a doc._id was badly encoded (contained a % sign).

When doing db.sync(), the error was very generic; looking at the originating stack, the culprit was `decodeURIComponent`

This commit fixes that, providing a new errors.MALFORMED_ID to handle that.
