### PR TITLE
TRY RUN - (#3171) - Improve consistency of error handling

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -156,7 +156,7 @@ AbstractPouchDB.prototype.post =
     opts = {};
   }
   if (typeof doc !== 'object' || Array.isArray(doc)) {
-    return callback(errors.NOT_AN_OBJECT);
+    return callback(errors.error(errors.NOT_AN_OBJECT));
   }
   this.bulkDocs({docs: [doc]}, opts, yankError(callback));
 });
@@ -168,7 +168,7 @@ AbstractPouchDB.prototype.put =
   var id = '_id' in doc;
   if (typeof doc !== 'object' || Array.isArray(doc)) {
     callback = args.pop();
-    return callback(errors.NOT_AN_OBJECT);
+    return callback(errors.error(errors.NOT_AN_OBJECT));
   }
   doc = utils.clone(doc);
   while (true) {
@@ -230,13 +230,13 @@ AbstractPouchDB.prototype.putAttachment =
 
   return api.get(docId).then(function (doc) {
     if (doc._rev !== rev) {
-      throw errors.REV_CONFLICT;
+      throw errors.error(errors.REV_CONFLICT);
     }
 
     return createAttachment(doc);
   }, function (err) {
      // create new doc
-    if (err.error === errors.MISSING_DOC.error) {
+    if (err.reason === errors.MISSING_DOC.message) {
       return createAttachment({_id: docId});
     } else {
       throw err;
@@ -254,7 +254,7 @@ AbstractPouchDB.prototype.removeAttachment =
       return;
     }
     if (obj._rev !== rev) {
-      callback(errors.REV_CONFLICT);
+      callback(errors.error(errors.REV_CONFLICT));
       return;
     }
     if (!obj._attachments) {
@@ -474,7 +474,7 @@ AbstractPouchDB.prototype.get =
     opts = {};
   }
   if (typeof id !== 'string') {
-    return callback(errors.INVALID_ID);
+    return callback(errors.error(errors.INVALID_ID));
   }
   if (utils.isLocalId(id) && typeof this._getLocal === 'function') {
     return this._getLocal(id, callback);
@@ -524,8 +524,7 @@ AbstractPouchDB.prototype.get =
           var l = leaves[i];
           // looks like it's the only thing couchdb checks
           if (!(typeof(l) === "string" && /^\d+-/.test(l))) {
-            return callback(errors.error(errors.BAD_REQUEST,
-              "Invalid rev format"));
+            return callback(errors.error(errors.INVALID_REV));
           }
         }
         finishOpenRevs();
@@ -643,7 +642,7 @@ AbstractPouchDB.prototype.getAttachment =
       opts.ctx = res.ctx;
       self._getAttachment(res.doc._attachments[attachmentId], opts, callback);
     } else {
-      return callback(errors.MISSING_DOC);
+      return callback(errors.error(errors.MISSING_DOC));
     }
   });
 });
