### PR TITLE
(#3251) - add read queue to avoid leveldb corruption

### DIFF
--- a/lib/adapters/leveldb/leveldb.js
+++ b/lib/adapters/leveldb/leveldb.js
@@ -117,7 +117,7 @@ function LevelPouch(opts, callback) {
       }
       db = dbStore.get(name);
       db._docCount  = -1;
-      db._writeQueue = new Deque();
+      db._queue = new Deque();
       if (opts.db || opts.noMigrate) {
         afterDBCreated();
       } else {
@@ -170,22 +170,82 @@ function LevelPouch(opts, callback) {
   };
 
   api._info = function (callback) {
-    countDocs(function (err, docCount) {
-      if (err) {
-        return callback(err);
-      }
-      stores.metaStore.get(UPDATE_SEQ_KEY, function (err, otherUpdateSeq) {
-        if (err) {
-          otherUpdateSeq = db._updateSeq;
-        }
-
-        return callback(null, {
-          doc_count: docCount,
-          update_seq: otherUpdateSeq
-        });
-      });
+    var res = {
+      doc_count: db._docCount,
+      update_seq: db._updateSeq
+    };
+    return process.nextTick(function () {
+      callback(null, res);
     });
   };
+
+  function tryCode(fun, args) {
+    try {
+      fun.apply(null, args);
+    } catch (err) {
+      args[args.length - 1](err);
+    }
+  }
+
+  function executeNext() {
+    var firstTask = db._queue.peekFront();
+
+    if (firstTask.type === 'read') {
+      runReadOperation(firstTask);
+    } else { // write, only do one at a time
+      runWriteOperation(firstTask);
+    }
+  }
+
+  function runReadOperation(firstTask) {
+    // do multiple reads at once simultaneously, because it's safe
+
+    var readTasks = [firstTask];
+    var i = 1;
+    var nextTask = db._queue.get(i);
+    while (typeof nextTask !== 'undefined' && nextTask.type === 'read') {
+      readTasks.push(nextTask);
+      i++;
+      nextTask = db._queue.get(i);
+    }
+
+    var numDone = 0;
+
+    readTasks.forEach(function (readTask) {
+      var args = readTask.args;
+      var callback = args[args.length - 1];
+      args[args.length - 1] = utils.getArguments(function (cbArgs) {
+        callback.apply(null, cbArgs);
+        if (++numDone === readTasks.length) {
+          process.nextTick(function () {
+            // all read tasks have finished
+            readTasks.forEach(function () {
+              db._queue.shift();
+            });
+            if (db._queue.length) {
+              executeNext();
+            }
+          });
+        }
+      });
+      tryCode(readTask.fun, args);
+    });
+  }
+
+  function runWriteOperation(firstTask) {
+    var args = firstTask.args;
+    var callback = args[args.length - 1];
+    args[args.length - 1] = utils.getArguments(function (cbArgs) {
+      callback.apply(null, cbArgs);
+      process.nextTick(function () {
+        db._queue.shift();
+        if (db._queue.length) {
+          executeNext();
+        }
+      });
+    });
+    tryCode(firstTask.fun, args);
+  }
 
   // all read/write operations to the database are done in a queue,
   // similar to how websql/idb works. this avoids problems such
@@ -193,24 +253,29 @@ function LevelPouch(opts, callback) {
   // it updates stuff. in the future we can revisit this.
   function writeLock(fun) {
     return utils.getArguments(function (args) {
-
-      var callback = args[args.length - 1];
-      args[args.length - 1] = utils.getArguments(function (cbArgs) {
-        callback.apply(null, cbArgs);
-        process.nextTick(function () {
-          db._writeQueue.shift();
-          if (db._writeQueue.length) {
-            db._writeQueue.peekFront()();
-          }
-        });
+      db._queue.push({
+        fun: fun,
+        args: args,
+        type: 'write'
       });
 
-      db._writeQueue.push(function () {
-        fun.apply(null, args);
+      if (db._queue.length === 1) {
+        process.nextTick(executeNext);
+      }
+    });
+  }
+
+  // same as the writelock, but multiple can run at once
+  function readLock(fun) {
+    return utils.getArguments(function (args) {
+      db._queue.push({
+        fun: fun,
+        args: args,
+        type: 'read'
       });
 
-      if (db._writeQueue.length === 1) {
-        db._writeQueue.peekFront()();
+      if (db._queue.length === 1) {
+        process.nextTick(executeNext);
       }
     });
   }
@@ -223,32 +288,10 @@ function LevelPouch(opts, callback) {
     return parseInt(s, 10);
   }
 
-  function makeDoc(rawDoc, callback) {
-    var doc = rawDoc.data;
-    doc._id = rawDoc.metadata.id;
-    if ('_rev' in doc) {
-      if (doc._rev !== rawDoc.metadata.rev) {
-        return callback(new Error('wrong doc returned'));
-      }
-    } else {
-      // we didn't always store rev
-      doc._rev = rawDoc.metadata.rev;
-    }
-    callback(null, {doc: doc, metadata: rawDoc.metadata});
-  }
-
-  api._get = function (id, opts, callback) {
+  api._get = readLock(function (id, opts, callback) {
     opts = utils.clone(opts);
-    var docChanged = [];
-
-    function didDocChange(doc) {
-      docChanged.push(doc);
-    }
-
-    db.on('pouchdb-id-' + id, didDocChange);
 
     stores.docStore.get(id, function (err, metadata) {
-      db.removeListener('pouchdb-id-' + id, didDocChange);
 
       if (err || !metadata) {
         return callback(errors.error(errors.MISSING_DOC, 'missing'));
@@ -258,34 +301,12 @@ function LevelPouch(opts, callback) {
         return callback(errors.error(errors.MISSING_DOC, "deleted"));
       }
 
-      var updated;
-
-      function ifUpdate(doc) {
-        updated = doc;
-      }
-
       var rev = merge.winningRev(metadata);
       rev = opts.rev ? opts.rev : rev;
 
       var seq = metadata.rev_map[rev];
 
-      var anyChanged = docChanged.filter(function (doc) {
-        return doc.metadata.seq === seq;
-      });
-
-      if (anyChanged.length) {
-        return makeDoc(anyChanged.pop(), callback);
-      }
-
-      db.on('pouchdb-' + seq, ifUpdate);
-
       stores.bySeqStore.get(formatSeq(seq), function (err, doc) {
-        db.removeListener('pouchdb-' + seq, ifUpdate);
-        if (updated) {
-          return makeDoc(updated, callback);
-
-        }
-
         if (!doc) {
           return callback(errors.error(errors.MISSING_DOC));
         }
@@ -306,7 +327,7 @@ function LevelPouch(opts, callback) {
         return callback(null, {doc: doc, metadata: metadata});
       });
     });
-  };
+  });
 
   // not technically part of the spec, but if putAttachment has its own
   // method...
@@ -349,7 +370,6 @@ function LevelPouch(opts, callback) {
     var txn = new LevelTransaction();
     var docCountDelta = 0;
     var newUpdateSeq = db._updateSeq;
-    var toEmit = [];
 
     // parse the docs and give each a sequence number
     var userDocs = req.docs;
@@ -584,8 +604,6 @@ function LevelPouch(opts, callback) {
           valueEncoding: safeJsonEncoding
         }];
         txn.batch(batch);
-        toEmit.push(['pouchdb-id-' + doc.metadata.id, doc]);
-        toEmit.push(['pouchdb-' + seqKey, doc]);
         results[index] = doc;
         fetchedDocs.set(doc.metadata.id, doc.metadata);
         callback2();
@@ -724,20 +742,12 @@ function LevelPouch(opts, callback) {
           encoding: 'json'
         }
       ]);
-      toEmit.forEach(function (change) {
-        // notify about doc/seq changes
-        db.emit(change[0], change[1]);
-      });
       txn.execute(db, function (err) {
         if (err) {
           return callback(err);
         }
         db._docCount += docCountDelta;
         db._updateSeq = newUpdateSeq;
-        toEmit.forEach(function (change) {
-          // notify about doc/seq changes
-          db.emit(change[0], change[1]);
-        });
         LevelPouch.Changes.notify(name);
         process.nextTick(function () {
           callback(null, aresults);
@@ -762,7 +772,7 @@ function LevelPouch(opts, callback) {
       });
     });
   });
-  api._allDocs = function (opts, callback) {
+  api._allDocs = readLock(function (opts, callback) {
     opts = utils.clone(opts);
     countDocs(function (err, docCount) {
       if (err) {
@@ -884,7 +894,7 @@ function LevelPouch(opts, callback) {
 
       docstream.pipe(throughStream);
     });
-  };
+  });
 
   api._changes = function (opts) {
     opts = utils.clone(opts);

--- a/tests/integration/test.compaction.js
+++ b/tests/integration/test.compaction.js
@@ -1432,6 +1432,123 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('#3251 massively parallel autocompaction while getting', function () {
+      var db = new PouchDB(dbs.name, {auto_compaction: true});
+
+      var doc = {_id: 'foo'};
+
+      return db.put(doc).then(function (res) {
+        doc._rev = res.rev;
+      }).then(function () {
+
+        var updatePromise = PouchDB.utils.Promise.resolve();
+
+        for (var i  = 0; i < 20; i++) {
+          /* jshint loopfunc: true */
+          updatePromise = updatePromise.then(function () {
+            return db.put(doc).then(function (res) {
+              doc._rev = res.rev;
+            });
+          });
+        }
+
+        var tasks = [updatePromise];
+        for (var ii = 0; ii < 300; ii++) {
+          /* jshint loopfunc: true */
+          var task = db.get('foo');
+          for (var j =0; j < 10; j++) {
+            task = task.then(function () {
+              return new PouchDB.utils.Promise(function (resolve) {
+                setTimeout(resolve, Math.floor(Math.random() * 10));
+              });
+            }).then(function () {
+              return db.get('foo');
+            });
+          }
+          tasks.push(task);
+        }
+        return PouchDB.utils.Promise.all(tasks);
+      });
+    });
+
+    it('#3251 massively parallel autocompaction while allDocsing', function () {
+      var db = new PouchDB(dbs.name, {auto_compaction: true});
+
+      var doc = {_id: 'foo'};
+
+      return db.put(doc).then(function (res) {
+        doc._rev = res.rev;
+      }).then(function () {
+
+        var updatePromise = PouchDB.utils.Promise.resolve();
+
+        for (var i  = 0; i < 20; i++) {
+          /* jshint loopfunc: true */
+          updatePromise = updatePromise.then(function () {
+            return db.put(doc).then(function (res) {
+              doc._rev = res.rev;
+            });
+          });
+        }
+
+        var tasks = [updatePromise];
+        for (var ii = 0; ii < 300; ii++) {
+          /* jshint loopfunc: true */
+          var task = db.allDocs({key: 'foo', include_docs: true});
+          for (var j =0; j < 10; j++) {
+            task = task.then(function () {
+              return new PouchDB.utils.Promise(function (resolve) {
+                setTimeout(resolve, Math.floor(Math.random() * 10));
+              });
+            }).then(function () {
+              return db.allDocs({key: 'foo', include_docs: true});
+            });
+          }
+          tasks.push(task);
+        }
+        return PouchDB.utils.Promise.all(tasks);
+      });
+    });
+
+    it('#3251 massively parallel autocompaction while changesing', function () {
+      var db = new PouchDB(dbs.name, {auto_compaction: true});
+
+      var doc = {_id: 'foo'};
+
+      return db.put(doc).then(function (res) {
+        doc._rev = res.rev;
+      }).then(function () {
+
+        var updatePromise = PouchDB.utils.Promise.resolve();
+
+        for (var i  = 0; i < 20; i++) {
+          /* jshint loopfunc: true */
+          updatePromise = updatePromise.then(function () {
+            return db.put(doc).then(function (res) {
+              doc._rev = res.rev;
+            });
+          });
+        }
+
+        var tasks = [updatePromise];
+        for (var ii = 0; ii < 300; ii++) {
+          /* jshint loopfunc: true */
+          var task = db.changes({include_docs: true});
+          for (var j =0; j < 10; j++) {
+            task = task.then(function () {
+              return new PouchDB.utils.Promise(function (resolve) {
+                setTimeout(resolve, Math.floor(Math.random() * 10));
+              });
+            }).then(function () {
+              return db.changes({include_docs: true});
+            });
+          }
+          tasks.push(task);
+        }
+        return PouchDB.utils.Promise.all(tasks);
+      });
+    });
+
     it('#3089 Many orphaned attachments w/ auto-compaction', function () {
       // now that we've established md5sum collisions,
       // we can use that to detect true attachment replacement


### PR DESCRIPTION
With these tests I can reproduce the LevelDB race condition where it starts reading before a batch and ends reading after a batch. It only fails for `get()` and `allDocs()` - `changes()` seems fine for some reason.
