### PR TITLE
Encode attachment IDs

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -424,6 +424,10 @@ function HttpPouch(opts, callback) {
     }, callback);
   });
 
+  function encodeAttachmentId(attachmentId) {
+    return attachmentId.split("/").map(encodeURIComponent).join("/");
+  }
+
   // Get the attachment
   api.getAttachment =
     utils.adapterFun('getAttachment', function (docId, attachmentId, opts,
@@ -440,7 +444,7 @@ function HttpPouch(opts, callback) {
       docId = encodeDocId(docId);
     }
     opts.auto_encode = false;
-    api.get(docId + '/' + attachmentId, opts, callback);
+    api.get(docId + '/' + encodeAttachmentId(attachmentId), opts, callback);
   });
 
   // Remove the attachment given by the id and rev
@@ -450,7 +454,7 @@ function HttpPouch(opts, callback) {
     ajax({
       headers: host.headers,
       method: 'DELETE',
-      url: genDBUrl(host, encodeDocId(docId) + '/' + attachmentId) + '?rev=' +
+      url: genDBUrl(host, encodeDocId(docId) + '/' + encodeAttachmentId(attachmentId)) + '?rev=' +
            rev
     }, callback);
   });
@@ -472,7 +476,7 @@ function HttpPouch(opts, callback) {
       blob = rev;
       rev = null;
     }
-    var id = encodeDocId(docId) + '/' + attachmentId;
+    var id = encodeDocId(docId) + '/' + encodeAttachmentId(attachmentId);
     var url = genDBUrl(host, id);
     if (rev) {
       url += '?rev=' + rev;

--- a/tests/test.attachments.js
+++ b/tests/test.attachments.js
@@ -552,6 +552,29 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('Test put attachment with unencoded name', function (done) {
+      var db = new PouchDB(dbs.name);
+      db.put({ _id: 'mydoc' }, function (err, resp) {
+        var blob = testUtils.makeBlob('Mytext');
+        db.putAttachment('mydoc', 'my/text?@', resp.rev, blob, 'text/plain',
+                         function (err, res) {
+          should.exist(res.ok);
+
+          db.get('mydoc', { attachments: true }, function (err, res) {
+            should.exist(res._attachments['my/text?@']);
+
+            db.getAttachment('mydoc', 'my/text?@', function (err, attachment) {
+              testUtils.readBlob(attachment, function (data) {
+                data.should.eql('Mytext');
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
     it('Testing with invalid rev', function (done) {
       var db = new PouchDB(dbs.name);
       var doc = { _id: 'adoc' };


### PR DESCRIPTION
I found that if I saved an attachment with an id including `?` then the revision query parameter wouldn't be recognised and I'd get a 409 conflict. I know, a silly thing to do, but perhaps we should be escaping attachment IDs anyway?

In this pull request, attachment IDs are URL encoded, _except_ slashes `/`, so people can continue to upload attachments like `path/to/index.html`.
