### PR TITLE
(#2880) - fix typo in comment/test name

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -487,7 +487,7 @@ function HttpPouch(opts, callback) {
       try {
         blob = utils.atob(blob);
       } catch (err) {
-        // it's not base64-encoded, so just use as a regular binary string
+        // it's not base64-encoded, so throw error
         return callback(utils.extend({}, errors.BAD_ARG,
           {reason: "Attachments need to be base64 encoded"}));
       }

--- a/tests/test.attachments.js
+++ b/tests/test.attachments.js
@@ -365,7 +365,7 @@ adapters.forEach(function (adapter) {
       });
     });
 
-    it('Test putAttachment with base64 plaintext kirby', function () {
+    it('Test putAttachment with base64 plaintext', function () {
       var db = new PouchDB(dbs.name);
       return db.putAttachment('doc', 'att', null, 'Zm9v', 'text/plain').then(function () {
         return db.getAttachment('doc', 'att');
@@ -379,7 +379,7 @@ adapters.forEach(function (adapter) {
       });
     });
 
-    it('Test putAttachment with incorrect base64 kirby', function () {
+    it('Test putAttachment with incorrect base64', function () {
       var db = new PouchDB(dbs.name);
       return db.putAttachment('doc', 'att', null, '\u65e5\u672c\u8a9e', 'text/plain').then(function () {
         throw new Error('shouldnt have gotten here');


### PR DESCRIPTION
Sorry, I got sloppy with that commit and forgot to fix the comment, as well as the string I had appended to the test names to make it easier to grep them... >_<
