### PR TITLE
(#3062) - refactor idb/websql to share more code

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -310,12 +310,10 @@ function init(api, opts, callback) {
         return doc;
       }
       var newDoc = utils.parseDoc(doc, newEdits);
-      newDoc._bulk_seq = i;
       return newDoc;
     });
 
     var docInfoErrors = docInfos.filter(function (docInfo) {
-      delete docInfo._bulk_seq;
       return docInfo.error;
     });
     if (docInfoErrors.length) {
@@ -327,57 +325,8 @@ function init(api, opts, callback) {
     var preconditionErrored = false;
 
     function processDocs() {
-      if (!docInfos.length) {
-        return;
-      }
-
-      var idsToDocs = new utils.Map();
-
-      docInfos.forEach(function (currentDoc, resultsIdx) {
-        if (currentDoc._id && utils.isLocalId(currentDoc._id)) {
-          api[currentDoc._deleted ? '_removeLocal' : '_putLocal'](
-              currentDoc, {ctx: txn}, function (err, resp) {
-            if (err) {
-              results[resultsIdx] = err;
-            } else {
-              results[resultsIdx] = {};
-            }
-          });
-          return;
-        }
-
-        var id = currentDoc.metadata.id;
-        if (idsToDocs.has(id)) {
-          idsToDocs.get(id).push([currentDoc, resultsIdx]);
-        } else {
-          idsToDocs.set(id, [[currentDoc, resultsIdx]]);
-        }
-      });
-
-      // in the case of new_edits, the user can provide multiple docs
-      // with the same id. these need to be processed sequentially
-      idsToDocs.forEach(function (docs, id) {
-        var numDone = 0;
-
-        function docWritten() {
-          if (++numDone < docs.length) {
-            nextDoc();
-          }
-        }
-        function nextDoc() {
-          var value = docs[numDone];
-          var currentDoc = value[0];
-          var resultsIdx = value[1];
-
-          if (fetchedDocs.has(id)) {
-            utils.updateDoc(fetchedDocs.get(id), currentDoc, results,
-                            resultsIdx, docWritten, writeDoc, newEdits);
-          } else {
-            insertDoc(currentDoc, resultsIdx, docWritten);
-          }
-        }
-        nextDoc();
-      });
+      utils.processDocs(docInfos, api, fetchedDocs,
+        txn, results, writeDoc, opts);
     }
 
     function fetchExistingDocs(callback) {
@@ -414,9 +363,7 @@ function init(api, opts, callback) {
         return;
       }
       var aresults = results.map(function (result) {
-        if (result._bulk_seq) {
-          delete result._bulk_seq;
-        } else if (!Object.keys(result).length) {
+        if (!Object.keys(result).length) {
           return {
             ok: true
           };
@@ -437,47 +384,6 @@ function init(api, opts, callback) {
       IdbPouch.Changes.notify(name);
       docCount = -1; // invalidate
       callback(null, aresults);
-    }
-
-    function preprocessAttachment(att, finish) {
-      if (att.stub) {
-        return finish();
-      }
-      if (typeof att.data === 'string') {
-        var data;
-        try {
-          data = atob(att.data);
-        } catch (e) {
-          var err = errors.error(errors.BAD_ARG,
-                                "Attachments need to be base64 encoded");
-          return callback(err);
-        }
-        var length;
-        if (blobSupport) {
-          var type = att.content_type;
-          data = utils.fixBinary(data);
-          length = data.byteLength;
-          att.data = utils.createBlob([data], {type: type});
-        } else {
-          length = data.length;
-        }
-        utils.MD5(data).then(function (result) {
-          att.digest = 'md5-' + result;
-          att.length = length;
-          finish();
-        });
-        return;
-      }
-      utils.readAsBinaryString(att.data, function (binary) {
-        if (!blobSupport) {
-          att.data = btoa(binary);
-        }
-        utils.MD5(binary).then(function (result) {
-          att.digest = 'md5-' + result;
-          att.length = binary.length;
-          finish();
-        });
-      });
     }
 
     function verifyAttachment(digest, callback) {
@@ -524,44 +430,6 @@ function init(api, opts, callback) {
           checkDone();
         });
       });
-    }
-
-    function preprocessAttachments(callback) {
-      if (!docInfos.length) {
-        return callback();
-      }
-
-      var docv = 0;
-      docInfos.forEach(function (docInfo) {
-        var attachments = docInfo.data && docInfo.data._attachments ?
-          Object.keys(docInfo.data._attachments) : [];
-
-        if (!attachments.length) {
-          return done();
-        }
-
-        var recv = 0;
-        function attachmentProcessed() {
-          recv++;
-          if (recv === attachments.length) {
-            done();
-          }
-        }
-
-        for (var key in docInfo.data._attachments) {
-          if (docInfo.data._attachments.hasOwnProperty(key)) {
-            preprocessAttachment(docInfo.data._attachments[key],
-                                 attachmentProcessed);
-          }
-        }
-      });
-
-      function done() {
-        docv++;
-        if (docInfos.length === docv) {
-          callback();
-        }
-      }
     }
 
     function writeDoc(docInfo, winningRev, deleted, callback, _up, resultsIdx) {
@@ -686,17 +554,6 @@ function init(api, opts, callback) {
       }
     }
 
-    function insertDoc(docInfo, resultsIdx, callback) {
-      var winningRev = merge.winningRev(docInfo.metadata);
-      var deleted = utils.isDeleted(docInfo.metadata, winningRev);
-      // Cant insert new deleted documents
-      if ('was_delete' in opts && deleted) {
-        results[resultsIdx] = errors.MISSING_DOC;
-        return callback();
-      }
-      writeDoc(docInfo, winningRev, deleted, callback, true, resultsIdx);
-    }
-
     function saveAttachment(digest, data, callback) {
       var objectStore = txn.objectStore(ATTACH_STORE);
       objectStore.get(digest).onsuccess = function (e) {
@@ -716,7 +573,12 @@ function init(api, opts, callback) {
     }
 
     var txn;
-    preprocessAttachments(function () {
+    var blobType = blobSupport ? 'blob' : 'base64';
+    utils.preprocessAttachments(docInfos, blobType, function (err) {
+      if (err) {
+        return callback(err);
+      }
+
       var stores = [
         DOC_STORE, BY_SEQ_STORE,
         ATTACH_STORE, META_STORE,

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -568,7 +568,6 @@ function WebSqlPouch(opts, callback) {
         return doc;
       }
       var newDoc = utils.parseDoc(doc, newEdits);
-      newDoc._bulk_seq = i;
       return newDoc;
     });
 
@@ -582,13 +581,14 @@ function WebSqlPouch(opts, callback) {
     var tx;
     var results = new Array(docInfos.length);
     var fetchedDocs = new utils.Map();
-    var numDocsWritten = 0;
 
+    var preconditionErrored;
     function complete() {
+      if (preconditionErrored) {
+        return callback(preconditionErrored);
+      }
       var aresults = results.map(function (result) {
-        if (result._bulk_seq) {
-          delete result._bulk_seq;
-        } else if (!Object.keys(result).length) {
+        if (!Object.keys(result).length) {
           return {
             ok: true
           };
@@ -607,7 +607,7 @@ function WebSqlPouch(opts, callback) {
         };
       });
       WebSqlPouch.Changes.notify(name);
-
+      docCount = -1; // invalidate
       callback(null, aresults);
     }
 
@@ -658,69 +658,6 @@ function WebSqlPouch(opts, callback) {
       });
     }
 
-    function preprocessAttachment(att, finish) {
-      if (att.stub) {
-        return finish();
-      }
-      if (typeof att.data === 'string') {
-        try {
-          att.data = atob(att.data);
-        } catch (e) {
-          var err = errors.error(errors.BAD_ARG,
-                                "Attachments need to be base64 encoded");
-          return callback(err);
-        }
-        var data = utils.fixBinary(att.data);
-        att.data = utils.createBlob([data], {type: att.content_type});
-      }
-      utils.readAsBinaryString(att.data, function (binary) {
-        att.data = binary;
-        utils.MD5(binary).then(function (result) {
-          att.digest = 'md5-' + result;
-          att.length = binary.length;
-          finish();
-        });
-      });
-    }
-
-    function preprocessAttachments(callback) {
-      if (!docInfos.length) {
-        return callback();
-      }
-
-      var docv = 0;
-
-      docInfos.forEach(function (docInfo) {
-        var attachments = docInfo.data && docInfo.data._attachments ?
-          Object.keys(docInfo.data._attachments) : [];
-        var recv = 0;
-
-        if (!attachments.length) {
-          return done();
-        }
-
-        function processedAttachment() {
-          recv++;
-          if (recv === attachments.length) {
-            done();
-          }
-        }
-
-        for (var key in docInfo.data._attachments) {
-          if (docInfo.data._attachments.hasOwnProperty(key)) {
-            preprocessAttachment(docInfo.data._attachments[key],
-                                 processedAttachment);
-          }
-        }
-      });
-
-      function done() {
-        docv++;
-        if (docInfos.length === docv) {
-          callback();
-        }
-      }
-    }
 
     function writeDoc(docInfo, winningRev, deleted, callback, isUpdate,
                       resultsIdx) {
@@ -857,78 +794,9 @@ function WebSqlPouch(opts, callback) {
       }
     }
 
-    function insertDoc(docInfo, resultsIdx, callback) {
-      // Cant insert new deleted documents
-      var winningRev = merge.winningRev(docInfo.metadata);
-      var deleted = utils.isDeleted(docInfo.metadata, winningRev);
-      if ('was_delete' in opts && deleted) {
-        results[resultsIdx] = errors.MISSING_DOC;
-        return callback();
-      }
-      writeDoc(docInfo, winningRev, deleted, callback, false, resultsIdx);
-    }
-
-    function checkDoneWritingDocs() {
-      if (++numDocsWritten === docInfos.length) {
-        complete();
-      }
-    }
-
     function processDocs() {
-      if (!docInfos.length) {
-        return complete();
-      }
-
-      var idsToDocs = new utils.Map();
-
-      docInfos.forEach(function (currentDoc, resultsIdx) {
-
-        if (currentDoc._id && utils.isLocalId(currentDoc._id)) {
-          api[currentDoc._deleted ? '_removeLocal' : '_putLocal'](
-              currentDoc, {ctx: tx}, function (err, resp) {
-            if (err) {
-              results[resultsIdx] = err;
-            } else {
-              results[resultsIdx] = {};
-            }
-            checkDoneWritingDocs();
-          });
-          return;
-        }
-
-        var id = currentDoc.metadata.id;
-        if (idsToDocs.has(id)) {
-          idsToDocs.get(id).push([currentDoc, resultsIdx]);
-        } else {
-          idsToDocs.set(id, [[currentDoc, resultsIdx]]);
-        }
-      });
-
-      // in the case of new_edits, the user can provide multiple docs
-      // with the same id. these need to be processed sequentially
-      idsToDocs.forEach(function (docs, id) {
-        var numDone = 0;
-
-        function docWritten() {
-          checkDoneWritingDocs();
-          if (++numDone < docs.length) {
-            nextDoc();
-          }
-        }
-        function nextDoc() {
-          var value = docs[numDone];
-          var currentDoc = value[0];
-          var resultsIdx = value[1];
-
-          if (fetchedDocs.has(id)) {
-            utils.updateDoc(fetchedDocs.get(id), currentDoc, results,
-                            resultsIdx, docWritten, writeDoc, newEdits);
-          } else {
-            insertDoc(currentDoc, resultsIdx, docWritten);
-          }
-        }
-        nextDoc();
-      });
+      utils.processDocs(docInfos, api, fetchedDocs,
+        tx, results, writeDoc, opts);
     }
 
     function fetchExistingDocs(callback) {
@@ -981,18 +849,20 @@ function WebSqlPouch(opts, callback) {
       });
     }
 
-    preprocessAttachments(function () {
+    utils.preprocessAttachments(docInfos, 'binary', function (err) {
+      if (err) {
+        return callback(err);
+      }
       db.transaction(function (txn) {
         tx = txn;
         verifyAttachments(function (err) {
           if (err) {
-            return callback(err);
+            preconditionErrored = err;
+          } else {
+            fetchExistingDocs(processDocs);
           }
-          fetchExistingDocs(processDocs);
         });
-      }, unknownError(callback), function () {
-        docCount = -1;
-      });
+      }, unknownError(callback), complete);
     });
   };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -631,10 +631,11 @@ exports.compare = function (left, right) {
   return left < right ? -1 : left > right ? 1 : 0;
 };
 
-exports.updateDoc = function (prev, docInfo, results, id, cb, write, newEdits) {
+exports.updateDoc = function updateDoc(prev, docInfo, results,
+                                       i, cb, write, newEdits) {
 
   if (exports.revExists(prev, docInfo.metadata.rev)) {
-    results[id] = docInfo;
+    results[i] = docInfo;
     return cb();
   }
 
@@ -657,8 +658,7 @@ exports.updateDoc = function (prev, docInfo, results, id, cb, write, newEdits) {
 
   if (inConflict) {
     var err = errors.REV_CONFLICT;
-    err._bulk_seq = docInfo._bulk_seq;
-    results[id] = err;
+    results[i] = err;
     return cb();
   }
 
@@ -668,5 +668,173 @@ exports.updateDoc = function (prev, docInfo, results, id, cb, write, newEdits) {
   var winningRev = merge.winningRev(docInfo.metadata);
   deleted = exports.isDeleted(docInfo.metadata, winningRev);
 
-  write(docInfo, winningRev, deleted, cb, true, id);
+  write(docInfo, winningRev, deleted, cb, true, i);
+};
+
+exports.processDocs = function processDocs(docInfos, api, fetchedDocs,
+                                           tx, results, writeDoc, opts) {
+
+  if (!docInfos.length) {
+    return;
+  }
+
+  function insertDoc(docInfo, resultsIdx, callback) {
+    // Cant insert new deleted documents
+    var winningRev = merge.winningRev(docInfo.metadata);
+    var deleted = exports.isDeleted(docInfo.metadata, winningRev);
+    if ('was_delete' in opts && deleted) {
+      results[resultsIdx] = errors.MISSING_DOC;
+      return callback();
+    }
+    writeDoc(docInfo, winningRev, deleted, callback, false, resultsIdx);
+  }
+
+  var newEdits = opts.new_edits;
+  var idsToDocs = new exports.Map();
+
+  docInfos.forEach(function (currentDoc, resultsIdx) {
+
+    if (currentDoc._id && exports.isLocalId(currentDoc._id)) {
+      api[currentDoc._deleted ? '_removeLocal' : '_putLocal'](
+        currentDoc, {ctx: tx}, function (err, resp) {
+          if (err) {
+            results[resultsIdx] = err;
+          } else {
+            results[resultsIdx] = {};
+          }
+        });
+      return;
+    }
+
+    var id = currentDoc.metadata.id;
+    if (idsToDocs.has(id)) {
+      idsToDocs.get(id).push([currentDoc, resultsIdx]);
+    } else {
+      idsToDocs.set(id, [[currentDoc, resultsIdx]]);
+    }
+  });
+
+  // in the case of new_edits, the user can provide multiple docs
+  // with the same id. these need to be processed sequentially
+  idsToDocs.forEach(function (docs, id) {
+    var numDone = 0;
+
+    function docWritten() {
+      if (++numDone < docs.length) {
+        nextDoc();
+      }
+    }
+    function nextDoc() {
+      var value = docs[numDone];
+      var currentDoc = value[0];
+      var resultsIdx = value[1];
+
+      if (fetchedDocs.has(id)) {
+        exports.updateDoc(fetchedDocs.get(id), currentDoc, results,
+          resultsIdx, docWritten, writeDoc, newEdits);
+      } else {
+        insertDoc(currentDoc, resultsIdx, docWritten);
+      }
+    }
+    nextDoc();
+  });
+};
+
+exports.preprocessAttachments = function preprocessAttachments(
+    docInfos, blobType, callback) {
+
+  if (!docInfos.length) {
+    return callback();
+  }
+
+  var docv = 0;
+
+  function parseBase64(data) {
+    try {
+      return exports.atob(data);
+    } catch (e) {
+      var err = errors.error(errors.BAD_ARG,
+        "Attachments need to be base64 encoded");
+      return {error: err};
+    }
+  }
+
+  function preprocessAttachment(att, callback) {
+    if (att.stub) {
+      return callback();
+    }
+    if (typeof att.data === 'string') {
+      // input is a base64 string
+
+      var asBinary = parseBase64(att.data);
+      if (asBinary.error) {
+        return callback(asBinary.error);
+      }
+
+      att.length = asBinary.length;
+      if (blobType === 'blob') {
+        att.data = exports.createBlob([exports.fixBinary(asBinary)],
+          {type: att.content_type});
+      } else if (blobType === 'base64') {
+        att.data = exports.btoa(asBinary);
+      } else { // binary
+        att.data = asBinary;
+      }
+      exports.MD5(asBinary).then(function (result) {
+        att.digest = 'md5-' + result;
+        callback();
+      });
+    } else { // input is a blob
+      exports.readAsBinaryString(att.data, function (binary) {
+        if (blobType === 'binary') {
+          att.data = binary;
+        } else if (blobType === 'base64') {
+          att.data = exports.btoa(binary);
+        }
+        exports.MD5(binary).then(function (result) {
+          att.digest = 'md5-' + result;
+          att.length = binary.length;
+          callback();
+        });
+      });
+    }
+  }
+
+  var overallErr;
+
+  docInfos.forEach(function (docInfo) {
+    var attachments = docInfo.data && docInfo.data._attachments ?
+      Object.keys(docInfo.data._attachments) : [];
+    var recv = 0;
+
+    if (!attachments.length) {
+      return done();
+    }
+
+    function processedAttachment(err) {
+      overallErr = err;
+      recv++;
+      if (recv === attachments.length) {
+        done();
+      }
+    }
+
+    for (var key in docInfo.data._attachments) {
+      if (docInfo.data._attachments.hasOwnProperty(key)) {
+        preprocessAttachment(docInfo.data._attachments[key],
+          processedAttachment);
+      }
+    }
+  });
+
+  function done() {
+    docv++;
+    if (docInfos.length === docv) {
+      if (overallErr) {
+        callback(overallErr);
+      } else {
+        callback();
+      }
+    }
+  }
 };


### PR DESCRIPTION
This is just some odd refactoring I did while working on #3062. The goal was to increase the code shared between `idb.js` and `websql.js` in the hopes that that can later be extended to `leveldb.js`.

Also notice that `_bulk_seq` is totally useless and we can remove it wherever we see it.
