### PR TITLE
(#2651) - allow % in doc IDs

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -207,7 +207,6 @@ exports.parseDoc = function (doc, newEdits) {
 
   exports.invalidIdError(doc._id);
 
-  doc._id = decodeURIComponent(doc._id);
   doc._rev = [nRevNum, newRevId].join('-');
 
   var result = {metadata : {}, data : {}};

--- a/tests/test.basics.js
+++ b/tests/test.basics.js
@@ -709,6 +709,35 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('Test doc with percent in ID', function () {
+      var db = new PouchDB(dbs.name);
+      var doc = {
+        foo: 'bar',
+        _id: 'foo%bar'
+      };
+      return db.put(doc).then(function (res) {
+        res.id.should.equal('foo%bar');
+        return db.get('foo%bar');
+      }).then(function (doc) {
+        doc._id.should.equal('foo%bar');
+        var queryFun = {
+          map: function (doc) {
+            emit(doc.foo, doc);
+          }
+        };
+        return db.query(queryFun, {
+          include_docs: true,
+          reduce: false
+        });
+      }).then(function (res) {
+        var x = res.rows[0];
+        x.id.should.equal('foo%bar');
+        should.exist(x.key);
+        should.exist(x.value._rev);
+        should.exist(x.doc._rev);
+      });
+    });
+
     it('db.info should give correct name', function (done) {
       var db = new PouchDB(dbs.name);
       db.info().then(function (info) {


### PR DESCRIPTION
Unless someone can explain why that `decodeURIComponent` is there, we seem to be better off without it.
