### PR TITLE
(#3139) - less verbose travis logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,8 @@ before_script:
   - "sudo sed -i 's/^127\\.0\\.0\\.1.*$/127.0.0.1 localhost/' /etc/hosts"
 
     # Lets know what CouchDB we are playing with
-    # and make sure its logging debug
   - "curl -X GET http://127.0.0.1:5984/"
-  - "curl -X PUT http://127.0.0.1:5984/_config/log/level -d '\"debug\"'"
 
-
-after_failure:
-  - "curl -X GET http://127.0.0.1:5984/_log?bytes=1000000"
 
 script: npm run $COMMAND
 


### PR DESCRIPTION
So if you've used Travis on Firefox, you've no doubt seen this:

![screenshot 2014-12-08 08 39 07](https://cloud.githubusercontent.com/assets/283842/5340048/f047e388-7eb5-11e4-8fa4-a9581b8bd7da.png)

It's basically unusable. I cannot quickly restart many jobs. Also, the detailed CouchDB logs have never helped me out once, so I wouldn't mind getting rid of them.
