### PR TITLE
(#3134) - open_revs returned in right order

### DIFF
--- a/lib/merge.js
+++ b/lib/merge.js
@@ -231,13 +231,24 @@ PouchMerge.collectLeaves = function (revs) {
   var leaves = [];
   PouchMerge.traverseRevTree(revs, function (isLeaf, pos, id, acc, opts) {
     if (isLeaf) {
-      leaves.unshift({rev: pos + "-" + id, pos: pos, opts: opts});
+      leaves.push({
+        rev: pos + "-" + id,
+        pos: pos,
+        id: id,
+        opts: opts
+      });
     }
   });
   leaves.sort(function (a, b) {
-    return b.pos - a.pos;
+    if (a.pos !== b.pos) {
+      return b.pos - a.pos;
+    }
+    return a.id < b.id ? 1 : -1;
   });
-  leaves.map(function (leaf) { delete leaf.pos; });
+  leaves.forEach(function (leaf) {
+    delete leaf.pos;
+    delete leaf.id;
+  });
   return leaves;
 };
 


### PR DESCRIPTION
Before this fix, only `http-http` passes.
After this fix, all combinations of `http` and `local` pass.
