### PR TITLE
(#3144) - properly destroy databases created with {db: require('memdown')}

### DIFF
--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -114,11 +114,12 @@ function PouchDB(name, opts, callback) {
 
     self.destroy = utils.adapterFun('destroy', function (callback) {
       var self = this;
+      var opts = this.__opts || {};
       self.info(function (err, info) {
         if (err) {
           return callback(err);
         }
-        self.constructor.destroy(info.db_name, callback);
+        self.constructor.destroy(info.db_name, opts, callback);
       });
     });
 

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -76,7 +76,6 @@ PouchDB.destroy = utils.toPromise(function (name, opts, callback) {
     callback = opts;
     opts = {};
   }
-
   if (name && typeof name === 'object') {
     opts = name;
     name = undefined;

--- a/tests/integration/test.defaults.js
+++ b/tests/integration/test.defaults.js
@@ -76,6 +76,30 @@ if (!process.env.LEVEL_ADAPTER &&
         });
       });
     });
+
+    it('should allow us to destroy memdown', function () {
+      var opts = {db: require('memdown') };
+      return new PouchDB('mydb', opts).then(function (db) {
+        return db.put({_id: 'foo'}).then(function () {
+          return new PouchDB('mydb', opts).then(function (otherDB) {
+            return db.info().then(function (info1) {
+              return otherDB.info().then(function (info2) {
+                info1.doc_count.should.equal(info2.doc_count);
+                return otherDB.destroy();
+              }).then(function () {
+                return new PouchDB('mydb', opts).then(function (db3) {
+                  return db3.info().then(function (info) {
+                    info.doc_count.should.equal(0);
+                    return db3.destroy();
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
     it('should allow us to use memdown by default', function () {
       var CustomPouch = PouchDB.defaults({db: require('memdown')});
       return new CustomPouch('mydb').then(function (db) {


### PR DESCRIPTION
test fails without this commit
