### PR TITLE
(#2771) - implement attachments=true for allDocs()

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -630,6 +630,11 @@ function HttpPouch(opts, callback) {
       params.push('include_docs=true');
     }
 
+    if (opts.attachments) {
+      // added in CouchDB 1.6.0
+      params.push('attachments=true');
+    }
+
     if (opts.key) {
       params.push('key=' + encodeURIComponent(JSON.stringify(opts.key)));
     }

--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -74,6 +74,32 @@ function decodeMetadata(storedObject) {
   return metadata;
 }
 
+// Read a blob from the database, encoding as necessary
+// and translating from base64 if the IDB doesn't support
+// native Blobs
+function readBlobData(body, type, encode, callback) {
+  if (encode) {
+    if (!body) {
+      callback('');
+    } else if (typeof body !== 'string') { // we have blob support
+      utils.readAsBinaryString(body, function (binary) {
+        callback(utils.btoa(binary));
+      });
+    } else { // no blob support
+      callback(body);
+    }
+  } else {
+    if (!body) {
+      callback(utils.createBlob([''], {type: type}));
+    } else if (typeof body !== 'string') { // we have blob support
+      callback(body);
+    } else { // no blob support
+      body = utils.fixBinary(atob(body));
+      callback(utils.createBlob([body], {type: type}));
+    }
+  }
+}
+
 function IdbPouch(opts, callback) {
   var api = this;
 
@@ -778,27 +804,10 @@ function init(api, opts, callback) {
     var type = attachment.content_type;
 
     txn.objectStore(ATTACH_STORE).get(digest).onsuccess = function (e) {
-      var data = e.target.result.body;
-      if (opts.encode) {
-        if (!data) {
-          callback(null, '');
-        } else if (typeof data !== 'string') { // we have blob support
-          utils.readAsBinaryString(data, function (binary) {
-            callback(null, btoa(binary));
-          });
-        } else { // no blob support
-          callback(null, data);
-        }
-      } else {
-        if (!data) {
-          callback(null, utils.createBlob([''], {type: type}));
-        } else if (typeof data !== 'string') { // we have blob support
-          callback(null, data);
-        } else { // no blob support
-          data = utils.fixBinary(atob(data));
-          callback(null, utils.createBlob([data], {type: type}));
-        }
-      }
+      var body = e.target.result.body;
+      readBlobData(body, type, opts.encode, function (blobData) {
+        callback(null, blobData);
+      });
     };
   };
 
@@ -852,18 +861,54 @@ function init(api, opts, callback) {
       }
     }
 
-    var transaction = idb.transaction([DOC_STORE, BY_SEQ_STORE], 'readonly');
-    transaction.oncomplete = function () {
+    var stores = [DOC_STORE, BY_SEQ_STORE];
+    if (opts.attachments) {
+      stores.push(ATTACH_STORE);
+    }
+    var transaction = idb.transaction(stores, 'readonly');
+
+    function onResultsReady() {
       callback(null, {
         total_rows: totalRows,
         offset: opts.skip,
         rows: results
       });
+    }
+
+    function postProcessAttachments() {
+      return utils.Promise.all(results.map(function (row) {
+        if (row.doc && row.doc._attachments) {
+          var attNames = Object.keys(row.doc._attachments);
+          return utils.Promise.all(attNames.map(function (att) {
+            var attObj = row.doc._attachments[att];
+            var body = attObj.body;
+            var type = attObj.content_type;
+            return new utils.Promise(function (resolve) {
+              readBlobData(body, type, true, function (base64) {
+                row.doc._attachments[att] = utils.extend(
+                  utils.pick(attObj, ['digest', 'content_type']),
+                  { data: base64 }
+                );
+                resolve();
+              });
+            });
+          }));
+        }
+      }));
+    }
+
+    transaction.oncomplete = function () {
+      if (opts.attachments) {
+        postProcessAttachments().then(onResultsReady);
+      } else {
+        onResultsReady();
+      }
     };
 
     var oStore = transaction.objectStore(DOC_STORE);
     var oCursor = descending ? oStore.openCursor(keyRange, descending)
       : oStore.openCursor(keyRange);
+    var attStore = opts.attachments && transaction.objectStore(ATTACH_STORE);
     var results = [];
     oCursor.onsuccess = function (e) {
       if (!e.target.result) {
@@ -873,6 +918,14 @@ function init(api, opts, callback) {
       var metadata = decodeMetadata(cursor.value);
       // metadata.winningRev added later, some dbs might be missing it
       var winningRev = metadata.winningRev || merge.winningRev(metadata);
+
+      function fetchAttachment(doc, att) {
+        var attObj = doc.doc._attachments[att];
+        var digest = attObj.digest;
+        attStore.get(digest).onsuccess = function (e) {
+          attObj.body = e.target.result.body;
+        };
+      }
 
       function allDocsInner(metadata, data) {
         var doc = {
@@ -893,7 +946,11 @@ function init(api, opts, callback) {
           }
           for (var att in doc.doc._attachments) {
             if (doc.doc._attachments.hasOwnProperty(att)) {
-              doc.doc._attachments[att].stub = true;
+              if (opts.attachments) {
+                fetchAttachment(doc, att);
+              } else {
+                doc.doc._attachments[att].stub = true;
+              }
             }
           }
         }

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -824,6 +824,32 @@ function LevelPouch(opts, callback) {
       var results = [];
       var docstream = stores.docStore.readStream(readstreamOpts);
 
+      function fetchAttachments() {
+        return utils.Promise.all(results.map(function (row) {
+          if (row.doc && row.doc._attachments) {
+            var attNames = Object.keys(row.doc._attachments);
+            return utils.Promise.all(attNames.map(function (att) {
+              var attObj = row.doc._attachments[att];
+              return new utils.Promise(function (resolve, reject) {
+                stores.binaryStore.get(attObj.digest, function (err, buffer) {
+                  var base64 = '';
+                  if (err && err.name !== 'NotFoundError') {
+                    return reject(err);
+                  } else if (!err) {
+                    base64 = utils.btoa(buffer);
+                  }
+                  row.doc._attachments[att] = utils.extend(
+                    utils.pick(attObj, ['digest', 'content_type']),
+                    {data: base64}
+                  );
+                  resolve();
+                });
+              });
+            }));
+          }
+        }));
+      }
+
       var throughStream = through(function (entry, _, next) {
         if (!utils.isDeleted(entry.value)) {
           if (skip-- > 0) {
@@ -883,11 +909,15 @@ function LevelPouch(opts, callback) {
           allDocsInner(metadata);
         }
       }, function (next) {
-        callback(null, {
-          total_rows: docCount,
-          offset: opts.skip,
-          rows: results
-        });
+        utils.Promise.resolve().then(function () {
+          return opts.attachments && fetchAttachments();
+        }).then(function () {
+          callback(null, {
+            total_rows: docCount,
+            offset: opts.skip,
+            rows: results
+          });
+        }, callback);
         next();
       }).on('unpipe', function () {
         throughStream.end();

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -1128,6 +1128,17 @@ function WebSqlPouch(opts, callback) {
           );
         sql += ' LIMIT ' + limit + ' OFFSET ' + offset;
 
+        function fetchAttachment(doc, att) {
+          var attObj = doc.doc._attachments[att];
+          var attOpts = {encode: true, ctx: tx};
+          api._getAttachment(attObj, attOpts, function (_, base64) {
+            doc.doc._attachments[att] = utils.extend(
+              utils.pick(attObj, ['digest', 'content_type']),
+              { data: base64 }
+            );
+          });
+        }
+
         tx.executeSql(sql, sqlArgs, function (tx, result) {
           for (var i = 0, l = result.rows.length; i < l; i++) {
             var item = result.rows.item(i);
@@ -1147,7 +1158,11 @@ function WebSqlPouch(opts, callback) {
               }
               for (var att in doc.doc._attachments) {
                 if (doc.doc._attachments.hasOwnProperty(att)) {
-                  doc.doc._attachments[att].stub = true;
+                  if (opts.attachments) {
+                    fetchAttachment(doc, att);
+                  } else {
+                    doc.doc._attachments[att].stub = true;
+                  }
                 }
               }
             }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -67,6 +67,15 @@ exports.lastIndexOf = function (str, char) {
 exports.clone = function (obj) {
   return exports.extend(true, {}, obj);
 };
+// like underscore/lodash _.pick()
+exports.pick = function (obj, arr) {
+  var res = {};
+  for (var i = 0, len = arr.length; i < len; i++) {
+    var prop = arr[i];
+    res[prop] = obj[prop];
+  }
+  return res;
+};
 exports.inherits = require('inherits');
 // Determine id an ID is valid
 //   - invalid IDs begin with an underescore that does not begin '_design' or


### PR DESCRIPTION
Not supported in CouchDB < 1.6.0, but Travis tests 1.6.1, so we should be okay.
