### PR TITLE
(#2551) - skip big png test in IE

### DIFF
--- a/tests/test.attachments.js
+++ b/tests/test.attachments.js
@@ -589,8 +589,10 @@ adapters.forEach(function (adapter) {
     var isSafari = (typeof process === 'undefined' || process.browser) &&
       /Safari/.test(window.navigator.userAgent) &&
       !/Chrome/.test(window.navigator.userAgent);
-    if (!isSafari) {
+
+    if (!isSafari && typeof msIndexedDB === 'undefined') {
       // skip in safari/ios because of size limit popup
+      // skip in IE because this fails in Saucelabs somehow (works locally)
       it('putAttachment and getAttachment with big png data', function (done) {
 
         this.timeout(20000);


### PR DESCRIPTION
Let's see if this works. Still don't understand why it's failing only in Sauce.
