### PR TITLE
(#2543) - avoid excessive sort() in merge.js

### DIFF
--- a/lib/merge.js
+++ b/lib/merge.js
@@ -13,6 +13,28 @@ var extend = require('pouchdb-extend');
 // Path = {pos: position_from_root, ids: Tree}
 // Tree = [Key, Opts, [Tree, ...]], in particular single node: [Key, []]
 
+// classic binary search
+function binarySearch(arr, item, comparator) {
+  var low = 0;
+  var high = arr.length;
+  var mid;
+  while (low < high) {
+    mid = (low + high) >>> 1;
+    if (comparator(arr[mid], item) < 0) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  return low;
+}
+
+// assuming the arr is sorted, insert the item in the proper place
+function insertSorted(arr, item, comparator) {
+  var idx = binarySearch(arr, item, comparator);
+  arr.splice(idx, 0, item);
+}
+
 // Turn a path as a flat array into a tree with a single branch
 function pathToTree(path) {
   var doc = path.shift();
@@ -27,6 +49,11 @@ function pathToTree(path) {
     leaf = nleaf;
   }
   return root;
+}
+
+// compare the IDs of two trees
+function compareTree(a, b) {
+  return a[0] < b[0] ? -1 : 1;
 }
 
 // Merge two trees together
@@ -61,8 +88,7 @@ function mergeTree(in_tree1, in_tree2) {
       }
       if (!merged) {
         conflicts = 'new_branch';
-        tree1[2].push(tree2[2][i]);
-        tree1[2].sort();
+        insertSorted(tree1[2], tree2[2][i], compareTree);
       }
     }
   }


### PR DESCRIPTION
So this is an old bug, but we've finally got around to fixing it.

Some kind of `sort()` is required, otherwise the `npm run test-unit` fails.

However, I found a more efficient method of sorting by just trusting that the array is already sorted and then using a binary search insertion.

Note as well that I'm using a custom comparator, so instead of comparing two arrays, I'm comparing the first elements in each arrays, which it was doing anyway but now I'm being explicit about it.

The added test is funny because it actually times out (>100 s) before this commit, but after this commit it finishes in a reasonable amount of time (< 5 seconds in all adapters).
