### PR TITLE
(#2605) - small edits to the release notes

### DIFF
--- a/docs/_posts/2014-08-12-pouchdb-3.0.0.md
+++ b/docs/_posts/2014-08-12-pouchdb-3.0.0.md
@@ -11,6 +11,10 @@ author: Calvin Metcalf
 
 Please [file issues](https://github.com/pouchdb/pouchdb/issues) or [tell us what you think](https://github.com/pouchdb/pouchdb/blob/master/CONTRIBUTING.md#get-in-touch). We would also like to give a huge thanks to our [new and existing contributors](https://github.com/pouchdb/pouchdb/graphs/contributors?from=2014-06-01&to=2014-08-12).
 
+{% include alert_start.html variant="warning"%}
+This release includes a migration. Your existing database will be updated automatically, but you cannot downgrade to a previous version of PouchDB once you've upgraded.
+{% include alert_end.html %}
+
 ### Breaking Changes:
 * The browser build `pouchdb-nightly.js` has been renamed to `pouchdb.js`. It was never really a nightly anyway. ([#2146](https://github.com/pouchdb/pouchdb/issues/2146)) 
 * `opts.server` has been deprecated from the `replicate()` and `sync()` APIs. You can still replicate from one HTTP server to another, but the data will flow through PouchDB rather than being server-initiated. ([#2313](https://github.com/pouchdb/pouchdb/issues/2313))
@@ -18,9 +22,9 @@ Please [file issues](https://github.com/pouchdb/pouchdb/issues) or [tell us what
 
 ### Major Changes:
 
- *  Local documents are now unversioned for better map/reduce performance and to better align the `update_seq` with CouchDB ([#2023](https://github.com/pouchdb/pouchdb/issues/2023)). Also fixes an issue with replication and `changes()`. ([#2342](https://github.com/pouchdb/pouchdb/issues/2342))
- * Constructor option `opts.size` to work around Safari/iOS storage quotas (#2347)
+ * Constructor option `opts.size` to work around Safari/iOS storage quotas ([#2347](https://github.com/pouchdb/pouchdb/issues/2347))
  * `PouchDB.defaults()` for default constructor options, which permits many new features in pouchdb-server. ([#2054](https://github.com/pouchdb/pouchdb/issues/2054))
+ *  `_local` documents are now unversioned in the underlying backend for better map/reduce performance and to better align the `update_seq` with CouchDB ([#2023](https://github.com/pouchdb/pouchdb/issues/2023)). Also fixes an issue with replication and `changes()`. ([#2342](https://github.com/pouchdb/pouchdb/issues/2342))
  * Performance improvements. ([#2391](https://github.com/pouchdb/pouchdb/issues/2391), [#2392](https://github.com/pouchdb/pouchdb/issues/2392), [#2393](https://github.com/pouchdb/pouchdb/issues/2393))
  * MD5 hashes are now calculated incrementally in a way that won't freeze the DOM. ([#445](https://github.com/pouchdb/pouchdb/issues/445), [#2497](https://github.com/pouchdb/pouchdb/issues/2497))
  * More efficient replication. ([#2466](https://github.com/pouchdb/pouchdb/issues/2466), [#2475](https://github.com/pouchdb/pouchdb/issues/2475))


### PR DESCRIPTION
We forgot to mention there's a migration, the "local" docs thing confused someone on Twitter thinking it meant they didn't need to add a `_rev` anymore, and one of the links was missing.
