### PR TITLE
(#2923) - add blob-util to docs

### DIFF
--- a/docs/_guides/attachments.md
+++ b/docs/_guides/attachments.md
@@ -11,6 +11,12 @@ The big difference between storage engines like WebSQL/IndexedDB and the older l
 
 PouchDB attachments allow you to use that to full advantage to store images, zip files, or whatever you want.
 
+{% include alert_start.html variant="info" %}
+
+Although it's not required, you may find <a href='https://github.com/nolanlawson/blob-util'>blob-util</a> to be useful for working with binary data in the browser.
+
+{% include alert_end.html %}
+
 How attachments are stored
 ----------
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -658,7 +658,7 @@ Within Node, you must use a `Buffer` instead of a `Blob`:
 var attachment = new Buffer('Is there life on Mars?');
 {% endhighlight %}
 
-For details, see the [Mozilla docs on `Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) or the [Node docs on `Buffer`](http://nodejs.org/api/buffer.html).  If you need a shim for older browsers that don't support the `Blob` constructor, you can use [this one](https://gist.github.com/nolanlawson/10340255).
+For details, see the [Mozilla docs on `Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) or the [Node docs on `Buffer`](http://nodejs.org/api/buffer.html).  If you need a shim for older browsers that don't support the `Blob` constructor, you can use [blob-util](https://github.com/nolanlawson/blob-util).
 
 ### Save an inline attachment
 

--- a/docs/external.md
+++ b/docs/external.md
@@ -127,10 +127,14 @@ Android adapter with a native Java interface to PouchDB.
 
 {% include anchor.html title="Tools" hash="Tools" %}
 
-#### [Revision Tree Visualizer](http://neojski.github.io/visualizeRevTree)
+#### [blob-util](https://github.com/nolanlawson/blob-util)
 
-A tool drawing revision tree of a couchdb document. You can see what is a conflict, which revisions are deleted and which is winning. ([Github](https://github.com/neojski/visualizeRevTree))
+Not strictly PouchDB-related, but a useful set of shims and utility functions for working with Blobs in the browser.
 
 #### [Puton](http://puton.jit.su/)
 
 A bookmarklet for inspecting PouchDB databases within the browser. ([Github](http://github.com/ymichael/puton))
+
+#### [Revision Tree Visualizer](http://neojski.github.io/visualizeRevTree)
+
+A tool drawing revision tree of a couchdb document. You can see what is a conflict, which revisions are deleted and which is winning. ([Github](https://github.com/neojski/visualizeRevTree))


### PR DESCRIPTION
I've been working with Blobs and image data a lot at work recently, and it's really hard. Especially when it comes to supporting "older" browsers (and by "older," I mean Android <4.4 of course >_<).

So I wrote [a blob library](https://github.com/nolanlawson/blob-util) to make stuff easier. This commit is a shameless plug for that library.
