### PR TITLE
(#1738) - single batch() for leveldb bulkDocs()

### DIFF
--- a/lib/adapters/idb/idb-bulk-docs.js
+++ b/lib/adapters/idb/idb-bulk-docs.js
@@ -190,7 +190,7 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
   }
 
   function writeDoc(docInfo, winningRev, deleted, callback, isUpdate,
-                    resultsIdx) {
+                    delta, resultsIdx) {
 
     var doc = docInfo.data;
     doc._id = docInfo.metadata.id;

--- a/lib/adapters/leveldb/leveldb-transaction.js
+++ b/lib/adapters/leveldb/leveldb-transaction.js
@@ -1,0 +1,84 @@
+'use strict';
+
+// similar to an idb or websql transaction object
+// designed to be passed around. basically just caches
+// things in-memory and then does a big batch() operation
+// when you're done
+
+var utils = require('../../utils');
+
+function getCacheFor(transaction, store) {
+  var prefix = store.prefix();
+  var cache = transaction._cache;
+  var subCache = cache.get(prefix);
+  if (!subCache) {
+    subCache = new utils.Map();
+    cache.set(prefix, subCache);
+  }
+  return subCache;
+}
+
+function LevelTransaction() {
+  this._batch = [];
+  this._cache = new utils.Map();
+}
+
+LevelTransaction.prototype.get = function (store, key, callback) {
+  var cache = getCacheFor(this, store);
+  var exists = cache.get(key);
+  if (exists) {
+    return process.nextTick(function () {
+      callback(null, exists);
+    });
+  } else if (exists === null) { // deleted marker
+    return process.nextTick(function () {
+      callback({name: 'NotFoundError'});
+    });
+  }
+  store.get(key, function (err, res) {
+    if (err) {
+      if (err.name === 'NotFoundError') {
+        cache.set(key, null);
+      }
+      return callback(err);
+    }
+    cache.set(key, res);
+    callback(null, res);
+  });
+};
+
+LevelTransaction.prototype.batch = function (batch) {
+  for (var i = 0, len = batch.length; i < len; i++) {
+    var operation = batch[i];
+
+    var cache = getCacheFor(this, operation.prefix);
+
+    if (operation.type === 'put') {
+      cache.set(operation.key, operation.value);
+    } else {
+      cache.set(operation.key, null);
+    }
+  }
+  this._batch = this._batch.concat(batch);
+};
+
+LevelTransaction.prototype.execute = function (db, callback) {
+
+  var keys = new utils.Set();
+  var uniqBatches = [];
+
+  // remove duplicates; last one wins
+  for (var i = this._batch.length - 1; i >= 0; i--) {
+    var operation = this._batch[i];
+    var lookupKey = operation.prefix.prefix() + '\xff' + operation.key;
+    if (keys.has(lookupKey)) {
+      continue;
+    }
+    keys.add(lookupKey);
+    uniqBatches.push(operation);
+  }
+
+  db.batch(uniqBatches, callback);
+};
+
+module.exports = LevelTransaction;

--- a/lib/adapters/leveldb/leveldb.js
+++ b/lib/adapters/leveldb/leveldb.js
@@ -14,11 +14,13 @@ function requireLeveldown() {
 }
 requireLeveldown();
 
-var errors = require('../deps/errors');
-var merge = require('../merge');
-var utils = require('../utils');
-var migrate = require('../deps/migrate');
+var errors = require('../../deps/errors');
+var merge = require('../../merge');
+var utils = require('../../utils');
+var migrate = require('../../deps/migrate');
 var Deque = require("double-ended-queue");
+
+var LevelTransaction = require('./leveldb-transaction');
 
 var DOC_STORE = 'document-store';
 var BY_SEQ_STORE = 'by-sequence';
@@ -26,7 +28,6 @@ var ATTACHMENT_STORE = 'attach-store';
 var BINARY_STORE = 'attach-binary-store';
 var LOCAL_STORE = 'local-store';
 var META_STORE = 'meta-store';
-var BATCH_SIZE = 50;
 
 // leveldb barks if we try to open a db multiple times
 // so we cache opened connections here for initstore()
@@ -115,11 +116,7 @@ function LevelPouch(opts, callback) {
         return callback(err);
       }
       db = dbStore.get(name);
-      db._docCountQueue = {
-        queue : [],
-        running : false,
-        docCount : -1
-      };
+      db._docCount  = -1;
       db._writeQueue = new Deque();
       if (opts.db || opts.noMigrate) {
         afterDBCreated();
@@ -143,17 +140,12 @@ function LevelPouch(opts, callback) {
           db._updateSeq = value || 0;
         }
         stores.metaStore.get(DOC_COUNT_KEY, function (err, value) {
-          db._docCountQueue.docCount = !err ? value : 0;
-          countDocs(function (err) { // notify queue that the docCount is ready
-            if (err) {
-              api.emit('error', err);
-            }
-            stores.metaStore.get(UUID_KEY, function (err, value) {
-              instanceId = !err ? value : utils.uuid();
-              stores.metaStore.put(UUID_KEY, instanceId, function (err, value) {
-                process.nextTick(function () {
-                  callback(null, api);
-                });
+          db._docCount = !err ? value : 0;
+          stores.metaStore.get(UUID_KEY, function (err, value) {
+            instanceId = !err ? value : utils.uuid();
+            stores.metaStore.put(UUID_KEY, instanceId, function (err, value) {
+              process.nextTick(function () {
+                callback(null, api);
               });
             });
           });
@@ -163,44 +155,10 @@ function LevelPouch(opts, callback) {
   }
 
   function countDocs(callback) {
-    if (db._docCountQueue.running || !db._docCountQueue.queue.length ||
-      db._docCountQueue.docCount === -1) {
-      return incrementDocCount(0, callback); // wait for fresh data
-    }
-    return db._docCountQueue.docCount; // use cached value
-  }
-
-  function applyNextDocCountDelta() {
-    if (db._docCountQueue.running || !db._docCountQueue.queue.length ||
-      db._docCountQueue.docCount === -1) {
-      return;
-    }
-    db._docCountQueue.running = true;
-    var item = db._docCountQueue.queue.shift();
     if (db.isClosed()) {
-      return item.callback(new Error('database is closed'));
+      return callback(new Error('database is closed'));
     }
-    stores.metaStore.get(DOC_COUNT_KEY, function (err, docCount) {
-      docCount = !err ? docCount : 0;
-
-      function complete(err) {
-        db._docCountQueue.docCount = docCount;
-        item.callback(err, docCount);
-        db._docCountQueue.running = false;
-        applyNextDocCountDelta();
-      }
-
-      if (item.delta === 0) {
-        complete();
-      } else {
-        stores.metaStore.put(DOC_COUNT_KEY, docCount + item.delta, complete);
-      }
-    });
-  }
-
-  function incrementDocCount(delta, callback) {
-    db._docCountQueue.queue.push({delta : delta, callback : callback});
-    applyNextDocCountDelta();
+    return callback(null, db._docCount); // use cached value
   }
 
   api.type = function () {
@@ -387,12 +345,15 @@ function LevelPouch(opts, callback) {
   api._bulkDocs = writeLock(function (req, opts, callback) {
     var newEdits = opts.new_edits;
     var results = new Array(req.docs.length);
-    var lock = new utils.Set();
-    var docIdsToMetadata = new utils.Map();
+    var fetchedDocs = new utils.Map();
+    var txn = new LevelTransaction();
+    var docCountDelta = 0;
+    var newUpdateSeq = db._updateSeq;
+    var toEmit = [];
 
     // parse the docs and give each a sequence number
     var userDocs = req.docs;
-    var info = userDocs.map(function (doc, i) {
+    var docInfos = userDocs.map(function (doc, i) {
       if (doc._id && utils.isLocalId(doc._id)) {
         return doc;
       }
@@ -404,8 +365,7 @@ function LevelPouch(opts, callback) {
 
       return newDoc;
     });
-    var current = 0;
-    var infoErrors = info.filter(function (doc) {
+    var infoErrors = docInfos.filter(function (doc) {
       return doc.error;
     });
 
@@ -416,7 +376,7 @@ function LevelPouch(opts, callback) {
     // verify any stub attachments as a precondition test
 
     function verifyAttachment(digest, callback) {
-      stores.attachmentStore.get(digest, function (levelErr) {
+      txn.get(stores.attachmentStore, digest, function (levelErr) {
         if (levelErr) {
           var err = errors.error(errors.MISSING_STUB,
                                 'unknown stub attachment with digest ' +
@@ -461,17 +421,44 @@ function LevelPouch(opts, callback) {
       });
     }
 
+    function fetchExistingDocs(finish) {
+      var numDone = 0;
+      var overallErr;
+      function checkDone() {
+        if (++numDone === userDocs.length) {
+          return finish(overallErr);
+        }
+      }
+
+      userDocs.forEach(function (doc) {
+        if (doc._id && utils.isLocalId(doc._id)) {
+          // skip local docs
+          return checkDone();
+        }
+        txn.get(stores.docStore, doc._id, function (err, info) {
+          if (err) {
+            if (err.name !== 'NotFoundError') {
+              overallErr = err;
+            }
+          } else {
+            fetchedDocs.set(doc._id, info);
+          }
+          checkDone();
+        });
+      });
+    }
+
     function autoCompact(callback) {
 
       var promise = utils.Promise.resolve();
 
-      docIdsToMetadata.forEach(function (metadata, docId) {
+      fetchedDocs.forEach(function (metadata, docId) {
         // TODO: parallelize, for now need to be sequential to
         // pass orphaned attachment tests
         promise = promise.then(function () {
           return new utils.Promise(function (resolve, reject) {
-            var revsToDelete = utils.compactTree(metadata);
-            api._doCompactionNoLock(docId, revsToDelete, function (err) {
+            var revs = utils.compactTree(metadata);
+            api._doCompactionNoLock(docId, revs, {ctx: txn}, function (err) {
               if (err) {
                 return reject(err);
               }
@@ -493,153 +480,17 @@ function LevelPouch(opts, callback) {
       return complete();
     }
 
-    var inProgress = 0;
-    function processDocs() {
-      var index = current;
-      if (inProgress > BATCH_SIZE) {
-        return;
-      }
-      if (index >= info.length) {
-        if (inProgress === 0) {
-          return finish();
-        } else {
-          return;
-        }
-      }
-      var currentDoc = info[index];
-      current++;
-      inProgress++;
-      if (currentDoc._id && utils.isLocalId(currentDoc._id)) {
-        api[currentDoc._deleted ? '_removeLocalNoLock' : '_putLocalNoLock'](
-            currentDoc, function (err, resp) {
-          if (err) {
-            results[index] = err;
-          } else {
-            results[index] = {};
-          }
-          inProgress--;
-          processDocs();
-        });
-        return;
-      }
+    function writeDoc(doc, winningRev, deleted, callback2,
+                      isUpdate, delta, index) {
+      docCountDelta += delta;
 
-      if (lock.has(currentDoc.metadata.id)) {
-        results[index] = errors.error(errors.REV_CONFLICT);
-        inProgress--;
-        return processDocs();
-      }
-      lock.add(currentDoc.metadata.id);
-
-      stores.docStore.get(currentDoc.metadata.id, function (err, oldDoc) {
-        if (err) {
-          if (err.name === 'NotFoundError') {
-            docIdsToMetadata.set(currentDoc.metadata.id,
-              currentDoc.metadata);
-            insertDoc(currentDoc, index, function () {
-              lock.delete(currentDoc.metadata.id);
-              inProgress--;
-              processDocs();
-            });
-          } else {
-            err.error = true;
-            results[index] = err;
-            lock.delete(currentDoc.metadata.id);
-            inProgress--;
-            processDocs();
-          }
-        } else {
-          docIdsToMetadata.set(currentDoc.metadata.id,
-            currentDoc.metadata);
-          updateDoc(oldDoc, currentDoc, index, function () {
-            lock.delete(currentDoc.metadata.id);
-            inProgress--;
-            processDocs();
-          });
-        }
-      });
-
-      if (newEdits) {
-        processDocs();
-      }
-    }
-
-    function insertDoc(doc, index, callback) {
-      // Can't insert new deleted documents
-      if ('was_delete' in opts && utils.isDeleted(doc.metadata)) {
-        results[index] = errors.error(errors.MISSING_DOC, 'deleted');
-        return callback();
-      }
-      writeDoc(doc, index, false, function (err) {
-        if (err) {
-          return callback(err);
-        }
-        if (utils.isDeleted(doc.metadata)) {
-          return callback();
-        }
-        incrementDocCount(1, callback);
-      });
-    }
-
-    function updateDoc(oldDoc, docInfo, index, callback) {
-
-      if (utils.revExists(oldDoc, docInfo.metadata.rev)) {
-        results[index] = docInfo;
-        callback();
-        return;
-      }
-
-      var previouslyDeleted = utils.isDeleted(oldDoc);
-      var deleted = utils.isDeleted(docInfo.metadata);
-      var isRoot = /^1-/.test(docInfo.metadata.rev);
-
-      if (previouslyDeleted && !deleted && newEdits && isRoot) {
-        var newDoc = docInfo.data;
-        newDoc._rev = oldDoc.rev;
-        newDoc._id = docInfo.metadata.id;
-        docInfo = utils.parseDoc(newDoc, newEdits);
-      }
-
-      var merged =
-        merge.merge(oldDoc.rev_tree, docInfo.metadata.rev_tree[0], 1000);
-
-      var inConflict = newEdits && ((previouslyDeleted && deleted) ||
-        (!previouslyDeleted && newEdits && merged.conflicts !== 'new_leaf') ||
-        (previouslyDeleted && !deleted && merged.conflicts === 'new_branch'));
-
-      if (inConflict) {
-        results[index] = errors.error(errors.REV_CONFLICT);
-        return callback();
-      }
-      var newRev = docInfo.metadata.rev;
-      docInfo.metadata.rev_tree = merged.tree;
-      docInfo.metadata.rev_map = oldDoc.rev_map;
-
-      var delta = 0;
-      if (newEdits || merge.winningRev(docInfo.metadata) === newRev) {
-        // if newEdits==false and we're pushing existing revisions,
-        // then the only thing that matters is whether this revision
-        // is the winning one, and thus replaces an old one
-        delta = (previouslyDeleted === deleted) ? 0 :
-          previouslyDeleted < deleted ? -1 : 1;
-      }
-
-      incrementDocCount(delta, function (err) {
-        if (err) {
-          return callback(err);
-        }
-        writeDoc(docInfo, index, true, callback);
-      });
-
-    }
-
-    function writeDoc(doc, index, isUpdate, callback2) {
       var err = null;
       var recv = 0;
 
       doc.data._id = doc.metadata.id;
       doc.data._rev = doc.metadata.rev;
 
-      if (utils.isDeleted(doc.metadata)) {
+      if (deleted) {
         doc.data._deleted = true;
       }
 
@@ -713,14 +564,12 @@ function LevelPouch(opts, callback) {
         var seq = doc.metadata.rev_map[doc.metadata.rev];
         if (seq) {
           // check that there aren't any existing revisions with the same
-          // reivision id, else we shouldn't do anything
+          // revision id, else we shouldn't do anything
           return callback2();
         }
-        seq = ++db._updateSeq;
+        seq = ++newUpdateSeq;
         doc.metadata.rev_map[doc.metadata.rev] = doc.metadata.seq = seq;
         var seqKey = formatSeq(seq);
-        db.emit('pouchdb-id-' + doc.metadata.id, doc);
-        db.emit('pouchdb-' + seqKey, doc);
         var batch = [{
           key: seqKey,
           value: doc.data,
@@ -734,21 +583,12 @@ function LevelPouch(opts, callback) {
           type: 'put',
           valueEncoding: safeJsonEncoding
         }];
-        db.batch(batch, function (err) {
-          if (!err) {
-            db.emit('pouchdb-id-' + doc.metadata.id, doc);
-            db.emit('pouchdb-' + seqKey, doc);
-          }
-          return stores.metaStore.put(UPDATE_SEQ_KEY, db._updateSeq,
-            function (err) {
-            if (err) {
-              results[index] = err;
-            } else {
-              results[index] = doc;
-            }
-            return callback2();
-          });
-        });
+        txn.batch(batch);
+        toEmit.push(['pouchdb-id-' + doc.metadata.id, doc]);
+        toEmit.push(['pouchdb-' + seqKey, doc]);
+        results[index] = doc;
+        fetchedDocs.set(doc.metadata.id, doc.metadata);
+        callback2();
       }
 
       if (!attachments.length) {
@@ -764,7 +604,7 @@ function LevelPouch(opts, callback) {
 
       function fetchAtt() {
         return new utils.Promise(function (resolve, reject) {
-          stores.attachmentStore.get(digest, function (err, oldAtt) {
+          txn.get(stores.attachmentStore, digest, function (err, oldAtt) {
             if (err && err.name !== 'NotFoundError') {
               return reject(err);
             }
@@ -791,12 +631,14 @@ function LevelPouch(opts, callback) {
         }
 
         return new utils.Promise(function (resolve, reject) {
-          stores.attachmentStore.put(digest, newAtt, function (err) {
-            if (err) {
-              return reject(err);
-            }
-            resolve(!oldAtt);
-          });
+          txn.batch([{
+            type: 'put',
+            prefix: stores.attachmentStore,
+            key: digest,
+            value: newAtt,
+            valueEncoding: 'json'
+          }]);
+          resolve(!oldAtt);
         });
       }
 
@@ -830,10 +672,14 @@ function LevelPouch(opts, callback) {
           // small optimization - don't bother writing it again
           return callback(err);
         }
-        // doing this in batch causes a test to fail, wtf?
-        stores.binaryStore.put(digest, data, function (err) {
-          callback(err);
-        });
+        txn.batch([{
+          type: 'put',
+          prefix: stores.binaryStore,
+          key: digest,
+          value: new Buffer(data, 'binary'),
+          encoding: 'binary'
+        }]);
+        callback();
       });
     }
 
@@ -862,17 +708,58 @@ function LevelPouch(opts, callback) {
           rev: rev
         };
       });
-      LevelPouch.Changes.notify(name);
-      process.nextTick(function () {
-        callback(null, aresults);
+      txn.batch([
+        {
+          prefix: stores.metaStore,
+          type: 'put',
+          key: UPDATE_SEQ_KEY,
+          value: newUpdateSeq,
+          encoding: 'json'
+        },
+        {
+          prefix: stores.metaStore,
+          type: 'put',
+          key: DOC_COUNT_KEY,
+          value: db._docCount + docCountDelta,
+          encoding: 'json'
+        }
+      ]);
+      toEmit.forEach(function (change) {
+        // notify about doc/seq changes
+        db.emit(change[0], change[1]);
       });
+      txn.execute(db, function (err) {
+        if (err) {
+          return callback(err);
+        }
+        db._docCount += docCountDelta;
+        db._updateSeq = newUpdateSeq;
+        toEmit.forEach(function (change) {
+          // notify about doc/seq changes
+          db.emit(change[0], change[1]);
+        });
+        LevelPouch.Changes.notify(name);
+        process.nextTick(function () {
+          callback(null, aresults);
+        });
+      });
+    }
+
+    if (!docInfos.length) {
+      return callback(null, []);
     }
 
     verifyAttachments(function (err) {
       if (err) {
         return callback(err);
       }
-      processDocs();
+      fetchExistingDocs(function (err) {
+        if (err) {
+          return callback(err);
+        }
+        utils.processDocs(docInfos, api, fetchedDocs,
+          txn, results, writeDoc, opts, finish);
+      });
     });
   });
   api._allDocs = function (opts, callback) {
@@ -1191,16 +1078,23 @@ function LevelPouch(opts, callback) {
     });
   };
 
-  api._doCompaction = writeLock(function (docId, revs, callback) {
-    api._doCompactionNoLock(docId, revs, callback);
+  api._doCompaction = writeLock(function (docId, revs, opts, callback) {
+    api._doCompactionNoLock(docId, revs, opts, callback);
   });
 
   // the NoLock version is for use by bulkDocs
-  api._doCompactionNoLock = function (docId, revs, callback) {
+  api._doCompactionNoLock = function (docId, revs, opts, callback) {
+    if (typeof opts === 'function') {
+      callback = opts;
+      opts = {};
+    }
+
     if (!revs.length) {
       return callback();
     }
-    stores.docStore.get(docId, function (err, metadata) {
+    var txn = opts.ctx || new LevelTransaction();
+
+    txn.get(stores.docStore, docId, function (err, metadata) {
       if (err) {
         return callback(err);
       }
@@ -1240,7 +1134,12 @@ function LevelPouch(opts, callback) {
         if (err) {
           return callback(err);
         }
-        db.batch(batch, callback);
+        txn.batch(batch);
+        if (opts.ctx) {
+          // don't execute immediately
+          return callback();
+        }
+        txn.execute(db, callback);
       }
 
       function deleteOrphanedAttachments() {
@@ -1263,7 +1162,7 @@ function LevelPouch(opts, callback) {
           refsToDelete.set(docId + '@' + rev, true);
         });
         possiblyOrphanedAttachments.forEach(function (digest) {
-          stores.attachmentStore.get(digest, function (err, attData) {
+          txn.get(stores.attachmentStore, digest, function (err, attData) {
             if (err) {
               if (err.name === 'NotFoundError') {
                 return checkDone();
@@ -1312,7 +1211,7 @@ function LevelPouch(opts, callback) {
           type: 'del',
           prefix: stores.bySeqStore
         });
-        stores.bySeqStore.get(formatSeq(seq), function (err, doc) {
+        txn.get(stores.bySeqStore, formatSeq(seq), function (err, doc) {
           if (err) {
             if (err.name === 'NotFoundError') {
               return checkDone();
@@ -1341,16 +1240,31 @@ function LevelPouch(opts, callback) {
     });
   };
 
-  api._putLocal = writeLock(function (doc, callback) {
-    api._putLocalNoLock(doc, callback);
+  api._putLocal = function (doc, opts, callback) {
+    if (typeof opts === 'function') {
+      callback = opts;
+      opts = {};
+    }
+    if (opts.ctx) {
+      api._putLocalNoLock(doc, opts, callback);
+    } else {
+      api._putLocalWithLock(doc, opts, callback);
+    }
+  };
+
+  api._putLocalWithLock = writeLock(function (doc, opts, callback) {
+    api._putLocalNoLock(doc, opts, callback);
   });
 
   // the NoLock version is for use by bulkDocs
-  api._putLocalNoLock = function (doc, callback) {
+  api._putLocalNoLock = function (doc, opts, callback) {
     delete doc._revisions; // ignore this, trust the rev
     var oldRev = doc._rev;
     var id = doc._id;
-    stores.localStore.get(id, function (err, resp) {
+
+    var txn = opts.ctx || new LevelTransaction();
+
+    txn.get(stores.localStore, id, function (err, resp) {
       if (err) {
         if (oldRev) {
           return callback(errors.error(errors.REV_CONFLICT));
@@ -1364,34 +1278,72 @@ function LevelPouch(opts, callback) {
       } else {
         doc._rev = '0-' + (parseInt(oldRev.split('-')[1], 10) + 1);
       }
-      stores.localStore.put(id, doc, function (err) {
+      var batch = [
+        {
+          type: 'put',
+          prefix: stores.localStore,
+          key: id,
+          value: doc,
+          valueEncoding: 'json'
+        }
+      ];
+
+      txn.batch(batch);
+      var ret = {ok: true, id: doc._id, rev: doc._rev};
+
+      if (opts.ctx) {
+        // don't execute immediately
+        return callback(null, ret);
+      }
+      txn.execute(db, function (err) {
         if (err) {
           return callback(err);
         }
-        var ret = {ok: true, id: doc._id, rev: doc._rev};
         callback(null, ret);
       });
     });
   };
 
-  api._removeLocal = writeLock(function (doc, callback) {
-    api._removeLocalNoLock(doc, callback);
+  api._removeLocal = function (doc, opts, callback) {
+    if (typeof opts === 'function') {
+      callback = opts;
+      opts = {};
+    }
+    if (opts.ctx) {
+      api._removeLocalNoLock(doc, opts, callback);
+    } else {
+      api._removeLocalWithLock(doc, opts, callback);
+    }
+  };
+
+  api._removeLocalWithLock = writeLock(function (doc, opts, callback) {
+    api._removeLocalNoLock(doc, opts, callback);
   });
 
   // the NoLock version is for use by bulkDocs
-  api._removeLocalNoLock = function (doc, callback) {
-    stores.localStore.get(doc._id, function (err, resp) {
+  api._removeLocalNoLock = function (doc, opts, callback) {
+    var txn = opts.ctx || new LevelTransaction();
+    txn.get(stores.localStore, doc._id, function (err, resp) {
       if (err) {
         return callback(err);
       }
       if (resp._rev !== doc._rev) {
         return callback(errors.error(errors.REV_CONFLICT));
       }
-      stores.localStore.del(doc._id, function (err) {
+      txn.batch([{
+        prefix: stores.localStore,
+        type: 'del',
+        key: doc._id
+      }]);
+      var ret = {ok: true, id: doc._id, rev: '0-0'};
+      if (opts.ctx) {
+        // don't execute immediately
+        return callback(null, ret);
+      }
+      txn.execute(db, function (err) {
         if (err) {
           return callback(err);
         }
-        var ret = {ok: true, id: doc._id, rev: '0-0'};
         callback(null, ret);
       });
     });

--- a/lib/adapters/websql.js
+++ b/lib/adapters/websql.js
@@ -810,7 +810,7 @@ function WebSqlPouch(opts, callback) {
 
 
     function writeDoc(docInfo, winningRev, deleted, callback, isUpdate,
-                      resultsIdx) {
+                      docCount, resultsIdx) {
 
       function finish() {
         var data = docInfo.data;

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ PouchDB.adapter('websql', require('./adapters/websql'));
 PouchDB.plugin(require('pouchdb-mapreduce'));
 
 if (!process.browser) {
-  var ldbAdapter = require('./adapters/leveldb');
+  var ldbAdapter = require('./adapters/leveldb/leveldb');
   PouchDB.adapter('ldb', ldbAdapter);
   PouchDB.adapter('leveldb', ldbAdapter);
 }

--- a/lib/plugins/levelalt.js
+++ b/lib/plugins/levelalt.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var LevelPouch = require('../adapters/leveldb');
+var LevelPouch = require('../adapters/leveldb/leveldb');
 var leveldown = require('leveldown');
 var utils = require('../utils');
 module.exports = altFactory;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -698,17 +698,31 @@ exports.updateDoc = function updateDoc(prev, docInfo, results,
     return cb();
   }
 
+  var newRev = docInfo.metadata.rev;
   docInfo.metadata.rev_tree = merged.tree;
+  if (prev.rev_map) {
+    docInfo.metadata.rev_map = prev.rev_map; // used by leveldb
+  }
 
   // recalculate
   var winningRev = merge.winningRev(docInfo.metadata);
   deleted = exports.isDeleted(docInfo.metadata, winningRev);
 
-  writeDoc(docInfo, winningRev, deleted, cb, true, i);
+  var delta = 0;
+  if (newEdits || winningRev === newRev) {
+    // if newEdits==false and we're pushing existing revisions,
+    // then the only thing that matters is whether this revision
+    // is the winning one, and thus replaces an old one
+    delta = (previouslyDeleted === deleted) ? 0 :
+      previouslyDeleted < deleted ? -1 : 1;
+  }
+
+  writeDoc(docInfo, winningRev, deleted, cb, true, delta, i);
 };
 
 exports.processDocs = function processDocs(docInfos, api, fetchedDocs,
-                                           tx, results, writeDoc, opts) {
+                                           tx, results, writeDoc, opts,
+                                           overallCallback) {
 
   if (!docInfos.length) {
     return;
@@ -722,28 +736,42 @@ exports.processDocs = function processDocs(docInfos, api, fetchedDocs,
       results[resultsIdx] = errors.error(errors.MISSING_DOC, 'deleted');
       return callback();
     }
-    writeDoc(docInfo, winningRev, deleted, callback, false, resultsIdx);
+
+    var delta = deleted ? 0 : 1;
+
+    writeDoc(docInfo, winningRev, deleted, callback, false, delta, resultsIdx);
   }
 
   var newEdits = opts.new_edits;
   var idsToDocs = new exports.Map();
 
+  var docsDone = 0;
+  var docsToDo = docInfos.length;
+
+  function checkAllDocsDone() {
+    if (++docsDone === docsToDo && overallCallback) {
+      overallCallback();
+    }
+  }
+
   docInfos.forEach(function (currentDoc, resultsIdx) {
 
     if (currentDoc._id && exports.isLocalId(currentDoc._id)) {
       api[currentDoc._deleted ? '_removeLocal' : '_putLocal'](
-        currentDoc, {ctx: tx}, function (err, resp) {
+        currentDoc, {ctx: tx}, function (err) {
           if (err) {
             results[resultsIdx] = err;
           } else {
             results[resultsIdx] = {};
           }
+          checkAllDocsDone();
         });
       return;
     }
 
     var id = currentDoc.metadata.id;
     if (idsToDocs.has(id)) {
+      docsToDo--; // duplicate
       idsToDocs.get(id).push([currentDoc, resultsIdx]);
     } else {
       idsToDocs.set(id, [[currentDoc, resultsIdx]]);
@@ -758,6 +786,8 @@ exports.processDocs = function processDocs(docInfos, api, fetchedDocs,
     function docWritten() {
       if (++numDone < docs.length) {
         nextDoc();
+      } else {
+        checkAllDocsDone();
       }
     }
     function nextDoc() {

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -380,7 +380,7 @@ if (typeof module !== 'undefined' && module.exports) {
     testDir = process.env.TESTS_DIR ? process.env.TESTS_DIR : './tmp';
     testDir = testDir.slice(-1) === '/' ? testDir : testDir + '/';
     global.PouchDB.prefix = testDir + global.PouchDB.prefix;
-    require('../../lib/adapters/leveldb').use_prefix = true;
+    require('../../lib/adapters/leveldb/leveldb').use_prefix = true;
     require('bluebird').onPossiblyUnhandledRejection(function (e, promise) {
       throw e;
     });


### PR DESCRIPTION
This modifies leveldb's `bulkDocs()` so that it does
everything in a single batch. Note the addition
of the LevelTransaction to make it easier to
accomplish this.

`leveldb.js` is also refactored to use utils.processDocs,
just the same as idb and websql, cutting down on
code duplication.
