### PR TITLE
(#3059) - Can't refresh appcache

### DIFF
--- a/bin/build-site.js
+++ b/bin/build-site.js
@@ -45,7 +45,7 @@ function buildJekyll(path) {
 if (!process.env.BUILD) {
   watchGlob('**', buildJekyll);
   buildJekyll();
-  http_server.createServer({root: '_site'}).listen(4000);
+  http_server.createServer({root: '_site', cache: '-1'}).listen(4000);
   console.log('Server address: http://0.0.0.0:4000');
 } else {
   execSync('jekyll build');


### PR DESCRIPTION
Had a cheeky peak at the http-server docs:
https://github.com/nodeapps/http-server#available-options

-c Set cache time (in seconds) for cache-control max-age header, e.g. -c10 for 10 seconds (defaults to '3600'). To disable caching, use -c-1.

Seems to work a treat.
