### PR TITLE
Typo correction

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -487,7 +487,7 @@ db.changes()
 
 * The `'complete'` event only fires when you aren't doing live changes. With live changes, use the `'uptodate'` event instead.
 * The `changes()` method was not an event emitter before PouchDB 2.2.0, and instead of the `'change'` and `'complete'` events it took `complete` and `onChange` function options. This is deprecated and could be removed in PouchDB version 3.
-* The `'since'`option formally took 'latest' but has been changed to 'now' to keep consistency with CouchDB, 'latest' is deprecated but will still work to ensure backwards compatibility.
+* The `'since'`option formerly took 'latest' but has been changed to 'now' to keep consistency with CouchDB. 'latest' is deprecated but will still work to ensure backwards compatibility.
 
 {% include anchor.html title="Replicate a database" hash="replication" %}
 


### PR DESCRIPTION
Changed 'formally' to 'formerly' to indicate 'previously' or 'in the past'
