### PR TITLE
(#3195) - Stringify "since" parameter when calling _changes

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -820,6 +820,10 @@ function HttpPouch(opts, callback) {
         return;
       }
       params.since = since;
+      if (typeof params.since === "object") {
+        params.since = JSON.stringify(params.since);
+      }
+
       if (opts.descending) {
         if (limit) {
           params.limit = leftToFetch;

--- a/lib/changes.js
+++ b/lib/changes.js
@@ -140,10 +140,6 @@ Changes.prototype.doChanges = function (opts) {
   if (!opts.since) {
     opts.since = 0;
   }
-  if (typeof opts.since === "object") {
-    opts.since = JSON.stringify(opts.since);
-  }
-
   if (opts.since === 'now') {
     this.db.info().then(function (info) {
       if (self.isCancelled) {


### PR DESCRIPTION
CouchDB 2.0 represents sequence numbers as an array. Ensure we stringify the array before passing it as a query parameter.

This commit also reverts 8961f5e - stringify should occur when building the HTTP request instead (which should catch this globally).
