### PR TITLE
(#3074) - implement attachments=true for changes()

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -748,6 +748,10 @@ function HttpPouch(opts, callback) {
       params.include_docs = true;
     }
 
+    if (opts.attachments) {
+      params.attachments = true;
+    }
+
     if (opts.continuous) {
       params.feed = 'longpoll';
     }

--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -5,6 +5,31 @@ var merge = require('../merge');
 var errors = require('../deps/errors');
 var vuvuzela = require('vuvuzela');
 
+// IndexedDB requires a versioned database structure, so we use the
+// version here to manage migrations.
+var ADAPTER_VERSION = 4;
+
+// The object stores created for each database
+// DOC_STORE stores the document meta data, its revision history and state
+// Keyed by document id
+var DOC_STORE = 'document-store';
+// BY_SEQ_STORE stores a particular version of a document, keyed by its
+// sequence id
+var BY_SEQ_STORE = 'by-sequence';
+// Where we store attachments
+var ATTACH_STORE = 'attach-store';
+// Where we store many-to-many relations
+// between attachment digests and seqs
+var ATTACH_AND_SEQ_STORE = 'attach-seq-store';
+
+// Where we store database-wide meta data in a single record
+// keyed by id: META_STORE
+var META_STORE = 'meta-store';
+// Where we store local documents
+var LOCAL_STORE = 'local-store';
+// Where we detect blob support
+var DETECT_BLOB_SUPPORT_STORE = 'detect-blob-support';
+
 var cachedDBs = {};
 var taskQueue = {
   running: false,
@@ -100,6 +125,67 @@ function readBlobData(body, type, encode, callback) {
   }
 }
 
+function fetchAttachmentsIfNecessary(doc, opts, txn, cb) {
+  var attachments = Object.keys(doc._attachments || {});
+  if (!attachments.length) {
+    return cb && cb();
+  }
+  var numDone = 0;
+
+  function checkDone() {
+    if (++numDone === attachments.length && cb) {
+      cb();
+    }
+  }
+
+  function fetchAttachment(doc, att) {
+    var attObj = doc._attachments[att];
+    var digest = attObj.digest;
+    txn.objectStore(ATTACH_STORE).get(digest).onsuccess = function (e) {
+      attObj.body = e.target.result.body;
+      checkDone();
+    };
+  }
+
+  attachments.forEach(function (att) {
+    if (opts.attachments && opts.include_docs) {
+      fetchAttachment(doc, att);
+    } else {
+      doc._attachments[att].stub = true;
+      checkDone();
+    }
+  });
+}
+
+// IDB-specific postprocessing necessary because
+// we don't know whether we stored a true Blob or
+// a base64-encoded string, and if it's a Blob it
+// needs to be read outside of the transaction context
+function postProcessAttachments(results) {
+  return utils.Promise.all(results.map(function (row) {
+    if (row.doc && row.doc._attachments) {
+      var attNames = Object.keys(row.doc._attachments);
+      return utils.Promise.all(attNames.map(function (att) {
+        var attObj = row.doc._attachments[att];
+        if (!('body' in attObj)) { // already processed
+          return;
+        }
+        var body = attObj.body;
+        var type = attObj.content_type;
+        return new utils.Promise(function (resolve) {
+          readBlobData(body, type, true, function (base64) {
+            row.doc._attachments[att] = utils.extend(
+              utils.pick(attObj, ['digest', 'content_type']),
+              { data: base64 }
+            );
+            resolve();
+          });
+        });
+      }));
+    }
+  }));
+}
+
 function IdbPouch(opts, callback) {
   var api = this;
 
@@ -113,31 +199,6 @@ function IdbPouch(opts, callback) {
 }
 
 function init(api, opts, callback) {
-
-  // IndexedDB requires a versioned database structure, so we use the
-  // version here to manage migrations.
-  var ADAPTER_VERSION = 4;
-
-  // The object stores created for each database
-  // DOC_STORE stores the document meta data, its revision history and state
-  // Keyed by document id
-  var DOC_STORE = 'document-store';
-  // BY_SEQ_STORE stores a particular version of a document, keyed by its
-  // sequence id
-  var BY_SEQ_STORE = 'by-sequence';
-  // Where we store attachments
-  var ATTACH_STORE = 'attach-store';
-  // Where we store many-to-many relations
-  // between attachment digests and seqs
-  var ATTACH_AND_SEQ_STORE = 'attach-seq-store';
-
-  // Where we store database-wide meta data in a single record
-  // keyed by id: META_STORE
-  var META_STORE = 'meta-store';
-  // Where we store local documents
-  var LOCAL_STORE = 'local-store';
-  // Where we detect blob support
-  var DETECT_BLOB_SUPPORT_STORE = 'detect-blob-support';
 
   var name = opts.name;
 
@@ -737,31 +798,9 @@ function init(api, opts, callback) {
       });
     }
 
-    function postProcessAttachments() {
-      return utils.Promise.all(results.map(function (row) {
-        if (row.doc && row.doc._attachments) {
-          var attNames = Object.keys(row.doc._attachments);
-          return utils.Promise.all(attNames.map(function (att) {
-            var attObj = row.doc._attachments[att];
-            var body = attObj.body;
-            var type = attObj.content_type;
-            return new utils.Promise(function (resolve) {
-              readBlobData(body, type, true, function (base64) {
-                row.doc._attachments[att] = utils.extend(
-                  utils.pick(attObj, ['digest', 'content_type']),
-                  { data: base64 }
-                );
-                resolve();
-              });
-            });
-          }));
-        }
-      }));
-    }
-
     transaction.oncomplete = function () {
       if (opts.attachments) {
-        postProcessAttachments().then(onResultsReady);
+        postProcessAttachments(results).then(onResultsReady);
       } else {
         onResultsReady();
       }
@@ -770,7 +809,6 @@ function init(api, opts, callback) {
     var oStore = transaction.objectStore(DOC_STORE);
     var oCursor = descending ? oStore.openCursor(keyRange, descending)
       : oStore.openCursor(keyRange);
-    var attStore = opts.attachments && transaction.objectStore(ATTACH_STORE);
     var results = [];
     oCursor.onsuccess = function (e) {
       if (!e.target.result) {
@@ -780,14 +818,6 @@ function init(api, opts, callback) {
       var metadata = decodeMetadata(cursor.value);
       // metadata.winningRev added later, some dbs might be missing it
       var winningRev = metadata.winningRev || merge.winningRev(metadata);
-
-      function fetchAttachment(doc, att) {
-        var attObj = doc.doc._attachments[att];
-        var digest = attObj.digest;
-        attStore.get(digest).onsuccess = function (e) {
-          attObj.body = e.target.result.body;
-        };
-      }
 
       function allDocsInner(metadata, data) {
         var doc = {
@@ -806,15 +836,7 @@ function init(api, opts, callback) {
           if (opts.conflicts) {
             doc.doc._conflicts = merge.collectConflicts(metadata);
           }
-          for (var att in doc.doc._attachments) {
-            if (doc.doc._attachments.hasOwnProperty(att)) {
-              if (opts.attachments) {
-                fetchAttachment(doc, att);
-              } else {
-                doc.doc._attachments[att].stub = true;
-              }
-            }
-          }
+          fetchAttachmentsIfNecessary(doc.doc, opts, transaction);
         }
         var deleted = utils.isDeleted(metadata, winningRev);
         if (opts.deleted === 'ok') {
@@ -958,7 +980,12 @@ function init(api, opts, callback) {
     var txn;
 
     function fetchChanges() {
-      txn = idb.transaction([DOC_STORE, BY_SEQ_STORE], 'readonly');
+      var objectStores = [DOC_STORE, BY_SEQ_STORE];
+      if (opts.attachments) {
+        objectStores.push(ATTACH_STORE);
+      }
+      txn = idb.transaction(objectStores, 'readonly');
+      txn.onerror = idbError(opts.complete);
       txn.oncomplete = onTxnComplete;
 
       var req;
@@ -1013,7 +1040,17 @@ function init(api, opts, callback) {
           if (returnDocs) {
             results.push(change);
           }
-          opts.onChange(change);
+          // process the attachment immediately
+          // for the benefit of live listeners
+          if (opts.attachments && opts.include_docs) {
+            fetchAttachmentsIfNecessary(doc, opts, txn, function () {
+              postProcessAttachments([change]).then(function () {
+                opts.onChange(change);
+              });
+            });
+          } else {
+            opts.onChange(change);
+          }
         }
         if (numResults !== limit) {
           cursor.continue();
@@ -1022,11 +1059,23 @@ function init(api, opts, callback) {
     }
 
     function onTxnComplete() {
-      if (!opts.continuous) {
+
+      function finish() {
         opts.complete(null, {
           results: results,
           last_seq: lastSeq
         });
+      }
+
+
+      if (!opts.continuous) {
+        if (opts.attachments) {
+          // cannot guarantee that postProcessing was already done,
+          // so do it again
+          postProcessAttachments(results).then(finish);
+        } else {
+          finish();
+        }
       }
     }
   };

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -39,6 +39,35 @@ var vuvuEncoding = {
   type: 'cheap-json'
 };
 
+function fetchAttachments(results, stores) {
+  return utils.Promise.all(results.map(function (row) {
+    if (row.doc && row.doc._attachments) {
+      var attNames = Object.keys(row.doc._attachments);
+      return utils.Promise.all(attNames.map(function (att) {
+        var attObj = row.doc._attachments[att];
+        if ('data' in attObj) { // already fetched
+          return;
+        }
+        return new utils.Promise(function (resolve, reject) {
+          stores.binaryStore.get(attObj.digest, function (err, buffer) {
+            var base64 = '';
+            if (err && err.name !== 'NotFoundError') {
+              return reject(err);
+            } else if (!err) {
+              base64 = utils.btoa(buffer);
+            }
+            row.doc._attachments[att] = utils.extend(
+              utils.pick(attObj, ['digest', 'content_type']),
+              {data: base64}
+            );
+            resolve();
+          });
+        });
+      }));
+    }
+  }));
+}
+
 function LevelPouch(opts, callback) {
   opts = utils.clone(opts);
   var api = this;
@@ -841,32 +870,6 @@ function LevelPouch(opts, callback) {
       var results = [];
       var docstream = stores.docStore.readStream(readstreamOpts);
 
-      function fetchAttachments() {
-        return utils.Promise.all(results.map(function (row) {
-          if (row.doc && row.doc._attachments) {
-            var attNames = Object.keys(row.doc._attachments);
-            return utils.Promise.all(attNames.map(function (att) {
-              var attObj = row.doc._attachments[att];
-              return new utils.Promise(function (resolve, reject) {
-                stores.binaryStore.get(attObj.digest, function (err, buffer) {
-                  var base64 = '';
-                  if (err && err.name !== 'NotFoundError') {
-                    return reject(err);
-                  } else if (!err) {
-                    base64 = utils.btoa(buffer);
-                  }
-                  row.doc._attachments[att] = utils.extend(
-                    utils.pick(attObj, ['digest', 'content_type']),
-                    {data: base64}
-                  );
-                  resolve();
-                });
-              });
-            }));
-          }
-        }));
-      }
-
       var throughStream = through(function (entry, _, next) {
         if (!utils.isDeleted(entry.value)) {
           if (skip-- > 0) {
@@ -927,7 +930,7 @@ function LevelPouch(opts, callback) {
         }
       }, function (next) {
         utils.Promise.resolve().then(function () {
-          return opts.attachments && fetchAttachments();
+          return opts.attachments && fetchAttachments(results, stores);
         }).then(function () {
           callback(null, {
             total_rows: docCount,
@@ -992,7 +995,13 @@ function LevelPouch(opts, callback) {
       changeStream.unpipe(throughStream);
       changeStream.destroy();
       if (!opts.continuous && !opts.cancelled) {
-        opts.complete(null, {results: results, last_seq: last_seq});
+        utils.Promise.resolve().then(function () {
+          if (opts.include_docs && opts.attachments) {
+            return fetchAttachments(results, stores);
+          }
+        }).then(function () {
+          opts.complete(null, {results: results, last_seq: last_seq});
+        });
       }
     }
     var changeStream = stores.bySeqStore.readStream(streamOpts);
@@ -1024,7 +1033,15 @@ function LevelPouch(opts, callback) {
             filter(change)) {
           called++;
 
-          utils.call(opts.onChange, change);
+          if (opts.attachments && opts.include_docs) {
+            // fetch attachment immediately for the benefit
+            // of live listeners
+            fetchAttachments([change], stores).then(function () {
+              opts.onChange(change);
+            });
+          } else {
+            opts.onChange(change);
+          }
 
           if (returnDocs) {
             results.push(change);

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -28,6 +28,40 @@ function unescapeBlob(str) {
     .replace(/\u0001\u0002/g, '\u0001')
     .replace(/\u0002\u0002/g, '\u0002');
 }
+function fetchAttachmentsIfNecessary(doc, opts, api, txn, cb) {
+  var attachments = Object.keys(doc._attachments || {});
+  if (!attachments.length) {
+    return cb && cb();
+  }
+  var numDone = 0;
+
+  function checkDone() {
+    if (++numDone === attachments.length && cb) {
+      cb();
+    }
+  }
+
+  function fetchAttachment(doc, att) {
+    var attObj = doc._attachments[att];
+    var attOpts = {encode: true, ctx: txn};
+    api._getAttachment(attObj, attOpts, function (_, base64) {
+      doc._attachments[att] = utils.extend(
+        utils.pick(attObj, ['digest', 'content_type']),
+        { data: base64 }
+      );
+      checkDone();
+    });
+  }
+
+  attachments.forEach(function (att) {
+    if (opts.attachments && opts.include_docs) {
+      fetchAttachment(doc, att);
+    } else {
+      doc._attachments[att].stub = true;
+      checkDone();
+    }
+  });
+}
 
 var cachedDatabases = {};
 
@@ -998,17 +1032,6 @@ function WebSqlPouch(opts, callback) {
           );
         sql += ' LIMIT ' + limit + ' OFFSET ' + offset;
 
-        function fetchAttachment(doc, att) {
-          var attObj = doc.doc._attachments[att];
-          var attOpts = {encode: true, ctx: tx};
-          api._getAttachment(attObj, attOpts, function (_, base64) {
-            doc.doc._attachments[att] = utils.extend(
-              utils.pick(attObj, ['digest', 'content_type']),
-              { data: base64 }
-            );
-          });
-        }
-
         tx.executeSql(sql, sqlArgs, function (tx, result) {
           for (var i = 0, l = result.rows.length; i < l; i++) {
             var item = result.rows.item(i);
@@ -1026,15 +1049,7 @@ function WebSqlPouch(opts, callback) {
               if (opts.conflicts) {
                 doc.doc._conflicts = merge.collectConflicts(metadata);
               }
-              for (var att in doc.doc._attachments) {
-                if (doc.doc._attachments.hasOwnProperty(att)) {
-                  if (opts.attachments) {
-                    fetchAttachment(doc, att);
-                  } else {
-                    doc.doc._attachments[att].stub = true;
-                  }
-                }
-              }
+              fetchAttachmentsIfNecessary(doc.doc, opts, api, tx);
             }
             if (item.deleted) {
               if (opts.deleted === 'ok') {
@@ -1112,9 +1127,14 @@ function WebSqlPouch(opts, callback) {
         sql += ' LIMIT ' + limit;
       }
 
+      var lastSeq = 0;
       db.readTransaction(function (tx) {
         tx.executeSql(sql, sqlArgs, function (tx, result) {
-          var lastSeq = 0;
+          function reportChange(change) {
+            return function () {
+              opts.onChange(change);
+            };
+          }
           for (var i = 0, l = result.rows.length; i < l; i++) {
             var res = result.rows.item(i);
             var metadata = vuvuzela.parse(res.metadata);
@@ -1129,19 +1149,27 @@ function WebSqlPouch(opts, callback) {
               if (returnDocs) {
                 results.push(change);
               }
-              opts.onChange(change);
+              // process the attachment immediately
+              // for the benefit of live listeners
+              if (opts.attachments && opts.include_docs) {
+                fetchAttachmentsIfNecessary(doc, opts, api, tx,
+                  reportChange(change));
+              } else {
+                reportChange(change)();
+              }
             }
             if (numResults === limit) {
               break;
             }
           }
-          if (!opts.continuous) {
-            opts.complete(null, {
-              results: results,
-              last_seq: lastSeq
-            });
-          }
         });
+      }, unknownError(opts.complete), function () {
+        if (!opts.continuous) {
+          opts.complete(null, {
+            results: results,
+            last_seq: lastSeq
+          });
+        }
       });
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -171,7 +171,7 @@ exports.filterChange = function (opts) {
     }
     if (!opts.include_docs) {
       delete change.doc;
-    } else {
+    } else if (!opts.attachments) {
       for (var att in change.doc._attachments) {
         if (change.doc._attachments.hasOwnProperty(att)) {
           change.doc._attachments[att].stub = true;
@@ -332,6 +332,7 @@ Changes.prototype.addListener = function (dbName, id, db, opts) {
   function eventFunction() {
     db.changes({
       include_docs: opts.include_docs,
+      attachments: opts.attachments,
       conflicts: opts.conflicts,
       continuous: false,
       descending: false,


### PR DESCRIPTION
Holy moly, this was way more code than I thought it would be. In order to get it to work for both live and non-live changes, there was some fiddling involved.

In any case, we now have `attachments=true` for `changes()`!
