### PR TITLE
(#3188) - WIP - fall back from JSON to vuvuzela

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -3,7 +3,6 @@
 var utils = require('../utils');
 var merge = require('../merge');
 var errors = require('../deps/errors');
-var vuvuzela = require('vuvuzela');
 
 // IndexedDB requires a versioned database structure, so we use the
 // version here to manage migrations.
@@ -79,7 +78,7 @@ function idbError(callback) {
 // format for the revision trees other than JSON.
 function encodeMetadata(metadata, winningRev, deleted) {
   return {
-    data: vuvuzela.stringify(metadata),
+    data: utils.safeJsonStringify(metadata),
     winningRev: winningRev,
     deletedOrLocal: deleted ? '1' : '0',
     seq: metadata.seq, // highest seq for this doc
@@ -91,7 +90,7 @@ function decodeMetadata(storedObject) {
   if (!storedObject) {
     return null;
   }
-  var metadata = vuvuzela.parse(storedObject.data);
+  var metadata = utils.safeJsonParse(storedObject.data);
   metadata.winningRev = storedObject.winningRev;
   metadata.deletedOrLocal = storedObject.deletedOrLocal === '1';
   metadata.seq = storedObject.seq;

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -18,7 +18,6 @@ var errors = require('../deps/errors');
 var merge = require('../merge');
 var utils = require('../utils');
 var migrate = require('../deps/migrate');
-var vuvuzela = require('vuvuzela');
 var Deque = require("double-ended-queue");
 
 var DOC_STORE = 'document-store';
@@ -41,9 +40,9 @@ var UUID_KEY = '_local_uuid';
 
 var MD5_PREFIX = 'md5-';
 
-var vuvuEncoding = {
-  encode: vuvuzela.stringify,
-  decode: vuvuzela.parse,
+var safeJsonEncoding = {
+  encode: utils.safeJsonStringify,
+  decode: utils.safeJsonParse,
   buffer: false,
   type: 'cheap-json'
 };
@@ -131,7 +130,7 @@ function LevelPouch(opts, callback) {
   }
 
   function afterDBCreated() {
-    stores.docStore = db.sublevel(DOC_STORE, {valueEncoding: vuvuEncoding});
+    stores.docStore = db.sublevel(DOC_STORE, {valueEncoding: safeJsonEncoding});
     stores.bySeqStore = db.sublevel(BY_SEQ_STORE, {valueEncoding: 'json'});
     stores.attachmentStore =
       db.sublevel(ATTACHMENT_STORE, {valueEncoding: 'json'});
@@ -732,7 +731,7 @@ function LevelPouch(opts, callback) {
           value: doc.metadata,
           prefix: stores.docStore,
           type: 'put',
-          valueEncoding: vuvuEncoding
+          valueEncoding: safeJsonEncoding
         }];
         db.batch(batch, function (err) {
           if (!err) {
@@ -1217,7 +1216,7 @@ function LevelPouch(opts, callback) {
         key: metadata.id,
         value: metadata,
         type: 'put',
-        valueEncoding: vuvuEncoding,
+        valueEncoding: safeJsonEncoding,
         prefix: stores.docStore
       });
 

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -3,7 +3,6 @@
 var utils = require('../utils');
 var merge = require('../merge');
 var errors = require('../deps/errors');
-var vuvuzela = require('vuvuzela');
 var parseHexString = require('../deps/parse-hex');
 
 function quote(str) {
@@ -942,7 +941,7 @@ function WebSqlPouch(opts, callback) {
           ' WHERE doc_id=' + DOC_STORE + '.id AND rev=?) WHERE id=?'
           : 'INSERT INTO ' + DOC_STORE +
           ' (id, winningseq, max_seq, json) VALUES (?,?,?,?);';
-        var metadataStr = vuvuzela.stringify(docInfo.metadata);
+        var metadataStr = utils.safeJsonStringify(docInfo.metadata);
         var id = docInfo.metadata.id;
         var params = isUpdate ?
           [metadataStr, seq, winningRev, id] :
@@ -981,7 +980,7 @@ function WebSqlPouch(opts, callback) {
         tx.executeSql('SELECT json FROM ' + DOC_STORE +
           ' WHERE id = ?', [id], function (tx, result) {
           if (result.rows.length) {
-            var metadata = vuvuzela.parse(result.rows.item(0).json);
+            var metadata = utils.safeJsonParse(result.rows.item(0).json);
             fetchedDocs.set(id, metadata);
           }
           checkDone();
@@ -1068,7 +1067,7 @@ function WebSqlPouch(opts, callback) {
         return finish();
       }
       var item = results.rows.item(0);
-      metadata = vuvuzela.parse(item.metadata);
+      metadata = utils.safeJsonParse(item.metadata);
       if (item.deleted && !opts.rev) {
         err = errors.error(errors.MISSING_DOC, 'deleted');
         return finish();
@@ -1162,7 +1161,7 @@ function WebSqlPouch(opts, callback) {
         tx.executeSql(sql, sqlArgs, function (tx, result) {
           for (var i = 0, l = result.rows.length; i < l; i++) {
             var item = result.rows.item(i);
-            var metadata = vuvuzela.parse(item.metadata);
+            var metadata = utils.safeJsonParse(item.metadata);
             var data = unstringifyDoc(item.data, metadata.id, item.rev);
             var winningRev = data._rev;
             var doc = {
@@ -1273,7 +1272,7 @@ function WebSqlPouch(opts, callback) {
           }
           for (var i = 0, l = result.rows.length; i < l; i++) {
             var item = result.rows.item(i);
-            var metadata = vuvuzela.parse(item.metadata);
+            var metadata = utils.safeJsonParse(item.metadata);
             lastSeq = item.maxSeq;
 
             var doc = unstringifyDoc(item.winningDoc, metadata.id,
@@ -1350,7 +1349,7 @@ function WebSqlPouch(opts, callback) {
         if (!result.rows.length) {
           callback(errors.MISSING_DOC);
         } else {
-          var data = vuvuzela.parse(result.rows.item(0).metadata);
+          var data = utils.safeJsonParse(result.rows.item(0).metadata);
           callback(null, data.rev_tree);
         }
       });
@@ -1366,7 +1365,7 @@ function WebSqlPouch(opts, callback) {
       // update doc store
       var sql = 'SELECT json AS metadata FROM ' + DOC_STORE + ' WHERE id = ?';
       tx.executeSql(sql, [docId], function (tx, result) {
-        var metadata = vuvuzela.parse(result.rows.item(0).metadata);
+        var metadata = utils.safeJsonParse(result.rows.item(0).metadata);
         merge.traverseRevTree(metadata.rev_tree, function (isLeaf, pos,
                                                            revHash, ctx, opts) {
           var rev = pos + '-' + revHash;
@@ -1376,7 +1375,7 @@ function WebSqlPouch(opts, callback) {
         });
 
         var sql = 'UPDATE ' + DOC_STORE + ' SET json = ? WHERE id = ?';
-        tx.executeSql(sql, [vuvuzela.stringify(metadata), docId]);
+        tx.executeSql(sql, [utils.safeJsonStringify(metadata), docId]);
       });
 
       compactRevs(revs, docId, tx);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -894,3 +894,21 @@ exports.compactTree = function compactTree(metadata) {
   });
   return revs;
 };
+
+var vuvuzela = require('vuvuzela');
+
+exports.safeJsonParse = function safeJsonParse(str) {
+  try {
+    return JSON.parse(str);
+  } catch (e) {
+    return vuvuzela.parse(str);
+  }
+};
+
+exports.safeJsonStringify = function safeJsonStringify(json) {
+  try {
+    return JSON.stringify(json);
+  } catch (e) {
+    return vuvuzela.stringify(json);
+  }
+};


### PR DESCRIPTION
If this is green, then I will provide performance numbers to justify it.

It seems we can get a tiny boost in performance of `temp-views` (11258ms -> 11077ms in Chrome) by using the regular JSON parse/stringify and only falling back to vuvuzela if we get a recursion error in a try/catch. The only question marks for me are:
1. can we even catch a recursion error? this might break on different platforms, but if so Travis will tell us.
2. does the cost of not being able to inline the try/catch function outweigh the benefits of using the native JSON.parse?
