### PR TITLE
(#3128) - WIP - add failing test

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -597,6 +597,61 @@ adapters.forEach(function (adapters) {
       return chain;
     });
 
+    it('#3128 Complicated conflicts 2', function () {
+      var db = new PouchDB(dbs.name);
+      var remote = new PouchDB(dbs.remote);
+
+      var doc = {_id: 'foo'};
+      var firstRev;
+
+      var chain = PouchDB.utils.Promise.resolve().then(function () {
+        return db.put(doc).then(function (info) {
+          firstRev = info.rev;
+        });
+      });
+
+      function addConflict(i) {
+        chain = chain.then(function () {
+          return db.bulkDocs({
+            docs: [{
+              _id: 'foo',
+              _rev: '2-' + i
+            }],
+            new_edits: false
+          });
+        });
+      }
+
+      for (var i = 0; i < 50; i++) {
+        addConflict(i);
+      }
+      return chain.then(function () {
+        var revs1;
+        var revs2;
+        return db.get('foo', {
+          conflicts: true,
+          revs: true,
+          open_revs: 'all'
+        }).then(function (res) {
+          revs1 = res.map(function (x) {
+            return x.ok._rev;
+          });
+          return db.replicate.to(remote);
+        }).then(function () {
+          return remote.get('foo', {
+            conflicts: true,
+            revs: true,
+            open_revs: 'all'
+          });
+        }).then(function (res) {
+          revs2 = res.map(function (x) {
+            return x.ok._rev;
+          });
+          revs1.should.deep.equal(revs2);
+        });
+      });
+    });
+
     it('Test checkpoint read only 3 :)', function (done) {
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);


### PR DESCRIPTION
Somehow the revs are not being transferred to the remote DB, except between http-http.

```
{doc_count: 1, update_seq: 3, db_name: "testdb", auto_compaction: false}
["3-g", "2-e", "1-a"]
{doc_count: 1, update_seq: 3, db_name: "test_repl_remote", auto_compaction: false}
["3-g", "2-e", "1-a"]
Object {doc_count: 1, update_seq: 5, db_name: "testdb", auto_compaction: false}
["3-g", "3-c", "2-e", "2-b", "1-a"]
{doc_count: 1, update_seq: 3, db_name: "test_repl_remote", auto_compaction: false}
["3-g", "2-e", "1-a"]
```
