### PR TITLE
(#136) - Fix "Test create attachment and doc in one go without callback" for clustered CouchDB

### DIFF
--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -1167,7 +1167,7 @@ adapters.forEach(function (adapter) {
         },
         live: true,
         onChange: function (change) {
-          if (change.seq === 1) {
+          if (change.id === 'anotherdoc2') {
             change.id.should.equal('anotherdoc2', 'Doc has been created');
             db.get(change.id, { attachments: true }, function (err, doc) {
               doc._attachments.should.be


### PR DESCRIPTION
We cannot rely on an ordered update sequence in clustered CouchDB. Instead of looking at the sequence number, identify a change using the document id.
