### PR TITLE
(#2781) - rollback to websql on safari/ios 8

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -1316,7 +1316,13 @@ function init(api, opts, callback) {
 }
 
 IdbPouch.valid = function () {
-  return global.indexedDB && isModernIdb();
+  // Issue #2533, we finally gave up on doing bug
+  // detection instead of browser sniffing. Safari brought us
+  // to our knees.
+  var isSafari = typeof openDatabase !== 'undefined' &&
+    /Safari/.test(navigator.userAgent) &&
+    !/Chrome/.test(navigator.userAgent);
+  return !isSafari && global.indexedDB && isModernIdb();
 };
 
 function destroy(name, opts, callback) {


### PR DESCRIPTION
Yeah, I know: I'm finally resorting to browser-sniffing. Even though we have [a working reproducible test](http://bl.ocks.org/nolanlawson/c83e9039edf2278047e9).

But listen, I just do not have the time to rearchitect our entire adapter validation logic to make it asynchronous so we can detect a dumb bug that hopefully the WebKit devs will fix soon anyway.

Submitting this as-is. Saucelabs doesn't support Safari 7.1 or iOS 8 yet, so you'll have to take my word for it that it passes.

I look forward to when we can revert this commit.
