### PR TITLE
(#2581) - fix websql size on Android <=4.3

### DIFF
--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -116,11 +116,18 @@ function unstringifyDoc(doc, id, rev) {
 
 function getSize(opts) {
   if ('size' in opts) {
-    // triggers immediate popup, fixes #2347
+    // triggers immediate popup in iOS, fixes #2347
     // e.g. 5000001 asks for 5 MB, 10000001 asks for 10 MB,
     return opts.size * 1000000;
   }
-  return 0; // doesn't matter as long as it's <= 5000000
+  // In iOS, doesn't matter as long as it's <= 5000000.
+  // Except that if you request too much, our tests fail
+  // because of the native "do you accept?" popup.
+  // In Android <=4.3, this value is actually used as an
+  // honest-to-god ceiling for data, so we need to
+  // set it to a decently high number.
+  var isAndroid = /Android/.test(window.navigator.userAgent);
+  return isAndroid ? 5000000 : 1;
 }
 
 function WebSqlPouch(opts, callback) {


### PR DESCRIPTION
This is the first time we've actually used browser-sniffing in PouchDB. I'm not happy about it, but I cannot think of any other way.

If we choose 0, Android <=4.3 barfs.
If we choose 1, Android <=4.3 barfs 2/3 of the way through.
If we choose 5000000, iOS shows the popup about 1/2 of the way through.

We could set it to some arbitrarily "good" value for our unit tests (e.g. 1000000), but this is arguably not the best thing for users.

Users want to not have to deal with this thing. If we set it to 5000000 for Android and 1 for iOS, then we're minimizing their risk of running into a DOM Exception 18 on Android while also minimizing the risk that they will see the popup on iOS. (I chose 1 instead of 0 because I don't know what other platforms might barf immediately if given the 0. At least with 1, they only barf after you stuff too much data in them.)

You can take my word for it that this commit passes on Android 4.1, 4.3, and 4.4+websql.
