### PR TITLE
(#2623) - compaction improvements

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -442,27 +442,61 @@ AbstractPouchDB.prototype.compact =
     opts = {};
   }
   var self = this;
-  this.changes({complete: function (err, res) {
-    if (err) {
-      callback(); // TODO: silently fail
-      return;
-    }
-    var count = res.results.length;
-    if (!count) {
-      callback();
-      return;
-    }
-    res.results.forEach(function (row) {
-      self.compactDocument(row.id, 0, function () {
-        count--;
-        if (!count) {
-          callback();
-        }
-      });
-    });
-  }});
-});
 
+  opts = utils.clone(opts || {});
+
+  self.get('_local/compaction').catch(function () {
+    return false;
+  }).then(function (doc) {
+    if (typeof self._compact === 'function') {
+      if (doc && doc.last_seq) {
+        opts.last_seq = doc.last_seq;
+      }
+      return self._compact(opts, callback);
+    }
+
+  });
+});
+AbstractPouchDB.prototype._compact = function (opts, callback) {
+  var done = false;
+  var started = 0;
+  var copts = {
+    returnDocs: false
+  };
+  var self = this;
+  var lastSeq;
+  function finish() {
+    self.get('_local/compaction').catch(function () {
+      return false;
+    }).then(function (doc) {
+      doc = doc || {_id: '_local/compaction'};
+      doc.last_seq = lastSeq;
+      return self.put(doc);
+    }).then(function () {
+      callback();
+    }, callback);
+  }
+  if (opts.last_seq) {
+    copts.since = opts.last_seq;
+  }
+  function afterCompact() {
+    started--;
+    if (!started && done) {
+      finish();
+    }
+  }
+  function onChange(row) {
+    started++;
+    self.compactDocument(row.id, 0).then(afterCompact, callback);
+  }
+  self.changes(copts).on('change', onChange).on('complete', function (resp) {
+    done = true;
+    lastSeq = resp.last_seq;
+    if (!started) {
+      finish();
+    }
+  }).on('error', callback);
+};
 /* Begin api wrappers. Specific functionality to storage belongs in the 
    _[method] */
 AbstractPouchDB.prototype.get =

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -662,7 +662,6 @@ function LevelPouch(opts, callback) {
 
     processDocs();
   };
-
   api._allDocs = function (opts, callback) {
     opts = utils.clone(opts);
     countDocs(function (err, docCount) {


### PR DESCRIPTION
compaction now instead of grabbing every single change in the databases history and then compacting each of them, it instead goes through the changes feed and does the compaction on each event and thus use possible less memory (but there is no way for it to use more memory).  

It also saves the last seq it compacted to so that it can start from there next time.

Also I added a hook for adapter specific compaction methods, and added one for level which uses the changes stream to make sure that only one document is compacted at a time, meaning compaction for leveldb will take longer, but use significantly less memory, aka you can do stuff while that's going on in the background and leveldb is likely the only one that will work on arbitrarily large databases.
