### PR TITLE
(#2655) - test and fix auto_compaction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,11 @@ env:
   - CLIENT=selenium:firefox COMMAND=test
   - CLIENT=selenium:phantomjs ES5_SHIM=true COMMAND=test
 
+  # Test auto-compaction in Node, Phantom, and Firefox
+  - AUTO_COMPACTION=true CLIENT=node COMMAND=test
+  - AUTO_COMPACTION=true CLIENT=selenium:firefox COMMAND=test
+  - AUTO_COMPACTION=true CLIENT=selenium:phantomjs ES5_SHIM=true COMMAND=test
+
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome COMMAND=test
   - CLIENT=saucelabs:chrome ADAPTERS=websql COMMAND=test

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -20,6 +20,9 @@ if (process.env.ES5_SHIM || process.env.ES5_SHIMS) {
 if (process.env.ADAPTERS) {
   queryParams.adapters = process.env.ADAPTERS;
 }
+if (process.env.AUTO_COMPACTION) {
+  queryParams.autoCompaction = true;
+}
 
 var indexfile = "./lib/index.js";
 var outfile = "./dist/pouchdb.js";

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -51,6 +51,9 @@ if (process.env.ADAPTERS) {
 if (process.env.ES5_SHIM || process.env.ES5_SHIMS) {
   qs.es5shim = true;
 }
+if (process.env.AUTO_COMPACTION) {
+  qs.autoCompaction = true;
+}
 testUrl += '?';
 testUrl += querystring.stringify(qs);
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -101,7 +101,8 @@ function AbstractPouchDB() {
   var self = this;
   EventEmitter.call(this);
   self.autoCompact = function (callback) {
-    if (!self.auto_compaction) {
+    // http doesn't have auto-compaction
+    if (!self.auto_compaction || self.type() === 'http') {
       return callback;
     }
     return function (err, res) {
@@ -115,6 +116,9 @@ function AbstractPouchDB() {
             callback(null, res);
           }
         };
+        if (!res.length) {
+          return callback(null, res);
+        }
         res.forEach(function (doc) {
           if (doc.ok && doc.id) { // if no id, then it was a local doc
             // TODO: we need better error handling
@@ -403,7 +407,7 @@ AbstractPouchDB.prototype.revsDiff =
 // by compacting we mean removing all revisions which
 // are further from the leaf in revision tree than max_height
 AbstractPouchDB.prototype.compactDocument =
-  function (docId, max_height, callback) {
+  utils.adapterFun('compactDocument', function (docId, max_height, callback) {
   var self = this;
   this._getRevisionTree(docId, function (err, rev_tree) {
     if (err) {
@@ -427,7 +431,7 @@ AbstractPouchDB.prototype.compactDocument =
     });
     self._doCompaction(docId, rev_tree, revs, callback);
   });
-};
+});
 
 // compact the whole database using single document
 // compaction

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -922,7 +922,7 @@ function LevelPouch(opts, callback) {
       var seqs = metadata.rev_map; // map from rev to seq
       metadata.rev_tree = rev_tree;
       if (!revs.length) {
-        callback();
+        return callback();
       }
       var batch = [];
       batch.push({

--- a/tests/test.defaults.js
+++ b/tests/test.defaults.js
@@ -1,5 +1,6 @@
 'use strict';
-if (!process.env.LEVEL_ADAPTER && !process.env.LEVEL_PREFIX) {
+if (!process.env.LEVEL_ADAPTER &&
+    !process.env.LEVEL_PREFIX && !process.env.AUTO_COMPACTION) {
   // these tests don't make sense for anything other than default leveldown
   var path = require('path');
   var mkdirp = require('mkdirp');

--- a/tests/test.issue915.js
+++ b/tests/test.issue915.js
@@ -1,5 +1,6 @@
 'use strict';
-if (!process.env.LEVEL_ADAPTER && !process.env.LEVEL_PREFIX) {
+if (!process.env.LEVEL_ADAPTER &&
+    !process.env.LEVEL_PREFIX && !process.env.AUTO_COMPACTION) {
   // these tests don't make sense for anything other than default leveldown
   var fs = require('fs');
   describe('Remove DB', function () {

--- a/tests/test.migration.js
+++ b/tests/test.migration.js
@@ -1,5 +1,6 @@
 'use strict';
-if (!process.env.LEVEL_ADAPTER && !process.env.LEVEL_PREFIX) {
+if (!process.env.LEVEL_ADAPTER &&
+    !process.env.LEVEL_PREFIX && !process.env.AUTO_COMPACTION) {
   // these tests don't make sense for anything other than default leveldown
   var fs = require('fs');
   var ncp = require('ncp').ncp;

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -365,6 +365,8 @@ if (typeof module !== 'undefined' && module.exports) {
       console.log('Using client-side leveldown prefix: ' + defaults.prefix);
     }
     global.PouchDB = global.PouchDB.defaults(defaults);
+  } else if (process.env.AUTO_COMPACTION) {
+    global.PouchDB = global.PouchDB.defaults({auto_compaction: true});
   }
   if (typeof process !== 'undefined') {
     testDir = process.env.TESTS_DIR ? process.env.TESTS_DIR : './tmp';

--- a/tests/webrunner.js
+++ b/tests/webrunner.js
@@ -47,9 +47,12 @@ function asyncLoadScript(url, callback) {
   firstScript.parentNode.insertBefore(script, firstScript);
 }
 
-function modifyAdapters() {
+function modifyGlobals() {
   if (preferredAdapters) {
     window.PouchDB.preferredAdapters = preferredAdapters;
+  }
+  if (window.location.search.indexOf('autoCompaction') !== -1) {
+    window.PouchDB = window.PouchDB.defaults({auto_compaction: true});
   }
 }
 
@@ -65,7 +68,7 @@ function startTests() {
   }
 
   function onReady() {
-    modifyAdapters();
+    modifyGlobals();
     var runner = mocha.run();
     window.results = {
       lastPassed: '',
@@ -102,14 +105,20 @@ if (window.cordova) {
       window.location.search.indexOf('grep') === -1;
   var hasEs5Shim = window.ES5_SHIM &&
       window.location.search.indexOf('es5Shim') === -1;
+  var hasAutoCompaction = window.AUTO_COMPACTION &&
+    window.location.search.indexOf('autoCompaction') === -1;
 
-  if (hasGrep || hasEs5Shim) {
+  if (hasGrep || hasEs5Shim || hasAutoCompaction) {
     var params = [];
     if (hasGrep) {
       params.push('grep=' + encodeURIComponent(window.GREP));
     }
     if (hasEs5Shim) {
       params.push('es5Shim=' + encodeURIComponent(window.ES5_SHIM));
+    }
+    if (hasAutoCompaction) {
+      params.push('autoCompaction=' +
+        encodeURIComponent(window.AUTO_COMPACTION));
     }
     window.location.search += (window.location.search ? '&' : '?') +
       params.join('&');


### PR DESCRIPTION
Predictably, there were a few bugs in auto_compaction, but not as many as I thought.

This adds a Travis test for each of Node, Phantom, and Firefox to test auto-compaction. I hate adding this many tests to Travis, but I don't see any other way to do it, since the compaction logic is different for all three adapters, and I want to play it safe.
