### PR TITLE
(#3195) - Stringify "since" parameter when fetching _changes

### DIFF
--- a/lib/changes.js
+++ b/lib/changes.js
@@ -140,6 +140,10 @@ Changes.prototype.doChanges = function (opts) {
   if (!opts.since) {
     opts.since = 0;
   }
+  if (typeof opts.since === "object") {
+    opts.since = JSON.stringify(opts.since);
+  }
+
   if (opts.since === 'now') {
     this.db.info().then(function (info) {
       if (self.isCancelled) {


### PR DESCRIPTION
In CouchDB 2.0, the sequence number may be represented as an array.
This commit stringifies the "since" parameter if it is an object to cope
with this scenario.
