### PR TITLE
(pouchdb/mapreduce#228) - fix phantomjs test

### DIFF
--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -65,7 +65,7 @@ testUrl += '?';
 testUrl += querystring.stringify(qs);
 
 if (process.env.TRAVIS &&
-    client.browser !== 'firefox' &&
+    client.runner === 'saucelabs' &&
     process.env.TRAVIS_SECURE_ENV_VARS === 'false') {
   console.error('Not running test, cannot connect to saucelabs');
   process.exit(0);


### PR DESCRIPTION
This is what's preventing the phantomjs
tests from running in Travis for express-pouchdb
and pouchdb-server.
