### PR TITLE
(#136) - Fix "changes since old style" test against CouchDB 2.0

### DIFF
--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -77,7 +77,7 @@ adapters.forEach(function (adapter) {
     });
 
     it('Changes Since Old Style', function (done) {
-      var docs = [
+      var docs1 = [
         {_id: '0', integer: 0},
         {_id: '1', integer: 1},
         {_id: '2', integer: 2},
@@ -89,21 +89,31 @@ adapters.forEach(function (adapter) {
         {_id: '8', integer: 9},
         {_id: '9', integer: 9},
         {_id: '10', integer: 10},
-        {_id: '11', integer: 11},
-        {_id: '12', integer: 12},
-        {_id: '13', integer: 13}
+        {_id: '11', integer: 11}
       ];
       var db = new PouchDB(dbs.name);
-      db.bulkDocs({ docs: docs }, function (err, info) {
-        var promise = db.changes({
-          since: 12,
-          complete: function (err, results) {
-            results.results.length.should.equal(2);
-            done();
-          }
+
+      db.bulkDocs({ docs: docs1 }, function (err, info) {
+        db.info(function (err, info) {
+          var update_seq = info.update_seq;
+
+          var docs2 = [
+            {_id: '12', integer: 12},
+            {_id: '13', integer: 13}
+          ];
+
+          db.bulkDocs({ docs: docs2 }, function (err, info) {
+            var promise = db.changes({
+              since: update_seq,
+              complete: function (err, results) {
+                results.results.length.should.be.at.least(2);
+                done();
+              }
+            });
+            should.exist(promise);
+            promise.cancel.should.be.a('function');
+          });
         });
-        should.exist(promise);
-        promise.cancel.should.be.a('function');
       });
     });
 


### PR DESCRIPTION
CouchDB 2.0 does not use numeric sequence numbers so we cannot predict the value that will be returned. Change the test to use the sequence number returned by the database rather than assuming it will be a specific number.
