### PR TITLE
(#2935) - new_edits=false works regardless of order

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -26,10 +26,10 @@ function arrayFirst(arr, callback) {
 // if the first result is an error, return an error
 function yankError(callback) {
   return function (err, results) {
-    if (err || results[0].error) {
+    if (err || (results[0] && results[0].error)) {
       callback(err || results[0]);
     } else {
-      callback(null, results[0]);
+      callback(null, results.length ? results[0]  : results);
     }
   };
 }
@@ -778,7 +778,32 @@ AbstractPouchDB.prototype.bulkDocs =
     }
   }
 
-  return this._bulkDocs(req, opts, this.autoCompact(callback));
+  if (!opts.new_edits && this.type() !== 'http') {
+    // ensure revisions of the same doc are sorted, so that
+    // the local adapter processes them correctly (#2935)
+    req.docs.sort(function (a, b) {
+      var idCompare = utils.compare(a._id, b._id);
+      if (idCompare !== 0) {
+        return idCompare;
+      }
+      var aStart = a._revisions ? a._revisions.start : 0;
+      var bStart = b._revisions ? b._revisions.start : 0;
+      return utils.compare(aStart, bStart);
+    });
+  }
+
+  return this._bulkDocs(req, opts, this.autoCompact(function (err, res) {
+    if (err) {
+      return callback(err);
+    }
+    if (!opts.new_edits) {
+      // this is what couch does when new_edits is false
+      res = res.filter(function (x) {
+        return x.error;
+      });
+    }
+    callback(null, res);
+  }));
 });
 
 AbstractPouchDB.prototype.registerDependentDatabase =

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -608,3 +608,7 @@ exports.explain404 = function (str) {
 };
 
 exports.parseUri = require('./deps/parse-uri');
+
+exports.compare = function (left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+};


### PR DESCRIPTION
This fix ensures that the input order of revisions
to the same document does not affect how those revisions
are loaded using bulkDocs with new_edits=false.
