### PR TITLE
(#2549) - document that the SQLite plugin is passing

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -4,7 +4,7 @@ title: Adapters
 sidebar: nav.html
 ---
 
-PouchDB is not a self-contained database; it is a unified abstraction layer over other databases. By default, PouchDB ships with [IndexedDB][] and [WebSQL][] adapters in the browser, and a [LevelDB][] adapter in Node.js.
+PouchDB is not a self-contained database; it is a CouchDB-style abstraction layer over other databases. By default, PouchDB ships with [IndexedDB][] and [WebSQL][] adapters in the browser, and a [LevelDB][] adapter in Node.js.
 
 PouchDB attempts to provide a consistent API that "just works" across every browser and JavaScript environment, and in most cases, you can just use the defaults. However, if you're trying to reach the widest possible audience, or if you want the best performance, then you will sometimes want to tinker with the adapter settings.
 
@@ -128,10 +128,7 @@ However, this only occurs if the adapter is `'websql'`, not `'idb'` (e.g. on And
 var websqlPouch = new PouchDB('myDB', {adapter: 'websql'});
 ```
 
-{% include alert_start.html variant="warning"%}
-The SQLite plugin does not yet pass our test suite with 100% success.  However, it should work for most basic use cases.  We will update this page when support reaches 100%.
-{% include alert_end.html%}
-
+The SQLite plugin is known to pass the PouchDB test suite on both iOS and Android. You may run into issues on Windows Phone 8.
 
 ### Experimental adapter plugins
 


### PR DESCRIPTION
@brodybits just merged the final iOS fix this morning, and is going to publish the first official version to the PhoneGap Build plugin registry.  (It's been a long time coming.)

To be precise, here's the current status of the SQLite plugin:

| Platform | Passing | Comments |
| --- | --- | --- |
| iOS | 100% | Tested on the iOS 7 iPad simulator. |
| Android 4+ | 100%* | Technicaly 99.9%, since the web worker tests aren't passing. (Who cares tho, amirite?) Filing a bug now though; I'm guessing it's the fault of Cordova rather than the SQLite plugin. |
| Android 2.3+ | unknown | I've never been able to get the test suite to pass on Android 2.3 (with or without the SQLite plugin) due to some callback from the HTTP adapter not returning. Also, too many of the tests are not ES3-compliant and even with the shims, they still fail. This is a big TODO for us and is not the fault of the plugin, which as far as I can tell works perfectly in Android 2.3 for storing local data. |
| Windows Phone 8 | unknown | I don't have a WP8 device, but @brodybits informs me that the tests are all passing except for the unicode tests, which means that the only thing that might not be working with PouchDB is secondary indexes. |
