### PR TITLE
(#3213) - perf: don't store id and rev (idb)

### DIFF
--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -98,6 +98,19 @@ function decodeMetadata(storedObject) {
   return metadata;
 }
 
+// read the doc back out from the database. we don't store the
+// _id or _rev because we already have _doc_id_rev.
+function decodeDoc(doc) {
+  if (!doc) {
+    return doc;
+  }
+  var idx = utils.lastIndexOf(doc._doc_id_rev, ':');
+  doc._id = doc._doc_id_rev.substring(0, idx - 1);
+  doc._rev = doc._doc_id_rev.substring(idx + 1);
+  delete doc._doc_id_rev;
+  return doc;
+}
+
 // Read a blob from the database, encoding as necessary
 // and translating from base64 if the IDB doesn't support
 // native Blobs
@@ -706,6 +719,8 @@ function init(api, opts, callback) {
 
       function finish() {
         docInfo.data._doc_id_rev = docIdRev;
+        delete docInfo.data._id;
+        delete docInfo.data._rev;
         var seqStore = txn.objectStore(BY_SEQ_STORE);
         var index = seqStore.index('_doc_id_rev');
 
@@ -843,8 +858,8 @@ function init(api, opts, callback) {
 
       objectStore.index('_doc_id_rev').get(key).onsuccess = function (e) {
         doc = e.target.result;
-        if (doc && doc._doc_id_rev) {
-          delete(doc._doc_id_rev);
+        if (doc) {
+          doc = decodeDoc(doc);
         }
         if (!doc) {
           err = errors.MISSING_DOC;
@@ -969,10 +984,6 @@ function init(api, opts, callback) {
         };
         if (opts.include_docs) {
           doc.doc = data;
-          doc.doc._rev = winningRev;
-          if (doc.doc._doc_id_rev) {
-            delete(doc.doc._doc_id_rev);
-          }
           if (opts.conflicts) {
             doc.doc._conflicts = merge.collectConflicts(metadata);
           }
@@ -1008,7 +1019,8 @@ function init(api, opts, callback) {
         var index = transaction.objectStore(BY_SEQ_STORE).index('_doc_id_rev');
         var key = metadata.id + "::" + winningRev;
         index.get(key).onsuccess = function (event) {
-          allDocsInner(decodeMetadata(cursor.value), event.target.result);
+          allDocsInner(decodeMetadata(cursor.value),
+            decodeDoc(event.target.result));
         };
       }
     };
@@ -1124,7 +1136,7 @@ function init(api, opts, callback) {
 
     function onGetCursor(cursor) {
 
-      var doc = cursor.value;
+      var doc = decodeDoc(cursor.value);
       var seq = cursor.key;
 
       lastSeq = seq;
@@ -1153,12 +1165,11 @@ function init(api, opts, callback) {
         var req = bySeqStore.index('_doc_id_rev').openCursor(
           global.IDBKeyRange.bound(docIdRev, docIdRev + '\uffff'));
         req.onsuccess = function (e) {
-          onGetWinningDoc(e.target.result.value);
+          onGetWinningDoc(decodeDoc(e.target.result.value));
         };
       }
 
       function onGetWinningDoc(winningDoc) {
-        delete winningDoc['_doc_id_rev'];
 
         var change = opts.processChange(winningDoc, metadata, opts);
         change.seq = metadata.seq;


### PR DESCRIPTION
There's no need to store the _id and _rev if
we already have _doc_id_rev. For map/reduce especially,
this takes up a lot of unnecessary space.
