### PR TITLE
Added wrapper-promise for blob detection feature

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -1478,47 +1478,43 @@ function init(api, opts, callback) {
 
         // make sure blob support is only checked one
         blobSupportPromise = new utils.Promise(function (resolve) {
+          var blob = utils.createBlob([''], {type: 'image/png'});
+          txn.objectStore(DETECT_BLOB_SUPPORT_STORE).put(blob, 'key');
+          txn.oncomplete = function () {
+            // have to do it in a separate transaction, else the correct
+            // content type is always returned
+            txn = idb.transaction([META_STORE, DETECT_BLOB_SUPPORT_STORE],
+              'readwrite');
+            var getBlobReq = txn.objectStore(
+              DETECT_BLOB_SUPPORT_STORE).get('key');
+            getBlobReq.onsuccess = function (e) {
 
-          try {
-            var blob = utils.createBlob([''], {type: 'image/png'});
-            txn.objectStore(DETECT_BLOB_SUPPORT_STORE).put(blob, 'key');
-            txn.oncomplete = function () {
-              // have to do it in a separate transaction, else the correct
-              // content type is always returned
-              txn = idb.transaction([META_STORE, DETECT_BLOB_SUPPORT_STORE],
-                'readwrite');
-              var getBlobReq = txn.objectStore(
-                DETECT_BLOB_SUPPORT_STORE).get('key');
-              getBlobReq.onsuccess = function (e) {
+              var storedBlob = e.target.result;
+              var url = URL.createObjectURL(storedBlob);
 
-                var storedBlob = e.target.result;
-                var url = URL.createObjectURL(storedBlob);
-
-                utils.ajax({
-                  url: url,
-                  cache: true,
-                  binary: true
-                }, function (err, res) {
-                  if (err && err.status === 405) {
-                    // firefox won't let us do that. but firefox doesn't
-                    // have the blob type bug that Chrome does, so that's ok
-                    resolve(true);
-                  } else {
-                    resolve(!!(res && res.type === 'image/png'));
-                    if (err && err.status === 404) {
-                      utils.explain404(
-                        'PouchDB is just detecting blob URL support.');
-                    }
+              utils.ajax({
+                url: url,
+                cache: true,
+                binary: true
+              }, function (err, res) {
+                if (err && err.status === 405) {
+                  // firefox won't let us do that. but firefox doesn't
+                  // have the blob type bug that Chrome does, so that's ok
+                  resolve(true);
+                } else {
+                  resolve(!!(res && res.type === 'image/png'));
+                  if (err && err.status === 404) {
+                    utils.explain404(
+                      'PouchDB is just detecting blob URL support.');
                   }
-                  URL.revokeObjectURL(url);
-                });
-              };
+                }
+                URL.revokeObjectURL(url);
+              });
             };
-
-          } catch (err) {
-            resolve(false);
-            checkSetupComplete();
-          }
+          };
+        }).catch(function (err) {
+          blobSupport = false;
+          checkSetupComplete();
         });
       }
 


### PR DESCRIPTION
... to ensure that the ajax request is only called once even though there are multiple PouchDB instances on the page.

Discussion #2990
