### PR TITLE
(#3056) - implement doc_ids filter

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -410,6 +410,7 @@ All options default to `false` unless otherwise specified.
   * `options.attachments`: Include attachments.
 * `options.descending`: Reverse the order of the output documents.
 * `options.filter`: Reference a filter function from a design document to selectively get updates.
+* `options.doc_ids`: Only show changes for docs with these ids (array of strings).
 * `options.since`: Start the results from the change immediately after the given sequence number, you can also pass 'now' if you want only new changes.
 * `options.live`: Uses the  `_longpoll_` feed. 
 * `options.limit`: Limit the number of results to this number.
@@ -504,7 +505,7 @@ All options default to `false` unless otherwise specified.
 
 * `options.filter`: Reference a filter function from a design document to selectively get updates.
 * `options.query_params`: Query params sent to the filter function.
-* `options.doc_ids`: Only replicate docs with these ids.
+* `options.doc_ids`: Only replicate docs with these ids (array of strings).
 * `options.live`: If `true`, starts subscribing to future changes in the `source` database and continue replicating them.
 * `options.since`: Replicate changes after the given sequence number.
 * `options.create_target`: Create target database if it does not exist. Only for server replications.

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -2,6 +2,13 @@
 
 var CHANGES_BATCH_SIZE = 25;
 
+// according to http://stackoverflow.com/a/417184/680742,
+// the de factor URL length limit is 2000 characters.
+// but since most of our measurements don't take the full
+// URL into account, we fudge it a bit.
+// TODO: we could measure the full URL to enforce exactly 2000 chars
+var MAX_URL_LENGTH = 1800;
+
 var utils = require('../utils');
 var errors = require('../deps/errors');
 var log = require('debug')('pouchdb:http');
@@ -683,9 +690,6 @@ function HttpPouch(opts, callback) {
 
     if (typeof opts.keys !== 'undefined') {
 
-      var MAX_URL_LENGTH = 2000;
-      // according to http://stackoverflow.com/a/417184/680742,
-      // the de factor URL length limit is 2000 characters
 
       var keysAsString =
         'keys=' + encodeURIComponent(JSON.stringify(opts.keys));
@@ -782,6 +786,27 @@ function HttpPouch(opts, callback) {
         }
       }
     }
+
+    var method = 'GET';
+    var body;
+
+    if (opts.doc_ids) {
+      // set this automagically for the user; it's annoying that couchdb
+      // requires both a "filter" and a "doc_ids" param.
+      params.filter = '_doc_ids';
+
+      var docIdsJson = JSON.stringify(opts.doc_ids);
+
+      if (docIdsJson.length < MAX_URL_LENGTH) {
+        params.doc_ids = docIdsJson;
+      } else {
+        // anything greater than ~2000 is unsafe for gets, so
+        // use POST instead
+        method = 'POST';
+        body = {doc_ids: opts.doc_ids };
+      }
+    }
+
     if (opts.continuous && api._useSSE) {
       return  api.sse(opts, params, returnDocs);
     }
@@ -811,10 +836,11 @@ function HttpPouch(opts, callback) {
       // Set the options for the ajax call
       var xhrOpts = {
         headers: host.headers,
-        method: 'GET',
+        method: method,
         url: genDBUrl(host, '_changes' + paramStr),
         // _changes can take a long time to generate, especially when filtered
-        timeout: opts.timeout
+        timeout: opts.timeout,
+        body: body
       };
       lastFetchedSeq = since;
 

--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -955,6 +955,7 @@ function init(api, opts, callback) {
       };
     }
 
+    var docIds = opts.doc_ids && new utils.Set(opts.doc_ids);
     var descending = opts.descending ? 'prev' : null;
     var lastSeq = 0;
 
@@ -1013,7 +1014,7 @@ function init(api, opts, callback) {
 
       var doc = cursor.value;
 
-      if (opts.doc_ids && opts.doc_ids.indexOf(doc._id) === -1) {
+      if (docIds && !docIds.has(doc._id)) {
         return cursor.continue();
       }
 

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -68,6 +68,20 @@ function fetchAttachments(results, stores) {
   }));
 }
 
