### PR TITLE
(#2708) - implement attachment stub length

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -639,6 +639,7 @@ AbstractPouchDB.prototype.get =
           var att = doc._attachments[key];
           att.data = data;
           delete att.stub;
+          delete att.length;
           if (!--count) {
             callback(null, doc);
           }

--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -371,13 +371,18 @@ function init(api, opts, callback) {
                                 "Attachments need to be base64 encoded");
           return callback(err);
         }
+        var length;
         if (blobSupport) {
           var type = att.content_type;
           data = utils.fixBinary(data);
+          length = data.byteLength;
           att.data = utils.createBlob([data], {type: type});
+        } else {
+          length = data.length;
         }
         utils.MD5(data).then(function (result) {
           att.digest = 'md5-' + result;
+          att.length = length;
           finish();
         });
         return;
@@ -390,6 +395,7 @@ function init(api, opts, callback) {
         }
         utils.MD5(binary).then(function (result) {
           att.digest = 'md5-' + result;
+          att.length = binary.length;
           finish();
         });
       };

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -640,8 +640,10 @@ function LevelPouch(opts, callback) {
     }
 
     function saveAttachment(docInfo, digest, key, data, callback) {
-      delete docInfo.data._attachments[key].data;
-      docInfo.data._attachments[key].digest = digest;
+      var att = docInfo.data._attachments[key];
+      delete att.data;
+      att.digest = digest;
+      att.length = data.length;
       stores.attachmentStore.get(digest, function (err, oldAtt) {
         if (err && err.name !== 'NotFoundError') {
           return callback(err);

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -583,6 +583,7 @@ function WebSqlPouch(opts, callback) {
         att.data = binary;
         utils.MD5(binary).then(function (result) {
           att.digest = 'md5-' + result;
+          att.length = binary.length;
           finish();
         });
       };


### PR DESCRIPTION
Also non-stubs don't have a length value. Added a bunch of tests to test various cases, including PNGs, plaintext, and empty plaintext.
