### PR TITLE
(#3182) - avoid on-the-fly idb migrations

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -7,7 +7,7 @@ var vuvuzela = require('vuvuzela');
 
 // IndexedDB requires a versioned database structure, so we use the
 // version here to manage migrations.
-var ADAPTER_VERSION = 4;
+var ADAPTER_VERSION = 5;
 
 // The object stores created for each database
 // DOC_STORE stores the document meta data, its revision history and state
@@ -78,21 +78,18 @@ function idbError(callback) {
 // If we could do it all over again, we'd probably use a
 // format for the revision trees other than JSON.
 function encodeMetadata(metadata, winningRev, deleted) {
-  var storedObject = {data: vuvuzela.stringify(metadata)};
-  storedObject.winningRev = winningRev;
-  storedObject.seq = metadata.seq; // highest seq for this doc
-  storedObject.deletedOrLocal = deleted ? '1' : '0';
-  storedObject.id = metadata.id;
-  return storedObject;
+  return {
+    data: vuvuzela.stringify(metadata),
+    winningRev: winningRev,
+    deletedOrLocal: deleted ? '1' : '0',
+    seq: metadata.seq, // highest seq for this doc
+    id: metadata.id
+  };
 }
 
 function decodeMetadata(storedObject) {
   if (!storedObject) {
     return null;
-  }
-  if (!storedObject.data) {
-    // old format, when we didn't store it stringified
-    return storedObject;
   }
   var metadata = vuvuzela.parse(storedObject.data);
   metadata.winningRev = storedObject.winningRev;
@@ -314,13 +311,13 @@ function init(api, opts, callback) {
     };
   }
 
-  // migrations to get to version 3
-
+  // migration to version 3 (part 1)
   function createLocalStoreSchema(db) {
     db.createObjectStore(LOCAL_STORE, {keyPath: '_id'})
       .createIndex('_doc_id_rev', '_doc_id_rev', {unique: true});
   }
 
+  // migration to version 3 (part 2)
   function migrateLocalStore(txn, cb) {
     var localStore = txn.objectStore(LOCAL_STORE);
     var docStore = txn.objectStore(DOC_STORE);
@@ -367,7 +364,7 @@ function init(api, opts, callback) {
     };
   }
 
-  // migrations to get to version 4
+  // migration to version 4 (part 1)
   function addAttachAndSeqStore(db) {
     var attAndSeqStore = db.createObjectStore(ATTACH_AND_SEQ_STORE,
       {autoIncrement: true});
@@ -375,7 +372,8 @@ function init(api, opts, callback) {
     attAndSeqStore.createIndex('digestSeq', 'digestSeq', {unique: true});
   }
 
-  function migrateAttsAndSeqs(txn) {
+  // migration to version 4 (part 2)
+  function migrateAttsAndSeqs(txn, callback) {
     var seqStore = txn.objectStore(BY_SEQ_STORE);
     var attStore = txn.objectStore(ATTACH_STORE);
     var attAndSeqStore = txn.objectStore(ATTACH_AND_SEQ_STORE);
@@ -387,13 +385,13 @@ function init(api, opts, callback) {
     req.onsuccess = function (e) {
       var count = e.target.result;
       if (!count) {
-        return; // done
+        return callback(); // done
       }
 
       seqStore.openCursor().onsuccess = function (e) {
         var cursor = e.target.result;
         if (!cursor) {
-          return; // done
+          return callback(); // done
         }
         var doc = cursor.value;
         var seq = cursor.primaryKey;
@@ -414,6 +412,79 @@ function init(api, opts, callback) {
         cursor.continue();
       };
     };
+  }
+
+  // migration to version 5
+  // Instead of relying on on-the-fly migration of metadata,
+  // this brings the doc-store to its modern form:
+  // - metadata.winningrev
+  // - metadata.seq
+  // - stringify the metadata when storing it
+  function migrateMetadata(txn) {
+
+    function decodeMetadataCompat(storedObject) {
+      if (!storedObject.data) {
+        // old format, when we didn't store it stringified
+        storedObject.deletedOrLocal = storedObject.deletedOrLocal === '1';
+        return storedObject;
+      }
+      return decodeMetadata(storedObject);
+    }
+
+    // ensure that every metadata has a winningRev and seq,
+    // which was previously created on-the-fly but better to migrate
+    var bySeqStore = txn.objectStore(BY_SEQ_STORE);
+    var docStore = txn.objectStore(DOC_STORE);
+    var cursor = docStore.openCursor();
+    cursor.onsuccess = function (e) {
+      var cursor = e.target.result;
+      if (!cursor) {
+        return; // done
+      }
+      var metadata = decodeMetadataCompat(cursor.value);
+
+      metadata.winningRev = metadata.winningRev || merge.winningRev(metadata);
+
+      function fetchMetadataSeq() {
+        // metadata.seq was added post-3.2.0, so if it's missing,
+        // we need to fetch it manually
+        var start = metadata.id + '::';
+        var end = metadata.id + '::\uffff';
+        var req = bySeqStore.index('_doc_id_rev').openCursor(
+          global.IDBKeyRange.bound(start, end));
+
+        var metadataSeq = 0;
+        req.onsuccess = function (e) {
+          var cursor = e.target.result;
+          if (!cursor) {
+            metadata.seq = metadataSeq;
+            return onGetMetadataSeq();
+          }
+          var seq = cursor.primaryKey;
+          if (seq > metadataSeq) {
+            metadataSeq = seq;
+          }
+          cursor.continue();
+        };
+      }
+
+      function onGetMetadataSeq() {
+        var metadataToStore = encodeMetadata(metadata,
+          metadata.winningRev, metadata.deletedOrLocal);
+
+        var req = docStore.put(metadataToStore);
+        req.onsuccess = function () {
+          cursor.continue();
+        };
+      }
+
+      if (metadata.seq) {
+        return onGetMetadataSeq();
+      }
+
+      fetchMetadataSeq();
+    };
+
   }
 
   api.type = function () {
@@ -768,8 +839,7 @@ function init(api, opts, callback) {
       }
       var objectStore = txn.objectStore(BY_SEQ_STORE);
 
-      // metadata.winningRev was added later, so older DBs might not have it
-      var rev = opts.rev || metadata.winningRev || merge.winningRev(metadata);
+      var rev = opts.rev || metadata.winningRev;
       var key = metadata.id + '::' + rev;
 
       objectStore.index('_doc_id_rev').get(key).onsuccess = function (e) {
@@ -888,8 +958,7 @@ function init(api, opts, callback) {
       }
       var cursor = e.target.result;
       var metadata = decodeMetadata(cursor.value);
-      // metadata.winningRev added later, some dbs might be missing it
-      var winningRev = metadata.winningRev || merge.winningRev(metadata);
+      var winningRev = metadata.winningRev;
 
       function allDocsInner(metadata, data) {
         var doc = {
@@ -1031,8 +1100,7 @@ function init(api, opts, callback) {
     var docIds = opts.doc_ids && new utils.Set(opts.doc_ids);
     var descending = opts.descending ? 'prev' : null;
 
-    // Ignore the `since` parameter when `descending` is true
-    opts.since = opts.since && !descending ? opts.since : 0;
+    opts.since = opts.since || 0;
     var lastSeq = opts.since;
 
     var limit = 'limit' in opts ? opts.limit : -1;
@@ -1069,52 +1137,20 @@ function init(api, opts, callback) {
       var metadata;
 
       function onGetMetadata() {
-        if (typeof metadata.seq !== 'number') {
-          return fetchMetadataSeq(); // on-the-fly migration
-        }
-        onGetMetadataSeq();
-      }
-
-      function fetchMetadataSeq() {
-        // metadata.seq was added post-3.2.0, so if it's missing,
-        // we need to fetch it manually
-        var start = doc._id + '::';
-        var end = doc._id + '::\uffff';
-        var req = bySeqStore.index('_doc_id_rev').openCursor(
-          global.IDBKeyRange.bound(start, end));
-
-        var metadataSeq = 0;
-        req.onsuccess = function (e) {
-          var cursor = e.target.result;
-          if (!cursor) {
-            metadata.seq = metadataSeq;
-            return onGetMetadataSeq();
-          }
-          var seq = cursor.primaryKey;
-          if (seq > metadataSeq) {
-            metadataSeq = seq;
-          }
-          cursor.continue();
-        };
-      }
-
-      function onGetMetadataSeq() {
         if (metadata.seq !== seq) {
           // some other seq is later
           return cursor.continue();
         }
 
-        // metadata.winningRev was only added later
-        var winningRev = metadata.winningRev || merge.winningRev(metadata);
-        if (winningRev === doc._rev) {
+        if (metadata.winningRev === doc._rev) {
           return onGetWinningDoc(doc);
         }
 
-        fetchWinningDoc(winningRev);
+        fetchWinningDoc();
       }
 
-      function fetchWinningDoc(winningRev) {
-        var docIdRev = doc._id + '::' + winningRev;
+      function fetchWinningDoc() {
+        var docIdRev = doc._id + '::' + metadata.winningRev;
         var req = bySeqStore.index('_doc_id_rev').openCursor(
           global.IDBKeyRange.bound(docIdRev, docIdRev + '\uffff'));
         req.onsuccess = function (e) {
@@ -1186,7 +1222,8 @@ function init(api, opts, callback) {
 
       if (descending) {
         req = bySeqStore.openCursor(
-          global.IDBKeyRange.lowerBound(opts.since, true), descending);
+
+          null, descending);
       } else {
         req = bySeqStore.openCursor(
           global.IDBKeyRange.lowerBound(opts.since, true));
@@ -1265,11 +1302,7 @@ function init(api, opts, callback) {
         }
       });
       compactRevs(revs, docId, txn);
-      // winningRev is not guaranteed to be there, since it's
-      // not formally migrated. deletedOrLocal is a
-      // now-unfortunate name that really just means "deleted"
-      var winningRev = metadata.winningRev ||
-        merge.winningRev(metadata);
+      var winningRev = metadata.winningRev;
       var deleted = metadata.deletedOrLocal;
       txn.objectStore(DOC_STORE).put(
         encodeMetadata(metadata, winningRev, deleted));
@@ -1404,30 +1437,39 @@ function init(api, opts, callback) {
   req.onupgradeneeded = function (e) {
     var db = e.target.result;
     if (e.oldVersion < 1) {
-      createSchema(db); // new db, initial schema
-      return;
+      return createSchema(db); // new db, initial schema
     }
-    // promises would be great here, IndexedDB. >_<
+    // do migrations
+
     var txn = e.currentTarget.transaction;
+    // these migrations have to be done in this function, before
+    // control is returned to the event loop, because IndexedDB
+
+    if (e.oldVersion < 3) {
+      createLocalStoreSchema(db); // v2 -> v3
+    }
     if (e.oldVersion < 4) {
-      addAttachAndSeqStore(db); // v4
-      if (e.oldVersion < 3) {
-        createLocalStoreSchema(db); // v3
-        if (e.oldVersion < 2) {
-          addDeletedOrLocalIndex(txn, function () { // v2
-            migrateLocalStore(txn, function () { // v3
-              migrateAttsAndSeqs(txn); // v4
-            });
-          });
-        } else {
-          migrateLocalStore(txn, function () { // v3
-            migrateAttsAndSeqs(txn); // v4
-          });
-        }
-      } else {
-        migrateAttsAndSeqs(txn); // v4
+      addAttachAndSeqStore(db); // v3 -> v4
+    }
+
+    var migrations = [
+      addDeletedOrLocalIndex, // v1 -> v2
+      migrateLocalStore,      // v2 -> v3
+      migrateAttsAndSeqs,     // v3 -> v4
+      migrateMetadata         // v4 -> v5
+    ];
+
+    var i = e.oldVersion;
+
+    function next() {
+      var migration = migrations[i - 1];
+      i++;
+      if (migration) {
+        migration(txn, next);
       }
     }
+
+    next();
   };
 
   req.onsuccess = function (e) {


### PR DESCRIPTION
I was getting tired of the code complexity with
having to figure out whether `metadata.winningRev`
and `metadata.seq` were there or not. I prefer to
just migrate everything to be sure.

~~This also removes the docStore's 'seq' index, which
we weren't using and which apparently doesn't offer
any performance benefit.~~ _see below_
