### PR TITLE
(#2574) - fix new_edits=false race in leveldb

### DIFF
--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -519,18 +519,18 @@ function LevelPouch(opts, callback) {
       }
 
       function finish() {
-        if (!doc.metadata.rev_map[doc.metadata.rev]) {
+        var seq = doc.metadata.rev_map[doc.metadata.rev];
+        if (!seq) {
           // check that there aren't any existing revisions with the same
           // reivision id, else we shouldn't increment updateSeq
-          db._updateSeq++;
+          seq = ++db._updateSeq;
         }
-        doc.metadata.seq = doc.metadata.seq || db._updateSeq;
-        doc.metadata.rev_map[doc.metadata.rev] = doc.metadata.seq;
-        var seq = formatSeq(doc.metadata.seq);
+        doc.metadata.rev_map[doc.metadata.rev] = doc.metadata.seq = seq;
+        var seqKey = formatSeq(seq);
         db.emit('pouchdb-id-' + doc.metadata.id, doc);
-        db.emit('pouchdb-' + seq, doc);
+        db.emit('pouchdb-' + seqKey, doc);
         db.batch([{
-          key: seq,
+          key: seqKey,
           value: doc.data,
           prefix: stores.bySeqStore,
           type: 'put',
@@ -544,7 +544,7 @@ function LevelPouch(opts, callback) {
         }], function (err) {
           if (!err) {
             db.emit('pouchdb-id-' + doc.metadata.id, doc);
-            db.emit('pouchdb-' + seq, doc);
+            db.emit('pouchdb-' + seqKey, doc);
           }
           return stores.metaStore.put(UPDATE_SEQ_KEY, db._updateSeq,
             function (err) {

--- a/tests/test.bulk_docs.js
+++ b/tests/test.bulk_docs.js
@@ -241,6 +241,36 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('Testing successive new_edits to two doc', function () {
+
+      var db = new PouchDB(dbs.name);
+      var doc1 = {
+        '_id': 'foo',
+        '_rev': '1-x',
+        '_revisions': {
+          'start': 1,
+          'ids': ['x']
+        }
+      };
+      var doc2 = {
+        '_id': 'bar',
+        '_rev': '1-x',
+        '_revisions': {
+          'start': 1,
+          'ids': ['x']
+        }
+      };
+
+      return db.put(doc1, {new_edits: false}).then(function () {
+        return db.put(doc2, {new_edits: false});
+      }).then(function () {
+        return db.put(doc1, {new_edits: false});
+      }).then(function () {
+        return db.get('foo');
+      }).then(function () {
+        return db.get('bar');
+      });
+    });
 
     it('Bulk with new_edits=false in req body', function (done) {
       var db = new PouchDB(dbs.name);


### PR DESCRIPTION
Test fails before, succeeds after. The failure only occurs in leveldb, and it throws exactly the error I was seeing.

Booyah.
