### PR TITLE
(#136) Skip all_docs.keys assertions which fail under CouchDB 2.0

### DIFF
--- a/tests/integration/test.all_docs.js
+++ b/tests/integration/test.all_docs.js
@@ -101,12 +101,19 @@ adapters.forEach(function (adapter) {
                 keys: keys,
                 startkey: 'a'
               }, function (err, result) {
-                should.exist(err);
+                
+                // blocked on COUCHDB-2523
+                if (!testUtils.isCouchMaster()) {
+                  should.exist(err);
+                }
                 db.allDocs({
                   keys: keys,
                   endkey: 'a'
                 }, function (err, result) {
-                  should.exist(err);
+                  // blocked on COUCHDB-2523
+                  if (!testUtils.isCouchMaster()) {
+                    should.exist(err);
+                  }
                   db.allDocs({ keys: [] }, function (err, result) {
                     result.rows.should.have.length(0);
                     db.get('2', function (err, doc) {


### PR DESCRIPTION
CouchDB 2.0 breaks compatibility around query parameter validation for _all_docs. Skip the tests which assert this until the bugs are fixed. Jira ticket is https://issues.apache.org/jira/browse/COUCHDB-2523
