### PR TITLE
Don't bail just because db._docCountQueue.docCount is -1

### DIFF
--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -126,8 +126,7 @@ function LevelPouch(opts, callback) {
   }
 
   function applyNextDocCountDelta() {
-    if (db._docCountQueue.running || !db._docCountQueue.queue.length ||
-      db._docCountQueue.docCount === -1) {
+    if (db._docCountQueue.running || !db._docCountQueue.queue.length) {
       return;
     }
     db._docCountQueue.running = true;


### PR DESCRIPTION
There's a condition when the queue length is non-zero, but the docCount is still -1 -- in that case applyNextDocCountDelta() just returns silently and the adapter never finishes initializing itself because its callback never fires.  This is just a quicky hack-fix, I'm not familiar enough with all the parts to know what other ramifications this might have.
