### PR TITLE
use a query to find update_seq instead of manually tracking it

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -228,21 +228,7 @@ function init(api, opts, callback) {
 
     var results = new Array(docInfos.length);
     var fetchedDocs = new utils.Map();
-    var updateSeq = 0;
-    var numDocsWritten = 0;
     var preconditionErrored = false;
-
-    function writeMetaData(e) {
-      var meta = e.target.result;
-      meta.updateSeq = (meta.updateSeq || 0) + updateSeq;
-      txn.objectStore(META_STORE).put(meta);
-    }
-
-    function checkDoneWritingDocs() {
-      if (++numDocsWritten === docInfos.length) {
-        txn.objectStore(META_STORE).get(META_STORE).onsuccess = writeMetaData;
-      }
-    }
 
     function processDocs() {
       if (!docInfos.length) {
@@ -260,7 +246,6 @@ function init(api, opts, callback) {
             } else {
               results[resultsIdx] = {};
             }
-            checkDoneWritingDocs();
           });
           return;
         }
@@ -279,7 +264,6 @@ function init(api, opts, callback) {
         var numDone = 0;
 
         function docWritten() {
-          checkDoneWritingDocs();
           if (++numDone < docs.length) {
             nextDoc();
           }
@@ -528,7 +512,6 @@ function init(api, opts, callback) {
       }
 
       function finish() {
-        updateSeq++;
         docInfo.data._doc_id_rev = docInfo.data._id + "::" + docInfo.data._rev;
         var seqStore = txn.objectStore(BY_SEQ_STORE);
         var index = seqStore.index('_doc_id_rev');
@@ -559,7 +542,6 @@ function init(api, opts, callback) {
           var getKeyReq = index.getKey(docInfo.data._doc_id_rev);
           getKeyReq.onsuccess = function (e) {
             var putReq = seqStore.put(docInfo.data, e.target.result);
-            updateSeq--; // discount, since it's an update, not a new seq
             putReq.onsuccess = afterPut;
           };
         };
@@ -921,10 +903,15 @@ function init(api, opts, callback) {
         return callback(error);
       }
       var updateSeq = 0;
-      var txn = idb.transaction([META_STORE], 'readonly');
-
-      txn.objectStore(META_STORE).get(META_STORE).onsuccess = function (e) {
-        updateSeq = e.target.result && e.target.result.updateSeq || 0;
+      var txn = idb.transaction([BY_SEQ_STORE], 'readonly');
+      txn.objectStore(BY_SEQ_STORE).openCursor(null, "prev").onsuccess =
+        function (event) {
+        var cursor = event.target.result;
+        if (cursor) {
+          updateSeq = cursor.key;
+        } else {
+          updateSeq = 0;
+        }
       };
 
       txn.oncomplete = function () {


### PR DESCRIPTION
I think there is a simpler way to get the update_seq in IndexedDB. There may be performance problems I'm unaware of, but the call to _info doesn't seem particularly performance sensitive, and this avoids a write to META on every bulkDoc call.
