### PR TITLE
(#2905) - use readAsBinaryString if available

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -44,13 +44,10 @@ function preprocessAttachments(doc) {
     if (attachment.data && typeof attachment.data !== 'string') {
       if (typeof process === undefined || process.browser) {
         return new utils.Promise(function (resolve) {
-          var reader = new FileReader();
-          reader.onloadend = function (e) {
-            attachment.data = utils.btoa(
-              utils.arrayBufferToBinaryString(e.target.result));
+          utils.readAsBinaryString(attachment.data, function (binary) {
+            attachment.data = utils.btoa(binary);
             resolve();
-          };
-          reader.readAsArrayBuffer(attachment.data);
+          });
         });
       } else {
         attachment.data = attachment.data.toString('base64');

--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -371,9 +371,7 @@ function init(api, opts, callback) {
         });
         return;
       }
-      var reader = new FileReader();
-      reader.onloadend = function (e) {
-        var binary = utils.arrayBufferToBinaryString(this.result || '');
+      utils.readAsBinaryString(att.data, function (binary) {
         if (!blobSupport) {
           att.data = btoa(binary);
         }
@@ -382,8 +380,7 @@ function init(api, opts, callback) {
           att.length = binary.length;
           finish();
         });
-      };
-      reader.readAsArrayBuffer(att.data);
+      });
     }
 
     function verifyAttachment(digest, callback) {
@@ -709,12 +706,9 @@ function init(api, opts, callback) {
         if (!data) {
           callback(null, '');
         } else if (typeof data !== 'string') { // we have blob support
-          var reader = new FileReader();
-          reader.onloadend = function (e) {
-            var binary = utils.arrayBufferToBinaryString(this.result || '');
+          utils.readAsBinaryString(data, function (binary) {
             callback(null, btoa(binary));
-          };
-          reader.readAsArrayBuffer(data);
+          });
         } else { // no blob support
           callback(null, data);
         }

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -567,8 +567,7 @@ function LevelPouch(opts, callback) {
       }
 
       function onLoadEnd(doc, key, attachmentSaved) {
-        return function (e) {
-          var data = utils.arrayBufferToBinaryString(e.target.result);
+        return function (data) {
           utils.MD5(data).then(
             onMD5Load(doc, key, data, attachmentSaved)
           );
@@ -596,9 +595,8 @@ function LevelPouch(opts, callback) {
         } else if (!process.browser) {
           data = att.data;
         } else { // browser
-          var reader = new FileReader();
-          reader.onloadend = onLoadEnd(doc, key, attachmentSaved);
-          reader.readAsArrayBuffer(att.data);
+          utils.readAsBinaryString(att.data,
+            onLoadEnd(doc, key, attachmentSaved));
           continue;
         }
         utils.MD5(data).then(

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -577,17 +577,14 @@ function WebSqlPouch(opts, callback) {
         var data = utils.fixBinary(att.data);
         att.data = utils.createBlob([data], {type: att.content_type});
       }
-      var reader = new FileReader();
-      reader.onloadend = function (e) {
-        var binary = utils.arrayBufferToBinaryString(this.result);
+      utils.readAsBinaryString(att.data, function (binary) {
         att.data = binary;
         utils.MD5(binary).then(function (result) {
           att.digest = 'md5-' + result;
           att.length = binary.length;
           finish();
         });
-      };
-      reader.readAsArrayBuffer(att.data);
+      });
     }
 
     function preprocessAttachments(callback) {

--- a/lib/deps/ajax-browser.js
+++ b/lib/deps/ajax-browser.js
@@ -219,21 +219,9 @@ function ajax(options, adapterCallback) {
     }
   }
   if (options.body && (options.body instanceof Blob)) {
-    var reader = new FileReader();
-    reader.onloadend = function (e) {
-
-      var binary = "";
-      var bytes = new Uint8Array(this.result);
-      var length = bytes.byteLength;
-
-      for (var i = 0; i < length; i++) {
-        binary += String.fromCharCode(bytes[i]);
-      }
-
-      binary = utils.fixBinary(binary);
-      xhr.send(binary);
-    };
-    reader.readAsArrayBuffer(options.body);
+    utils.readAsBinaryString(options.body, function (binary) {
+      xhr.send(utils.fixBinary(binary));
+    });
   } else {
     xhr.send(options.body);
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -393,6 +393,24 @@ exports.fixBinary = function (bin) {
   return buf;
 };
 
+// shim for browsers that don't support it
+exports.readAsBinaryString = function (blob, callback) {
+  var reader = new FileReader();
+  var hasBinaryString = typeof reader.readAsBinaryString === 'function';
+  reader.onloadend = function (e) {
+    var result = e.target.result || '';
+    if (hasBinaryString) {
+      return callback(result);
+    }
+    callback(exports.arrayBufferToBinaryString(result));
+  };
+  if (hasBinaryString) {
+    reader.readAsBinaryString(blob);
+  } else {
+    reader.readAsArrayBuffer(blob);
+  }
+};
+
 exports.once = function (fun) {
   var called = false;
   return exports.getArguments(function (args) {


### PR DESCRIPTION
A profile of [the GIF-loading scenario after the `hex()` problem is fixed](http://bl.ocks.org/nolanlawson/11b1af329e1f8f27fa13) shows that the next most expensive function is `utils.arrayBufferToBinaryString()` (~2.4% self time).  

But that function turns out to be totally unnecessary on every platform except IE,  since those other platforms already have a native `readAsBinaryString`. So we're better off shimming it.
