### PR TITLE
(#2803) - throw 412s when stubs are missing

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -254,6 +254,7 @@ function init(api, opts, callback) {
     var fetchedDocs = new utils.Map();
     var updateSeq = 0;
     var numDocsWritten = 0;
+    var preconditionErrored = false;
 
     function writeMetaData(e) {
       var meta = e.target.result;
@@ -352,6 +353,9 @@ function init(api, opts, callback) {
     }
 
     function complete() {
+      if (preconditionErrored) {
+        return;
+      }
       var aresults = results.map(function (result) {
         if (result._bulk_seq) {
           delete result._bulk_seq;
@@ -414,6 +418,52 @@ function init(api, opts, callback) {
         });
       };
       reader.readAsArrayBuffer(att.data);
+    }
+
+    function verifyAttachment(digest, callback) {
+      var req = txn.objectStore([ATTACH_STORE]).get(digest);
+      req.onsuccess = function (e) {
+        if (!e.target.result) {
+          var err = new Error('unknown stub attachment with digest ' + digest);
+          err.status = 412;
+          callback(err);
+        } else {
+          callback();
+        }
+      };
+    }
+
+    function verifyAttachments(finish) {
+      var digests = [];
+      docInfos.forEach(function (docInfo) {
+        if (docInfo.data && docInfo.data._attachments) {
+          Object.keys(docInfo.data._attachments).forEach(function (filename) {
+            var att = docInfo.data._attachments[filename];
+            if (att.stub) {
+              digests.push(att.digest);
+            }
+          });
+        }
+      });
+      if (!digests.length) {
+        return finish();
+      }
+      var numDone = 0;
+      var err;
+
+      function checkDone() {
+        if (++numDone === digests.length) {
+          finish(err);
+        }
+      }
+      digests.forEach(function (digest) {
+        verifyAttachment(digest, function (attErr) {
+          if (attErr && !err) {
+            err = attErr;
+          }
+          checkDone();
+        });
+      });
     }
 
     function preprocessAttachments(callback) {
@@ -604,7 +654,13 @@ function init(api, opts, callback) {
       txn.ontimeout = idbError(callback);
       txn.oncomplete = complete;
 
-      fetchExistingDocs(processDocs);
+      verifyAttachments(function (err) {
+        if (err) {
+          preconditionErrored = true;
+          return callback(err);
+        }
+        fetchExistingDocs(processDocs);
+      });
     });
   };
 

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -355,6 +355,54 @@ function LevelPouch(opts, callback) {
     if (infoErrors.length) {
       return callback(infoErrors[0]);
     }
+
+    // verify any stub attachments as a precondition test
+
+    function verifyAttachment(digest, callback) {
+      stores.attachmentStore.get(digest, function (levelErr) {
+        if (levelErr) {
+          var err = new Error('unknown stub attachment with digest ' + digest);
+          err.status = 412;
+          callback(err);
+        } else {
+          callback();
+        }
+      });
+    }
+
+    function verifyAttachments(finish) {
+      var digests = [];
+      userDocs.forEach(function (doc) {
+        if (doc && doc._attachments) {
+          Object.keys(doc._attachments).forEach(function (filename) {
+            var att = doc._attachments[filename];
+            if (att.stub) {
+              digests.push(att.digest);
+            }
+          });
+        }
+      });
+      if (!digests.length) {
+        return finish();
+      }
+      var numDone = 0;
+      var err;
+
+      function checkDone() {
+        if (++numDone === digests.length) {
+          finish(err);
+        }
+      }
+      digests.forEach(function (digest) {
+        verifyAttachment(digest, function (attErr) {
+          if (attErr && !err) {
+            err = attErr;
+          }
+          checkDone();
+        });
+      });
+    }
+
     var inProgress = 0;
     function processDocs() {
       var index = current;
@@ -660,7 +708,12 @@ function LevelPouch(opts, callback) {
       return err;
     }
 
-    processDocs();
+    verifyAttachments(function (err) {
+      if (err) {
+        return callback(err);
+      }
+      processDocs();
+    });
   };
   api._allDocs = function (opts, callback) {
     opts = utils.clone(opts);

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -515,6 +515,53 @@ function WebSqlPouch(opts, callback) {
       });
     }
 
+    function verifyAttachment(digest, callback) {
+      var sql = 'SELECT count(*) as cnt FROM ' + ATTACH_STORE +
+        ' WHERE digest=?';
+      tx.executeSql(sql, [digest], function (tx, result) {
+        if (result.rows.item(0).cnt === 0) {
+          var err = new Error('unknown stub attachment with digest ' + digest);
+          err.status = 412;
+          callback(err);
+        } else {
+          callback();
+        }
+      });
+    }
+
+    function verifyAttachments(finish) {
+      var digests = [];
+      docInfos.forEach(function (docInfo) {
+        if (docInfo.data && docInfo.data._attachments) {
+          Object.keys(docInfo.data._attachments).forEach(function (filename) {
+            var att = docInfo.data._attachments[filename];
+            if (att.stub) {
+              digests.push(att.digest);
+            }
+          });
+        }
+      });
+      if (!digests.length) {
+        return finish();
+      }
+      var numDone = 0;
+      var err;
+
+      function checkDone() {
+        if (++numDone === digests.length) {
+          finish(err);
+        }
+      }
+      digests.forEach(function (digest) {
+        verifyAttachment(digest, function (attErr) {
+          if (attErr && !err) {
+            err = attErr;
+          }
+          checkDone();
+        });
+      });
+    }
+
     function preprocessAttachment(att, finish) {
       if (att.stub) {
         return finish();
@@ -841,7 +888,12 @@ function WebSqlPouch(opts, callback) {
     preprocessAttachments(function () {
       db.transaction(function (txn) {
         tx = txn;
-        fetchExistingDocs(processDocs);
+        verifyAttachments(function (err) {
+          if (err) {
+            return callback(err);
+          }
+          fetchExistingDocs(processDocs);
+        });
       }, unknownError(callback), function () {
         docCount = -1;
       });

--- a/tests/test.attachments.js
+++ b/tests/test.attachments.js
@@ -83,6 +83,92 @@ adapters.forEach(function (adapter) {
       }
     };
 
+    it('issue 2803 should throw 412', function () {
+      var db = new PouchDB(dbs.name);
+      return db.put(binAttDoc).then(function () {
+        return db.get(binAttDoc._id);
+      }).then(function (doc) {
+        doc._attachments['bar.txt'] = {
+          stub: true,
+          digest: 'md5-sorryIDoNotReallyExist=='
+        };
+        return db.put(doc);
+      }).then(function (res) {
+        should.not.exist(res, 'should throw');
+      }).catch(function (err) {
+        should.exist(err.status, 'got improper error: ' + err);
+        err.status.should.equal(412);
+      });
+    });
+
+    it('issue 2803 should throw 412 part 2', function () {
+      var stubDoc = {
+        _id: 'stubby',
+        "_attachments": {
+          "foo.txt": {
+            "content_type": "text/plain",
+            "digest": "md5-aEI7pOYCRBLTRQvvqYrrJQ==",
+            "stub": true
+          },
+        }
+      };
+      var db = new PouchDB(dbs.name);
+      return db.put(stubDoc).then(function (res) {
+        should.not.exist(res, 'should throw');
+      }).catch(function (err) {
+        should.exist(err.status, 'got improper error: ' + err);
+        err.status.should.equal(412, 'got improper error: ' + err);
+      });
+    });
+
+    it('issue 2803 should throw 412 part 3', function () {
+      var db = new PouchDB(dbs.name);
+      return db.put(binAttDoc).then(function () {
+        return db.get(binAttDoc._id);
+      }).then(function (doc) {
+        doc._attachments['foo.json'] = jsonDoc._attachments['foo.json'];
+      }).then(function () {
+        return db.get(binAttDoc._id);
+      }).then(function (doc) {
+        doc._attachments['bar.txt'] = {
+          stub: true,
+          digest: 'md5-sorryIDoNotReallyExist=='
+        };
+        return db.put(doc);
+      }).then(function (res) {
+        should.not.exist(res, 'should throw');
+      }).catch(function (err) {
+        should.exist(err.status, 'got improper error: ' + err);
+        err.status.should.equal(412);
+      });
+    });
+
+    it('issue 2803 should throw 412 part 4', function () {
+      var db = new PouchDB(dbs.name);
+      return db.put(binAttDoc).then(function () {
+        return db.get(binAttDoc._id);
+      }).then(function (doc) {
+        doc._attachments['foo.json'] = jsonDoc._attachments['foo.json'];
+      }).then(function () {
+        return db.get(binAttDoc._id);
+      }).then(function (doc) {
+        doc._attachments['bar.txt'] = {
+          stub: true,
+          digest: 'md5-sorryIDoNotReallyExist=='
+        };
+        doc._attachments['baz.txt'] = {
+          stub: true,
+          digest: 'md5-yahNoIDoNotExistEither=='
+        };
+        return db.put(doc);
+      }).then(function (res) {
+        should.not.exist(res, 'should throw');
+      }).catch(function (err) {
+        should.exist(err.status, 'got improper error: ' + err);
+        err.status.should.equal(412);
+      });
+    });
+
     it('Test some attachments', function (done) {
       var db = new PouchDB(dbs.name);
       db.put(binAttDoc, function (err, write) {


### PR DESCRIPTION
We are supposed to throw a 412 error if a stub is missing.

Interestingly, CouchDB also throws a 412 error if you have the exact same digest but shared between two attachments in the same document. However, I think it's nice that PouchDB just looks up the attachment by digest, without regard for the parent document or filename. So I do not test this case; I only test the case where the digest is unknown.

If you're wondering why the logic looks so tortured, recall that IndexedDB and WebSQL are jealous lovers, and if you try to do any other async operation within the normal callback chain (such as FileReader), then the transaction will become stale and auto-close. So I am very careful to do `verifyAttachments` outside of `preprocessAttachments`, since the former entails transactional stuff whereas the latter entails FileReader stuff.
