### PR TITLE
(#136) - Test against 1 node CouchDB cluster

### DIFF
--- a/bin/run-couch-master-on-travis.sh
+++ b/bin/run-couch-master-on-travis.sh
@@ -31,7 +31,7 @@ cd ~/couchdb
 make
 
 # All done, run a cluster
-python dev/run &
+python dev/run -n 1 &
 
 # Lets get rid of this at some point :)
 sleep 10


### PR DESCRIPTION
When spinning up a CouchDB cluster to test against, just use one node.
This ensures that we're still testing against the clustered interface but removes any problems with eventual consistency between nodes in the cluster.

I'd suggest reverting this once we have all the tests passing but, for now, this is useful to remove much of the "noise" in the failures.
