### PR TITLE
(#3040) - tweaks to perf tests

### DIFF
--- a/tests/performance/perf.views.js
+++ b/tests/performance/perf.views.js
@@ -28,7 +28,7 @@ module.exports = function (PouchDB, opts) {
     {
       name: 'temp-views',
       assertions: 1,
-      iterations: 10,
+      iterations: 1,
       setup: function (db, callback) {
         var tasks = [];
         for (var i = 0; i < 100; i++) {

--- a/tests/performance/utils.js
+++ b/tests/performance/utils.js
@@ -25,6 +25,7 @@ exports.runTests = function (PouchDB, suiteName, testCases, opts) {
       var randomizer = Math.random();
 
       t.test('setup', function (t) {
+        opts.size = 3000;
         db = new PouchDB('test' + randomizer, opts);
         testCase.setup(db, function (err, res) {
           setupObj = res;


### PR DESCRIPTION
Justification for these changes:
- 10 iterations is way too many for `temp-views`; it doesn't even finish in Travis for Firefox, and that's because it's already really slow even with just one iteration. My perf report showed numbers for 1 iteration, and you can see they still take ~10x longer than the other tests..
- For Safari you need to request a huge size up-front so that the popup doesn't appear during the test and throw off your numbers.