@@ -730,12 +729,12 @@ AbstractPouchDB.prototype.bulkDocs =
   }
 
   if (!req || !req.docs || !Array.isArray(req.docs)) {
-    return callback(errors.MISSING_BULK_DOCS);
+    return callback(errors.error(errors.MISSING_BULK_DOCS));
   }
 
   for (var i = 0; i < req.docs.length; ++i) {
     if (typeof req.docs[i] !== 'object' || Array.isArray(req.docs[i])) {
-      return callback(errors.NOT_AN_OBJECT);
+      return callback(errors.error(errors.NOT_AN_OBJECT));
     }
   }
 

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -464,8 +464,8 @@ function HttpPouch(opts, callback) {
         binary = utils.atob(blob);
       } catch (err) {
         // it's not base64-encoded, so throw error
-        return callback(utils.extend({}, errors.BAD_ARG,
-          {reason: "Attachments need to be base64 encoded"}));
+        return callback(errors.error(errors.BAD_ARG,
+                        'Attachments need to be base64 encoded'));
       }
       if (isBrowser) {
         blob = utils.createBlob([utils.fixBinary(binary)], {type: type});
@@ -495,7 +495,7 @@ function HttpPouch(opts, callback) {
     var id = '_id' in doc;
     var callback = args.pop();
     if (typeof doc !== 'object' || Array.isArray(doc)) {
-      return callback(errors.NOT_AN_OBJECT);
+      return callback(errors.error(errors.NOT_AN_OBJECT));
     }
 
     doc = utils.clone(doc);
@@ -566,7 +566,7 @@ function HttpPouch(opts, callback) {
     }
     opts = utils.clone(opts);
     if (typeof doc !== 'object') {
-      return callback(errors.NOT_AN_OBJECT);
+      return callback(errors.error(errors.NOT_AN_OBJECT));
     }
     if (! ("_id" in doc)) {
       doc._id = utils.uuid();
@@ -913,7 +913,7 @@ function HttpPouch(opts, callback) {
         var maximumWait = opts.maximumWait || 30000;
 
         if (retryWait > maximumWait) {
-          utils.call(opts.complete, err || errors.UNKNOWN_ERROR);
+          utils.call(opts.complete, err || errors.error(errors.UNKNOWN_ERROR));
           return;
         }
 

--- a/lib/adapters/idb.js
+++ b/lib/adapters/idb.js
@@ -595,8 +595,9 @@ function init(api, opts, callback) {
       var req = txn.objectStore([ATTACH_STORE]).get(digest);
       req.onsuccess = function (e) {
         if (!e.target.result) {
-          var err = new Error('unknown stub attachment with digest ' + digest);
-          err.status = 412;
+          var err = errors.error(errors.MISSING_STUB,
+                                 'unknown stub attachment with digest ' +
+                                 digest);
           callback(err);
         } else {
           callback();
@@ -842,7 +843,7 @@ function init(api, opts, callback) {
       // When we ask with opts.rev we expect the answer to be either
       // doc (possibly with _deleted=true) or missing error
       if (!metadata) {
-        err = errors.MISSING_DOC;
+        err = errors.error(errors.MISSING_DOC, 'missing');
         return finish();
       }
       if (utils.isDeleted(metadata) && !opts.rev) {
@@ -860,7 +861,7 @@ function init(api, opts, callback) {
           doc = decodeDoc(doc);
         }
         if (!doc) {
-          err = errors.MISSING_DOC;
+          err = errors.error(errors.MISSING_DOC, 'missing');
           return finish();
         }
         finish();
@@ -1263,7 +1264,7 @@ function init(api, opts, callback) {
 
   api._close = function (callback) {
     if (idb === null) {
-      return callback(errors.NOT_OPEN);
+      return callback(errors.error(errors.NOT_OPEN));
     }
 
     // https://developer.mozilla.org/en-US/docs/IndexedDB/IDBDatabase#close
@@ -1280,7 +1281,7 @@ function init(api, opts, callback) {
     req.onsuccess = function (event) {
       var doc = decodeMetadata(event.target.result);
       if (!doc) {
-        callback(errors.MISSING_DOC);
+        callback(errors.error(errors.MISSING_DOC));
       } else {
         callback(null, doc.rev_tree);
       }
@@ -1330,7 +1331,7 @@ function init(api, opts, callback) {
     req.onsuccess = function (e) {
       var doc = e.target.result;
       if (!doc) {
-        callback(errors.MISSING_DOC);
+        callback(errors.error(errors.MISSING_DOC));
       } else {
         delete doc['_doc_id_rev']; // for backwards compat
         callback(null, doc);
@@ -1371,7 +1372,7 @@ function init(api, opts, callback) {
       req.onsuccess = function (e) {
         var oldDoc = e.target.result;
         if (!oldDoc || oldDoc._rev !== oldRev) {
-          callback(errors.REV_CONFLICT);
+          callback(errors.error(errors.REV_CONFLICT));
         } else { // update
           var req = oStore.put(doc);
           req.onsuccess = function () {
@@ -1386,7 +1387,7 @@ function init(api, opts, callback) {
       req = oStore.add(doc);
       req.onerror = function (e) {
         // constraint error, already exists
-        callback(errors.REV_CONFLICT);
+        callback(errors.error(errors.REV_CONFLICT));
         e.preventDefault(); // avoid transaction abort
         e.stopPropagation(); // avoid transaction onerror
       };
@@ -1415,7 +1416,7 @@ function init(api, opts, callback) {
     req.onsuccess = function (e) {
       var oldDoc = e.target.result;
       if (!oldDoc || oldDoc._rev !== doc._rev) {
-        callback(errors.MISSING_DOC);
+        callback(errors.error(errors.MISSING_DOC));
       } else {
         oStore.delete(id);
         ret = {ok: true, id: id, rev: '0-0'};

--- a/lib/adapters/leveldb.js
+++ b/lib/adapters/leveldb.js
@@ -293,7 +293,7 @@ function LevelPouch(opts, callback) {
       db.removeListener('pouchdb-id-' + id, didDocChange);
 
       if (err || !metadata) {
-        return callback(errors.MISSING_DOC);
+        return callback(errors.error(errors.MISSING_DOC, 'missing'));
       }
 
       if (utils.isDeleted(metadata) && !opts.rev) {
@@ -329,7 +329,7 @@ function LevelPouch(opts, callback) {
         }
 
         if (!doc) {
-          return callback(errors.MISSING_DOC);
+          return callback(errors.error(errors.MISSING_DOC));
         }
         if ('_id' in doc && doc._id !== metadata.id) {
           // this failing implies something very wrong
@@ -418,8 +418,9 @@ function LevelPouch(opts, callback) {
     function verifyAttachment(digest, callback) {
       stores.attachmentStore.get(digest, function (levelErr) {
         if (levelErr) {
-          var err = new Error('unknown stub attachment with digest ' + digest);
-          err.status = 412;
+          var err = errors.error(errors.MISSING_STUB,
+                                'unknown stub attachment with digest ' +
+                                digest);
           callback(err);
         } else {
           callback();
@@ -523,7 +524,7 @@ function LevelPouch(opts, callback) {
       }
 
       if (lock.has(currentDoc.metadata.id)) {
-        results[index] = errors.REV_CONFLICT;
+        results[index] = errors.error(errors.REV_CONFLICT);
         inProgress--;
         return processDocs();
       }
@@ -565,7 +566,7 @@ function LevelPouch(opts, callback) {
     function insertDoc(doc, index, callback) {
       // Can't insert new deleted documents
       if ('was_delete' in opts && utils.isDeleted(doc.metadata)) {
-        results[index] = errors.MISSING_DOC;
+        results[index] = errors.error(errors.MISSING_DOC, 'deleted');
         return callback();
       }
       writeDoc(doc, index, false, function (err) {
@@ -606,7 +607,7 @@ function LevelPouch(opts, callback) {
         (previouslyDeleted && !deleted && merged.conflicts === 'new_branch'));
 
       if (inConflict) {
-        results[index] = errors.REV_CONFLICT;
+        results[index] = errors.error(errors.REV_CONFLICT);
         return callback();
       }
       var newRev = docInfo.metadata.rev;
@@ -692,8 +693,8 @@ function LevelPouch(opts, callback) {
           try {
             data = utils.atob(att.data);
           } catch (e) {
-            callback(utils.extend({}, errors.BAD_ARG,
-              {reason: "Attachments need to be base64 encoded"}));
+            callback(errors.error(errors.BAD_ARG,
+                     'Attachments need to be base64 encoded'));
             return;
           }
         } else if (!process.browser) {
@@ -1168,7 +1169,7 @@ function LevelPouch(opts, callback) {
 
   api._close = function (callback) {
     if (db.isClosed()) {
-      return callback(errors.NOT_OPEN);
+      return callback(errors.error(errors.NOT_OPEN));
     }
     db.close(function (err) {
       if (err) {
@@ -1183,7 +1184,7 @@ function LevelPouch(opts, callback) {
   api._getRevisionTree = function (docId, callback) {
     stores.docStore.get(docId, function (err, metadata) {
       if (err) {
-        callback(errors.MISSING_DOC);
+        callback(errors.error(errors.MISSING_DOC));
       } else {
         callback(null, metadata.rev_tree);
       }
@@ -1333,7 +1334,7 @@ function LevelPouch(opts, callback) {
   api._getLocal = function (id, callback) {
     stores.localStore.get(id, function (err, doc) {
       if (err) {
-        callback(errors.MISSING_DOC);
+        callback(errors.error(errors.MISSING_DOC));
       } else {
         callback(null, doc);
       }
@@ -1352,11 +1353,11 @@ function LevelPouch(opts, callback) {
     stores.localStore.get(id, function (err, resp) {
       if (err) {
         if (oldRev) {
-          return callback(errors.REV_CONFLICT);
+          return callback(errors.error(errors.REV_CONFLICT));
         }
       }
       if (resp && resp._rev !== oldRev) {
-        return callback(errors.REV_CONFLICT);
+        return callback(errors.error(errors.REV_CONFLICT));
       }
       if (!oldRev) {
         doc._rev = '0-1';
@@ -1384,7 +1385,7 @@ function LevelPouch(opts, callback) {
         return callback(err);
       }
       if (resp._rev !== doc._rev) {
-        return callback(errors.REV_CONFLICT);
+        return callback(errors.error(errors.REV_CONFLICT));
       }
       stores.localStore.del(doc._id, function (err) {
         if (err) {

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -287,7 +287,7 @@ function WebSqlPouch(opts, callback) {
 
   var db = openDB(name, POUCH_VERSION, name, size);
   if (!db) {
-    return callback(errors.UNKNOWN_ERROR);
+    return callback(errors.error(errors.UNKNOWN_ERROR));
   } else if (typeof db.readTransaction !== 'function') {
     // doesn't exist in sqlite plugin
     db.readTransaction = db.transaction;
@@ -765,8 +765,9 @@ function WebSqlPouch(opts, callback) {
         ' WHERE digest=?';
       tx.executeSql(sql, [digest], function (tx, result) {
         if (result.rows.item(0).cnt === 0) {
-          var err = new Error('unknown stub attachment with digest ' + digest);
-          err.status = 412;
+          var err = errors.error(errors.MISSING_STUB,
+                                'unknown stub attachment with digest ' +
+                                digest);
           callback(err);
         } else {
           callback();
@@ -1063,7 +1064,7 @@ function WebSqlPouch(opts, callback) {
     }
     tx.executeSql(sql, sqlArgs, function (a, results) {
       if (!results.rows.length) {
-        err = errors.MISSING_DOC;
+        err = errors.error(errors.MISSING_DOC, 'missing');
         return finish();
       }
       var item = results.rows.item(0);
@@ -1347,7 +1348,7 @@ function WebSqlPouch(opts, callback) {
       var sql = 'SELECT json AS metadata FROM ' + DOC_STORE + ' WHERE id = ?';
       tx.executeSql(sql, [docId], function (tx, result) {
         if (!result.rows.length) {
-          callback(errors.MISSING_DOC);
+          callback(errors.error(errors.MISSING_DOC));
         } else {
           var data = utils.safeJsonParse(result.rows.item(0).metadata);
           callback(null, data.rev_tree);
@@ -1393,7 +1394,7 @@ function WebSqlPouch(opts, callback) {
           var doc = unstringifyDoc(item.json, id, item.rev);
           callback(null, doc);
         } else {
-          callback(errors.MISSING_DOC);
+          callback(errors.error(errors.MISSING_DOC));
         }
       });
     });
@@ -1434,10 +1435,10 @@ function WebSqlPouch(opts, callback) {
             callback(null, ret);
           }
         } else {
-          callback(errors.REV_CONFLICT);
+          callback(errors.error(errors.REV_CONFLICT));
         }
       }, function () {
-        callback(errors.REV_CONFLICT);
+        callback(errors.error(errors.REV_CONFLICT));
         return false; // ack that we handled the error
       });
     }
@@ -1462,7 +1463,7 @@ function WebSqlPouch(opts, callback) {
       var params = [doc._id, doc._rev];
       tx.executeSql(sql, params, function (tx, res) {
         if (!res.rowsAffected) {
-          return callback(errors.MISSING_DOC);
+          return callback(errors.error(errors.MISSING_DOC));
         }
         ret = {ok: true, id: doc._id, rev: '0-0'};
       });

--- a/lib/changes.js
+++ b/lib/changes.js
@@ -197,10 +197,8 @@ Changes.prototype.filterChanges = function (opts) {
   var callback = opts.complete;
   if (opts.filter === '_view') {
     if (!opts.view || typeof opts.view !== 'string') {
-      var err = new  Error('`view` filter parameter is not provided.');
-      err.status = errors.BAD_REQUEST.status;
-      err.name = errors.BAD_REQUEST.name;
-      err.error = true;
+      var err = errors.error(errors.BAD_REQUEST,
+                             '`view` filter parameter is not provided.');
       callback(err);
       return;
     }
@@ -212,7 +210,7 @@ Changes.prototype.filterChanges = function (opts) {
         return;
       }
       if (err) {
-        callback(err);
+        callback(errors.generateErrorFromResponse(err));
         return;
       }
       if (ddoc && ddoc.views && ddoc.views[viewName[1]]) {
@@ -225,10 +223,7 @@ Changes.prototype.filterChanges = function (opts) {
       var msg = ddoc.views ? 'missing json key: ' + viewName[1] :
         'missing json key: views';
       if (!err) {
-        err = new  Error(msg);
-        err.status = errors.MISSING_DOC.status;
-        err.name = errors.MISSING_DOC.name;
-        err.error = true;
+        err = errors.error(errors.MISSING_DOC, msg);
       }
       callback(err);
       return;
@@ -242,7 +237,7 @@ Changes.prototype.filterChanges = function (opts) {
         return;
       }
       if (err) {
-        callback(err);
+        callback(errors.generateErrorFromResponse(err));
         return;
       }
       if (ddoc && ddoc.filters && ddoc.filters[filterName[1]]) {
@@ -254,10 +249,7 @@ Changes.prototype.filterChanges = function (opts) {
         var msg = (ddoc && ddoc.filters) ? 'missing json key: ' + filterName[1]
           : 'missing json key: filters';
         if (!err) {
-          err = new  Error(msg);
-          err.status = errors.MISSING_DOC.status;
-          err.name = errors.MISSING_DOC.name;
-          err.error = true;
+          err = errors.error(errors.MISSING_DOC, msg);
         }
         callback(err);
         return;

--- a/lib/deps/ajax-browser.js
+++ b/lib/deps/ajax-browser.js
@@ -55,22 +55,8 @@ function ajax(options, adapterCallback) {
     }
     if (Array.isArray(obj)) {
       obj = obj.map(function (v) {
-        var obj;
-        if (v.ok) {
-          return v;
-        } else if (v.error && v.error === 'conflict') {
-          obj = errors.REV_CONFLICT;
-          obj.id = v.id;
-          return obj;
-        } else if (v.error && v.error === 'forbidden') {
-          obj = errors.FORBIDDEN;
-          obj.id = v.id;
-          obj.reason = v.reason;
-          return obj;
-        } else if (v.missing) {
-          obj = errors.MISSING_DOC;
-          obj.missing = v.missing;
-          return obj;
+        if (v.error || v.missing) {
+          return errors.generateErrorFromResponse(v);
         } else {
           return v;
         }
@@ -80,44 +66,13 @@ function ajax(options, adapterCallback) {
   }
 
   function onError(err, cb) {
-    var errParsed, errObj, errType, key;
+    var errParsed, errObj;
     try {
       errParsed = JSON.parse(err.responseText);
       //would prefer not to have a try/catch clause
-      for (key in errors) {
-        if (errors.hasOwnProperty(key) &&
-            errors[key].name === errParsed.error) {
-          errType = errors[key];
-          break;
-        }
-      }
-      if (!errType) {
-        errType = errors.UNKNOWN_ERROR;
-        if (err.status) {
-          errType.status = err.status;
-        }
-        if (err.statusText) {
-          err.name = err.statusText;
-        }
-      }
-      errObj = errors.error(errType, errParsed.reason);
+      errObj = errors.generateErrorFromResponse(errParsed);
     } catch (e) {
-      for (var key in errors) {
-        if (errors.hasOwnProperty(key) && errors[key].status === err.status) {
-          errType = errors[key];
-          break;
-        }
-      }
-      if (!errType) {
-        errType = errors.UNKNOWN_ERROR;
-        if (err.status) {
-          errType.status = err.status;
-        }
-        if (err.statusText) {
-          err.name = err.statusText;
-        }
-      }
-      errObj = errors.error(errType);
+      errObj = errors.generateErrorFromResponse(err);
     }
     if (err.withCredentials && err.status === 0) {
       // apparently this is what we get when the method

--- a/lib/deps/ajax.js
+++ b/lib/deps/ajax.js
@@ -48,22 +48,8 @@ function ajax(options, adapterCallback) {
     }
     if (Array.isArray(obj)) {
       obj = obj.map(function (v) {
-        var obj;
-        if (v.ok) {
-          return v;
-        } else if (v.error && v.error === 'conflict') {
-          obj = errors.REV_CONFLICT;
-          obj.id = v.id;
-          return obj;
-        } else if (v.error && v.error === 'forbidden') {
-          obj = errors.FORBIDDEN;
-          obj.id = v.id;
-          obj.reason = v.reason;
-          return obj;
-        } else if (v.missing) {
-          obj = errors.MISSING_DOC;
-          obj.missing = v.missing;
-          return obj;
+        if (v.error || v.missing) {
+          return errors.generateErrorFromResponse(v);
         } else {
           return v;
         }
@@ -73,7 +59,7 @@ function ajax(options, adapterCallback) {
   }
 
   function onError(err, cb) {
-    var errParsed, errObj, errType, key;
+    var errParsed, errObj;
     if (err.code && err.status) {
       var err2 = new Error(err.message || err.code);
       err2.status = err.status;
@@ -82,40 +68,9 @@ function ajax(options, adapterCallback) {
     try {
       errParsed = JSON.parse(err.responseText);
       //would prefer not to have a try/catch clause
-      for (key in errors) {
-        if (errors.hasOwnProperty(key) &&
-            errors[key].name === errParsed.error) {
-          errType = errors[key];
-          break;
-        }
-      }
-      if (!errType) {
-        errType = errors.UNKNOWN_ERROR;
-        if (err.status) {
-          errType.status = err.status;
-        }
-        if (err.statusText) {
-          err.name = err.statusText;
-        }
-      }
-      errObj = errors.error(errType, errParsed.reason);
+      errObj = errors.generateErrorFromResponse(errParsed);
     } catch (e) {
-      for (var key in errors) {
-        if (errors.hasOwnProperty(key) && errors[key].status === err.status) {
-          errType = errors[key];
-          break;
-        }
-      }
-      if (!errType) {
-        errType = errors.UNKNOWN_ERROR;
-        if (err.status) {
-          errType.status = err.status;
-        }
-        if (err.statusText) {
-          err.name = err.statusText;
-        }
-      }
-      errObj = errors.error(errType);
+      errObj = errors.generateErrorFromResponse(err);
     }
     cb(errObj);
   }
@@ -163,15 +118,7 @@ function ajax(options, adapterCallback) {
       if (options.binary) {
         data = JSON.parse(data.toString());
       }
-      if (data.reason === 'missing') {
-        error = errors.MISSING_DOC;
-      } else if (data.reason === 'no_db_file') {
-        error = errors.error(errors.DB_MISSING, data.reason);
-      } else if (data.error === 'conflict') {
-        error = errors.REV_CONFLICT;
-      } else {
-        error = errors.error(errors.UNKNOWN_ERROR, data.reason, data.error);
-      }
+      error = errors.generateErrorFromResponse(data);
       error.status = response.statusCode;
       callback(error);
     }

--- a/lib/deps/errors.js
+++ b/lib/deps/errors.js
@@ -117,13 +117,117 @@ exports.FORBIDDEN = new PouchError({
   error: 'forbidden',
   reason: 'Forbidden by design doc validate_doc_update function'
 });
+exports.INVALID_REV = new PouchError({
+  status: 400,
+  error: 'bad_request',
+  reason: 'Invalid rev format'
+});
+exports.FILE_EXISTS = new PouchError({
+  status: 412,
+  error: 'file_exists',
+  reason: 'The database could not be created, the file already exists.'
+});
+exports.MISSING_STUB = new PouchError({
+  status: 412,
+  error: 'missing_stub'
+});
 exports.error = function (error, reason, name) {
-  function CustomPouchError(msg) {
-    this.message = reason;
-    if (name) {
+  function CustomPouchError(reason) {
+    // inherit error properties from our parent error manually
+    // so as to allow proper JSON parsing.
+    /* jshint ignore:start */
+    for (var p in error) {
+      if (typeof error[p] !== 'function') {
+        this[p] = error[p];
+      }
+    }
+    /* jshint ignore:end */
+    if (name !== undefined) {
       this.name = name;
     }
+    if (reason !== undefined) {
+      this.reason = reason;
+    }
   }
-  CustomPouchError.prototype = error;
+  CustomPouchError.prototype = PouchError.prototype;
   return new CustomPouchError(reason);
+};
+// Find one of the errors defined above based on the value
+// of the specified property.
+// If reason is provided prefer the error matching that reason.
+// This is for differentiating between errors with the same name and status,
+// eg, bad_request.
+exports.getErrorTypeByProp = function (prop, value, reason) {
+  var errors = exports;
+  var keys = Object.keys(errors).filter(function (key) {
+    var error = errors[key];
+    return typeof error !== 'function' && error[prop] === value;
+  });
+  var key = reason && keys.filter(function (key) {
+        var error = errors[key];
+        return error.message === reason;
+      })[0] || keys[0];
+  return (key) ? errors[key] : null;
+};
+exports.generateErrorFromResponse = function (res) {
+  var error, errName, errType, errMsg, errReason;
+  var errors = exports;
+
+  errName = (res.error === true && typeof res.name === 'string') ?
+              res.name :
+              res.error;
+  errReason = res.reason;
+  errType = errors.getErrorTypeByProp('name', errName, errReason);
+
+  if (res.missing ||
+      errReason === 'missing' ||
+      errReason === 'deleted' ||
+      errName === 'not_found') {
+    errType = errors.MISSING_DOC;
+  } else if (errName === 'doc_validation') {
+    // doc validation needs special treatment since
+    // res.reason depends on the validation error.
+    // see utils.js
+    errType = errors.DOC_VALIDATION;
+    errMsg = errReason;
+  } else if (errName === 'bad_request' && errType.message !== errReason) {
+    // if bad_request error already found based on reason don't override.
+
+    // attachment errors.
+    if (errReason.indexOf('unknown stub attachment') === 0) {
+      errType = errors.MISSING_STUB;
+      errMsg = errReason;
+    } else {
+      errType = errors.BAD_REQUEST;
+    }
+  }
+
+  // fallback to error by statys or unknown error.
+  if (!errType) {
+    errType = errors.getErrorTypeByProp('status', res.status, errReason) ||
+                errors.UNKNOWN_ERROR;
+  }
+
+  error = errors.error(errType, errReason, errName);
+
+  // Keep custom message.
+  if (errMsg) {
+    error.message = errMsg;
+  }
+
+  // Keep helpful response data in our error messages.
+  if (res.id) {
+    error.id = res.id;
+  }
+  if (res.status) {
+    error.status = res.status;
+  }
+  if (res.statusText) {
+    error.name = res.statusText;
+  }
+  if (res.missing) {
+    error.missing = res.missing;
+  }
+
+  return error;
 };

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -187,9 +187,7 @@ function replicate(repId, src, target, opts, returnValue, result) {
       res.forEach(function (res) {
         if (res.error) {
           result.doc_write_failures++;
-          var error = new Error(res.reason || res.message || 'Unknown reason');
-          error.name = res.name || res.error;
-          errors.push(error);
+          errors.push(res);
         }
       });
       result.errors = result.errors.concat(errors);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -89,14 +89,11 @@ exports.inherits = require('inherits');
 exports.invalidIdError = function (id) {
   var err;
   if (!id) {
-    err = new TypeError(errors.MISSING_ID.message);
-    err.status = 412;
+    err = errors.error(errors.MISSING_ID);
   } else if (typeof id !== 'string') {
-    err = new TypeError(errors.INVALID_ID.message);
-    err.status = 400;
+    err = errors.error(errors.INVALID_ID);
   } else if (/^_/.test(id) && !(/^_(design|local)/).test(id)) {
-    err = new TypeError(errors.RESERVED_ID.message);
-    err.status = 400;
+    err = errors.error(errors.RESERVED_ID);
   }
   if (err) {
     throw err;
@@ -200,9 +197,7 @@ exports.parseDoc = function (doc, newEdits) {
     if (doc._rev) {
       revInfo = /^(\d+)-(.+)$/.exec(doc._rev);
       if (!revInfo) {
-        error = new Error('bad_request');
-        error.message = 'Invalid rev format';
-        error.error = true;
+        error = errors.error(errors.INVALID_REV);
         return error;
       }
       doc._rev_tree = [{
@@ -235,9 +230,7 @@ exports.parseDoc = function (doc, newEdits) {
     if (!doc._rev_tree) {
       revInfo = /^(\d+)-(.+)$/.exec(doc._rev);
       if (!revInfo) {
-        error = new Error('bad_request');
-        error.message = 'Invalid rev format';
-        error.error = true;
+        error = errors.error(errors.INVALID_REV);
         return error;
       }
       nRevNum = parseInt(revInfo[1], 10);
@@ -258,8 +251,8 @@ exports.parseDoc = function (doc, newEdits) {
     if (doc.hasOwnProperty(key)) {
       var specialKey = key[0] === '_';
       if (specialKey && !reservedWords[key]) {
-        error = new Error(errors.DOC_VALIDATION.message + ': ' + key);
-        error.status = errors.DOC_VALIDATION.status;
+        error = errors.error(errors.DOC_VALIDATION, key);
+        error.message = errors.DOC_VALIDATION.message + ': ' + key;
         throw error;
       } else if (specialKey && !dataWords[key]) {
         result.metadata[key.slice(1)] = doc[key];
@@ -699,7 +692,7 @@ exports.updateDoc = function updateDoc(prev, docInfo, results,
     (previouslyDeleted && !deleted && merged.conflicts === 'new_branch')));
 
   if (inConflict) {
-    var err = errors.REV_CONFLICT;
+    var err = errors.error(errors.REV_CONFLICT);
     results[i] = err;
     return cb();
   }
@@ -725,7 +718,7 @@ exports.processDocs = function processDocs(docInfos, api, fetchedDocs,
     var winningRev = merge.winningRev(docInfo.metadata);
     var deleted = exports.isDeleted(docInfo.metadata, winningRev);
     if ('was_delete' in opts && deleted) {
-      results[resultsIdx] = errors.MISSING_DOC;
+      results[resultsIdx] = errors.error(errors.MISSING_DOC, 'deleted');
       return callback();
     }
     writeDoc(docInfo, winningRev, deleted, callback, false, resultsIdx);
@@ -796,7 +789,7 @@ exports.preprocessAttachments = function preprocessAttachments(
       return exports.atob(data);
     } catch (e) {
       var err = errors.error(errors.BAD_ARG,
-        "Attachments need to be base64 encoded");
+                             'Attachments need to be base64 encoded');
       return {error: err};
     }
   }

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -62,6 +62,7 @@ adapters.forEach(function (adapter) {
 
     it('destroy a pouch', function (done) {
       new PouchDB(dbs.name, function (err, db) {
+        should.exist(db);
         db.destroy(function (err, info) {
           should.not.exist(err);
           should.exist(info);
@@ -73,6 +74,7 @@ adapters.forEach(function (adapter) {
 
     it('destroy a pouch, with a promise', function (done) {
       new PouchDB(dbs.name, function (err, db) {
+        should.exist(db);
         db.destroy().then(function (info) {
           should.exist(info);
           info.ok.should.equal(true);
@@ -469,13 +471,16 @@ adapters.forEach(function (adapter) {
     it('update with invalid rev', function (done) {
       var db = new PouchDB(dbs.name);
       db.post({test: 'somestuff'}, function (err, info) {
+        should.not.exist(err);
         db.put({
           _id: info.id,
           _rev: 'undefined',
           another: 'test'
         }, function (err, info2) {
           should.exist(err);
-          err.message.should.equal('Invalid rev format');
+          err.status.should.equal(PouchDB.Errors.INVALID_REV.status);
+          err.message.should.equal(PouchDB.Errors.INVALID_REV.message,
+                                   'correct error message returned');
           done();
         });
       });
@@ -491,7 +496,10 @@ adapters.forEach(function (adapter) {
       ];
       var db = new PouchDB(dbs.name);
       db.bulkDocs({ docs: bad_docs }, function (err, res) {
-        err.status.should.equal(500);
+        err.status.should.equal(PouchDB.Errors.DOC_VALIDATION.status);
+        err.message.should.equal(PouchDB.Errors.DOC_VALIDATION.message +
+                                 ': _zing',
+                                 'correct error message returned');
         done();
       });
     });
@@ -556,6 +564,8 @@ adapters.forEach(function (adapter) {
         test: 'somestuff'
       }, function (err, info) {
         should.exist(err);
+        err.message.should.equal(PouchDB.Errors.INVALID_ID.message,
+                                 'correct error message returned');
         done();
       });
     });
@@ -564,6 +574,8 @@ adapters.forEach(function (adapter) {
       var db = new PouchDB(dbs.name);
       db.put({test: 'somestuff' }, function (err, info) {
         should.exist(err);
+        err.message.should.equal(PouchDB.Errors.MISSING_ID.message,
+                                 'correct error message returned');
         done();
       });
     });
@@ -575,8 +587,9 @@ adapters.forEach(function (adapter) {
         test: 'somestuff'
       }, function (err, info) {
         should.exist(err);
-        err.name.should.equal('TypeError');
-        err.status.should.equal(400);
+        err.status.should.equal(PouchDB.Errors.RESERVED_ID.status);
+        err.message.should.equal(PouchDB.Errors.RESERVED_ID.message,
+                                 'correct error message returned');
         done();
       });
     });
@@ -659,9 +672,11 @@ adapters.forEach(function (adapter) {
     it('Error works', function () {
       var newError = PouchDB.Errors
         .error(PouchDB.Errors.BAD_REQUEST, 'love needs no message');
-      newError.status.should.equal(400);
-      newError.name.should.equal('bad_request');
-      newError.message.should.equal('love needs no message');
+      newError.status.should.equal(PouchDB.Errors.BAD_REQUEST.status);
+      newError.name.should.equal(PouchDB.Errors.BAD_REQUEST.name);
+      newError.message.should.equal(PouchDB.Errors.BAD_REQUEST.message,
+                                    'correct error message returned');
+      newError.reason.should.equal('love needs no message');
     });
 
     it('Fail to fetch a doc after db was deleted', function (done) {

--- a/tests/integration/test.bulk_docs.js
+++ b/tests/integration/test.bulk_docs.js
@@ -139,7 +139,10 @@ adapters.forEach(function (adapter) {
         foo: 'bar'
       }];
       db.bulkDocs({ docs: docs }, function (err, info) {
-        err.status.should.equal(400, 'correct error status returned');
+        err.status.should.equal(PouchDB.Errors.RESERVED_ID.status,
+                                'correct error status returned');
+        err.message.should.equal(PouchDB.Errors.RESERVED_ID.message,
+                                 'correct error message returned');
         should.not.exist(info, 'info is empty');
         done();
       });
@@ -153,7 +156,8 @@ adapters.forEach(function (adapter) {
 
       var db = new PouchDB(dbs.name);
       db.bulkDocs({ docs: docs }, function (err, info) {
-        err.status.should.equal(400, 'correct error returned');
+        err.status.should.equal(PouchDB.Errors.RESERVED_ID.status,
+                                'correct error returned');
         err.message.should.equal(PouchDB.Errors.RESERVED_ID.message,
                                  'correct error message returned');
         should.not.exist(info, 'info is empty');
@@ -164,8 +168,10 @@ adapters.forEach(function (adapter) {
     it('No docs', function (done) {
       var db = new PouchDB(dbs.name);
       db.bulkDocs({ 'doc': [{ 'foo': 'bar' }] }, function (err, result) {
-        err.status.should.equal(400);
-        err.message.should.equal('Missing JSON list of \'docs\'');
+        err.status.should.equal(PouchDB.Errors.MISSING_BULK_DOCS.status,
+                                'correct error returned');
+        err.message.should.equal(PouchDB.Errors.MISSING_BULK_DOCS.message,
+                                 'correct error message returned');
         done();
       });
     });
@@ -647,6 +653,13 @@ adapters.forEach(function (adapter) {
       }, { new_edits: false }, function (err, res) {
         db.get('foo', function (err, res) {
           should.exist(err, 'deleted');
+          err.status.should.equal(PouchDB.Errors.MISSING_DOC.status,
+                                   'correct error status returned');
+          err.message.should.equal(PouchDB.Errors.MISSING_DOC.message,
+                                   'correct error message returned');
+          // todo: does not work in pouchdb-server.
+          // err.reason.should.equal('deleted',
+          //                          'correct error reason returned');
           done();
         });
       });
@@ -742,8 +755,10 @@ adapters.forEach(function (adapter) {
       var db = new PouchDB(dbs.name);
       db.bulkDocs({ docs: 'foo' }, function (err, res) {
         should.exist(err, 'error reported');
-        err.status.should.equal(400);
-        err.message.should.equal('Missing JSON list of \'docs\'');
+        err.status.should.equal(PouchDB.Errors.MISSING_BULK_DOCS.status,
+                                'correct error status returned');
+        err.message.should.equal(PouchDB.Errors.MISSING_BULK_DOCS.message,
+                                 'correct error message returned');
         done();
       });
     });
@@ -752,13 +767,17 @@ adapters.forEach(function (adapter) {
       var db = new PouchDB(dbs.name);
       db.bulkDocs({ docs: ['foo'] }, function (err, res) {
         should.exist(err, 'error reported');
-        err.status.should.equal(400);
-        err.message.should.equal('Document must be a JSON object');
+        err.status.should.equal(PouchDB.Errors.NOT_AN_OBJECT.status,
+                                'correct error status returned');
+        err.message.should.equal(PouchDB.Errors.NOT_AN_OBJECT.message,
+                                 'correct error message returned');
       });
       db.bulkDocs({ docs: [[]] }, function (err, res) {
         should.exist(err, 'error reported');
-        err.status.should.equal(400);
-        err.message.should.equal('Document must be a JSON object');
+        err.status.should.equal(PouchDB.Errors.NOT_AN_OBJECT.status,
+                                'correct error status returned');
+        err.message.should.equal(PouchDB.Errors.NOT_AN_OBJECT.message,
+                                 'correct error message returned');
         done();
       });
     });

--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -312,8 +312,12 @@ adapters.forEach(function (adapter) {
           limit: 2,
           include_docs: true,
           complete: function (err, results) {
-            err.status.should.equal(404);
-            err.message.should.equal('missing json key: odd');
+            err.status.should.equal(PouchDB.Errors.MISSING_DOC.status,
+                                    'correct error status returned');
+            err.message.should.equal(PouchDB.Errors.MISSING_DOC.message,
+                                 'correct error message returned');
+            // todo: does not work in pouchdb-server.
+            // err.reason.should.equal('missing json key: odd');
             should.not.exist(results);
             done();
           }
@@ -343,8 +347,12 @@ adapters.forEach(function (adapter) {
           limit: 2,
           include_docs: true,
           complete: function (err, results) {
-            err.status.should.equal(404);
-            err.message.should.equal('missing json key: filters');
+            err.status.should.equal(PouchDB.Errors.MISSING_DOC.status,
+                                    'correct error status returned');
+            err.message.should.equal(PouchDB.Errors.MISSING_DOC.message,
+                                 'correct error message returned');
+            // todo: does not work in pouchdb-server.
+            // err.reason.should.equal('missing json key: filters');
             should.not.exist(results);
             done();
           }
@@ -399,8 +407,10 @@ adapters.forEach(function (adapter) {
         db.changes({
           filter: 'foobar/odd',
           complete: function (err, results) {
-            err.status.should.equal(404);
-            err.message.should.equal('missing');
+            err.status.should.equal(PouchDB.Errors.MISSING_DOC.status,
+                                    'correct error status returned');
+            err.message.should.equal(PouchDB.Errors.MISSING_DOC.message,
+                                 'correct error message returned');
             should.not.exist(results);
             done();
           }
@@ -427,8 +437,12 @@ adapters.forEach(function (adapter) {
           filter: '_view',
           view: 'foo/odd',
           complete: function (err, results) {
-            err.status.should.equal(404);
-            err.message.should.equal('missing json key: odd');
+            err.status.should.equal(PouchDB.Errors.MISSING_DOC.status,
+                                    'correct error status returned');
+            err.message.should.equal(PouchDB.Errors.MISSING_DOC.message,
+                                 'correct error message returned');
+            // todo: does not work in pouchdb-server.
+            // err.reason.should.equal('missing json key: odd');
             should.not.exist(results);
             done();
           }
@@ -451,8 +465,13 @@ adapters.forEach(function (adapter) {
           filter: '_view',
           view: 'foo/even',
           complete: function (err, results) {
-            err.status.should.equal(404);
-            err.message.should.equal('missing json key: views');
+            err.status.should.equal(PouchDB.Errors.MISSING_DOC.status,
+                                    'correct error status returned');
+            err.message.should.equal(PouchDB.Errors.MISSING_DOC.message,
+                                 'correct error message returned');
+            // todo: does not work in pouchdb-server.
+            // err.reason.should.equal('missing json key: views',
+            //                         'correct error reason returned');
             should.not.exist(results);
             done();
           }
@@ -476,9 +495,14 @@ adapters.forEach(function (adapter) {
         db.changes({
           filter: '_view',
           complete: function (err, results) {
-            err.status.should.equal(400);
-            err.message.should
-              .equal('`view` filter parameter is not provided.');
+            err.status.should.equal(PouchDB.Errors.BAD_REQUEST.status,
+                                    'correct error status returned');
+            err.message.should.equal(PouchDB.Errors.BAD_REQUEST.message,
+                                 'correct error message returned');
+            // todo: does not work in pouchdb-server.
+            // err.reason.should
+            //   .equal('`view` filter parameter is not provided.',
+            //          'correct error reason returned');
             should.not.exist(results);
             done();
           }

--- a/tests/integration/test.compaction.js
+++ b/tests/integration/test.compaction.js
@@ -206,7 +206,10 @@ adapters.forEach(function (adapter) {
           db.compact(function () {
             db.get('foo', { rev: firstRev }, function (err, res) {
               should.exist(err, 'got error');
-              err.message.should.equal('missing', 'correct reason');
+              err.status.should.equal(PouchDB.Errors.MISSING_DOC.status,
+                                      'correct error status returned');
+              err.message.should.equal(PouchDB.Errors.MISSING_DOC.message,
+                                   'correct error message returned');
               done();
             });
           });
@@ -226,7 +229,10 @@ adapters.forEach(function (adapter) {
           db.compact(function () {
             db.get(id, { rev: firstRev }, function (err, res) {
               should.exist(err, 'got error');
-              err.message.should.equal('missing', 'correct reason');
+              err.status.should.equal(PouchDB.Errors.MISSING_DOC.status,
+                                      'correct error status returned');
+              err.message.should.equal(PouchDB.Errors.MISSING_DOC.message,
+                                   'correct error message returned');
               done();
             });
           });

--- a/tests/integration/test.get.js
+++ b/tests/integration/test.get.js
@@ -41,7 +41,15 @@ adapters.forEach(function (adapter) {
         db.get(info.id, function (err, doc) {
           doc.should.have.property('test');
           db.get(info.id + 'asdf', function (err) {
-            err.should.have.property('name');
+            err.status.should.equal(PouchDB.Errors.MISSING_DOC.status,
+                                    'correct error status returned');
+            err.name.should.equal(PouchDB.Errors.MISSING_DOC.name,
+                                  'correct error name returned');
+            err.message.should.equal(PouchDB.Errors.MISSING_DOC.message,
+                                    'correct error message returned');
+            // todo: does not work in pouchdb-server.
+            // err.reason.should.equal(PouchDB.Errors.MISSING_DOC.reason,
+            //                           'correct error reason returned');
             done();
           });
         });
@@ -56,7 +64,15 @@ adapters.forEach(function (adapter) {
       }, function (err, info) {
         db.get(info.id, function (err, doc) {
           db.get(info.id + 'asdf', function (err) {
-            err.should.have.property('name');
+            err.status.should.equal(PouchDB.Errors.MISSING_DOC.status,
+                                    'correct error status returned');
+            err.name.should.equal(PouchDB.Errors.MISSING_DOC.name,
+                                  'correct error name returned');
+            err.message.should.equal(PouchDB.Errors.MISSING_DOC.message,
+                                    'correct error message returned');
+            // todo: does not work in pouchdb-server.
+            // err.reason.should.equal(PouchDB.Errors.MISSING_DOC.reason,
+            //                           'correct error reason returned');
             done();
           });
         });
@@ -71,8 +87,15 @@ adapters.forEach(function (adapter) {
           _rev: info.rev
         }, function (err, res) {
           db.get(info.id, function (err, res) {
-            err.name.should.equal('not_found');
-            err.message.should.equal('deleted');
+            err.status.should.equal(PouchDB.Errors.MISSING_DOC.status,
+                                      'correct error status returned');
+            err.name.should.equal(PouchDB.Errors.MISSING_DOC.name,
+                                      'correct error name returned');
+            err.message.should.equal(PouchDB.Errors.MISSING_DOC.message,
+                                      'correct error message returned');
+            // todo: does not work in pouchdb-server.
+            // err.reason.should.equal(PouchDB.Errors.MISSING_DOC.reason,
+            //                          'correct error reason returned');
             done();
           });
         });


### PR DESCRIPTION
When handling errors the message should always be a string and match
the one defined in errors.js, and reason should be the reason
given by CouchDB. Errors from validate_doc_update (forbidden and unauthorized)
should match errors.FORBIDDEN and errors.UNAUTHORIZED and their
reason property should be the value thrown

Provides a single error handling mechanism for both browser and node and
single and bulk doc operations.
As a result:
- new errors are always created so that a newer errors do not override
  properties of previous errors (in bulk docs operations).
- errors contain information about which docs failed (their ID) and the reason
  of the failure. Particularly helpful in replication errors.
- error.message is the 'message' specified in errors.js and error.reason
  is the 'reason' given by the response.
