### PR TITLE
(#3153) - avoid unnecessary allDocs() call

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -255,6 +255,9 @@ function replicate(repId, src, target, opts, returnValue, result) {
       var missing = currentBatch.diffs[id].missing;
       return missing.length === 1 && missing[0].slice(0, 2) === '1-';
     });
+    if (!ids.length) { // nothing to fetch
+      return utils.Promise.resolve();
+    }
     return src.allDocs({
       keys: ids,
       include_docs: true


### PR DESCRIPTION
I noticed that we do _all_docs requests even
when keys=[], which is wasteful.
