### PR TITLE
(#2545) - throw errors instead of returning them

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,12 +56,19 @@ exports.inherits = require('inherits');
 //   - any other string value is a valid id
 // Returns the specific error object for each case
 exports.invalidIdError = function (id) {
+  var err;
   if (!id) {
-    return errors.MISSING_ID;
+    err = new TypeError(errors.MISSING_ID.message);
+    err.status = 412;
   } else if (typeof id !== 'string') {
-    return errors.INVALID_ID;
+    err = new TypeError(errors.INVALID_ID.message);
+    err.status = 400;
   } else if (/^_/.test(id) && !(/^_(design|local)/).test(id)) {
-    return errors.RESERVED_ID;
+    err = new TypeError(errors.RESERVED_ID.message);
+    err.status = 400;
+  }
+  if (err) {
+    throw err;
   }
 };
 
@@ -140,6 +147,7 @@ exports.parseDoc = function (doc, newEdits) {
   var nRevNum;
   var newRevId;
   var revInfo;
+  var error;
   var opts = {status: 'available'};
   if (doc._deleted) {
     opts.deleted = true;
@@ -153,7 +161,8 @@ exports.parseDoc = function (doc, newEdits) {
     if (doc._rev) {
       revInfo = /^(\d+)-(.+)$/.exec(doc._rev);
       if (!revInfo) {
-        throw "invalid value for property '_rev'";
+        var err = new TypeError("invalid value for property '_rev'");
+        err.status = 400;
       }
       doc._rev_tree = [{
         pos: parseInt(revInfo[1], 10),
@@ -185,7 +194,9 @@ exports.parseDoc = function (doc, newEdits) {
     if (!doc._rev_tree) {
       revInfo = /^(\d+)-(.+)$/.exec(doc._rev);
       if (!revInfo) {
-        return errors.BAD_ARG;
+        error = new TypeError(errors.BAD_ARG.message);
+        error.status = errors.BAD_ARG.status;
+        throw error;
       }
       nRevNum = parseInt(revInfo[1], 10);
       newRevId = revInfo[2];
@@ -196,10 +207,7 @@ exports.parseDoc = function (doc, newEdits) {
     }
   }
 
-  var error = exports.invalidIdError(doc._id);
-  if (error) {
-    return error;
-  }
+  exports.invalidIdError(doc._id);
 
   doc._id = decodeURIComponent(doc._id);
   doc._rev = [nRevNum, newRevId].join('-');
@@ -209,8 +217,9 @@ exports.parseDoc = function (doc, newEdits) {
     if (doc.hasOwnProperty(key)) {
       var specialKey = key[0] === '_';
       if (specialKey && !reservedWords[key]) {
-        var base = errors.DOC_VALIDATION;
-        return errors.error(base, base.message + ': ' + key);
+        error = new Error(errors.DOC_VALIDATION.message + ': ' + key);
+        error.status = errors.DOC_VALIDATION.status;
+        throw error;
       } else if (specialKey && key !== '_attachments') {
         result.metadata[key.slice(1)] = doc[key];
       } else {

--- a/tests/test.basics.js
+++ b/tests/test.basics.js
@@ -480,7 +480,6 @@ adapters.forEach(function (adapter) {
       var db = new PouchDB(dbs.name);
       db.bulkDocs({ docs: bad_docs }, function (err, res) {
         err.status.should.equal(500);
-        err.name.should.equal('doc_validation');
         done();
       });
     });
@@ -554,7 +553,8 @@ adapters.forEach(function (adapter) {
         test: 'somestuff'
       }, function (err, info) {
         should.exist(err);
-        err.name.should.equal('bad_request');
+        err.name.should.equal('TypeError');
+        err.status.should.equal(400);
         done();
       });
     });

--- a/tests/test.bulk_docs.js
+++ b/tests/test.bulk_docs.js
@@ -125,7 +125,7 @@ adapters.forEach(function (adapter) {
         foo: 'bar'
       }];
       db.bulkDocs({ docs: docs }, function (err, info) {
-        err.name.should.equal('bad_request', 'correct error returned');
+        err.status.should.equal(400, 'correct error status returned');
         should.not.exist(info, 'info is empty');
         done();
       });
@@ -139,7 +139,7 @@ adapters.forEach(function (adapter) {
 
       var db = new PouchDB(dbs.name);
       db.bulkDocs({ docs: docs }, function (err, info) {
-        err.name.should.equal('bad_request', 'correct error returned');
+        err.status.should.equal(400, 'correct error returned');
         err.message.should.equal(PouchDB.Errors.RESERVED_ID.message,
                                  'correct error message returned');
         should.not.exist(info, 'info is empty');
@@ -151,7 +151,6 @@ adapters.forEach(function (adapter) {
       var db = new PouchDB(dbs.name);
       db.bulkDocs({ 'doc': [{ 'foo': 'bar' }] }, function (err, result) {
         err.status.should.equal(400);
-        err.name.should.equal('bad_request');
         err.message.should.equal('Missing JSON list of \'docs\'');
         done();
       });
@@ -380,7 +379,6 @@ adapters.forEach(function (adapter) {
       db.bulkDocs({ docs: 'foo' }, function (err, res) {
         should.exist(err, 'error reported');
         err.status.should.equal(400);
-        err.name.should.equal('bad_request');
         err.message.should.equal('Missing JSON list of \'docs\'');
         done();
       });
@@ -391,13 +389,11 @@ adapters.forEach(function (adapter) {
       db.bulkDocs({ docs: ['foo'] }, function (err, res) {
         should.exist(err, 'error reported');
         err.status.should.equal(400);
-        err.name.should.equal('bad_request');
         err.message.should.equal('Document must be a JSON object');
       });
       db.bulkDocs({ docs: [[]] }, function (err, res) {
         should.exist(err, 'error reported');
         err.status.should.equal(400);
-        err.name.should.equal('bad_request');
         err.message.should.equal('Document must be a JSON object');
         done();
       });


### PR DESCRIPTION
strictly speaking this is a breaking change as you can't use error name to identify the errors, but error.name means something kinda specific in js so hopefully thats ok.
