### PR TITLE
(#2880) - fix base64-encoded attachments in http.js

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -483,6 +483,16 @@ function HttpPouch(opts, callback) {
       url += '?rev=' + rev;
     }
 
+    if (typeof blob === 'string') {
+      try {
+        blob = utils.atob(blob);
+      } catch (err) {
+        // it's not base64-encoded, so just use as a regular binary string
+        return callback(utils.extend({}, errors.BAD_ARG,
+          {reason: "Attachments need to be base64 encoded"}));
+      }
+    }
+
     var opts = {
       headers: utils.clone(host.headers),
       method: 'PUT',

--- a/tests/test.attachments.js
+++ b/tests/test.attachments.js
@@ -365,6 +365,29 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('Test putAttachment with base64 plaintext kirby', function () {
+      var db = new PouchDB(dbs.name);
+      return db.putAttachment('doc', 'att', null, 'Zm9v', 'text/plain').then(function () {
+        return db.getAttachment('doc', 'att');
+      }).then(function (blob) {
+        return new PouchDB.utils.Promise(function (resolve) {
+          testUtils.base64Blob(blob, function (data) {
+            data.should.equal('Zm9v', 'should get the correct base64 back');
+            resolve();
+          });
+        });
+      });
+    });
+
+    it('Test putAttachment with incorrect base64 kirby', function () {
+      var db = new PouchDB(dbs.name);
+      return db.putAttachment('doc', 'att', null, '\u65e5\u672c\u8a9e', 'text/plain').then(function () {
+        throw new Error('shouldnt have gotten here');
+      }, function (err) {
+        should.exist(err);
+      });
+    });
+
     it('Test getAttachment with empty text', function (done) {
       var db = new PouchDB(dbs.name);
       db.put(binAttDoc2, function (err, res) {


### PR DESCRIPTION
The http adapter is not correctly handling base64-encoded
strings in putAttachment(). Instead of correctly recognizing
the text as base64, it actually just stores it as-is.

This also adds a test to ensure that we throw an error
if the user supplies a string that is not base64-encoded.
