### PR TITLE
(#2704) - fix for npm release

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -11,6 +11,11 @@ VERSION=$(node --eval "console.log(require('./package.json').version);")
 git checkout -b build
 
 npm run build
+
+# Publish npm release with tests/scripts/goodies
+npm publish
+
+# Create git tag, which is also the Bower/Github release
 git add dist -f
 git add lib/version-browser.js
 git rm -r bin docs scripts tests vendor
@@ -20,9 +25,6 @@ git commit -m "build $VERSION"
 # Tag and push
 git tag $VERSION
 git push --tags git@github.com:pouchdb/pouchdb.git $VERSION
-
-# Publish JS modules
-npm publish
 
 # Cleanup
 git checkout master


### PR DESCRIPTION
So, I realized while doing the 3.0.3 release that it's not okay to remove `bin`, `tests`, or even `vendor` for the npm release, because all of those things are relied upon by pouchdb-server, express-pouchdb, Level's *down authors, etc.

So this fix is to only remove that crap for bower, basically.
