### PR TITLE
136 - fixes for all_docs tests against clustered CouchDB / Cloudant

### DIFF
--- a/tests/integration/test.all_docs.js
+++ b/tests/integration/test.all_docs.js
@@ -227,10 +227,15 @@ adapters.forEach(function (adapter) {
                 conflicts: true,
                 style: 'all_docs',
                 complete: function (err, changes) {
-                  var result = changes.results[3];
-                  changes.results.map(function (x) { return x.id; })
+
+                  changes.results.map(function (x) { return x.id; }).sort()
                     .should.deep.equal(['0', '1', '2', '3'],
-                      'changes are ordered');
+                      'all ids are in _changes');
+
+                  var result = changes.results.filter(function (row, i) {
+                    return row.id === '3';
+                  })[0];
+                  
                   result.changes.should.have
                     .length(3, 'correct number of changes');
                   result.doc._rev.should.equal(conflictDoc2._rev);


### PR DESCRIPTION
Running the current test suite against Cloudant, I came across the following issues in all_docs. This PR addresses some incorrect assumptions in the tests which also hold for clustered CouchDB. I didn't find anything which required a change to PouchDB logic - just the tests.
