### PR TITLE
(#2558) - add license info to output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ bower_components
 tests/cordova/www
 phantomjsdriver.log
 tests/pouchdb_server
-dist/performance-bundle.js
+tests/performance-bundle.js

--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,7 @@ node_modules
 *~
 npm-debug.log
 vendor
-dist/performance-bundle.js
+tests/performance-bundle.js
 tests/cordova/www
 .idea
 phantomjsdriver.log

--- a/bin/add-license.js
+++ b/bin/add-license.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+// prepend a license to the beginning of all the output files
+
+'use strict';
+
+var version = require('../package.json').version;
+var fs = require('fs');
+
+/* jshint maxlen:100 */
+var comments = {
+
+  'pouchdb': 'PouchDB ' + version +
+    '\n' +
+    '\n(c) 2012-2014 Dale Harvey and the PouchDB team' +
+    '\nPouchDB may be freely distributed under the Apache license, version 2.0.' +
+    '\nFor all details and documentation:' +
+    '\nhttp://pouchdb.com',
+
+  'pouchdb.idb-alt': 'PouchDB alternative IndexedDB plugin ' + version +
+    '\nBased on level.js: https://github.com/maxogden/level.js' +
+    '\n' +
+    '\n(c) 2012-2014 Dale Harvey and the PouchDB team' +
+    '\nPouchDB may be freely distributed under the Apache license, version 2.0.' +
+    '\nFor all details and documentation:' +
+    '\nhttp://pouchdb.com',
+
+  'pouchdb.memory': 'PouchDB in-memory plugin ' + version +
+    '\nBased on MemDOWN: https://github.com/rvagg/memdown' +
+    '\n' +
+    '\n(c) 2012-2014 Dale Harvey and the PouchDB team' +
+    '\nPouchDB may be freely distributed under the Apache license, version 2.0.' +
+    '\nFor all details and documentation:' +
+    '\nhttp://pouchdb.com',
+
+  'pouchdb.localstorage': 'PouchDB localStorage plugin ' + version +
+    '\nBased on localstorage-down: https://github.com/No9/localstorage-down' +
+    '\n' +
+    '\n(c) 2012-2014 Dale Harvey and the PouchDB team' +
+    '\nPouchDB may be freely distributed under the Apache license, version 2.0.' +
+    '\nFor all details and documentation:' +
+    '\nhttp://pouchdb.com'
+};
+
+Object.keys(comments).forEach(function (name) {
+  var comment = comments[name];
+  comment = comment.replace(/(^|\n)/g, '$1//    ');
+
+  var filenames = [name + '.js', name + '.min.js'];
+
+  filenames.forEach(function (filename) {
+    filename = './dist/' + filename;
+    var contents = fs.readFileSync(filename);
+    contents = comment + '\n' + contents;
+
+    fs.writeFileSync(filename, contents);
+  });
+});
+
+
+

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -24,7 +24,7 @@ if (process.env.ADAPTERS) {
 var indexfile = "./lib/index.js";
 var outfile = "./dist/pouchdb.js";
 var perfRoot = './tests/performance/*.js';
-var performanceBundle = './dist/performance-bundle.js';
+var performanceBundle = './tests/performance-bundle.js';
 
 var w = watchify(indexfile).on('update', bundle);
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "build-main-js": "browserify . -s PouchDB > dist/pouchdb.js",
     "min": "uglifyjs dist/pouchdb.js -mc > dist/pouchdb.min.js",
     "build-plugins": "./bin/build-all-plugins.sh",
-    "build": "npm run version && mkdirp dist && npm run build-js",
+    "build": "npm run version && mkdirp dist && npm run build-js && npm run license",
+    "license": "./bin/add-license.js",
     "version": "node ./bin/get-version.js",
     "test-node": "./bin/test-node.sh",
     "test-browser": "mkdirp dist && npm run build-js && node ./bin/test-browser.js",
@@ -81,7 +82,7 @@
     "build-site": "node ./bin/build-site.js",
     "shell": "./bin/repl.js",
     "report-coverage": "node ./bin/run-coverage.js",
-    "build-perf": "browserify tests/performance/*.js > dist/performance-bundle.js"
+    "build-perf": "browserify tests/performance/*.js > tests/performance-bundle.js"
   },
   "browser": {
     "./deps/buffer": false,

--- a/tests/performance/test.html
+++ b/tests/performance/test.html
@@ -9,6 +9,6 @@
     <script src="/dist/pouchdb.localstorage.js"></script>
     <script src="/dist/pouchdb.idb-alt.js"></script>
     <script src="/dist/pouchdb.memory.js"></script>
-    <script src="/dist/performance-bundle.js"></script>
+    <script src="../performance-bundle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Also moved `performance-bundle.js` to `tests/` from `dist/` so users wouldn't get confused.

@daleharvey Feel free to modify this to say whatever you want; I mostly just copied from Backbone's license.
