### PR TITLE
(#2442) - Save replication fields in doc (follow-up)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,6 +44,18 @@ var reservedWords = toObject([
   '_replication_state_reason',
   '_replication_stats'
 ]);
+
+// List of reserved words that should end up the document
+var dataWords = toObject([
+  '_attachments',
+  //replication documents
+  '_replication_id',
+  '_replication_state',
+  '_replication_state_time',
+  '_replication_state_reason',
+  '_replication_stats'
+]);
+
 exports.clone = function (obj) {
   return exports.extend(true, {}, obj);
 };
@@ -217,7 +229,7 @@ exports.parseDoc = function (doc, newEdits) {
         error = new Error(errors.DOC_VALIDATION.message + ': ' + key);
         error.status = errors.DOC_VALIDATION.status;
         throw error;
-      } else if (specialKey && key !== '_attachments') {
+      } else if (specialKey && !dataWords[key]) {
         result.metadata[key.slice(1)] = doc[key];
       } else {
         result.data[key] = doc[key];

--- a/tests/test.basics.js
+++ b/tests/test.basics.js
@@ -492,9 +492,19 @@ adapters.forEach(function (adapter) {
         '_replication_stats': {}
       };
       var db = new PouchDB(dbs.name);
-      db.post(doc, function (err, res) {
+      db.post(doc, function (err, resp) {
         should.not.exist(err);
-        done();
+
+        db.get(resp.id, function (err, doc2) {
+          should.not.exist(err);
+
+          doc2._replication_id.should.equal('test');
+          doc2._replication_state.should.equal('triggered');
+          doc2._replication_state_time.should.equal(1);
+          doc2._replication_stats.should.eql({});
+
+          done();
+        });
       });
     });
 


### PR DESCRIPTION
Now replication fields are saved as data, not as metadata, which meant they disappeared.
