### PR TITLE
(#2677) - local docs start at 0-1, don't save _revisions

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -1060,10 +1060,11 @@ function init(api, opts, callback) {
       callback = opts;
       opts = {};
     }
+    delete doc._revisions; // ignore this, trust the rev
     var oldRev = doc._rev;
     var id = doc._id;
     if (!oldRev) {
-      doc._rev = '0-0';
+      doc._rev = '0-1';
     } else {
       doc._rev = '0-' + (parseInt(oldRev.split('-')[1], 10) + 1);
     }

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -958,6 +958,7 @@ function LevelPouch(opts, callback) {
   };
 
   api._putLocal = function (doc, callback) {
+    delete doc._revisions; // ignore this, trust the rev
     var oldRev = doc._rev;
     var id = doc._id;
     stores.localStore.get(id, function (err, resp) {
@@ -970,7 +971,7 @@ function LevelPouch(opts, callback) {
         return callback(errors.REV_CONFLICT);
       }
       if (!oldRev) {
-        doc._rev = '0-0';
+        doc._rev = '0-1';
       } else {
         doc._rev = '0-' + (parseInt(oldRev.split('-')[1], 10) + 1);
       }

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -1205,11 +1205,12 @@ function WebSqlPouch(opts, callback) {
       callback = opts;
       opts = {};
     }
+    delete doc._revisions; // ignore this, trust the rev
     var oldRev = doc._rev;
     var id = doc._id;
     var newRev;
     if (!oldRev) {
-      newRev = doc._rev = '0-0';
+      newRev = doc._rev = '0-1';
     } else {
       newRev = doc._rev = '0-' + (parseInt(oldRev.split('-')[1], 10) + 1);
     }

--- a/tests/test.local_docs.js
+++ b/tests/test.local_docs.js
@@ -26,6 +26,27 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('local docs - put then get w/ revisions', function () {
+      var db = new PouchDB(dbs.name);
+      var doc = {
+        _id: '_local/foo'
+      };
+      return db.put(doc).then(function (res) {
+        res.id.should.equal('_local/foo');
+        res.rev.should.be.a('string');
+        res.ok.should.equal(true);
+        return db.get('_local/foo');
+      }).then(function (doc) {
+        should.not.exist(doc._revisions);
+        doc._revisions = {start: 0, ids: ['1']};
+        return db.put(doc);
+      }).then(function () {
+        return db.get('_local/foo');
+      }).then(function (doc) {
+        should.not.exist(doc._revisions);
+      });
+    });
+
     it('local docs - put then remove then get', function () {
       var db = new PouchDB(dbs.name);
       var doc = {_id: '_local/foo'};
@@ -56,6 +77,27 @@ adapters.forEach(function (adapter) {
         res.ok.should.equal(true);
         delete doc._rev;
         return db.put(doc);
+      });
+    });
+
+    it('local docs - put after remove, check return vals', function () {
+      // as long as it starts with 0-, couch
+      // treats it as a new local doc
+      var db = new PouchDB(dbs.name);
+      var doc = {_id: '_local/quux'};
+      return db.put(doc).then(function (res) {
+        res.rev.should.equal('0-1');
+        res.ok.should.equal(true);
+        doc._rev = res.rev;
+        return db.put(doc);
+      }).then(function (res) {
+        res.rev.should.equal('0-2');
+        res.ok.should.equal(true);
+        doc._rev = res.rev;
+        return db.put(doc);
+      }).then(function (res) {
+        res.rev.should.equal('0-3');
+        res.ok.should.equal(true);
       });
     });
 


### PR DESCRIPTION
Two things:
- local docs should start at 0-1, not 0-0. This is not strictly
  necessary to solve the bug, but I find it easier to understand
  when we do exactly the same thing as CouchDB.
- CouchDB tries to "help" us by also giving us a revision object
  (e.g. `"_revisions":{"start":0,"ids":["5"]}` for rev `'0-5'`),
  which we save ver batim and then return back when you do a GET
  on that same local doc. That confuses CouchDB and it ends up
  giving us the wrong _rev the next time it PUTs the doc.
