### PR TITLE
(#2951) - fix concurrency in leveldb.js

### DIFF
--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -10,6 +10,7 @@ var merge = require('../merge');
 var utils = require('../utils');
 var migrate = require('../deps/migrate');
 var vuvuzela = require('vuvuzela');
+var Deque = require("double-ended-queue");
 
 var DOC_STORE = 'document-store';
 var BY_SEQ_STORE = 'by-sequence';
@@ -70,13 +71,12 @@ function LevelPouch(opts, callback) {
         return callback(err);
       }
       db = dbStore.get(name);
-      db._locks = db._locks || new utils.Set();
       db._docCountQueue = {
         queue : [],
         running : false,
         docCount : -1
       };
-      db._writeQueue = [];
+      db._writeQueue = new Deque();
       if (opts.db || opts.noMigrate) {
         afterDBCreated();
       } else {
@@ -196,18 +196,19 @@ function LevelPouch(opts, callback) {
       args[args.length - 1] = utils.getArguments(function (cbArgs) {
         callback.apply(null, cbArgs);
         process.nextTick(function () {
+          db._writeQueue.shift();
           if (db._writeQueue.length) {
-            db._writeQueue.shift()();
+            db._writeQueue.peekFront()();
           }
         });
       });
 
-      if (db._writeQueue.length) {
-        db._writeQueue.push(function () {
-          fun.apply(null, args);
-        });
-      } else {
+      db._writeQueue.push(function () {
         fun.apply(null, args);
+      });
+
+      if (db._writeQueue.length === 1) {
+        db._writeQueue.peekFront()();
       }
     });
   }
@@ -339,26 +340,10 @@ function LevelPouch(opts, callback) {
     });
   };
 
-  api.lock = function (id) {
-    if (db._locks.has(id)) {
-      return false;
-    } else {
-      db._locks.add(id);
-      return true;
-    }
-  };
-
-  api.unlock = function (id) {
-    if (db._locks.has(id)) {
-      db._locks.delete(id);
-      return true;
-    }
-    return false;
-  };
-
   api._bulkDocs = writeLock(function (req, opts, callback) {
     var newEdits = opts.new_edits;
     var results = new Array(req.docs.length);
+    var lock = new utils.Set();
 
     // parse the docs and give each a sequence number
     var userDocs = req.docs;
@@ -448,7 +433,7 @@ function LevelPouch(opts, callback) {
       current++;
       inProgress++;
       if (currentDoc._id && utils.isLocalId(currentDoc._id)) {
-        api[currentDoc._deleted ? '_removeLocal' : '_putLocal'](
+        api[currentDoc._deleted ? '_removeLocalNoLock' : '_putLocalNoLock'](
             currentDoc, function (err, resp) {
           if (err) {
             results[index] = err;
@@ -461,31 +446,32 @@ function LevelPouch(opts, callback) {
         return;
       }
 
-      if (!api.lock(currentDoc.metadata.id)) {
+      if (lock.has(currentDoc.metadata.id)) {
         results[index] = makeErr(errors.REV_CONFLICT,
-                                 'someobody else is accessing this');
+                                 'somebody else is accessing this');
         inProgress--;
         return processDocs();
       }
+      lock.add(currentDoc.metadata.id);
 
       stores.docStore.get(currentDoc.metadata.id, function (err, oldDoc) {
         if (err) {
           if (err.name === 'NotFoundError') {
             insertDoc(currentDoc, index, function () {
-              api.unlock(currentDoc.metadata.id);
+              lock.delete(currentDoc.metadata.id);
               inProgress--;
               processDocs();
             });
           } else {
             err.error = true;
             results[index] = err;
-            api.unlock(currentDoc.metadata.id);
+            lock.delete(currentDoc.metadata.id);
             inProgress--;
             processDocs();
           }
         } else {
           updateDoc(oldDoc, currentDoc, index, function () {
-            api.unlock(currentDoc.metadata.id);
+            lock.delete(currentDoc.metadata.id);
             inProgress--;
             processDocs();
           });
@@ -766,7 +752,9 @@ function LevelPouch(opts, callback) {
         };
       });
       LevelPouch.Changes.notify(name);
-      process.nextTick(function () { callback(null, aresults); });
+      process.nextTick(function () {
+        callback(null, aresults);
+      });
     }
 
     function makeErr(err, seq) {
@@ -1181,6 +1169,11 @@ function LevelPouch(opts, callback) {
   };
 
   api._putLocal = writeLock(function (doc, callback) {
+    api._putLocalNoLock(doc, callback);
+  });
+
+  // the NoLock version is for use by bulkDocs
+  api._putLocalNoLock = function (doc, callback) {
     delete doc._revisions; // ignore this, trust the rev
     var oldRev = doc._rev;
     var id = doc._id;
@@ -1206,9 +1199,14 @@ function LevelPouch(opts, callback) {
         callback(null, ret);
       });
     });
-  });
+  };
 
   api._removeLocal = writeLock(function (doc, callback) {
+    api._removeLocalNoLock(doc, callback);
+  });
+
+  // the NoLock version is for use by bulkDocs
+  api._removeLocalNoLock = function (doc, callback) {
     stores.localStore.get(doc._id, function (err, resp) {
       if (err) {
         return callback(err);
@@ -1224,7 +1222,7 @@ function LevelPouch(opts, callback) {
         callback(null, ret);
       });
     });
-  });
+  };
 }
 
 LevelPouch.valid = function () {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "argsarray": "0.0.1",
     "bluebird": "^1.2.4",
+    "double-ended-queue": "^2.0.0-0",
     "es3ify": "^0.1.3",
     "inherits": "~2.0.1",
     "level-js": "^2.1.3",


### PR DESCRIPTION
So I figured out where the bug was coming from - I had
not implemented the writeLock correctly. Took this opportunity
to also use the `double-ended-queue` as suggested by
@calvinmetcalf.
