### PR TITLE
(#2831) - updated supported browsers list

### DIFF
--- a/docs/learn.md
+++ b/docs/learn.md
@@ -12,13 +12,13 @@ PouchDB is a free open-source project, written in JavaScript by these [wonderful
 
 PouchDB uses various backends so it can work across different browsers and in Node.js. It uses IndexedDB in Firefox/Chrome/Opera/IE, WebSQL in Safari and most mobile browsers, and LevelDB in Node.js. It is currently tested and fully supported in:
 
- * Firefox latest stable (v29)
- * Chrome latest stable (v34)
- * Desktop Safari latest stable (v7)
- * Internet Explorer v10+
- * Opera latest stable (v21)
- * Android 4.3+
- * iOS Safari latest stable (v7.1)
+ * Firefox latest stable (v29+)
+ * Chrome latest stable (v34+)
+ * Desktop Safari latest stable (v6+)
+ * Internet Explorer (v10+)
+ * Opera latest stable (v21+)
+ * Android 4.0+
+ * iOS Safari latest stable (v7.1+)
  * [Node.js](http://nodejs.org/)
 
 PouchDB is experimental on Android 2.x and various mobile browsers and environments including [Apache Cordova](http://cordova.apache.org/). It is known to work, but you may run into issues. As we resolve these issues we will update the fully supported list.


### PR DESCRIPTION
We are definitely passing in Android 4.0, we explicitly
test Travis in Safari 6 and iOS 7, so I've updated the
list of supported browsers accordingly.
