### PR TITLE
(#2685) - fix bogus conflicts, remove 20x speedup

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -4,6 +4,8 @@ var utils = require('./utils');
 var Pouch = require('./index');
 var EE = require('events').EventEmitter;
 
+var MAX_SIMULTANEOUS_REVS = 50;
+
 // We create a basic promise so the caller can cancel the replication possibly
 // before we have actually started listening to changes etc
 utils.inherits(Replication, EE);
@@ -205,61 +207,79 @@ function replicate(repId, src, target, opts, returnValue) {
     });
   }
 
-  function getDocs() {
-    var docIds = Object.keys(currentBatch.diffs);
-    if (!docIds.length) {
+
+  function getNextDoc() {
+    var diffs = currentBatch.diffs;
+    var id = Object.keys(diffs)[0];
+    var allMissing = diffs[id].missing;
+    // avoid url too long error by batching
+    var missingBatches = [];
+    for (var i = 0; i < allMissing.length; i += MAX_SIMULTANEOUS_REVS) {
+      missingBatches.push(allMissing.slice(i, Math.min(allMissing.length,
+        i + MAX_SIMULTANEOUS_REVS)));
+    }
+
+    return utils.Promise.all(missingBatches.map(function (missing) {
+      return src.get(id, {revs: true, open_revs: missing, attachments: true})
+        .then(function (docs) {
+          docs.forEach(function (doc) {
+            if (returnValue.cancelled) {
+              return completeReplication();
+            }
+            if (doc.ok) {
+              result.docs_read++;
+              currentBatch.pendingRevs++;
+              currentBatch.docs.push(doc.ok);
+              delete diffs[doc.ok._id];
+            }
+          });
+        });
+    }));
+  }
+
+  function getAllDocs() {
+    if (Object.keys(currentBatch.diffs).length > 0) {
+      return getNextDoc().then(getAllDocs);
+    } else {
       return utils.Promise.resolve();
     }
-    var idsToDocs = new utils.Map();
-    currentBatch.changes.forEach(function (change) {
-      idsToDocs.set(change.id, change.doc);
+  }
+
+
+  function getRevisionOneDocs() {
+    // filter out the generation 1 docs and get them
+    // leaving the non-generation one docs to be got otherwise
+    var ids = Object.keys(currentBatch.diffs).filter(function (id) {
+      var missing = currentBatch.diffs[id].missing;
+      return missing.length === 1 && missing[0].slice(0, 2) === '1-';
     });
-    return utils.Promise.all(docIds.map(function (docId) {
-      return mapToDocWithOpenRevs(docId, idsToDocs.get(docId));
-    })).then(function (docLists) {
-      docLists.forEach(function (docs) {
-        docs.forEach(processSourceDoc);
+    return src.allDocs({
+      keys: ids,
+      include_docs: true
+    }).then(function (res) {
+      if (returnValue.cancelled) {
+        completeReplication();
+        throw (new Error('cancelled'));
+      }
+      res.rows.forEach(function (row) {
+        if (row.doc && !row.deleted &&
+          row.value.rev.slice(0, 2) === '1-' && (
+            !row.doc._attachments ||
+            Object.keys(row.doc._attachments).length === 0
+          )
+        ) {
+          result.docs_read++;
+          currentBatch.pendingRevs++;
+          currentBatch.docs.push(row.doc);
+          delete currentBatch.diffs[row.id];
+        }
       });
     });
   }
 
-  function mapToDocWithOpenRevs(docId, doc) {
-    // as an optimization, we optimistically try to fetch all the open
-    // revs using just the docs returned from changes()
-    // if that's not possible, we do separate GETs for the open_revs
-    var missing = currentBatch.diffs[docId].missing;
-    var needOtherRevs = missing.length > 1 || missing[0] !== doc._rev;
-    if (doc._deleted || doc._attachments || needOtherRevs) {
-      // fetch individually (slower)
-      return src.get(docId, {
-        revs: true,
-        open_revs: "all", // avoid url too long error, don't send revs array
-        attachments: true
-      }).then(function (results) {
-        var missingMap = {};
-        missing.forEach(function (missingRev) {
-          missingMap[missingRev] = true;
-        });
-        return results.filter(function (res) {
-          var rev = res.ok ? res.ok._rev : res.missing;
-          return missingMap[rev];
-        });
-      });
-    }
-    return [{ok: doc}];
-  }
 
-  function processSourceDoc(doc) {
-    var diffs = currentBatch.diffs;
-    if (returnValue.cancelled) {
-      return completeReplication();
-    }
-    if (doc.ok) {
-      result.docs_read++;
-      currentBatch.pendingRevs++;
-      currentBatch.docs.push(doc.ok);
-      delete diffs[doc.ok._id];
-    }
+  function getDocs() {
+    return getRevisionOneDocs().then(getAllDocs);
   }
 
 
@@ -470,8 +490,7 @@ function replicate(repId, src, target, opts, returnValue) {
         batch_size: batch_size,
         style: 'all_docs',
         doc_ids: doc_ids,
-        returnDocs: false,
-        include_docs: true
+        returnDocs: false
       };
       if (opts.filter) {
         changesOpts.filter = opts.filter;


### PR DESCRIPTION
@daleharvey Correct me if I'm wrong, but shouldn't the `_conflicts` array be empty in these cases? For the remote db it's returning `['1-cf398aa8cceefcf9b8484d02bdaee3fe']` and for the local one, `['2-cf398aa8cceefcf9b8484d02bdaee3fe']`. Very bizarre.
