### PR TITLE
(#2698) - fix attachment md5 encoding

### DIFF
--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -28,6 +28,8 @@ var UPDATE_SEQ_KEY = '_local_last_update_seq';
 var DOC_COUNT_KEY = '_local_doc_count';
 var UUID_KEY = '_local_uuid';
 
+var MD5_PREFIX = 'md5-';
+
 function LevelPouch(opts, callback) {
   opts = utils.clone(opts);
   var api = this;
@@ -289,9 +291,9 @@ function LevelPouch(opts, callback) {
 
       if (process.browser) {
         if (opts.encode) {
-          data = utils.btoa(global.unescape(attach));
+          data = utils.btoa(attach);
         } else {
-          data = utils.createBlob([utils.fixBinary(global.unescape(attach))],
+          data = utils.createBlob([utils.fixBinary(attach)],
             {type: attachment.content_type});
         }
       } else {
@@ -490,18 +492,17 @@ function LevelPouch(opts, callback) {
         collectResults(err);
       }
 
-      function onMD5Load(doc, prefix, key, data, attachmentSaved) {
+      function onMD5Load(doc, key, data, attachmentSaved) {
         return function (result) {
-          saveAttachment(doc, prefix + result, key, data, attachmentSaved);
+          saveAttachment(doc, MD5_PREFIX + result, key, data, attachmentSaved);
         };
       }
 
-      function onLoadEnd(doc, prefix, key, attachmentSaved) {
+      function onLoadEnd(doc, key, attachmentSaved) {
         return function (e) {
-          var data = global.escape(
-            utils.arrayBufferToBinaryString(e.target.result));
+          var data = utils.arrayBufferToBinaryString(e.target.result);
           utils.MD5(data).then(
-            onMD5Load(doc, prefix, key, data, attachmentSaved)
+            onMD5Load(doc, key, data, attachmentSaved)
           );
         };
       }
@@ -516,30 +517,24 @@ function LevelPouch(opts, callback) {
         }
         var att = doc.data._attachments[key];
         var data;
-        var prefix;
         if (typeof att.data === 'string') {
           try {
             data = utils.atob(att.data);
-            if (process.browser) {
-              data = global.escape(data);
-            }
           } catch (e) {
             callback(utils.extend({}, errors.BAD_ARG,
               {reason: "Attachments need to be base64 encoded"}));
             return;
           }
-          prefix = process.browser ? 'md5-' : '';
         } else if (!process.browser) {
           data = att.data;
-          prefix = '';
         } else { // browser
           var reader = new FileReader();
-          reader.onloadend = onLoadEnd(doc, 'md5-', key, attachmentSaved);
+          reader.onloadend = onLoadEnd(doc, key, attachmentSaved);
           reader.readAsArrayBuffer(att.data);
           return;
         }
         utils.MD5(data).then(
-          onMD5Load(doc, prefix, key, data, attachmentSaved)
+          onMD5Load(doc, key, data, attachmentSaved)
         );
       }
 

--- a/lib/deps/md5.js
+++ b/lib/deps/md5.js
@@ -6,12 +6,18 @@ var setImmediateShim = global.setImmediate || global.setTimeout;
 
 function sliceShim(arrayBuffer, begin, end) {
   if (typeof arrayBuffer.slice === 'function') {
-    return arrayBuffer.slice(begin, end);
+    if (!begin) {
+      return arrayBuffer.slice();
+    } else if (!end) {
+      return arrayBuffer.slice(begin);
+    } else {
+      return arrayBuffer.slice(begin, end);
+    }
   }
   //
   // shim for IE courtesy of http://stackoverflow.com/a/21440217
   //
-  
+
   //If `begin`/`end` is unspecified, Chrome assumes 0, so we do the same
   //Chrome also converts the values to integers via flooring
   begin = Math.floor(begin || 0);
@@ -41,15 +47,50 @@ function sliceShim(arrayBuffer, begin, end) {
   return result;
 }
 
+// convert a 64-bit int to a binary string
+function intToString(int) {
+  var bytes = [
+    (int & 0xff),
+    ((int >>> 8) & 0xff),
+    ((int >>> 16) & 0xff),
+    ((int >>> 24) & 0xff)
+  ];
+  return bytes.map(function (byte) {
+    return String.fromCharCode(byte);
+  }).join('');
+}
+
+// convert an array of 64-bit ints into
+// a base64-encoded string
+function rawToBase64(raw) {
+  var res = '';
+  for (var i = 0; i < raw.length; i++) {
+    res += intToString(raw[i]);
+  }
+  return global.btoa(res);
+}
+
 module.exports = function (data, callback) {
   if (!process.browser) {
-    callback(null, crypto.createHash('md5').update(data).digest('hex'));
+    var base64 = crypto.createHash('md5').update(data).digest('base64');
+    callback(null, base64);
     return;
   }
-  var chunkSize = Math.min(524288, data.length);
-  var chunks = Math.ceil(data.length / chunkSize);
+  var inputIsString = typeof data === 'string';
+  var len = inputIsString ? data.length : data.byteLength;
+  var chunkSize = Math.min(524288, len);
+  var chunks = Math.ceil(len / chunkSize);
   var currentChunk = 0;
-  var buffer = new Md5();
+  var buffer = inputIsString ? new Md5() : new Md5.ArrayBuffer();
+
+  function append(buffer, data, start, end) {
+    if (inputIsString) {
+      buffer.appendBinary(data.substring(start, end));
+    } else {
+      buffer.append(sliceShim(data, start, end));
+    }
+  }
+
   function loadNextChunk() {
     var start = currentChunk * chunkSize;
     var end = start + chunkSize;
@@ -58,11 +99,13 @@ module.exports = function (data, callback) {
     }
     currentChunk++;
     if (currentChunk < chunks) {
-      buffer.append(sliceShim(data, start, end));
+      append(buffer, data, start, end);
       setImmediateShim(loadNextChunk);
     } else {
-      buffer.append(sliceShim(data, start, end));
-      callback(null, buffer.end());
+      append(buffer, data, start, end);
+      var raw = buffer.end(true);
+      var base64 = rawToBase64(raw);
+      callback(null, base64);
       buffer.destroy();
     }
   }

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -57,6 +57,10 @@ function genReplicationId(src, target, opts) {
       var queryData = src_id + target_id + filterFun +
         JSON.stringify(opts.query_params) + opts.doc_ids;
       return utils.MD5(queryData).then(function (md5) {
+        // can't use straight-up md5 alphabet, because
+        // the char '/' is interpreted as being for attachments,
+        // and + is also not url-safe
+        md5 = md5.replace(/\//g, '.').replace(/\+/g, '_');
         return '_local/' + md5;
       });
     });

--- a/tests/test.attachments.js
+++ b/tests/test.attachments.js
@@ -8,6 +8,23 @@ var repl_adapters = [
   ['local', 'local']
 ];
 
+/* jshint maxlen:false */
+var icons = [
+  "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAABIAAAASABGyWs+AAAACXZwQWcAAAAQAAAAEABcxq3DAAAC8klEQVQ4y6WTS2hcZQCFv//eO++ZpDMZZjKdZB7kNSUpeWjANikoWiMUtEigBdOFipS6Ercu3bpTKF23uGkWBUGsoBg1KRHapjU0U81rpp3ESdNMZu6dx70zc38XdSFYVz1wNmdxzuKcAy8I8RxNDfs705ne5FmX0+mXUtK0mka2kLvxRC9vAe3nGmRiCQ6reux4auDi6ZenL0wOjaa6uoKK2+kgv1O0l1dvby/8/tvVe1t/XAn6ArvZ3fyzNIBjsQS5YiH6/ul3v/z0/AcfTx8fC24+zgvV4SXccYTtYlGM9MSDMydee1W27OQPd5d+Hujure4bZRQVeLCTY2p44tJ7M2/Pjg1lOLQkXy2scP3OQ1b3Snzx3SK/PCoxOphh7q13ZqeGJy492MmhAkoyHMUlRN8b4yfnBnqSWLqJItzkXZPoWhzF4WZdjGJ6+7H0OoPxFG9OnppzCtGXCEdRZ16axu1yffjRmfPnYqEw7WIdj1OlO6wx1e0g7hckO1ReH4wSrkgUVcEfDITub6w9Gus7tqS4NAcOVfMpCFq2jdrjwxv2cG48SejPFe59/gmnyuuMHA0ien0oR1x0BgJ4XG5fwO9Hk802sm3TbFiYVhNNU1FUBYCBsRNEmiad469gYyNUgRDPipNIQKKVajo1s1F9WjqgVjZQELg9Ek3TUFNHCaXnEEiQEvkPDw4PqTfMalk3UKt1g81ioRgLRc6MxPtDbdtGKgIhBdgSKW2kLWm327SaLayGxfzCzY2vf/zms0pVLyn7lQOadbmxuHb7WrawhW220J+WKZXK6EaNsl7F0GsYep1q3eTW6grfLv90zZRyI7dfRDNtSPdE+av05PL8re+HgdlMPI2wJXrDRAACgdVusfZ4k+uLN+eXs/cvp7oitP895UQogt6oxYZiiYsnMxMXpjPjqaC/QwEoGRX71+yd7aXs3asPd/NXAm7vbv5g7//P1OHxpvsj8bMep8sPULdMY32vcKNSr/3nTC+MvwEdhUhhkKTyPgAAAEJ0RVh0Y29tbWVudABGaWxlIHNvdXJjZTogaHR0cDovL3d3dy5zc2J3aWtpLmNvbS9GaWxlOktpcmJ5SGVhZFNTQkIucG5nSbA1rwAAACV0RVh0Y3JlYXRlLWRhdGUAMjAxMC0xMi0xNFQxNjozNDoxMCswMDowMDpPBjcAAAAldEVYdG1vZGlmeS1kYXRlADIwMTAtMTAtMDdUMjA6NTA6MzYrMDA6MDCjC6s7AAAAAElFTkSuQmCC",
+  "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAC3ElEQVQ4jX2SX2xTdRzFP/d3f5d7u7ZbGes6LyAFWSiNmbMuSqb4wgxGVMiYT/BkNPMNfV1MDAFfNDHxwWSJU4wsMsKLEhI3gmE0JHO6FTBzMrZlS3V3Qun+sG70tvePD4ZlI8BJvi/fc/LN9+QceAIanm1oa2xo7HuSRn0c0dUq5fbd2teerLRHxqzuhzjDEs+0VYSrT4vHHbAW1ZrWg9aeYweurdv3vCsTL7Yy+GmHfcb3/Qn5T49MCYMW85Dz2Vphdl6jWPLJjmAOfSN/QsFY+ZdfNic5tuUFzLEfZjOLi1Xt5C7J44VJ6V/9Up546M0NFz/Xhp070l8789elf65DH3wvFYoACK2KNiMMz79Nx9ojEZOWP/Lx1NCv/7v8fTDK0fe34QF/ZsS5rkxhAUC4ZZJeGfQgovFNPu4+KtsAYsWad+rjM1TqHvcsqNmUY59pow/HqI07b62msEtqwijzku4inXmorqXllWpxybgb3f/akVLi7lAJ60KA+gMOTTcSWKc1rgZyi1f+8joB1PPDbn85W/GzYxOL1XgJaRDoTW9ID8ysnKyK24dSh/3auoSGUuGQFxb2UzlERL19Nu12AkiArkwhA6HDT29yLi+j1s3Oih/royUZjXihYg5W7txH5EGrhI17wMy6yWRUT47m7NHVHmypcirnl8SO6pBnNiWdr4q6+kZksxI3oiDCsLwE9/LARlguIm/lXbmuif3TTjG4Ejj724RbDuleezimbHv1dW/rrTQE62ByRLC8AJ4C2SkIIiauTbsD65rYlSlYp9LlTy5muBkx/WYZgMQ++HtcsGunR33S5+Y4NKcgHFQAeGSV09PsnZtRuu05uD8LZsDDXgDXhubd0DfAaM9l7/t1FtbC871Sbk5MbdX5oHwbOs+ovVPj9C7N0VhyUfv61Q/7x0qDqyk8CnURZcdkzufbC0p7bVn77otModRkGqdefs79qOj7xgPdf3d0KpBuuY7dAAAAAElFTkSuQmCC",
+  "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAABZ0RVh0Q3JlYXRpb24gVGltZQAwMS8wNy8wOCumXF8AAAAfdEVYdFNvZnR3YXJlAE1hY3JvbWVkaWEgRmlyZXdvcmtzIDi1aNJ4AAADHElEQVQ4EYXBe0wUBADH8R/CcSccQnfcIcbrXgRixKPSMIxklU4tJOUfyflIcmVJzamTVjJrJIRa6OZ4DmGMwSoEfKIVkcTC5qNRmqxpuki3VFiIjMc33fijka3PR/o3s7/R+Hl8QTgpxz2kHHWTuC8Cf7PxlCSr/ke0Ndrc5ioPJejONHxHjfiOGAkYNuNqDMX2WEC3pCf0H2LMScbLMcciiB0KJGbcwMy7RmYOG4kdMxA7EkBsRySB6X43JM3TJD6aoT3OvOlsPxVNX+807oyJ/rtiYFgMI271mdjdEcMjhQ8jl1eNpEDdV/PugrajpZu/ejndwafvpdB/1sHtS+EM/m4BBGNTuNCawPk2B6M3jNRXRvJSmpOG4je7Gj5Yekw7spLPXe8s42xdMfXvuzh3OIHerihADP1poeuQP0f2vMbX5fmcbnHS3eDg+6oCbp+ppWjV3Iu6Lzf10fzGotnUFVmp2pBGX3sS54+7KXsribq8V/nrl2aun66gfOOLnKx0cqLqKTalP14iyaQJ7uwsH/p7oli/OJV31q7i7bREmovfYPBSE83FG1m37BVWL17I1W8cbMn1RdIz+ofpCdHBtcvnhIxXf5zLjjLI23qQ4StNjF5rpSi/ltyd0FK9k8xk23hqQuhBSW49QGlOZjwdpZ8w2NsDV9vh8klGfvuJzuoytq6cjTTlM0l+msT0kMu6u/Bw3uBHza+zaJmFwsol7G3MoaRxHbtqMslcYWNb1Qr2dxYMRSSFV0iyaoItLjrizIUf6znRuZ/EjCie3+5iXomTZw+EMb82jNQSB8996CYxI5za5gKuXDvE00/O6pXk0T3BnoiQ75r2bSNnw3JU5sWc9iCy17j441cTQzcN5Kx3kdpqxesLsXTtCxwpzyc5ztEjyaUJBkmrJR0wxHtjrQjC+XMIK2/5kjPgg/uiHXuDBUOKN5JaJK2RFKhJkrItQTe7Z8SRNTUMc6QBebx+kMfrW98obxaZQ+mwz2KTLXhA0hI9gGuuv3/TZruNDL9grDKVS5qqe8wyFC00Wdlit7MgIOBLSYma8DfYI5E1lrjnEQAAAABJRU5ErkJggg==",
+  "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAB1klEQVR42n2TzytEURTHv3e8N1joRhZGzJsoCjsLhcw0jClKWbHwY2GnLGUlIfIP2IjyY2djZTHSMJNQSilFNkz24z0/Ms2MrnvfvMu8mcfZvPvuPfdzz/mecwgKLNYKb0cFEgXbRvwV2s2HuWazCbzKA5LvNecDXayBjv9NL7tEpSNgbYzQ5kZmAlSXgsGGXmS+MjhKxDHgC+quyaPKQtoPYMQPOh5U9H6tBxF+Icy/aolqAqLP5wjWd5r/Ip3YXVILrF4ZRYAxDhCOJ/yCwiMI+/xgjOEzmzIhAio04GeGayIXjQ0wGoAuQ5cmIjh8jNo0GF78QwNhpyvV1O9tdxSSR6PLl51FnIK3uQ4JJQME4sCxCIRxQbMwPNSjqaobsfskm9l4Ky6jvCzWEnDKU1ayQPe5BbN64vYJ2vwO7CIeLIi3ciYAoby0M4oNYBrXgdgAbC/MhGCRhyhCZwrcEz1Ib3KKO7f+2I4iFvoVmIxHigGiZHhPIb0bL1bQApFS9U/AC0ulSXrrhMotka/lQy0Ic08FDeIiAmDvA2HX01W05TopS2j2/H4T6FBVbj4YgV5+AecyLk+CtvmsQWK8WZZ+Hdf7QGu7fobMuZHyq1DoJLvUqQrfM966EU/qYGwAAAAASUVORK5CYII=",
+  "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAEG0lEQVQ4EQEQBO/7AQAAAAAAAAAAAAAAAAAAAACmm0ohDxD8bwT//ksOBPAhAAAAAPL8EN8IDQLB5eQEhVpltt8AAAAAAAAAAAAAAAABAAAAAAAAAACHf0UGKSgBgygY7m/w4O8F5t71ABMaCQAPEAQAAAAAAPwEBgAMFAn74/ISnunoA3RcZ7f2AAAAAAEAAAAAh39FBjo4AZYTAOtf1sLmAvb1+gAAAAAALzsVACEn+wAAAAAA/f4G/+LcAgH9AQIA+hAZpuDfBmhaZrb1AwAAAABtaCSGHAjraf///wD47/kB9vX7AAAAAAAYHgsAERT+AAAAAAACAf0BERT/AAQHB/746/IuBRIMFfL3G8ECpppKHigY7m/68vcCHRv0AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA//0ADgvzAgP//gAWBe1hUEgMOgIKDfxr9Oz3BRsiAf8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHCP///zu8gMjIftYAgkD/1ID//4ABwb6Af//AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFBPwBAAAAAAP0710CDgTvIQD//QAAAP8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD//QD8BAYADQv//gQAAAAAAAAAAAAAAgABAf4AAAAAAAAAAAAAAAAAAAAAAAABAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAP//gAAAAAABPL7D+D57Owh0MQAAAAAAAD08/sAAAAAAAAAAADj2fQA8ewGAAAAAAAAAAAAAAAAAAAAAAAAAAAA+/r1AAwECwIEAggDugsNBGcAAAAAAwMBAO7o+AAAAAAAAAAAAAgKBAAOEAUAAAAAAAAAAAAAAAAAAAAAAAAAAADz8vwA/QwRowTr6gSLHSQQYvfr9QUhJ/sA6OEEAPPy+QAAAAAAFR0IACEn+wAAAAAAAAAAAAAAAAAAAAAA4+YP/g0OAgDT3wWoAlpltt/d7BKYBAwH/uTmDf4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPL1Df798fUC+AgSqMfL9sICAAAAAOblAHXzBRSo////APTz+wD//wAAAAAAAAAAAAAAAAAAAAEBAP3+Bv/j5g/+7uL3AukDH97g3wZomJzA9wMAAAAAs7jd/kE8J7n9BwoSJSgGMQYD/wL++/8ABAUCAPb1BQDw7AIA8e8DAQAFBf/0DBqj6OgGTlpmtvUAAAAAAQAAAAAAAAAAAAAAAFFRPg1SSAwbGxv8cQn67mMHBf7/AwL/APb5AwH/DRCn294GpMLH9sKdoMD3AAAAAAAAAABEawlCEphz4AAAAABJRU5ErkJggg=="
+];
+
+var iconDigests = [
+  "md5-Mf8m9ehZnCXC717bPkqkCA==",
+  "md5-fdEZBYtnvr+nozYVDzzxpA==",
+  "md5-ImDARszfC+GA3Cv9TVW4HA==",
+  "md5-hBsgoz3ujHM4ioa72btwow==",
+  "md5-jDUyV6ySnTVANn2qq3332g=="
+];
+
 adapters.forEach(function (adapter) {
   describe('test.attachments.js-' + adapter, function () {
 
@@ -21,7 +38,6 @@ adapters.forEach(function (adapter) {
     after(function (done) {
       testUtils.cleanup([dbs.name], done);
     });
-
 
     var binAttDoc = {
       _id: 'bin_doc',
@@ -642,6 +658,52 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('putAttachment and getAttachment with plaintext', function (done) {
+      var db = new PouchDB(dbs.name);
+      db.put({ _id: 'foo' }, function (err, res) {
+        db.get('foo', function (err, doc) {
+          var data = binAttDoc._attachments['foo.txt'].data;
+          var blob = testUtils
+            .makeBlob(PouchDB.utils.fixBinary(PouchDB.utils.atob(data)),
+              'text/plain');
+          db.putAttachment('foo', 'foo.txt', doc._rev, blob, 'text/plain',
+                           function (err, info) {
+            should.not.exist(err, 'attachment inserted');
+            db.getAttachment('foo', 'foo.txt', function (err, blob) {
+              should.not.exist(err, 'attachment gotten');
+              testUtils.readBlob(blob, function (returnedData) {
+                PouchDB.utils.btoa(returnedData).should.equal(data);
+                db.get('foo', function (err, doc) {
+                  should.not.exist(err, 'err on get');
+                  delete doc._attachments["foo.txt"].revpos;
+                  delete doc._attachments["foo.txt"].length;
+
+                  // couchdb encodes plaintext strings differently from us
+                  // because of libicu vs. ascii. that's okay
+                  var digest = doc._attachments["foo.txt"].digest;
+                  var validDigests = [
+                    "md5-qUUYqS41RhwF0TrCsTAxFg==",
+                    "md5-aEI7pOYCRBLTRQvvqYrrJQ=="
+                  ];
+                  validDigests.indexOf(digest).should.not.equal(-1,
+                    'expected ' + digest  + ' to be in: ' +
+                      JSON.stringify(validDigests));
+                  delete doc._attachments["foo.txt"].digest;
+                  doc._attachments.should.deep.equal({
+                    "foo.txt": {
+                      "content_type": "text/plain",
+                      "stub": true
+                    }
+                  });
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
     it('putAttachment and getAttachment with png data', function (done) {
       var db = new PouchDB(dbs.name);
       db.put({ _id: 'foo' }, function (err, res) {
@@ -657,7 +719,19 @@ adapters.forEach(function (adapter) {
               should.not.exist(err, 'attachment gotten');
               testUtils.readBlob(blob, function (returnedData) {
                 PouchDB.utils.btoa(returnedData).should.equal(data);
-                done();
+                db.get('foo', function (err, doc) {
+                  should.not.exist(err, 'err on get');
+                  delete doc._attachments["foo.png"].revpos;
+                  delete doc._attachments["foo.png"].length;
+                  doc._attachments.should.deep.equal({
+                    "foo.png": {
+                      "content_type": "image/png",
+                      "digest": "md5-c6eA+rofKUsstTNQBKUc8A==",
+                      "stub": true
+                    }
+                  });
+                  done();
+                });
               });
             });
           });
@@ -671,8 +745,6 @@ adapters.forEach(function (adapter) {
     if (!isSafari) {
       // skip in safari/ios because of size limit popup
       it('putAttachment and getAttachment with big png data', function (done) {
-
-        this.timeout(20000);
 
         function getData(cb) {
           if (typeof process !== 'undefined' && !process.browser) {
@@ -706,7 +778,19 @@ adapters.forEach(function (adapter) {
                   should.not.exist(err, 'attachment gotten');
                   testUtils.readBlob(blob, function (returnedData) {
                     PouchDB.utils.btoa(returnedData).should.equal(data);
-                    done();
+                    db.get('foo', function (err, doc) {
+                      should.not.exist(err, 'err on get');
+                      delete doc._attachments["foo.png"].revpos;
+                      delete doc._attachments["foo.png"].length;
+                      doc._attachments.should.deep.equal({
+                        "foo.png": {
+                          "content_type": "image/png",
+                          "digest": "md5-kqr2YcdElgDs3RkMn1Ygbw==",
+                          "stub": true
+                        }
+                      });
+                      done();
+                    });
                   });
                 });
               });
@@ -793,6 +877,86 @@ repl_adapters.forEach(function (adapters) {
         var keys = Object.keys(doc._attachments);
         keys.sort();
         keys.should.deep.equal(['foo1.txt', 'foo2.txt', 'foo3.txt']);
+      });
+    });
+
+    it('Multiple attachments replicate, different docs (#2698)', function () {
+      var db = new PouchDB(dbs.name);
+      var remote = new PouchDB(dbs.remote);
+      var docs = [];
+      for (var i = 0; i < 5; i++) {
+        docs.push({
+          _id: i.toString(),
+          _attachments: {
+            'foo.txt': {
+              data: 'VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ=',
+              content_type: 'text/plain'
+            }
+          }
+        });
+      }
+      return remote.bulkDocs(docs).then(function (info) {
+        return remote.replicate.to(db);
+      }).then(function () {
+        return db.allDocs();
+      }).then(function (res) {
+        return PouchDB.utils.Promise.all(res.rows.map(function (row) {
+          return db.get(row.id, {attachments: true});
+        }));
+      }).then(function (docs) {
+        var attachments = docs.map(function (doc) {
+          delete doc._attachments['foo.txt'].revpos;
+          delete doc._attachments['foo.txt'].digest;
+          return doc._attachments;
+        });
+        attachments.should.deep.equal([1, 2, 3, 4, 5].map(function () {
+          return {
+            "foo.txt": {
+              "content_type": "text/plain",
+              "data": "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ="
+            }
+          };
+        }));
+      });
+    });
+
+    it('Multiple attachments replicate, different docs png (#2698)', function () {
+      var db = new PouchDB(dbs.name);
+      var remote = new PouchDB(dbs.remote);
+      var docs = [];
+      for (var i = 0; i < 5; i++) {
+        docs.push({
+          _id: i.toString(),
+          _attachments: {
+            'foo.png': {
+              data: icons[i],
+              content_type: 'image/png'
+            }
+          }
+        });
+      }
+      return remote.bulkDocs(docs).then(function (info) {
+        return remote.replicate.to(db);
+      }).then(function () {
+        return db.allDocs();
+      }).then(function (res) {
+        return PouchDB.utils.Promise.all(res.rows.map(function (row) {
+          return db.get(row.id, {attachments: true});
+        }));
+      }).then(function (docs) {
+        var attachments = docs.map(function (doc) {
+          delete doc._attachments['foo.png'].revpos;
+          return doc._attachments;
+        });
+        attachments.should.deep.equal(icons.map(function (icon, i) {
+          return {
+            "foo.png": {
+              "content_type": "image/png",
+              "data": icon,
+              "digest": iconDigests[i]
+            }
+          };
+        }));
       });
     });
   });

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -42,7 +42,7 @@ testUtils.couchHost = function () {
 
 testUtils.makeBlob = function (data, type) {
   if (typeof module !== 'undefined' && module.exports) {
-    return new Buffer(data);
+    return new Buffer(data, 'binary');
   } else {
     return PouchDB.utils.createBlob([data], { type: type });
   }
@@ -50,7 +50,7 @@ testUtils.makeBlob = function (data, type) {
 
 testUtils.readBlob = function (blob, callback) {
   if (typeof module !== 'undefined' && module.exports) {
-    callback(blob.toString());
+    callback(blob.toString('binary'));
   } else {
     var reader = new FileReader();
     reader.onloadend = function (e) {


### PR DESCRIPTION
This also significantly augments our test coverage,
because we're now testing that the md5sum we get
back from our md5 algorithm is exactly the same as
CouchDB's. The only exception if for plaintext, which
CouchDB hashes differently due to using ICU instead of
ASCII.
