### PR TITLE
only create one db instance when syncing

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -548,7 +548,8 @@ function replicate(repId, src, target, opts, returnValue) {
 }
 
 
-function toPouch(db, PouchConstructor) {
+function toPouch(db, opts) {
+  var PouchConstructor = opts.pouchConstructor || Pouch;
   if (typeof db === 'string') {
     return new PouchConstructor(db);
   } else if (db.then) {
@@ -573,9 +574,8 @@ function replicateWrapper(src, target, opts, callback) {
   opts = utils.clone(opts);
   opts.continuous = opts.continuous || opts.live;
   var replicateRet = new Replication(opts);
-  var PouchConstructor = opts.pouchConstructor || Pouch;
-  toPouch(src, PouchConstructor).then(function (src) {
-    return toPouch(target, PouchConstructor).then(function (target) {
+  toPouch(src, opts).then(function (src) {
+    return toPouch(target, opts).then(function (target) {
       return genReplicationId(src, target, opts).then(function (repId) {
         replicate(repId, src, target, opts, replicateRet);
       });
@@ -588,3 +588,4 @@ function replicateWrapper(src, target, opts, callback) {
 }
 
 exports.replicate = replicateWrapper;
+exports.toPouch = toPouch;

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -1,6 +1,7 @@
 'use strict';
 var utils = require('./utils');
-var replicate = require('./replicate').replicate;
+var replication = require('./replicate');
+var replicate = replication.replicate;
 var EE = require('events').EventEmitter;
 
 module.exports = Sync;
@@ -30,9 +31,11 @@ function Sync(src, target, opts, callback) {
     complete = opts.complete;
     delete opts.complete;
   }
-  this.push = replicate(src, target, opts);
+  var srcPouch = replication.toPouch(src, opts);
+  var targPouch = replication.toPouch(target, opts);
+  this.push = replicate(srcPouch, targPouch, opts);
 
-  this.pull = replicate(target, src, opts);
+  this.pull = replicate(targPouch, srcPouch, opts);
   var emittedCancel = false;
   function onCancel(data) {
     if (!emittedCancel) {


### PR DESCRIPTION
currently it creates 2 e.g. double http calls all the way through
