### PR TITLE
(#2890) - reduce md5 chunk size to 32768

### DIFF
--- a/lib/deps/md5.js
+++ b/lib/deps/md5.js
@@ -3,6 +3,7 @@
 var crypto = require('crypto');
 var Md5 = require('spark-md5');
 var setImmediateShim = global.setImmediate || global.setTimeout;
+var MD5_CHUNK_SIZE = 32768;
 
 function sliceShim(arrayBuffer, begin, end) {
   if (typeof arrayBuffer.slice === 'function') {
@@ -78,7 +79,7 @@ module.exports = function (data, callback) {
   }
   var inputIsString = typeof data === 'string';
   var len = inputIsString ? data.length : data.byteLength;
-  var chunkSize = Math.min(524288, len);
+  var chunkSize = Math.min(MD5_CHUNK_SIZE, len);
   var chunks = Math.ceil(len / chunkSize);
   var currentChunk = 0;
   var buffer = inputIsString ? new Md5() : new Md5.ArrayBuffer();


### PR DESCRIPTION
This is hardly a slam dunk, but by reducing the md5 chunk size, it seems to me to block DOM rendering much less than before.

In these videos I'm loading some large-ish GIFs wholesale into WebSQL in a WebView on a Nexus 5 running Android 4.4.4. The Blobs are provided via xhr with `xhr.responseType = 'arraybuffer'`, then `new Blob()`.

[Before 1](https://dl.dropboxusercontent.com/u/2588462/pouchdb/videos/2890/before.mp4), [After 1](https://dl.dropboxusercontent.com/u/2588462/pouchdb/videos/2890/after.mp4)
[Before 2](https://dl.dropboxusercontent.com/u/2588462/pouchdb/videos/2890/before2.mp4), [After 2](https://dl.dropboxusercontent.com/u/2588462/pouchdb/videos/2890/after2.mp4)

The DOM is still obviously getting blocked, because the GIFs freeze, but they seem to freeze a bit less when the chunk size is lower. But even if it's just my imagination, can we agree that 32KB is a more reasonable default than 500KB in browsers? Or that maybe we should make this configurable?
