### PR TITLE
(#2807) - auto_compaction properly trims tree

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -122,7 +122,7 @@ function AbstractPouchDB() {
         res.forEach(function (doc) {
           if (doc.ok && doc.id) { // if no id, then it was a local doc
             // TODO: we need better error handling
-            self.compactDocument(doc.id, 1, decCount);
+            self.compactDocument(doc.id, 0, decCount);
           } else {
             decCount();
           }
@@ -407,7 +407,7 @@ AbstractPouchDB.prototype.revsDiff =
 // by compacting we mean removing all revisions which
 // are further from the leaf in revision tree than max_height
 AbstractPouchDB.prototype.compactDocument =
-  utils.adapterFun('compactDocument', function (docId, max_height, callback) {
+  utils.adapterFun('compactDocument', function (docId, maxHeight, callback) {
   var self = this;
   this._getRevisionTree(docId, function (err, rev_tree) {
     if (err) {
@@ -417,7 +417,7 @@ AbstractPouchDB.prototype.compactDocument =
     var candidates = [];
     var revs = [];
     Object.keys(height).forEach(function (rev) {
-      if (height[rev] > max_height) {
+      if (height[rev] > maxHeight) {
         candidates.push(rev);
       }
     });

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -312,9 +312,9 @@ function replicate(repId, src, target, opts, returnValue, result) {
               result.docs_read++;
               currentBatch.pendingRevs++;
               currentBatch.docs.push(doc.ok);
-              delete diffs[doc.ok._id];
             }
           });
+          delete diffs[id];
         });
     }));
   }

--- a/tests/test.get.js
+++ b/tests/test.get.js
@@ -95,7 +95,7 @@ adapters.forEach(function (adapter) {
     });
 
     it('Get revisions of removed doc', function (done) {
-      var db = new PouchDB(dbs.name);
+      var db = new PouchDB(dbs.name, {auto_compaction: false});
       db.post({ test: 'somestuff' }, function (err, info) {
         var rev = info.rev;
         db.remove({
@@ -211,7 +211,7 @@ adapters.forEach(function (adapter) {
     });
 
     it('Test opts.revs=true with rev other than winning', function (done) {
-      var db = new PouchDB(dbs.name);
+      var db = new PouchDB(dbs.name, {auto_compaction: false});
       var docs = [
         {_id: 'foo', _rev: '1-a', value: 'foo a'},
         {_id: 'foo', _rev: '2-b', value: 'foo b'},
@@ -409,7 +409,7 @@ adapters.forEach(function (adapter) {
     });
 
     it('Retrieve old revision', function (done) {
-      var db = new PouchDB(dbs.name);
+      var db = new PouchDB(dbs.name, {auto_compaction: false});
       db.post({ version: 'first' }, function (err, info) {
         db.put({
           _id: info.id,

--- a/tests/test.replication.js
+++ b/tests/test.replication.js
@@ -566,7 +566,10 @@ adapters.forEach(function (adapters) {
                                 res.rows.should.have.length.above(0, 'second');
                                 res.rows[0].doc.value.should.equal('db1');
                                 db1.info(function (err, info) {
-                                  info.update_seq.should.equal(4);
+                                  // if auto_compaction is enabled, will
+                                  // be 5 because 2-c goes "missing" and
+                                  // the other db tries to re-put it
+                                  info.update_seq.should.be.within(4, 5);
                                   info.doc_count.should.equal(1);
                                   db2.info(function (err, info2) {
                                     info2.update_seq.should.equal(3);

--- a/tests/test.revs_diff.js
+++ b/tests/test.revs_diff.js
@@ -18,7 +18,7 @@ adapters.forEach(function (adapter) {
 
 
     it('Test revs diff', function (done) {
-      var db = new PouchDB(dbs.name);
+      var db = new PouchDB(dbs.name, {auto_compaction: false});
       var revs = [];
       db.post({
         test: 'somestuff',
@@ -70,7 +70,7 @@ adapters.forEach(function (adapter) {
           });
         });
       }
-      var db = new PouchDB(dbs.name);
+      var db = new PouchDB(dbs.name, {auto_compaction: false});
       createConflicts(db, function () {
         db.revsDiff({'939': ['1-a', '2-a', '2-b']}, function (err, results) {
           results.should.not.include.keys('939');
@@ -110,7 +110,7 @@ adapters.forEach(function (adapter) {
     });
 
     it('Test revs diff with reserved ID', function (done) {
-      var db = new PouchDB(dbs.name);
+      var db = new PouchDB(dbs.name, {auto_compaction: false});
       var revs = [];
       db.post({
         test: 'constructor',


### PR DESCRIPTION
I figured out the bug. It turned out we put a `1` as the height of the tree when it should have been `0`, because that value was referring to the max distance from the leaf in order to keep it.

So actually this has been broken for some time, because we only compacted a tree down to its leaf+1 branch, rather than down to the leaf. We also had a broken unit test that was not correctly verifying that all non-leafs are deleted.
