### PR TITLE
(#3146) - Adding pull replication performance tests

### DIFF
--- a/tests/common-utils.js
+++ b/tests/common-utils.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var commonUtils = {};
+
+// This is a duplicate of the function in integration/utils.js but the
+// current test set up makes it really hard to share that function. Since
+// we are apparently going to refactor the tests for now we'll just copy the
+// function in two places.
+commonUtils.couchHost = function () {
+  if (commonUtils.isNode()) {
+    return process.env.COUCH_HOST || 'http://localhost:5984';
+  } else if (window && window.COUCH_HOST) {
+    return window.COUCH_HOST;
+  } else if (window && window.cordova) {
+      // magic route to localhost on android emulator
+    return 'http://10.0.2.2:2020';
+  }
+  // In the browser we default to the CORS server, in future will change
+  return 'http://localhost:2020';
+};
+
+commonUtils.safeRandomDBName = function () {
+  return "test" + Math.random().toString().replace('.', '_');
+};
+
+commonUtils.createDocId = function (i) {
+  var intString = i.toString();
+  while (intString.length < 10) {
+    intString = '0' + intString;
+  }
+  return 'doc_' + intString;
+};
+
+commonUtils.isNode = function () {
+  // First part taken from
+  // http://timetler.com/2012/10/13/environment-detection-in-javascript/
+  // The !process.browser check is needed to see if we are in browserify
+  // which actually will pass the first part.
+  return typeof exports !== 'undefined' &&
+          this.exports !== exports &&
+          !process.browser;
+};
+
+module.exports = commonUtils;

--- a/tests/performance/perf.basics.js
+++ b/tests/performance/perf.basics.js
@@ -2,19 +2,13 @@
 
 module.exports = function (PouchDB, opts) {
 
-  // need to use bluebird for promises everywhere, so we're comparing
-  // apples to apples
   var Promise = require('bluebird');
-
   var utils = require('./utils');
+  var commonUtils = require('../common-utils.js');
 
-  function createDocId(i) {
-    var intString = i.toString();
-    while (intString.length < 10) {
-      intString = '0' + intString;
-    }
-    return 'doc_' + intString;
-  }
+  var RepTest = require('./replication-test.js')(PouchDB, Promise);
+  var oneGen = new RepTest();
+  var twoGen = new RepTest();
 
   var testCases = [
     {
@@ -48,12 +42,13 @@ module.exports = function (PouchDB, opts) {
       setup: function (db, callback) {
         var docs = [];
         for (var i = 0; i < 10000; i++) {
-          docs.push({_id : createDocId(i), foo : 'bar', baz : 'quux'});
+          docs.push({_id : commonUtils.createDocId(i),
+            foo : 'bar', baz : 'quux'});
         }
         db.bulkDocs({docs : docs}, callback);
       },
       test: function (db, itr, docs, done) {
-        db.get(createDocId(itr), done);
+        db.get(commonUtils.createDocId(itr), done);
       }
     }, {
       name: 'all-docs-skip-limit',
@@ -62,7 +57,8 @@ module.exports = function (PouchDB, opts) {
       setup: function (db, callback) {
         var docs = [];
         for (var i = 0; i < 1000; i++) {
-          docs.push({_id : createDocId(i), foo : 'bar', baz : 'quux'});
+          docs.push({_id : commonUtils.createDocId(i),
+            foo : 'bar', baz : 'quux'});
         }
         db.bulkDocs({docs : docs}, callback);
       },
@@ -84,9 +80,13 @@ module.exports = function (PouchDB, opts) {
       setup: function (db, callback) {
         var docs = [];
         for (var i = 0; i < 1000; i++) {
-          docs.push({_id : createDocId(i), foo : 'bar', baz : 'quux'});
+          docs.push({
+            _id: commonUtils.createDocId(i),
+            foo: 'bar',
+            baz: 'quux'
+          });
         }
-        db.bulkDocs({docs : docs}, callback);
+        db.bulkDocs({docs: docs}, callback);
       },
       test: function (db, itr, docs, done) {
         var tasks = [];
@@ -95,16 +95,72 @@ module.exports = function (PouchDB, opts) {
         }
         Promise.all(tasks.map(function (doc, i) {
           return db.allDocs({
-            startkey : createDocId(i * 100),
-            endkey : createDocId((i * 100) + 10)
+            startkey: commonUtils.createDocId(i * 100),
+            endkey: commonUtils.createDocId((i * 100) + 10)
           });
         })).then(function () {
           done();
         }, done);
       }
+    },
+    {
+      name: 'pull-replication-perf-skimdb',
+      assertions: 1,
+      iterations: 0,
+      setup: function (localDB, callback) {
+          var remoteCouchUrl = "http://skimdb.iriscouch.com/registry",
+              remoteDB = new PouchDB(remoteCouchUrl,
+                  {ajax: {pool: {maxSockets: 15}}}),
+              localPouches = [],
+              i;
+
+          for (i = 0; i < this.iterations; ++i) {
+            localPouches[i] = new PouchDB(commonUtils.safeRandomDBName());
+          }
+
+          return callback(null,
+              { localPouches: localPouches, remoteDB: remoteDB});
+        },
+      test: function (ignoreDB, itr, testContext, done) {
+          var localDB = testContext.localPouches[itr],
+              remoteDB = testContext.remoteDB;
+
+          var replication = PouchDB.replicate(remoteDB, localDB,
+              {live: false, batch_size: 100})
+              .on('change', function (info) {
+                  if (info.docs_written >= 200) {
+                    replication.cancel();
+                    done();
+                  }
+                })
+              .on('error', done);
+        },
+      tearDown: function (ignoreDB, testContext) {
+          if (testContext && testContext.localPouches) {
+            return Promise.all(
+                testContext.localPouches.map(function (localPouch) {
+                    return localPouch.destroy();
+                  }));
+          }
+        }
+    },
+    {
+      name: 'pull-replication-one-generation',
+      assertions: 1,
+      iterations: 1,
+      setup: oneGen.setup(1, 1),
+      test: oneGen.test(),
+      tearDown: oneGen.tearDown()
+    },
+    {
+      name: 'pull-replication-two-generation',
+      assertions: 1,
+      iterations: 1,
+      setup: twoGen.setup(1, 2),
+      test: twoGen.test(),
+      tearDown: twoGen.tearDown()
     }
   ];
 
   utils.runTests(PouchDB, 'basics', testCases, opts);
-
 };

--- a/tests/performance/replication-test.js
+++ b/tests/performance/replication-test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+module.exports = function (PouchDB, Promise) {
+
+  var NUM_DOCS = 1000;
+  var MAX_SOCKETS = 15;
+  var BATCH_SIZE = 100;
+
+  var commonUtils = require('../common-utils.js');
+  var log = require('debug')('pouchdb:tests:performance');
+
+  var PullRequestTestObject = function () {
+    this.localPouches = [];
+  };
+
+  PullRequestTestObject.prototype.setup = function (itr, gens) {
+    var self = this;
+    return function (localDB, callback) {
+      var remoteDBOpts = {ajax: {pool: {maxSockets: MAX_SOCKETS}}};
+      var remoteCouchUrl = commonUtils.couchHost() + "/" +
+        commonUtils.safeRandomDBName();
+
+      self.remoteDB = new PouchDB(remoteCouchUrl, remoteDBOpts);
+
+      var i;
+      var docs = [];
+      var localOpts = {ajax: {timeout: 60 * 1000}};
+
+      for (i = 0; i < itr; ++i) {
+        self.localPouches[i] = new PouchDB(commonUtils.safeRandomDBName());
+      }
+
+      for (i = 0; i < NUM_DOCS; i++) {
+        docs.push({
+          _id: commonUtils.createDocId(i),
+          foo: Math.random(),
+          bar: Math.random()
+        });
+      }
+
+      var addGeneration = function (generationCount, docs) {
+        return self.remoteDB.bulkDocs({docs: docs}, localOpts)
+          .then(function (bulkDocsResponse) {
+            --generationCount;
+            if (generationCount <= 0) {
+              return {};
+            }
+            var updatedDocs = bulkDocsResponse.map(function (doc) {
+              return {
+                _id: doc.id,
+                _rev: doc.rev,
+                foo: Math.random(),
+                bar: Math.random()
+              };
+            });
+            return addGeneration(generationCount, updatedDocs);
+          });
+      };
+
+      return addGeneration(gens, docs).then(callback);
+    };
+  };
+
+  PullRequestTestObject.prototype.test = function () {
+    var self = this;
+    return function (ignoreDB, itr, ignoreContext, done) {
+      var localDB = self.localPouches[itr];
+      PouchDB.replicate(self.remoteDB, localDB,
+        {live: false, batch_size: BATCH_SIZE})
+      .on('change', function (info) {
+        log("replication - info - " + JSON.stringify(info));
+      })
+      .on('complete', function (info) {
+        log("replication - complete - " + JSON.stringify(info));
+        done();
+      })
+      .on('error', function (err) {
+        log("replication - error - " + JSON.stringify(err));
+        throw err;
+      });
+    };
+  };
+
+  PullRequestTestObject.prototype.tearDown = function () {
+    var self = this;
+    return function (ignoreDB, ignoreContext) {
+      return self.remoteDB.destroy().then(function () {
+        return Promise.all(
+          self.localPouches.map(function (localPouch) {
+            return localPouch.destroy();
+          }));
+      });
+    };
+  };
+
+  return PullRequestTestObject;
+};

--- a/tests/performance/utils.js
+++ b/tests/performance/utils.js
@@ -2,6 +2,8 @@
 
 var reporter = require('./perf.reporter');
 var test = require('tape');
+var commonUtils = require('../common-utils.js');
+var Promise = require('bluebird');
 
 var grep;
 if (global.window && global.window.location && global.window.location.search) {
@@ -17,16 +19,21 @@ exports.runTests = function (PouchDB, suiteName, testCases, opts) {
         testCase.name.indexOf(grep) === -1) {
       return;
     }
+
+    if (testCase.iterations === 0) {
+      return;
+    }
+
     test('benchmarking', function (t) {
 
       var db;
       var setupObj;
 
-      var randomizer = Math.random();
+      var localDbName = commonUtils.safeRandomDBName();
 
       t.test('setup', function (t) {
         opts.size = 3000;
-        db = new PouchDB('test' + randomizer, opts);
+        db = new PouchDB(localDbName, opts);
         testCase.setup(db, function (err, res) {
           setupObj = res;
           if (i === 0) {
@@ -56,9 +63,14 @@ exports.runTests = function (PouchDB, suiteName, testCases, opts) {
         testCase.test(db, num, setupObj, after);
       });
       t.test('teardown', function (t) {
-        reporter.end(testCase);
-        var opts = {adapter : db.adapter};
-        PouchDB.destroy('test' + randomizer, opts, function () {
+        var testCaseTeardown =
+            testCase.tearDown ? testCase.tearDown : Promise.resolve;
+
+        testCaseTeardown(db, setupObj).then(function () {
+          reporter.end(testCase);
+          var opts = {adapter : db.adapter};
+          return PouchDB.destroy(localDbName, opts);
+        }).then(function () {
           t.end();
           if (i === testCases.length - 1) {
             reporter.complete(suiteName);


### PR DESCRIPTION
perf.basics.js -
- Moved createDocId to common-utils
- Added the test pull-replication-perf-skimdb, turned off by default (set to 0 iterations), which will download from @nolanlawson 's copy of skimdb to test bulk pull
  replication in a real world situation.
- Added the test pull-replication-one-generation that will generate 1000 first generation docs against a local CouchDB server and then pull replicate them.
- Added the test pull-replication-two-generations that will generate 1000 second generation docs against a local CouchDB server and then pull replication them.

pull.request.test.object.js -
 This contains a class that creates a test harness for pull replication tests. It lets the caller decide how many generations they want, how many docs, what batch size, how
many sockets, how many iterations and also what latency they want. The ability to control latency lets one implement a very crude simulation of network delays. See common-utils
for details on how this works.

test/performance/utils.js -
- Fixed the code so that if iterations == 0 then a test won't run at all.
- Switched the default PouchDB instance to use the common Util safeRandomDBName function
- Added a new feature to specify a tear down function for a test to do per test clean up

common-utils.js -
- Moved couchHost from tests/integration/utils to here so we can re-use it in the perf tests
- Added function safeRandomDBName to create unique names for DBs in tests
- simulateNetworkLatencyInNode introduces a reverse proxy through which requests are sent to the final destination. The reverse proxy will slow down each request by a
  specified latency. This is not a terribly accurate way to simulate network latency as it doesn't penalize, for example, for opening and closing lots of TCP/IP connections. But
  it's a start.
- simulateNetworkLatencyInBrowser - Simulates network latency by taking over XMLHTTPRequest and delaying each send request by a specified time. Again, as above, this is a very
  primitive way to simulate latency.
- isBrowser, self explanatory. Thanks to @calvinmetcalf for pointing out how to do this
- createDocId, generally useful
