### PR TITLE
(#2996) - Post component spacing

### DIFF
--- a/docs/static/less/pouchdb/post.less
+++ b/docs/static/less/pouchdb/post.less
@@ -1,4 +1,5 @@
 .post {
-  margin-bottom: 50px;
+  margin-top: 10px;
+  margin-bottom: 40px;
   &:last-of-type { margin-bottom: 10px; }
 }


### PR DESCRIPTION
Just adjusted the spacing because it was bothering me that the titles were so close to pictures, especially when hovered.

Before -> After
![screenshot from 2014-11-17 20 35 27](https://cloud.githubusercontent.com/assets/2445413/5077399/d1edf5a6-6e9a-11e4-9b48-a7f02b84e50f.png)
