### PR TITLE
(#3062) - fix removeLocal with missing doc

### DIFF
--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -1464,12 +1464,14 @@ function WebSqlPouch(opts, callback) {
       var params = [doc._id, doc._rev];
       tx.executeSql(sql, params, function (tx, res) {
         if (!res.rowsAffected) {
-          return callback(errors.REV_CONFLICT);
+          return callback(errors.MISSING_DOC);
         }
         ret = {ok: true, id: doc._id, rev: '0-0'};
       });
     }, unknownError(callback), function () {
-      callback(null, ret);
+      if (ret) {
+        callback(null, ret);
+      }
     });
   };
 }

--- a/tests/integration/test.local_docs.js
+++ b/tests/integration/test.local_docs.js
@@ -101,6 +101,18 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('local docs - remove missing', function () {
+      var db = new PouchDB(dbs.name);
+      return db.remove({
+        _id: '_local/foo',
+        _rev: '1-fake'
+      }).then(function () {
+        throw new Error('should not be here');
+      }, function (err) {
+        err.name.should.be.a('string');
+      });
+    });
+
     it('local docs - put after put w/ deleted:true', function () {
       var db = new PouchDB(dbs.name);
       var doc = {_id: '_local/foo'};


### PR DESCRIPTION
Just something small I noticed - `websql.js` was calling `complete` twice for `removeLocal`. This fixes that.
