### PR TITLE
Use a real PNG dataurl to detect blob support

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -1240,7 +1240,7 @@ function init(api, opts, callback) {
       // in version 37 they had a broken version where PNGs (and possibly
       // other binary types) aren't stored correctly.
       try {
-        var blob = utils.createBlob([''], {type: 'image/png'});
+        var blob = utils.createBlob([atob('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=')], {type: 'image/png'});
         txn.objectStore(DETECT_BLOB_SUPPORT_STORE).put(blob, 'key');
         txn.oncomplete = function () {
           // have to do it in a separate transaction, else the correct


### PR DESCRIPTION
Using an empty string results in a 404 error on Chrome 37, probably a security protection. Using a real png string (transparent one pixel) then no 404 happens.
`res.type` evaluates to `'none'`, so the detecting still works, detecting Chrome37 does not have blobsupport
