### PR TITLE
(#3181) - clean up "forin" loop for jshint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -28,6 +28,7 @@
     "afterEach",
     "testUtils",
     "emit",
-    "EventSource"
+    "EventSource",
+    "-Promise"
   ]
 }

--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -562,13 +562,11 @@ function init(api, opts, callback) {
       var id = docInfo.data._id = docInfo.metadata.id;
       var rev = docInfo.data._rev = docInfo.metadata.rev;
       var docIdRev = id + "::" + rev;
+      var attachments = Object.keys(docInfo.data._attachments || {});
 
       if (deleted) {
         docInfo.data._deleted = true;
       }
-
-      var attachments = docInfo.data._attachments ?
-        Object.keys(docInfo.data._attachments) : [];
 
       function collectResults(attachmentErr) {
         if (!err) {
@@ -586,17 +584,18 @@ function init(api, opts, callback) {
         collectResults(err);
       }
 
-      for (var key in docInfo.data._attachments) {
-        if (!docInfo.data._attachments[key].stub) {
-          var data = docInfo.data._attachments[key].data;
-          delete docInfo.data._attachments[key].data;
-          var digest = docInfo.data._attachments[key].digest;
+      attachments.forEach(function (key) {
+        var att = docInfo.data._attachments[key];
+        if (!att.stub) {
+          var data = att.data;
+          delete att.data;
+          var digest = att.digest;
           saveAttachment(digest, data, attachmentSaved);
         } else {
           recv++;
           collectResults();
         }
-      }
+      });
 
       // map seqs to attachment digests, which
       // we will need later during compaction

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -892,30 +892,30 @@ function WebSqlPouch(opts, callback) {
 
       docInfo.data._id = docInfo.metadata.id;
       docInfo.data._rev = docInfo.metadata.rev;
+      var attachments = Object.keys(docInfo.data._attachments || {});
+
 
       if (deleted) {
         docInfo.data._deleted = true;
       }
-
-      var attachments = docInfo.data._attachments ?
-        Object.keys(docInfo.data._attachments) : [];
 
       function attachmentSaved(err) {
         recv++;
         collectResults(err);
       }
 
-      for (var key in docInfo.data._attachments) {
-        if (!docInfo.data._attachments[key].stub) {
-          var data = docInfo.data._attachments[key].data;
-          delete docInfo.data._attachments[key].data;
-          var digest = docInfo.data._attachments[key].digest;
+      attachments.forEach(function (key) {
+        var att = docInfo.data._attachments[key];
+        if (!att.stub) {
+          var data = att.data;
+          delete att.data;
+          var digest = att.digest;
           saveAttachment(digest, data, attachmentSaved);
         } else {
           recv++;
           collectResults();
         }
-      }
+      });
 
       if (!attachments.length) {
         finish();

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "pouchdb-server": "^0.5.1",
     "commander": "~2.1.0",
     "uglify-js": "~2.4.6",
-    "jshint": "~2.3.0",
+    "jshint": "~2.5.10",
     "pouchdb-http-proxy": "~0.10.3",
     "corsproxy": "~0.2.13",
     "http-server": "~0.5.5",


### PR DESCRIPTION
In my IDE the jshint plugin complains about this.
I'm not sure why it passes on the command-line or
in Travis; maybe it depends on the jshint version.

Anyway I think it's more readable this way.
