### PR TITLE
(#3087) - simpler putLocal/removeLocal for idb

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -160,8 +160,7 @@ function init(api, opts, callback) {
     docStore.createIndex('deletedOrLocal', 'deletedOrLocal', {unique : false});
 
     // added in v3
-    db.createObjectStore(LOCAL_STORE, {keyPath: '_id'})
-      .createIndex('_doc_id_rev', '_doc_id_rev', {unique: true});
+    db.createObjectStore(LOCAL_STORE, {keyPath: '_id'});
 
     // added in v4
     var attAndSeqStore = db.createObjectStore(ATTACH_AND_SEQ_STORE,
@@ -1159,7 +1158,7 @@ function init(api, opts, callback) {
       if (!doc) {
         callback(errors.MISSING_DOC);
       } else {
-        delete doc['_doc_id_rev'];
+        delete doc['_doc_id_rev']; // for backwards compat
         callback(null, doc);
       }
     };
@@ -1178,7 +1177,6 @@ function init(api, opts, callback) {
     } else {
       doc._rev = '0-' + (parseInt(oldRev.split('-')[1], 10) + 1);
     }
-    doc._doc_id_rev = id + '::' + doc._rev;
 
     var tx = opts.ctx;
     var ret;
@@ -1195,28 +1193,12 @@ function init(api, opts, callback) {
     var oStore = tx.objectStore(LOCAL_STORE);
     var req;
     if (oldRev) {
-      var index = oStore.index('_doc_id_rev');
-      var docIdRev = id + '::' + oldRev;
-      req = index.get(docIdRev);
-      req.onsuccess = function (e) {
-        if (!e.target.result) {
-          callback(errors.REV_CONFLICT);
-        } else { // update
-          var req = oStore.put(doc);
-          req.onsuccess = function () {
-            ret = {ok: true, id: doc._id, rev: doc._rev};
-            if (opts.ctx) { // retuthis.immediately
-              callback(null, ret);
-            }
-          };
-        }
-      };
-    } else { // new doc
       req = oStore.get(id);
       req.onsuccess = function (e) {
-        if (e.target.result) { // already exists
+        var oldDoc = e.target.result;
+        if (!oldDoc || oldDoc._rev !== oldRev) {
           callback(errors.REV_CONFLICT);
-        } else { // insert
+        } else { // update
           var req = oStore.put(doc);
           req.onsuccess = function () {
             ret = {ok: true, id: doc._id, rev: doc._rev};
@@ -1224,6 +1206,20 @@ function init(api, opts, callback) {
               callback(null, ret);
             }
           };
+        }
+      };
+    } else { // new doc
+      req = oStore.add(doc);
+      req.onerror = function (e) {
+        // constraint error, already exists
+        callback(errors.REV_CONFLICT);
+        e.preventDefault(); // avoid transaction abort
+        e.stopPropagation(); // avoid transaction onerror
+      };
+      req.onsuccess = function (e) {
+        ret = {ok: true, id: doc._id, rev: doc._rev};
+        if (opts.ctx) { // return immediately
+          callback(null, ret);
         }
       };
     }
@@ -1237,23 +1233,18 @@ function init(api, opts, callback) {
         callback(null, ret);
       }
     };
-    var docIdRev = doc._id + '::' + doc._rev;
+    var id = doc._id;
     var oStore = tx.objectStore(LOCAL_STORE);
-    var index = oStore.index('_doc_id_rev');
-    var req = index.get(docIdRev);
+    var req = oStore.get(id);
 
     req.onerror = idbError(callback);
     req.onsuccess = function (e) {
-      var doc = e.target.result;
-      if (!doc) {
+      var oldDoc = e.target.result;
+      if (!oldDoc || oldDoc._rev !== doc._rev) {
         callback(errors.MISSING_DOC);
       } else {
-        var req = index.getKey(docIdRev);
-        req.onsuccess = function (e) {
-          var key = e.target.result;
-          oStore.delete(key);
-          ret = {ok: true, id: doc._id, rev: '0-0'};
-        };
+        oStore.delete(id);
+        ret = {ok: true, id: id, rev: '0-0'};
       }
     };
   };


### PR DESCRIPTION
I also got rid of the additional `_doc_id_rev` index, because it seems totally unnecessary. We have to do a `get` anyway, so that `get` might as well just be for the `id` instead of the `id+rev`.

Performance improvement as measured by the `temp-views` test:

firefox 35: 37989ms -> 36618ms (3.6% improvement)
chrome 39: 14915ms -> 13979ms (6.2% improvement)
