### PR TITLE
(#2898) - small edits to the docs

### DIFF
--- a/docs/_guides/attachments.md
+++ b/docs/_guides/attachments.md
@@ -179,7 +179,7 @@ Whather you supply attachments as base64-encoded strings or as Blobs/Buffers, un
 
 {% include alert_start.html variant="warning" %}
 
-Blobs can be tricky to work with, especially when it comes to cross-browser support. You may find <a href='https://github.com/nolanlawson/blob-util'>blob-util</a> to be a useful addition to the attachment API. For instance, it has an `imgSrcToBlob()` method that will work cross-browser.
+Blobs can be tricky to work with, especially when it comes to cross-browser support. You may find <a href='https://github.com/nolanlawson/blob-util'>blob-util</a> to be a useful addition to the attachment API. For instance, it has an <code>imgSrcToBlob()</code> method that will work cross-browser.
 
 {% include alert_end.html %}
 

--- a/docs/_guides/databases.md
+++ b/docs/_guides/databases.md
@@ -28,7 +28,7 @@ You can see a **[live example](http://bl.ocks.org/nolanlawson/bddac54b92c2d8d392
 <br/>python -m SimpleHTTPServer
 </code>
 <p/>
-Now the site is up and running at <a href='http://localhost:8000'>http://localhost:8000</a>. To find the correct `gist.github.com` URL, just click the "block" number at the top of the page.
+Now the site is up and running at <a href='http://localhost:8000'>http://localhost:8000</a>. To find the correct <code>gist.github.com</code> URL, just click the "block" number at the top of the page.
 
 {% include alert_end.html %}
 
@@ -108,7 +108,18 @@ In Chrome, just choose *Overflow icon* &#9776; &#8594; *Tools* &#8594; *Develope
 
 This is the raw IndexedDB representation of your PouchDB, so it may be a little fine-grained compared to what PouchDB shows. However, it's great for quick debugging.
 
-In Safari <8, the `kittens` database will be under *WebSQL* instead of *IndexedDB*.
+In Safari, the `kittens` database will be under *WebSQL* instead of *IndexedDB*.
+
+Deleting your local database
+----------------
+
+During development, it's often useful to destroy the local database, so you can see what your users will experience when they visit your site for the first time. A page refresh is not enough, because the data will still be there!
+
+In Chrome, you can use the [ClearBrowserData extension](https://chrome.google.com/webstore/detail/clearbrowserdata/apehfighfmpoieeniallefdeibodgmmb), which will add a trashcan icon to your toolbar, which you can click to delete all local data (IndexedDB, WebSQL, LocalStorage, cookies, etc.).
+
+In Firefox, you can use the [Clear Recent History+ add-on](https://addons.mozilla.org/en-US/firefox/addon/clear-recent-history/), so when you right-click a page you can quickly clear all data.
+
+In Safari, you can simply click *Safari* &#8594; *Clear History and Website Data*.
 
 Differences between the local and remote databases
 -------

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -44,7 +44,7 @@ In the browser, PouchDB prefers IndexedDB, and falls back to WebSQL if IndexedDB
 	<td>&#10003; (10+)</td>
 	<td>&#10003;</td>
 	<td>&#10003;</td>
-	<td>&#10003; (8+)</td>
+	<td></td>
 	<td>&#10003;</td>
 </tr>
 <tr>
@@ -86,7 +86,7 @@ In the browser, PouchDB prefers IndexedDB, and falls back to WebSQL if IndexedDB
 </tr>
 <tr>
     <td>IndexedDB</td>
-    <td>&#10003; (8+)</td> 
+    <td></td> 
     <td></td>
     <td>&#10003; (4.4+)</td>
     <td>&#10003; (10+)</td>
@@ -109,12 +109,17 @@ In the browser, PouchDB prefers IndexedDB, and falls back to WebSQL if IndexedDB
 </table>
 </div>
 
+{% include alert_start.html variant="info"%}
+Safari 7.1+ and iOS 8+ supposedly support IndexedDB, but their implementation has many bugs, so PouchDB currently ignores it.
+{% include alert_end.html%}
+
 If you're ever curious which adapter is being used in a particular browser, you can use the following method:
 
 ```js
 var pouch = new PouchDB('myDB');
 console.log(pouch.adapter); // prints either 'idb' or 'websql'
 ```
+
 
 ### SQLite plugin for Cordova/PhoneGap
 
@@ -132,8 +137,11 @@ The SQLite plugin is known to pass the PouchDB test suite on both iOS and Androi
 
 ### Experimental adapter plugins
 
-As of PouchDB 2.2.3, we are building some experimental browser plugins that use backends other than IndexedDB and WebSQL. You are free to use them, but they are not yet part of the official release (although they pass our unit test suite at 100%).
+PouchDB also offers separate browser plugins that use backends other than IndexedDB and WebSQL. These plugins pass our test suite at 100%, but are not yet part of the official release due to build issues with Browserify. They also add a hefty footprint due to external dependencies, so take them with a grain of salt.
 
+{% include alert_start.html variant="warning"%}
+Currently these plugins do not work with Browserify itself; you have to include them as separate scripts in your HTML page.
+{% include alert_end.html%}
 
 **Downloads:**
 
@@ -143,7 +151,7 @@ As of PouchDB 2.2.3, we are building some experimental browser plugins that use 
 
 #### LocalStorage plugin
 
-If you need to support even older browsers, such as IE &le; 9.0 and Opera Mini, you can use the `pouchdb.localstorage.js` plugin, which allows PouchDB to fall back to [LocalStorage][] on browsers that don't support either IndexedDB or WebSQL.  The [es5-shims][] will also be necessary.
+If you need to support very old browsers, such as IE &le; 9.0 and Opera Mini, you can use the `pouchdb.localstorage.js` plugin, which allows PouchDB to fall back to [LocalStorage][] on browsers that don't support either IndexedDB or WebSQL.  The [es5-shims][] will also be necessary.
 
 ```html
 <script src="pouchdb.js"></script>
@@ -246,7 +254,7 @@ There are many other LevelDOWN-based plugins &ndash; far too many to list here. 
 
 
 {% include alert_start.html variant="warning"%}
-We do not currently test against any LevelDOWN adapters other than LevelDB, so these backends should be considered very experimental.
+We do not currently test against any LevelDOWN adapters other than LevelDB and MemDOWN, so the other backends should be considered experimental.
 {% include alert_end.html%}
 
 {% include anchor.html title="PouchDB over HTTP" hash="pouchdb_over_http"%}
@@ -266,7 +274,7 @@ If you are ever unsure what to do, consider replicating from PouchDB to a CouchD
 
 #### PouchDB Server
 
-[PouchDB Server](https://github.com/pouchdb/pouchdb-server) is a standalone REST server that implements the CouchDB API, while using a LevelDB-based PouchDB under the hood.  Again, this is not an officially supported server yet.
+[PouchDB Server](https://github.com/pouchdb/pouchdb-server) is a standalone REST server that implements the CouchDB API, while using a LevelDB-based PouchDB under the hood.  PouchDB Server passes our unit test suite at 100%, but be aware that it is not as full-featured or battle-tested as CouchDB.
 
 #### PouchDB Express
 


### PR DESCRIPTION
Major changes:
- Safari 8 doesn't use IndexedDB; corrected that.
- Browser adapter plugins are no longer "experimental"; let's just be honest: they pass the tests, but they don't work in Browserify.
- Recommending some browser extensions to clear site data; I find it really useful during development and it occurred to me that developers might not know about them.
- Random formatting fixes
