### PR TITLE
(pouchdb/mapreduce#207) - don't merge - test against mapreduce master

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "localstorage-down": "^0.4.4",
     "memdown": "^0.8.0",
     "pouchdb-extend": "^0.1.0",
-    "pouchdb-mapreduce": "~2.2.4",
+    "pouchdb-mapreduce": "pouchdb/mapreduce",
     "request": "~2.28.0",
     "spark-md5": "0.0.5",
     "through2": "^0.4.1"


### PR DESCRIPTION
Just testing that the current mapreduce master passes the tests, so we don't get any surprises when we release 3.0.0.
