### PR TITLE
(#2810) - simpler check for outdated IndexedDB

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -42,30 +42,6 @@ function idbError(callback) {
   };
 }
 
-function isModernIdb() {
-  // check for outdated implementations of IDB
-  // that rely on the setVersion method instead of onupgradeneeded (issue #1207)
-
-  // cache based on appVersion, in case the browser is updated
-  var cacheKey = "_pouch__checkModernIdb_" +
-    (global.navigator && global.navigator.appVersion);
-  var cached = utils.hasLocalStorage() && global.localStorage[cacheKey];
-  if (cached) {
-    return JSON.parse(cached);
-  }
-
-  var dbName = '_pouch__checkModernIdb';
-  var result = global.indexedDB.open(dbName, 1).onupgradeneeded === null;
-
-  if (global.indexedDB.deleteDatabase) {
-    global.indexedDB.deleteDatabase(dbName); // db no longer needed
-  }
-  if (utils.hasLocalStorage()) {
-    global.localStorage[cacheKey] = JSON.stringify(result); // cache
-  }
-  return result;
-}
-
 // Unfortunately, the metadata has to be stringified
 // when it is put into the database, because otherwise
 // IndexedDB can throw errors for deeply-nested objects.
@@ -1378,7 +1354,10 @@ IdbPouch.valid = function () {
   var isSafari = typeof openDatabase !== 'undefined' &&
     /Safari/.test(navigator.userAgent) &&
     !/Chrome/.test(navigator.userAgent);
-  return !isSafari && global.indexedDB && isModernIdb();
+
+  // some outdated implementations of IDB that appear on Samsung
+  // and HTC Android devices <4.4 are missing IDBKeyRange
+  return !isSafari && global.indexedDB && global.IDBKeyRange;
 };
 
 function destroy(name, opts, callback) {


### PR DESCRIPTION
You will just have to take my word for it that this new test also susses out the broken IndexedDB implementation on certain Android devices just as well as the old test.

I've been playing around with a lot of old Android devices recently (God help me), so I figured this out after some futzing.

If you happen to have an HTC One running Android 4.3 or a Samsung Galaxy S3 running 4.3, you can verify this yourself. Or you can just believe me.
