### PR TITLE
(#2882 #2883) - don't manually track update_seq for websql

### DIFF
--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -319,7 +319,7 @@ function WebSqlPouch(opts, callback) {
       // initial schema
 
       var meta = 'CREATE TABLE IF NOT EXISTS ' + META_STORE +
-        ' (update_seq INTEGER, dbid, db_version INTEGER)';
+        ' (dbid, db_version INTEGER)';
       var attach = 'CREATE TABLE IF NOT EXISTS ' + ATTACH_STORE +
         ' (digest, json, body BLOB)';
       var doc = 'CREATE TABLE IF NOT EXISTS ' + DOC_STORE +
@@ -339,11 +339,11 @@ function WebSqlPouch(opts, callback) {
           tx.executeSql(BY_SEQ_STORE_DELETED_INDEX_SQL);
           tx.executeSql(BY_SEQ_STORE_DOC_ID_REV_INDEX_SQL);
           tx.executeSql(meta, [], function () {
-            // mark the update_seq, db version, and new dbid
+            // mark the db version, and new dbid
             var initSeq = 'INSERT INTO ' + META_STORE +
-              ' (update_seq, db_version, dbid) VALUES (?, ?, ?)';
+              ' (db_version, dbid) VALUES (?,?)';
             instanceId = utils.uuid();
-            var initSeqArgs = [0, ADAPTER_VERSION, instanceId];
+            var initSeqArgs = [ADAPTER_VERSION, instanceId];
             tx.executeSql(initSeq, initSeqArgs, function (tx) {
               onGetInstanceId(tx);
             });
@@ -441,9 +441,9 @@ function WebSqlPouch(opts, callback) {
   api._info = function (callback) {
     db.readTransaction(function (tx) {
       countDocs(tx, function (docCount) {
-        var sql = 'SELECT update_seq FROM ' + META_STORE;
-        tx.executeSql(sql, [], function (tx, result) {
-          var updateSeq = result.rows.item(0).update_seq;
+        var sql = 'SELECT MAX(seq) AS seq FROM ' + BY_SEQ_STORE;
+        tx.executeSql(sql, [], function (tx, res) {
+          var updateSeq = res.rows.item(0).seq || 0;
           callback(null, {
             doc_count: docCount,
             update_seq: updateSeq
@@ -477,7 +477,6 @@ function WebSqlPouch(opts, callback) {
 
     var tx;
     var results = new Array(docInfos.length);
-    var updateSeq = 0;
     var fetchedDocs = new utils.Map();
     var numDocsWritten = 0;
 
@@ -505,14 +504,7 @@ function WebSqlPouch(opts, callback) {
       });
       WebSqlPouch.Changes.notify(name);
 
-      var updateseq = 'SELECT update_seq FROM ' + META_STORE;
-      tx.executeSql(updateseq, [], function (tx, result) {
-        var update_seq = result.rows.item(0).update_seq + updateSeq;
-        var sql = 'UPDATE ' + META_STORE + ' SET update_seq=?';
-        tx.executeSql(sql, [update_seq], function () {
-          callback(null, aresults);
-        });
-      });
+      callback(null, aresults);
     }
 
     function verifyAttachment(digest, callback) {
@@ -633,7 +625,6 @@ function WebSqlPouch(opts, callback) {
                       resultsIdx) {
 
       function finish() {
-        updateSeq++;
         var data = docInfo.data;
         var deletedInt = deleted ? 1 : 0;
 
@@ -656,7 +647,6 @@ function WebSqlPouch(opts, callback) {
               ' SET json=?, deleted=? WHERE doc_id=? AND rev=?;';
             var sqlArgs = [json, deletedInt, id, rev];
             tx.executeSql(sql, sqlArgs, function (tx) {
-              updateSeq--; // discount, since it's an update, not a new seq
               dataWritten(tx, seq);
             });
           });


### PR DESCRIPTION
So apparently #2883 is not an issue, because the test just passes in all the adapters.

And as a follow-up to #2882, this commit moves the same logic to WebSQL.

LevelDB is still a TODO.
