### PR TITLE
(#2125) - test in chrome 32 as Android 4.4 surrogate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ env:
 
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome COMMAND=test
+  - CLIENT=saucelabs:chrome:32 COMMAND=test # roughly corresponds to Android 4.4
   - CLIENT=saucelabs:chrome:37 COMMAND=test
   - CLIENT=saucelabs:chrome ADAPTERS=websql COMMAND=test
   - CLIENT=saucelabs:safari:6 COMMAND=test


### PR DESCRIPTION
Not sure if this is really worth it, but I'm curious to see if it passes. For the record, my Android 4.4.4 is running Chrome 33, but I'm pretty sure the other 4.4.x's (which are [more common](https://developer.android.com/about/dashboards/index.html)) run 32. 
