### PR TITLE
(#2553) - parallelize bulkDocs for leveldb

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -1261,7 +1261,7 @@ function destroy(name, opts, callback) {
     if (IdbPouch.openReqList[name]) {
       IdbPouch.openReqList[name] = null;
     }
-    if (utils.hasLocalStorage()) {
+    if (utils.hasLocalStorage() && (name in global.localStorage)) {
       delete global.localStorage[name];
     }
     delete cachedDBs[name];

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -16,6 +16,7 @@ var ATTACHMENT_STORE = 'attach-store';
 var BINARY_STORE = 'attach-binary-store';
 var LOCAL_STORE = 'local-store';
 var META_STORE = 'meta-store';
+var BATCH_SIZE = 50;
 
 // leveldb barks if we try to open a db multiple times
 // so we cache opened connections here for initstore()
@@ -299,7 +300,6 @@ function LevelPouch(opts, callback) {
       callback(null, data);
     });
   };
-
   api.lock = function (id) {
     if (db._locks.has(id)) {
       return false;
@@ -310,13 +310,16 @@ function LevelPouch(opts, callback) {
   };
 
   api.unlock = function (id) {
-    db._locks.delete(id);
-    return true;
+    if (db._locks.has(id)) {
+      db._locks.delete(id);
+      return true;
+    }
+    return false;
   };
 
   api._bulkDocs = function (req, opts, callback) {
     var newEdits = opts.new_edits;
-    var results = [];
+    var results = new Array(req.docs.length);
 
     // parse the docs and give each a sequence number
     var userDocs = req.docs;
@@ -333,7 +336,7 @@ function LevelPouch(opts, callback) {
 
       return newDoc;
     });
-
+    var current = 0;
     var infoErrors = info.filter(function (doc) {
       return doc.error;
     });
@@ -341,58 +344,76 @@ function LevelPouch(opts, callback) {
     if (infoErrors.length) {
       return callback(infoErrors[0]);
     }
-
+    var inProgress = 0;
     function processDocs() {
-      if (info.length === 0) {
-        return complete();
+      var index = current;
+      if (inProgress > BATCH_SIZE) {
+        return;
       }
-      var currentDoc = info.shift();
+      if (index >= info.length) {
+        if (inProgress === 0) {
+          return complete();
+        } else {
+          return;
+        }
+      }
+      var currentDoc = info[index];
+      current++;
+      inProgress++;
       if (currentDoc._id && utils.isLocalId(currentDoc._id)) {
         api[currentDoc._deleted ? '_removeLocal' : '_putLocal'](
             currentDoc, function (err, resp) {
           if (err) {
-            results.push(err);
+            results[index] = err;
           } else {
-            results.push({});
+            results[index] = {};
           }
+          inProgress--;
           processDocs();
         });
         return;
       }
       stores.docStore.get(currentDoc.metadata.id, function (err, oldDoc) {
         if (!api.lock(currentDoc.metadata.id)) {
-          results.push(makeErr(errors.REV_CONFLICT,
-            'someobody else is accessing this'));
+          results[index] = makeErr(errors.REV_CONFLICT,
+            'someobody else is accessing this');
+          inProgress--;
           return processDocs();
         }
         if (err) {
           if (err.name === 'NotFoundError') {
-            insertDoc(currentDoc, function () {
+            insertDoc(currentDoc, index, function () {
               api.unlock(currentDoc.metadata.id);
+              inProgress--;
               processDocs();
             });
           } else {
             err.error = true;
-            results.push(err);
+            results[index] = err;
             api.unlock(currentDoc.metadata.id);
+            inProgress--;
             processDocs();
           }
         } else {
-          updateDoc(oldDoc, currentDoc, function () {
+          updateDoc(oldDoc, currentDoc, index, function () {
             api.unlock(currentDoc.metadata.id);
+            inProgress--;
             processDocs();
           });
         }
       });
+      if (newEdits) {
+        processDocs();
+      }
     }
 
-    function insertDoc(doc, callback) {
+    function insertDoc(doc, index, callback) {
       // Can't insert new deleted documents
       if ('was_delete' in opts && utils.isDeleted(doc.metadata)) {
-        results.push(makeErr(errors.MISSING_DOC, doc._bulk_seq));
+        results[index] = makeErr(errors.MISSING_DOC, doc._bulk_seq);
         return callback();
       }
-      writeDoc(doc, function (err) {
+      writeDoc(doc, index, function (err) {
         if (err) {
           return callback(err);
         }
@@ -403,7 +424,7 @@ function LevelPouch(opts, callback) {
       });
     }
 
-    function updateDoc(oldDoc, docInfo, callback) {
+    function updateDoc(oldDoc, docInfo, index, callback) {
       var merged =
         merge.merge(oldDoc.rev_tree, docInfo.metadata.rev_tree[0], 1000);
 
@@ -415,7 +436,7 @@ function LevelPouch(opts, callback) {
 
 
       if (conflict) {
-        results.push(makeErr(errors.REV_CONFLICT, docInfo._bulk_seq));
+        results[index] = makeErr(errors.REV_CONFLICT, docInfo._bulk_seq);
         return callback();
       }
       docInfo.metadata.rev_tree = merged.tree;
@@ -429,12 +450,12 @@ function LevelPouch(opts, callback) {
         if (err) {
           return callback(err);
         }
-        writeDoc(docInfo, callback);
+        writeDoc(docInfo, index, callback);
       });
 
     }
 
-    function writeDoc(doc, callback2) {
+    function writeDoc(doc, index, callback2) {
       var err = null;
       var recv = 0;
 
@@ -549,9 +570,9 @@ function LevelPouch(opts, callback) {
           return stores.metaStore.put(UPDATE_SEQ_KEY, db._updateSeq,
             function (err) {
             if (err) {
-              results.push(err);
+              results[index] = err;
             } else {
-              results.push(doc);
+              results[index] = doc;
             }
             return callback2();
           });


### PR DESCRIPTION
it sets an upper limit (set to 50) of simultaneous writes to have in progress, and starts a new one if the current ones are bellow the limit, turned off if new_edits = false as that can effect the same doc multiple times, we may want to switch that to a check for dup doc ids
