### PR TITLE
(#2934) - add more framework adapters to docs

### DIFF
--- a/docs/external.md
+++ b/docs/external.md
@@ -98,23 +98,41 @@ A standalone CouchDB-style REST interface server to PouchDB.
 
 An express submodule with a CouchDB-style REST interface to PouchDB. Powers PouchDB Server.
 
-{% include anchor.html title="MV* Adapters" hash="MV* Adapters" %}
+{% include anchor.html title="Framework adapters" hash="framework_adapters" %}
 
-#### [Backbone PouchDB](https://github.com/jo/backbone-pouch)
+### Angular
 
-Backbone PouchDB Sync Adapter.
-
-#### [Ember Pouch](https://github.com/nolanlawson/ember-pouch)
-
-Ember Data adapter for PouchDB/CouchDB.
-
-#### [AngularJS PouchDB Support](https://github.com/wspringer/angular-pouchdb)
+#### [angular-pouchdb](https://github.com/wspringer/angular-pouchdb)
 
 Wrapper for using PouchDB within Angular.js.
 
 #### [Factoryng - AngularJS Adapter](https://github.com/redgeoff/factoryng)
 
 An all-in-one AngularJS factory that wraps PouchDB and Delta Pouch.
+
+#### [ngPouch](https://github.com/jrhicks/ngPouch)
+
+Angular service to persist remote connection settings and maintain continuous replication.
+
+#### [ng-pouchdb](https://github.com/danielzen/ng-pouchdb)
+
+AngularJS binding for PouchDB.
+
+### Backbone
+
+#### [Backbone PouchDB](https://github.com/jo/backbone-pouch)
+
+Backbone PouchDB Sync Adapter.
+
+### Ember
+
+#### [Ember Pouch](https://github.com/nolanlawson/ember-pouch)
+
+Ember Data adapter for PouchDB/CouchDB.
+
+#### [ember-pouchdb](https://github.com/taras/ember-pouchdb)
+
+Promisy PouchDB wrapper for Ember.js
 
 {% include anchor.html title="Other languages" hash="Other languages" %}
 


### PR DESCRIPTION
According to my Twitter trolling, we are now up to 4 different AngularJS adapters. I have no idea which one is the best, but people seem to really like adapters, so I just added them all.

Also decided to be cosmopolitan and add back in the competitor to my own Ember wrapper. Although alphabetical ordering puts mine first. :wink:
