### PR TITLE
(#3217) - remove query() from test.basics.js

### DIFF
--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -739,23 +739,16 @@ adapters.forEach(function (adapter) {
       };
       return db.put(doc).then(function (res) {
         res.id.should.equal('foo%bar');
+        doc.foo.should.equal('bar');
         return db.get('foo%bar');
       }).then(function (doc) {
         doc._id.should.equal('foo%bar');
-        var queryFun = {
-          map: function (doc) {
-            emit(doc.foo, doc);
-          }
-        };
-        return db.query(queryFun, {
-          include_docs: true,
-          reduce: false
-        });
+        return db.allDocs({include_docs: true});
       }).then(function (res) {
         var x = res.rows[0];
         x.id.should.equal('foo%bar');
-        should.exist(x.key);
-        should.exist(x.value._rev);
+        x.doc._id.should.equal('foo%bar');
+        x.key.should.equal('foo%bar');
         should.exist(x.doc._rev);
       });
     });


### PR DESCRIPTION
@glynnbird Here's my alternative suggestion for #3217; I think it's fine to use `allDocs()` instead of `query()`.
