### PR TITLE
(#2735) - always populate the default constructor

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -550,7 +550,7 @@ function replicate(repId, src, target, opts, returnValue) {
   }
 }
 
-
+exports.toPouch = toPouch;
 function toPouch(db, opts) {
   var PouchConstructor = opts.PouchConstructor;
   if (typeof db === 'string') {
@@ -563,7 +563,8 @@ function toPouch(db, opts) {
 }
 
 
-exports.replicate = function replicateWrapper(src, target, opts, callback) {
+exports.replicate = replicateWrapper;
+function replicateWrapper(src, target, opts, callback) {
   if (typeof opts === 'function') {
     callback = opts;
     opts = {};
@@ -576,6 +577,7 @@ exports.replicate = function replicateWrapper(src, target, opts, callback) {
   }
   opts = utils.clone(opts);
   opts.continuous = opts.continuous || opts.live;
+  /*jshint validthis:true */
   opts.PouchConstructor = opts.PouchConstructor || this;
   var replicateRet = new Replication(opts);
   toPouch(src, opts).then(function (src) {
@@ -589,6 +591,4 @@ exports.replicate = function replicateWrapper(src, target, opts, callback) {
     opts.complete(err);
   });
   return replicateRet;
-};
-
-exports.toPouch = toPouch;
+}

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -4,13 +4,9 @@ var replication = require('./replicate');
 var replicate = replication.replicate;
 var EE = require('events').EventEmitter;
 
-module.exports = Sync;
 utils.inherits(Sync, EE);
-function Sync(src, target, opts, callback) {
-  if (!(this instanceof Sync)) {
-    return new Sync(src, target, opts, callback);
-  }
-  var self = this;
+module.exports = sync;
+function sync(src, target, opts, callback) {
   if (typeof opts === 'function') {
     callback = opts;
     opts = {};
@@ -18,8 +14,17 @@ function Sync(src, target, opts, callback) {
   if (typeof opts === 'undefined') {
     opts = {};
   }
-  this.canceled = false;
   opts = utils.clone(opts);
+  /*jshint validthis:true */
+  opts.PouchConstructor = opts.PouchConstructor || this;
+  src = replication.toPouch(src, opts);
+  target = replication.toPouch(target, opts);
+  return new Sync(src, target, opts, callback);
+}
+function Sync(src, target, opts, callback) {
+  var self = this;
+  this.canceled = false;
+  
   var onChange, complete;
   if ('onChange' in opts) {
     onChange = opts.onChange;
@@ -31,11 +36,10 @@ function Sync(src, target, opts, callback) {
     complete = opts.complete;
     delete opts.complete;
   }
-  var srcPouch = replication.toPouch(src, opts);
-  var targPouch = replication.toPouch(target, opts);
-  this.push = replicate(srcPouch, targPouch, opts);
 
-  this.pull = replicate(targPouch, srcPouch, opts);
+  this.push = replicate(src, target, opts);
+
+  this.pull = replicate(target, src, opts);
   var emittedCancel = false;
   function onCancel(data) {
     if (!emittedCancel) {

--- a/tests/test.sync.js
+++ b/tests/test.sync.js
@@ -332,5 +332,28 @@ adapters.forEach(function (adapters) {
         });
       });
     });
+    it('PouchDB.sync with strings for dbs', function (done) {
+      var doc1 = {
+          _id: 'adoc',
+          foo: 'bar'
+        };
+      var doc2 = {
+          _id: 'anotherdoc',
+          foo: 'baz'
+        };
+      var db = new PouchDB(dbs.name);
+      var remote = new PouchDB(dbs.remote);
+      db.put(doc1).then(function () {
+        return remote.put(doc2);
+      }).then(function () {
+        return PouchDB.sync(dbs.name, dbs.remote);
+      }).then(function (result) {
+        result.pull.ok.should.equal(true);
+        result.pull.docs_read.should.equal(1);
+        result.pull.docs_written.should.equal(1);
+        result.pull.errors.should.have.length(0);
+        done();
+      }, done);
+    });
   });
 });


### PR DESCRIPTION
fixes an issue with syncing while refering to dbs by name instead of by object
