### PR TITLE
(#136) - Skip all_docs.key assertions which fail under CouchDB 2.0

### DIFF
--- a/tests/integration/test.all_docs.js
+++ b/tests/integration/test.all_docs.js
@@ -513,7 +513,10 @@ adapters.forEach(function (adapter) {
               '2'
             ]
           }, function (err) {
-            should.exist(err);
+            // blocked on COUCHDB-2523
+            if (!testUtils.isCouchMaster()) {
+              should.exist(err);
+            }
             db.allDocs({
               key: '1',
               startkey: '1'


### PR DESCRIPTION
CouchDB 2.0 breaks compatiblity around query parameter validation for _all_docs. Skip the assertion that this error is returned during test "key" option.