+function createChangesFilter(opts) {
+  var baseFilter = utils.filterChange(opts);
+  var docIds = opts.doc_ids && new utils.Set(opts.doc_ids);
+  return function filter(change) {
+    // It's the responsibility of each adapter to actually do
+    // the doc_ids filtering, since websql/idb can do it
+    // more efficiently.
+    if (docIds && !docIds.has(change.id)) {
+      return false;
+    }
+    return baseFilter(change);
+  };
+}
+
 function LevelPouch(opts, callback) {
   opts = utils.clone(opts);
   var api = this;
@@ -967,7 +981,9 @@ function LevelPouch(opts, callback) {
     if (!streamOpts.reverse) {
       streamOpts.start = formatSeq(opts.since ? opts.since + 1 : 0);
     }
-    var filter = utils.filterChange(opts);
+
+    var filter = createChangesFilter(opts);
+
     var returnDocs;
     if ('returnDocs' in opts) {
       returnDocs = opts.returnDocs;

--- a/lib/changes.js
+++ b/lib/changes.js
@@ -166,7 +166,8 @@ Changes.prototype.doChanges = function (opts) {
   }
 
   if (this.db.type() !== 'http' &&
-    opts.filter && typeof opts.filter === 'string') {
+      opts.filter && typeof opts.filter === 'string' &&
+      !opts.doc_ids) {
     return this.filterChanges(opts);
   }
 

--- a/lib/deps/collections.js
+++ b/lib/deps/collections.js
@@ -49,8 +49,15 @@ LazyMap.prototype.forEach = function (cb) {
   });
 };
 
-function LazySet() {
+function LazySet(array) {
   this.store = new LazyMap();
+
+  // init with an array
+  if (array && Array.isArray(array)) {
+    for (var i = 0, len = array.length; i < len; i++) {
+      this.add(array[i]);
+    }
+  }
 }
 LazySet.prototype.add = function (key) {
   return this.store.set(key, true);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -157,16 +157,13 @@ exports.revExists = function (metadata, rev) {
   return found;
 };
 
-exports.filterChange = function (opts) {
-  return function (change) {
-    var req = {};
-    var hasFilter = opts.filter && typeof opts.filter === 'function';
+exports.filterChange = function filterChange(opts) {
+  var req = {};
+  var hasFilter = opts.filter && typeof opts.filter === 'function';
+  req.query = opts.query_params;
 
-    req.query = opts.query_params;
+  return function filter(change) {
     if (opts.filter && hasFilter && !opts.filter.call(this, change.doc, req)) {
-      return false;
-    }
-    if (opts.doc_ids && opts.doc_ids.indexOf(change.id) === -1) {
       return false;
     }
     if (!opts.include_docs) {
@@ -337,6 +334,7 @@ Changes.prototype.addListener = function (dbName, id, db, opts) {
       continuous: false,
       descending: false,
       filter: opts.filter,
+      doc_ids: opts.doc_ids,
       view: opts.view,
       since: opts.since,
       query_params: opts.query_params,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "through2": "^0.4.1",
     "vuvuzela": "^1.0.0",
     "debug": "^2.1.0",
-    "pouchdb-express-router": "0.0.1",
+    "pouchdb-express-router": "^0.0.2",
     "express": "^4.10.4"
   },
   "devDependencies": {


### PR DESCRIPTION
The implementation of https://github.com/pouchdb/pouchdb/pull/3056 was not quite right; here is my version.
- passes `filter=_doc_ids` to CouchDB, which is what actually triggers the filtering when combined with `doc_ids` (verified in the Network debugger)
- uses POST with `_changes` when there are a lot of doc_ids, verified in the debugger that we have a test case that POSTs as well as a test case that GETs
- removed `doc_ids` filtering from `utils`, made it the responsibility of each adapter, since `idb.js` and `websql.js` already do the filtering themselves anyway for performance reasons (and it also verifies that `http.js` is being queried correctly)
- fixed `doc_ids` for live changes; it actually wasn't working
- added a bunch of tests
