### PR TITLE
(#2555) - fix 'change' event for db.sync()

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -39,7 +39,6 @@ Replication.prototype.ready = function (src, target) {
   src.once('destroyed', onDestroy);
   target.once('destroyed', onDestroy);
   function cleanup() {
-    self.removeAllListeners();
     src.removeListener('destroyed', onDestroy);
     target.removeListener('destroyed', onDestroy);
   }

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -55,17 +55,25 @@ function Sync(src, target, opts, callback) {
   }
   var listeners = {};
 
-  function removal(event, func) {
-    if (event === 'change' &&
-      (func === pullChange ||
-      func === pushChange)) {
-      self.removeAllListeners('change');
-    } else if (event === 'cancel' &&
-      func === onCancel) {
-      self.removeAllListeners('cancel');
-    } else if (event in listeners && func === listeners[event]) {
-      self.removeAllListeners(event);
-    }
+  var removed = {};
+  function removeAll(type) { // type is 'push' or 'pull'
+    return function (event, func) {
+      var isChange = event === 'change' &&
+        (func === pullChange || func === pushChange);
+      var isCancel = event === 'cancel' && func === onCancel;
+      var isOtherEvent = event in listeners && func === listeners[event];
+
+      if (isChange || isCancel || isOtherEvent) {
+        if (!(event in removed)) {
+          removed[event] = {};
+        }
+        removed[event][type] = true;
+        if (Object.keys(removed[event]).length === 2) {
+          // both push and pull have asked to be removed
+          self.removeAllListeners(event);
+        }
+      }
+    };
   }
 
   this.on('newListener', function (event) {
@@ -76,6 +84,7 @@ function Sync(src, target, opts, callback) {
       self.pull.on('cancel', onCancel);
       self.push.on('cancel', onCancel);
     } else if (event !== 'error' &&
+      event !== 'removeListener' &&
       event !== 'complete' && !(event in listeners)) {
       listeners[event] = function (e) {
         self.emit(event, e);
@@ -101,8 +110,8 @@ function Sync(src, target, opts, callback) {
     }
   });
 
-  this.pull.on('removeListener', removal);
-  this.push.on('removeListener', removal);
+  this.pull.on('removeListener', removeAll('pull'));
+  this.push.on('removeListener', removeAll('push'));
 
   var promise = utils.Promise.all([
     this.push,


### PR DESCRIPTION
This ought to fix it. I also added some tests to ensure we're not leaking any listeners. Apparently calling `removeAllListeners` in `cleanup` is unnecessary, because that gets taken care of in `completeReplication` anyway.
