### PR TITLE
basic opt-in replication - retry

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -4,13 +4,69 @@ var utils = require('./utils');
 var EE = require('events').EventEmitter;
 
 var MAX_SIMULTANEOUS_REVS = 50;
-
+function randomNumber(min, max) {
+  min = parseInt(min, 10);
+  max = parseInt(max, 10);
+  if (min !== min) {
+    min = 0;
+  }
+  if (max !== max || max <= min) {
+    max = (min || 1) << 1; //doubling
+  } else {
+    max = max + 1;
+  }
+  var ratio = Math.random();
+  var range = max - min;
+    
+  return ~~(range * ratio + min); // ~~ coerces to an int, but fast.
+}
+function defaultBackOff(min) {
+  var max = 0;
+  if (!min) {
+    max = 2000;
+  }
+  return randomNumber(min, max);
+}
+function backOff(repId, src, target, opts, returnValue, result, error) {
+  if (opts.retry === false) {
+    returnValue.emit('error', error);
+    returnValue.removeAllListeners();
+    return;
+  }
+  opts.default_back_off = opts.default_back_off || 0;
+  opts.retries = opts.retries || 0;
+  if (typeof opts.back_off_function !== 'function') {
+    opts.back_off_function = defaultBackOff;
+  }
+  opts.retries++;
+  if (opts.max_retries && opts.retries > opts.max_retries) {
+    returnValue.emit('error', new Error('tried ' +
+      opts.retries + ' times but replication failed'));
+    returnValue.removeAllListeners();
+    return;
+  }
+  returnValue.emit('requestError', error);
+  if (returnValue.state === 'active') {
+    returnValue.emit('syncStopped');
+    returnValue.state = 'stopped';
+    returnValue.once('syncRestarted', function () {
+      opts.current_back_off = opts.default_back_off;
+    });
+  }
+  
+  opts.current_back_off = opts.current_back_off || opts.default_back_off;
+  opts.current_back_off = opts.back_off_function(opts.current_back_off);
+  setTimeout(function () {
+    replicate(repId, src, target, opts, returnValue);
+  }, opts.current_back_off);
+}
 // We create a basic promise so the caller can cancel the replication possibly
 // before we have actually started listening to changes etc
 utils.inherits(Replication, EE);
 function Replication(opts) {
   EE.call(this);
   this.cancelled = false;
+  this.state = 'pending';
   var self = this;
   var promise = new utils.Promise(function (fulfill, reject) {
     self.once('complete', fulfill);
@@ -25,15 +81,26 @@ function Replication(opts) {
   // As we allow error handling via "error" event as well,
   // put a stub in here so that rejecting never throws UnhandledError.
   self.catch(function (err) {});
+
 }
 
 Replication.prototype.cancel = function () {
   this.cancelled = true;
+  this.state = 'cancelled';
   this.emit('cancel');
 };
 
 Replication.prototype.ready = function (src, target) {
   var self = this;
+  this.once('change', function () {
+    if (this.state === 'pending') {
+      self.state = 'active';
+      self.emit('syncStarted');
+    } else if (self.state === 'stopped') {
+      self.state = 'active';
+      self.emit('syncRestarted');
+    }
+  });
   function onDestroy() {
     self.cancel();
   }
@@ -146,7 +213,7 @@ Checkpointer.prototype.getCheckpoint = function () {
     return 0;
   });
 };
-function replicate(repId, src, target, opts, returnValue) {
+function replicate(repId, src, target, opts, returnValue, result) {
   var batches = [];               // list of batches to be processed
   var currentBatch;               // the batch currently being processed
   var pendingBatch = {
@@ -163,8 +230,11 @@ function replicate(repId, src, target, opts, returnValue) {
   var batches_limit = opts.batches_limit || 10;
   var changesPending = false;     // true while src.changes is running
   var doc_ids = opts.doc_ids;
-  var checkpointer = new Checkpointer(src, target, repId, returnValue);
-  var result = {
+  var state = {
+    cancelled: false
+  };
+  var checkpointer = new Checkpointer(src, target, repId, state);
+  result = result || {
     ok: true,
     start_time: new Date(),
     docs_read: 0,
@@ -174,6 +244,7 @@ function replicate(repId, src, target, opts, returnValue) {
   };
   var changesOpts = {};
   returnValue.ready(src, target);
+
 
 
   function writeDocs() {
@@ -186,7 +257,7 @@ function replicate(repId, src, target, opts, returnValue) {
     }, {
       new_edits: false
     }).then(function (res) {
-      if (returnValue.cancelled) {
+      if (state.cancelled) {
         completeReplication();
         throw new Error('cancelled');
       }
@@ -232,7 +303,7 @@ function replicate(repId, src, target, opts, returnValue) {
       return src.get(id, {revs: true, open_revs: missing, attachments: true})
         .then(function (docs) {
           docs.forEach(function (doc) {
-            if (returnValue.cancelled) {
+            if (state.cancelled) {
               return completeReplication();
             }
             if (doc.ok) {
@@ -266,7 +337,7 @@ function replicate(repId, src, target, opts, returnValue) {
       keys: ids,
       include_docs: true
     }).then(function (res) {
-      if (returnValue.cancelled) {
+      if (state.cancelled) {
         completeReplication();
         throw (new Error('cancelled'));
       }
@@ -298,7 +369,7 @@ function replicate(repId, src, target, opts, returnValue) {
       currentBatch.seq
     ).then(function (res) {
       writingCheckpoint = false;
-      if (returnValue.cancelled) {
+      if (state.cancelled) {
         completeReplication();
         throw new Error('cancelled');
       }
@@ -322,7 +393,7 @@ function replicate(repId, src, target, opts, returnValue) {
       });
     });
     return target.revsDiff(diff).then(function (diffs) {
-      if (returnValue.cancelled) {
+      if (state.cancelled) {
         completeReplication();
         throw new Error('cancelled');
       }
@@ -334,7 +405,7 @@ function replicate(repId, src, target, opts, returnValue) {
 
 
   function startNextBatch() {
-    if (returnValue.cancelled || currentBatch) {
+    if (state.cancelled || currentBatch) {
       return;
     }
     if (batches.length === 0) {
@@ -386,7 +457,7 @@ function replicate(repId, src, target, opts, returnValue) {
       return;
     }
     result.ok = false;
-    result.status = 'aborted';
+    result.status = 'aborting';
     result.errors.push(err);
     batches = [];
     pendingBatch = {
@@ -402,7 +473,7 @@ function replicate(repId, src, target, opts, returnValue) {
     if (replicationCompleted) {
       return;
     }
-    if (returnValue.cancelled) {
+    if (state.cancelled) {
       result.status = 'cancelled';
       if (writingCheckpoint) {
         return;
@@ -411,7 +482,7 @@ function replicate(repId, src, target, opts, returnValue) {
     result.status = result.status || 'complete';
     result.end_time = new Date();
     result.last_seq = last_seq;
-    replicationCompleted = returnValue.cancelled = true;
+    replicationCompleted = state.cancelled = true;
     var non403s = result.errors.filter(function (error) {
       return error.name !== 'unauthorized' && error.name !== 'forbidden';
     });
@@ -421,16 +492,16 @@ function replicate(repId, src, target, opts, returnValue) {
         error.other_errors = result.errors;
       }
       error.result = result;
-      returnValue.emit('error', error);
+      backOff(repId, src, target, opts, returnValue, result, error);
     } else {
       returnValue.emit('complete', result);
+      returnValue.removeAllListeners();
     }
-    returnValue.removeAllListeners();
   }
 
 
   function onChange(change) {
-    if (returnValue.cancelled) {
+    if (state.cancelled) {
       return completeReplication();
     }
     if (
@@ -448,7 +519,7 @@ function replicate(repId, src, target, opts, returnValue) {
 
   function onChangesComplete(changes) {
     changesPending = false;
-    if (returnValue.cancelled) {
+    if (state.cancelled) {
       return completeReplication();
     }
     if (changesOpts.since < changes.last_seq) {
@@ -468,7 +539,7 @@ function replicate(repId, src, target, opts, returnValue) {
 
   function onChangesError(err) {
     changesPending = false;
-    if (returnValue.cancelled) {
+    if (state.cancelled) {
       return completeReplication();
     }
     abortReplication('changes rejected', err);
@@ -542,7 +613,7 @@ function replicate(repId, src, target, opts, returnValue) {
     writingCheckpoint = true;
     checkpointer.writeCheckpoint(opts.since).then(function (res) {
       writingCheckpoint = false;
-      if (returnValue.cancelled) {
+      if (state.cancelled) {
         completeReplication();
         return;
       }
@@ -583,6 +654,7 @@ function replicateWrapper(src, target, opts, callback) {
   }
   opts = utils.clone(opts);
   opts.continuous = opts.continuous || opts.live;
+  opts.retry = opts.retry || false;
   /*jshint validthis:true */
   opts.PouchConstructor = opts.PouchConstructor || this;
   var replicateRet = new Replication(opts);


### PR DESCRIPTION
at the moment it is opt-in because I wanted to test it without all the other replication breaking, it has an element of randomness so that if multiple clients all lose connections at the same time they will not all attempt to reestablish it at the same time.
