### PR TITLE
Use consistent spacing in 'Create/update' heading

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -82,7 +82,7 @@ You can also delete a database using just the name:
 PouchDB.destroy('dbname', function(err, info) { });
 {% endhighlight %}
 
-{% include anchor.html title="Create / update a document" hash="create_document" %}
+{% include anchor.html title="Create/update a document" hash="create_document" %}
 
 ### Using db.put()
 {% highlight js %}


### PR DESCRIPTION
While making a [Dash docset for PouchDB](https://github.com/backspace/pouchdb-docset), I came across a small inconsistency in heading names. This makes both headings say “Create/update”.
