### PR TITLE
(#2658) - fix small errors in release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,13 +294,13 @@ Release Procedure
 -----------------
 
  * Copy the last release post from ./docs/_posts/date-pouchdb-version.md, ammend date and version and fill in release notes
- * Update docs/_config.yml to latest version
  * Push release post
  * `./node_modules/.bin/tin -v $VERSION
  * Put the new version in `lib/version-browser.js` too
  * `npm run release`
- * Copy the `dist/pouchdb*` files from the $VERSION tag on github, paste the release notes and add the distribution files to Github Releases
+ * Copy the `dist/pouchdb*` files from the $VERSION tag on github, paste the release notes and add the distribution files to Github Releases, rename `pouchdb.min.js` to `pouchdb-$VERSION.min.js` after you upload it.
  * `./node_modules/.bin/tin -v $VERSION+1-prerelease
  * Put the new prerelease version in `lib/version-browser.js` too
+ * Update docs/_config.yml to the current version
  * Push updated versions to master
  * `npm run publish-site`

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -12,7 +12,7 @@ git checkout -b build
 
 npm run build
 git add dist -f
-git add lib/version-browser.js
+git add bower.json component.json package.json lib/version-browser.js
 git rm -r bin docs scripts tests vendor
 
 git commit -m "build $VERSION"


### PR DESCRIPTION
Been doing it manually the past few releases, but I think with these new instructions and script, I won't miss anything and can actually run `npm run release`.
