### PR TITLE
(#2604) - Remove line breaks to stop HTML breaking markdown rendering

### DIFF
--- a/docs/_includes/anchor.html
+++ b/docs/_includes/anchor.html
@@ -3,12 +3,5 @@
 {% else %}
   {% assign class = 'h2' %}
 {% endif %}
-<div id='{{ include.hash }}'>
-  <a
-     class='{{ class }} anchor'
-     href='#{{ include.hash }}'
-     name='{{ include.hash }}'
-  >
-    {{ include.title }}
-  </a>
-</div>
+<div id='{{ include.hash }}'></div>
+<a class='{{ class }} anchor' href='#{{ include.hash }}' name='{{ include.hash }}'>{{ include.title }}</a>


### PR DESCRIPTION
Less readable HTML but at least it doesn't break the site!
