### PR TITLE
Add easy to run couchdb server with Docker and Fig

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,48 +61,10 @@ You will now have various distributions of PouchDB in your `dist` folder, congra
 
  * If you are on windows, you will need `node-gyp` to install levelup, visit https://github.com/TooTallNate/node-gyp#installation for installation instructions.
 
-Running PouchDB Tests
+Testing PouchDB
 --------------------------------------
 
-The PouchDB test suite expects an instance of CouchDB running in Admin Party on http://127.0.0.1:5984, you can configure this by sending the `COUCH_HOST` env var.
-
- * PouchDB has been primarily developed on Linux and OSX, if you are using Windows then these instructions will have problems, we would love your help fixing them though.
-
-### Node Tests
-
-Run all tests with:
-
-    $ npm test
-
-### Browser Tests
-
-Browser tests can be run automatically with:
-
-    $ CLIENT=selenium:firefox npm test
-
-or you can run:
-
-    $ npm run dev
-
-and open [http://127.0.0.1:8000/tests/integration/](http://127.0.0.1:8000/integration/) in your browser of choice. The performance tests are located @ [http://localhost:8000/tests/performance/](http://localhost:8000/tests/performance/).
-
-### Test Options
-
-#### Subset of tests:
-
-    $ GREP=test.replication.js npm test
-
-or append `?grep=test.replication.js` if you opened the tests in a browser manually.
-
-#### Test alternative server
-
-    $ COUCH_HOST=http://user:pass@myname.host.com npm run dev
-
-or
-
-    $ COUCH_HOST=http://user:pass@myname.host.com npm test
-
-For more information about options for testing including please checkout [TESTING.md](TESTING.md).
+Running PouchDB tests is really simple (5 minutes), go to [TESTING](./TESTING.md) for instructions.
 
 Debugging PouchDB
 --------------------------------------

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,15 +1,20 @@
 Running PouchDB Tests
 --------------------------------------
 
-The PouchDB test suite expects an instance of CouchDB running in Admin Party on http://127.0.0.1:5984, you can configure this by sending the `COUCH_HOST` env var.
-
- * PouchDB has been primarily developed on Linux and OSX, if you are using Windows then these instructions will have problems, we would love your help fixing them though.
+The PouchDB test suite expects an instance of CouchDB running in [Admin Party](http://guide.couchdb.org/draft/security.html#party) on http://127.0.0.1:5984, you can configure this by sending the `COUCH_HOST` env var.
 
 ### Node Tests
+
+Given that you have [installed a CouchDB server](#installing-a-couchdb-server).
 
 Run all tests with:
 
     $ npm test
+
+If your CouchDB server listen on a different host or port,
+you need to point the tests to the right `COUCH_HOST`:
+
+    $ COUCH_HOST=http://127.0.0.1:15984 npm test
 
 ### Browser Tests
 
@@ -185,3 +190,25 @@ Or even make the `preferredAdapters` list any crazy thing you want:
     http://localhost:8000/tests/test.html?adapters=websql,memory,idb,localstorage
 
 Keep in mind that `preferredAdapters` only applies to non-http, non-https adapters.
+
+### Installing a CouchDB server
+
+Regular install
+---------------------------
+
+See the [official CouchDB documentation](http://docs.couchdb.org/en/1.6.1/install/index.html) for a guide on how to install CouchDB.
+
+Docker install
+-----------------------------
+
+Don't have a CouchDB installed on your machine? Don't want one? Let's use [docker](https://www.docker.com/)
+and [fig](http://www.fig.sh/).
+
+1. [Install Docker](https://docs.docker.com/installation/#installation)
+2. [Install Fig](http://www.fig.sh/install.html)
+3. Run `fig -f tests/misc/fig.yml up -d` from PouchDB project root folder to download and run a CouchDB server in docker
+4. Check with `fig -f tests/misc/fig.yml ps` that `couchdb` is running and listen on `0.0.0.0:15984`
+5. Run the test suite with: `COUCH_HOST=http://127.0.0.1:15984 npm test`
+
+Now everytime you want to run the test suite, you just need to:
+    $ fig -f tests/misc/fig.yml start

--- a/tests/misc/fig.yml
+++ b/tests/misc/fig.yml
@@ -1,0 +1,4 @@
+couchdb:
+  image: klaemo/couchdb:1.6.1
+  ports:
+    - "15984:5984"


### PR DESCRIPTION
I added some instructions and a fig.yml file to help users get started on testing
pouchdb changes.

I feel like a docker based approach is the fastest and most accurate way. Because now the tested couchdb server version is written in the fig.yml file.

With this approach you could even have multi couchdb version testing easily.

If you want to go further that way let me know.

update CONTRIBUTING and TESTING accordingly
remove test part from CONTRIBUTING, link to TESTING, DRY

What do you think?
