### PR TITLE
(#136) - Skip attachments tests which fail due to CouchDB 2.0 bugs

### DIFF
--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -200,6 +200,11 @@ adapters.forEach(function (adapter) {
     });
 
     it('#3074 non-live changes()', function () {
+      // blocked on COUCHDB-2519
+      if (testUtils.isCouchMaster()) {
+        return true;
+      }
+      
       var db = new PouchDB(dbs.name);
       var docs = [];
       for (var i = 0; i < 5; i++) {
@@ -267,6 +272,10 @@ adapters.forEach(function (adapter) {
     });
 
     it('#3074 live changes()', function () {
+      // blocked on COUCHDB-2519
+      if (testUtils.isCouchMaster()) {
+        return true;
+      }
 
       var db = new PouchDB(dbs.name);
 
@@ -708,6 +717,11 @@ adapters.forEach(function (adapter) {
     });
 
     it('#2771 allDocs() 7, revisions and deletions', function () {
+      // blocked on COUCHDB-2519
+      if (testUtils.isCouchMaster()) {
+        return true;
+      }
+
       var db = new PouchDB(dbs.name, {auto_compaction: false});
       var doc = {
         _id: 'doc',


### PR DESCRIPTION
Skip attachment tests which fail due to missing support for attachments=true in the CouchDB 2.0 changes feed (https://issues.apache.org/jira/browse/COUCHDB-2519)
