### PR TITLE
(#2926) - remove vendor from cordova app

### DIFF
--- a/bin/run-cordova.sh
+++ b/bin/run-cordova.sh
@@ -23,7 +23,6 @@ TESTS_DIR=./tests/cordova
 rm -fr $TESTS_DIR/www
 mkdir -p $TESTS_DIR/www
 
-cp -r vendor $TESTS_DIR/www/vendor
 mkdir -p $TESTS_DIR/www/node_modules
 cp -r node_modules/mocha node_modules/chai node_modules/es5-shim \
     $TESTS_DIR/www/node_modules


### PR DESCRIPTION
I have no idea why I did this, but it's definitely not necessary to include the selenium jar within the Cordova app. This balloons the app's size unnecessarily, and the scripts still run fine without it.
