### PR TITLE
Prevent tests failing against CouchDB 2.0 which does not support temp views

### DIFF
--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -742,6 +742,11 @@ adapters.forEach(function (adapter) {
         return db.get('foo%bar');
       }).then(function (doc) {
         doc._id.should.equal('foo%bar');
+        doc.foo.should.equal('bar');
+        // return here if testing against CouchDB2.0 - no temporary views
+        if (testUtils.isCouchMaster()) {
+          return true;
+        }
         var queryFun = {
           map: function (doc) {
             emit(doc.foo, doc);
@@ -752,6 +757,10 @@ adapters.forEach(function (adapter) {
           reduce: false
         });
       }).then(function (res) {
+        // return here if testing against CouchDB2.0 - no temporary views
+        if (testUtils.isCouchMaster()) {
+          return true;
+        }
         var x = res.rows[0];
         x.id.should.equal('foo%bar');
         should.exist(x.key);


### PR DESCRIPTION
Not sure if this is how you would like to proceed here. The test is actually verifying that a document with an id with a "%" sign is allowed. But it goes on to create a temporary view to retrieve the document, which seems overkill for the test.

I've added some escape points if this is running in your test suite against "couchdb master".

Please contact me if you want to approach this differently.
