### PR TITLE
(#2577) - add some attachments tests

### DIFF
--- a/tests/test.attachments.js
+++ b/tests/test.attachments.js
@@ -542,6 +542,85 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('Test put with partial stubs', function () {
+      var db = new PouchDB(dbs.name);
+      var doc = {
+        _id: 'doc',
+        _attachments: {
+          'foo.txt': {
+            content_type: 'text/plain',
+            data: 'Zm9v'
+          },
+          'bar.txt': {
+            content_type: 'text/plain',
+            data: 'Zm9v'
+          }
+        }
+      };
+      return db.put(doc).then(function () {
+        return db.get(doc._id);
+      }).then(function (doc) {
+        doc._attachments['baz.txt'] = {
+          content_type: 'text/plain',
+          data: 'Zm9v'
+        };
+        // at this point, foo and bar are stubs, but baz is not
+        return db.put(doc);
+      }).then(function () {
+        return db.get(doc._id, {attachments: true});
+      }).then(function (doc) {
+        doc._rev.should.not.equal('2-x');
+        Object.keys(doc._attachments).should.have.length(3);
+        Object.keys(doc._attachments).forEach(function (key) {
+          var att = doc._attachments[key];
+          att.data.should.equal('Zm9v');
+          att.content_type.should.equal('text/plain');
+        });
+      });
+    });
+
+    it('Test put with attachments and new_edits=false', function () {
+      var db = new PouchDB(dbs.name);
+      var doc = {
+        _id: 'doc',
+        _rev: '2-x',
+        _attachments: {
+          'foo.txt': {
+            content_type: 'text/plain',
+            data: 'Zm9v'
+          },
+          'bar.txt': {
+            content_type: 'text/plain',
+            data: 'Zm9v'
+          },
+          'baz.txt': {
+            content_type: 'text/plain',
+            data: 'Zm9v'
+          }
+        },
+        _revisions: {
+          'start': 2,
+          'ids': ['x', 'a']
+        }
+      };
+      return db.bulkDocs([doc], {new_edits: false}).then(function () {
+        return db.get(doc._id);
+      }).then(function () {
+          // at this point, foo and bar are stubs, but baz is not
+          return db.bulkDocs([doc], {new_edits: false});
+        }).then(function () {
+          return db.get(doc._id, {attachments: true});
+        }).then(function (doc) {
+          doc._rev.should.equal('2-x');
+          Object.keys(doc._attachments).should.have.length(3);
+          Object.keys(doc._attachments).forEach(function (key) {
+            var att = doc._attachments[key];
+            att.data.should.equal('Zm9v');
+            att.content_type.should.equal('text/plain');
+          });
+        });
+    });
+
     it('Test stubs', function (done) {
       var db = new PouchDB(dbs.name);
       db.putAttachment('a', 'foo2.txt', '', '', 'text/plain', function (err) {


### PR DESCRIPTION
Just wanted to add some tests so I can understand how `npm-fullfat-registry` may be using PouchDB with stubs attachments and new_edits=false.
