### PR TITLE
(#3113) - Make leveldown an optional dependency

### DIFF
--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -1,9 +1,18 @@
 'use strict';
 
 var levelup = require('levelup');
-var originalLeveldown = require('leveldown');
 var sublevel = require('level-sublevel');
 var through = require('through2').obj;
+
+var originalLeveldown;
+function requireLeveldown() {
+  // wrapped try/catch inside a function to confine code
+  // de-optimalization
+  try {
+    originalLeveldown = require('leveldown');
+  } catch (e) {}
+}
+requireLeveldown();
 
 var errors = require('../deps/errors');
 var merge = require('../merge');
@@ -94,6 +103,13 @@ function LevelPouch(opts, callback) {
   }
 
   var leveldown = opts.db || originalLeveldown;
+  if (!leveldown) {
+    return callback(new Error(
+      "leveldown not available " +
+      "(specify another backend using the 'db' option)"
+    ));
+  }
+
   if (typeof leveldown.destroy !== 'function') {
     leveldown.destroy = function (name, cb) { cb(); };
   }

--- a/lib/deps/migrate.js
+++ b/lib/deps/migrate.js
@@ -6,7 +6,6 @@ var utils = require('../utils');
 var merge = require('../merge');
 var levelup = require('levelup');
 var through = require('through2').obj;
-var leveldown = require("leveldown");
 
 var stores = [
   'document-store',
@@ -22,6 +21,9 @@ var DOC_COUNT_KEY = '_local_doc_count';
 var UUID_KEY = '_local_uuid';
 
 exports.toSublevel = function (name, db, callback) {
+  // local require to prevent crashing if leveldown isn't installed.
+  var leveldown = require("leveldown");
+
   var base = path.resolve(name);
   function move(store, index, cb) {
     var storePath = path.join(base, store);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "inherits": "~2.0.1",
     "level-js": "^2.1.3",
     "level-sublevel": "~5.2.0",
-    "leveldown": "~0.10.2",
     "levelup": "~0.18.4",
     "lie": "^2.6.0",
     "localstorage-down": "^0.6.2",
@@ -37,6 +36,9 @@
     "debug": "^2.1.0",
     "pouchdb-express-router": "^0.0.2",
     "express": "^4.10.4"
+  },
+  "optionalDependencies": {
+    "leveldown": "~0.10.2"
   },
   "devDependencies": {
     "rimraf": "2.2.8",


### PR DESCRIPTION
Possible alternative for #3113, main difference is:
- other leveldb backends (e.g. memdown) are supported
- wraps the try/catch statement in an IIFE to prevent the whole file from getting de-optimized
