### PR TITLE
(#2449) - expose HTTP headers for plug-in use

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -133,6 +133,7 @@ function HttpPouch(opts, callback) {
   var dbUrl = genDBUrl(host, '');
 
   api.getUrl = function () {return dbUrl; };
+  api.getHeaders = function () {return utils.clone(host.headers); };
 
   var ajaxOpts = opts.ajax || {};
   opts = utils.clone(opts);


### PR DESCRIPTION
A bit different than described in bug #2449, but this exposes what I need more conveniently, and it's not public API anyway. Required for most of my plug-ins (e.g. show, list, update, auth, etc...)
