### PR TITLE
(#2660) using xhr.timeout

### DIFF
--- a/lib/deps/ajax-browser.js
+++ b/lib/deps/ajax-browser.js
@@ -3,7 +3,6 @@
 var createBlob = require('./blob.js');
 var errors = require('./errors');
 var utils = require("../utils");
-var hasUpload;
 
 function ajax(options, adapterCallback) {
 
@@ -128,7 +127,6 @@ function ajax(options, adapterCallback) {
     cb(errObj);
   }
 
-  var timer;
   var xhr;
   if (options.xhr) {
     xhr = new options.xhr();
@@ -188,7 +186,6 @@ function ajax(options, adapterCallback) {
     if (xhr.readyState !== 4 || requestCompleted) {
       return;
     }
-    clearTimeout(timer);
     if (xhr.status >= 200 && xhr.status < 300) {
       var data;
       if (options.binary) {
@@ -205,18 +202,10 @@ function ajax(options, adapterCallback) {
   };
 
   if (options.timeout > 0) {
-    timer = setTimeout(abortReq, options.timeout);
-    xhr.onprogress = function () {
-      clearTimeout(timer);
-      timer = setTimeout(abortReq, options.timeout);
+    xhr.timeout = options.timeout;
+    xhr.ontimeout = function () {
+      onError(xhr, callback);
     };
-    if (typeof hasUpload === 'undefined') {
-      // IE throws an error if you try to access it directly
-      hasUpload = Object.keys(xhr).indexOf('upload') !== -1;
-    }
-    if (hasUpload) { // does not exist in ie9
-      xhr.upload.onprogress = xhr.onprogress;
-    }
   }
   if (options.body && (options.body instanceof Blob)) {
     var reader = new FileReader();


### PR DESCRIPTION
Responses are never delivered when we use XHR.upload in
mobile safari when making requests against URLs
that are handled by NSURLPrototocol.

This is to fix #2660.

Not sure if there was a good reason this wasn't done in the first place...
