### PR TITLE
(#3008) - fix base64 putAttachment in http.js

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -5,6 +5,7 @@ var CHANGES_BATCH_SIZE = 25;
 var utils = require('../utils');
 var errors = require('../deps/errors');
 var log = require('debug')('pouchdb:http:log');
+var isBrowser = typeof process === 'undefined' || process.browser;
 
 function encodeDocId(id) {
   if (/^_(design|local)/.test(id)) {
@@ -21,7 +22,7 @@ function preprocessAttachments(doc) {
   return utils.Promise.all(Object.keys(doc._attachments).map(function (key) {
     var attachment = doc._attachments[key];
     if (attachment.data && typeof attachment.data !== 'string') {
-      if (typeof process === undefined || process.browser) {
+      if (isBrowser) {
         return new utils.Promise(function (resolve) {
           utils.readAsBinaryString(attachment.data, function (binary) {
             attachment.data = utils.btoa(binary);
@@ -451,12 +452,18 @@ function HttpPouch(opts, callback) {
     }
 
     if (typeof blob === 'string') {
+      var binary;
       try {
-        blob = utils.atob(blob);
+        binary = utils.atob(blob);
       } catch (err) {
         // it's not base64-encoded, so throw error
         return callback(utils.extend({}, errors.BAD_ARG,
           {reason: "Attachments need to be base64 encoded"}));
+      }
+      if (isBrowser) {
+        blob = utils.createBlob([utils.fixBinary(binary)], {type: type});
+      } else {
+        blob = binary ? new Buffer(binary, 'binary') : '';
       }
     }
 

--- a/tests/test.attachments.js
+++ b/tests/test.attachments.js
@@ -1165,6 +1165,25 @@ adapters.forEach(function (adapter) {
       });
     }
 
+    it('#3008 test correct encoding/decoding of \\u0000 etc.', function () {
+
+      var base64 =
+        'iVBORw0KGgoAAAANSUhEUgAAAhgAAAJLCAYAAAClnu9J' +
+        'AAAgAElEQVR4Xuy9B7ylZXUu/p62T5nOMAPM0BVJICQi' +
+        'ogjEJN5ohEgQ';
+
+      var db = new PouchDB(dbs.name);
+      return db.putAttachment('foo', 'foo.bin', base64, 'image/png').then(function () {
+        return db.getAttachment('foo', 'foo.bin');
+      }).then(function (blob) {
+        return new PouchDB.utils.Promise(function (resolve) {
+          testUtils.readBlob(blob, resolve);
+        });
+      }).then(function (bin) {
+        PouchDB.utils.btoa(bin).should.equal(base64);
+      });
+    });
+
 
     var isSafari = (typeof process === 'undefined' || process.browser) &&
       /Safari/.test(window.navigator.userAgent) &&


### PR DESCRIPTION
`putAttachment` wasn't working correctly in `http.js` with base64-encoded strings, now it is.
