### PR TITLE
(#2773) - attachments work after Chrome 37-38 upgrade

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -663,7 +663,6 @@ function init(api, opts, callback) {
   };
 
   api._getAttachment = function (attachment, opts, callback) {
-    var result;
     var txn;
     opts = utils.clone(opts);
     if (opts.ctx) {
@@ -678,26 +677,27 @@ function init(api, opts, callback) {
     txn.objectStore(ATTACH_STORE).get(digest).onsuccess = function (e) {
       var data = e.target.result.body;
       if (opts.encode) {
-        if (blobSupport) {
+        if (!data) {
+          callback(null, '');
+        } else if (typeof data !== 'string') { // we have blob support
           var reader = new FileReader();
           reader.onloadend = function (e) {
             var binary = utils.arrayBufferToBinaryString(this.result || '');
-            result = btoa(binary);
-            callback(null, result);
+            callback(null, btoa(binary));
           };
           reader.readAsArrayBuffer(data);
-        } else {
-          result = data;
-          callback(null, result);
+        } else { // no blob support
+          callback(null, data);
         }
       } else {
-        if (blobSupport) {
-          result = data || utils.createBlob([''], {type: type});
-        } else {
+        if (!data) {
+          callback(null, utils.createBlob([''], {type: type}));
+        } else if (typeof data !== 'string') { // we have blob support
+          callback(null, data);
+        } else { // no blob support
           data = utils.fixBinary(atob(data));
-          result = utils.createBlob([data], {type: type});
+          callback(null, utils.createBlob([data], {type: type}));
         }
-        callback(null, result);
       }
     };
   };


### PR DESCRIPTION
No tests added, because I don't know if we can write a test that upgrades a Saucelabs browser from Chrome 37 to 38. ;)

But the fix is pretty simple. We only care about the `blobSupport` variable when we write blobs. When we read blobs, we simply detect whether what we got back was a string or an object (or null/undefined).

Tested manually in Firefox and Chrome 35, 36, and 38. Would like a green on IE10 as well before we merge this.
