### PR TITLE
(#2456) - fix broken idb migration

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -163,15 +163,29 @@ function init(api, opts, callback) {
         var rev = merge.winningRev(metadata);
         if (local) {
           var docIdRev = docId + "::" + rev;
+          // remove all seq entries
+          // associated with this docId
+          var start = docId + "::";
+          var end = docId + "::~";
           var index = seqStore.index('_doc_id_rev');
-          index.get(docIdRev).onsuccess = function (e) {
-            var data = e.target.result;
-            localStore.put(data);
-            docStore.delete(cursor.primaryKey);
-            index.getKey(docIdRev).onsuccess = function (e) {
-              seqStore.delete(e.target.result);
+          var range = global.IDBKeyRange.bound(start, end, false, false);
+          var seqCursor = index.openCursor(range);
+          seqCursor.onsuccess = function (e) {
+            seqCursor = e.target.result;
+            if (!seqCursor) {
+              // done
+              docStore.delete(cursor.primaryKey);
               cursor.continue();
-            };
+            } else {
+              var data = seqCursor.value;
+              console.log('deleting');
+              console.log(data);
+              if (data._doc_id_rev === docIdRev) {
+                localStore.put(data);
+              }
+              seqStore.delete(seqCursor.primaryKey);
+              seqCursor.continue();
+            }
           };
         } else {
           cursor.continue();


### PR DESCRIPTION
Looks like we're going to have to release a PouchDB 3.0.1 ASAP.
