### PR TITLE
(#2931) - parallel compaction keeps db integrity

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -409,11 +409,11 @@ AbstractPouchDB.prototype.revsDiff =
 AbstractPouchDB.prototype.compactDocument =
   utils.adapterFun('compactDocument', function (docId, maxHeight, callback) {
   var self = this;
-  this._getRevisionTree(docId, function (err, rev_tree) {
+  this._getRevisionTree(docId, function (err, revTree) {
     if (err) {
       return callback(err);
     }
-    var height = computeHeight(rev_tree);
+    var height = computeHeight(revTree);
     var candidates = [];
     var revs = [];
     Object.keys(height).forEach(function (rev) {
@@ -422,14 +422,13 @@ AbstractPouchDB.prototype.compactDocument =
       }
     });
 
-    merge.traverseRevTree(rev_tree, function (isLeaf, pos, revHash, ctx, opts) {
+    merge.traverseRevTree(revTree, function (isLeaf, pos, revHash, ctx, opts) {
       var rev = pos + '-' + revHash;
       if (opts.status === 'available' && candidates.indexOf(rev) !== -1) {
-        opts.status = 'missing';
         revs.push(rev);
       }
     });
-    self._doCompaction(docId, rev_tree, revs, callback);
+    self._doCompaction(docId, revs, callback);
   });
 });
 

--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -1175,7 +1175,7 @@ function init(api, opts, callback) {
   // This function removes revisions of document docId
   // which are listed in revs and sets this document
   // revision to to rev_tree
-  api._doCompaction = function (docId, rev_tree, revs, callback) {
+  api._doCompaction = function (docId, revs, callback) {
     var txn = idb.transaction([
       DOC_STORE,
       BY_SEQ_STORE,
@@ -1210,7 +1210,13 @@ function init(api, opts, callback) {
 
     docStore.get(docId).onsuccess = function (event) {
       var metadata = decodeMetadata(event.target.result);
-      metadata.rev_tree = rev_tree;
+      merge.traverseRevTree(metadata.rev_tree, function (isLeaf, pos,
+                                                         revHash, ctx, opts) {
+        var rev = pos + '-' + revHash;
+        if (revs.indexOf(rev) !== -1) {
+          opts.status = 'missing';
+        }
+      });
 
       var count = revs.length;
       revs.forEach(function (rev) {

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -76,7 +76,7 @@ function LevelPouch(opts, callback) {
         running : false,
         docCount : -1
       };
-      db._compactionQueue = [];
+      db._writeQueue = [];
       if (opts.db || opts.noMigrate) {
         afterDBCreated();
       } else {
@@ -184,6 +184,33 @@ function LevelPouch(opts, callback) {
       });
     });
   };
+
+  // all read/write operations to the database are done in a queue,
+  // similar to how websql/idb works. this avoids problems such
+  // as e.g. compaction needing to have a lock on the database while
+  // it updates stuff. in the future we can revisit this.
+  function writeLock(fun) {
+    return utils.getArguments(function (args) {
+
+      var callback = args[args.length - 1];
+      args[args.length - 1] = utils.getArguments(function (cbArgs) {
+        callback.apply(null, cbArgs);
+        process.nextTick(function () {
+          if (db._writeQueue.length) {
+            db._writeQueue.shift()();
+          }
+        });
+      });
+
+      if (db._writeQueue.length) {
+        db._writeQueue.push(function () {
+          fun.apply(null, args);
+        });
+      } else {
+        fun.apply(null, args);
+      }
+    });
+  }
 
   function formatSeq(n) {
     return ('0000000000000000' + n).slice(-16);
@@ -329,7 +356,7 @@ function LevelPouch(opts, callback) {
     return false;
   };
 
-  api._bulkDocs = function (req, opts, callback) {
+  api._bulkDocs = writeLock(function (req, opts, callback) {
     var newEdits = opts.new_edits;
     var results = new Array(req.docs.length);
 
@@ -753,7 +780,7 @@ function LevelPouch(opts, callback) {
       }
       processDocs();
     });
-  };
+  });
   api._allDocs = function (opts, callback) {
     opts = utils.clone(opts);
     countDocs(function (err, docCount) {
@@ -1008,35 +1035,22 @@ function LevelPouch(opts, callback) {
     });
   };
 
-  api._doCompaction = function (docId, rev_tree, revs, callback) {
+  api._doCompaction = writeLock(function (docId, revs, callback) {
     if (!revs.length) {
       return callback();
     }
-    db._compactionQueue.push([docId, rev_tree, revs, callback]);
-    if (db._compactionQueue.length === 1) {
-      api._doCompactionSequentially(docId, rev_tree, revs, callback);
-    }
-  };
-
-  // execute compactions synchronously so we
-  // can correctly dedup attachments
-  api._doCompactionSequentially = function (docId, rev_tree, revs, callback) {
-    var originalCallback = callback;
-    callback = function (err) {
-      originalCallback(err);
-      process.nextTick(function () {
-        db._compactionQueue.shift();
-        if (db._compactionQueue.length) {
-          api._doCompactionSequentially.apply(api, db._compactionQueue[0]);
-        }
-      });
-    };
     stores.docStore.get(docId, function (err, metadata) {
       if (err) {
         return callback(err);
       }
       var seqs = metadata.rev_map; // map from rev to seq
-      metadata.rev_tree = rev_tree;
+      merge.traverseRevTree(metadata.rev_tree, function (isLeaf, pos,
+                                                         revHash, ctx, opts) {
+        var rev = pos + '-' + revHash;
+        if (revs.indexOf(rev) !== -1) {
+          opts.status = 'missing';
+        }
+      });
       var batch = [];
       batch.push({
         key: metadata.id,
@@ -1154,7 +1168,7 @@ function LevelPouch(opts, callback) {
         });
       });
     });
-  };
+  });
 
   api._getLocal = function (id, callback) {
     stores.localStore.get(id, function (err, doc) {
@@ -1166,7 +1180,7 @@ function LevelPouch(opts, callback) {
     });
   };
 
-  api._putLocal = function (doc, callback) {
+  api._putLocal = writeLock(function (doc, callback) {
     delete doc._revisions; // ignore this, trust the rev
     var oldRev = doc._rev;
     var id = doc._id;
@@ -1192,9 +1206,9 @@ function LevelPouch(opts, callback) {
         callback(null, ret);
       });
     });
-  };
+  });
 
-  api._removeLocal = function (doc, callback) {
+  api._removeLocal = writeLock(function (doc, callback) {
     stores.localStore.get(doc._id, function (err, resp) {
       if (err) {
         return callback(err);
@@ -1210,7 +1224,7 @@ function LevelPouch(opts, callback) {
         callback(null, ret);
       });
     });
-  };
+  });
 }
 
 LevelPouch.valid = function () {

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -1344,7 +1344,7 @@ function WebSqlPouch(opts, callback) {
     });
   };
 
-  api._doCompaction = function (docId, rev_tree, revs, callback) {
+  api._doCompaction = function (docId, revs, callback) {
     if (!revs.length) {
       return callback();
     }
@@ -1354,7 +1354,13 @@ function WebSqlPouch(opts, callback) {
       var sql = 'SELECT json AS metadata FROM ' + DOC_STORE + ' WHERE id = ?';
       tx.executeSql(sql, [docId], function (tx, result) {
         var metadata = vuvuzela.parse(result.rows.item(0).metadata);
-        metadata.rev_tree = rev_tree;
+        merge.traverseRevTree(metadata.rev_tree, function (isLeaf, pos,
+                                                           revHash, ctx, opts) {
+          var rev = pos + '-' + revHash;
+          if (revs.indexOf(rev) !== -1) {
+            opts.status = 'missing';
+          }
+        });
 
         var sql = 'UPDATE ' + DOC_STORE + ' SET json = ? WHERE id = ?';
         tx.executeSql(sql, [vuvuzela.stringify(metadata), docId]);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "levelup": "~0.18.4",
     "lie": "^2.6.0",
     "localstorage-down": "^0.6.2",
-    "memdown": "^0.11.0",
+    "memdown": "^1.0.0",
     "pouchdb-extend": "^0.1.2",
     "pouchdb-mapreduce": "~2.2.4",
     "request": "~2.28.0",


### PR DESCRIPTION
Contains two fixes:
1. adapter.js no longer passes the rev_tree to the underlying
   adapter. The adapter is expected to recalculate, since otherwise the database may change in the interim.
2. leveldb.js has a global write lock for all readwrite operations,
   similar to how WebSQL/IndexedDB work under the hood. I'm not
   100% satisfied with that, but it's better for the db to be
   correct than to be fast.
