### PR TITLE
(#136) - Fix "changes since and limit old style" against CouchDB 2.0

### DIFF
--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -137,22 +137,32 @@ adapters.forEach(function (adapter) {
       });
     });
 
-    it('Changes Since and limit Old Style limit 1', function (done) {
-      var docs = [
+    it('Changes Since and limit Old Style liimt 1', function (done) {
+      var docs1 = [
         {_id: '0', integer: 0},
         {_id: '1', integer: 1},
-        {_id: '2', integer: 2},
-        {_id: '3', integer: 3},
+        {_id: '2', integer: 2}
       ];
       var db = new PouchDB(dbs.name);
-      db.bulkDocs({ docs: docs }, function (err, info) {
-        db.changes({
-          since: 2,
-          limit: 1,
-          complete: function (err, results) {
-            results.results.length.should.equal(1);
-            done();
-          }
+      db.bulkDocs({ docs: docs1 }, function (err, info) {
+        db.info(function (err, info) {
+          var update_seq = info.update_seq;
+
+          var docs2 = [
+            {_id: '3', integer: 3},
+            {_id: '4', integer: 4}
+          ];
+
+          db.bulkDocs({ docs: docs2 }, function (err, info) {
+            db.changes({
+              since: update_seq,
+              limit: 1,
+              complete: function (err, results) {
+                results.results.length.should.equal(1);
+                done();
+              }
+            });
+          });
         });
       });
     });


### PR DESCRIPTION
Similar to previous fixes, we cannot assume incremental sequence numbers in CouchDB 2.0, so ask the server for a valid sequence number and use that as the since parameter.
