### PR TITLE
trigger "replicated" and "denied" events on db.sync & db.replicate

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -180,10 +180,12 @@ function replicate(repId, src, target, opts, returnValue, result) {
         throw new Error('cancelled');
       }
       var errors = [];
+      var errorsById = {};
       res.forEach(function (res) {
         if (res.error) {
           result.doc_write_failures++;
           errors.push(res);
+          errorsById[res.id] = res;
         }
       });
       result.errors = result.errors.concat(errors);
@@ -191,6 +193,16 @@ function replicate(repId, src, target, opts, returnValue, result) {
       var non403s = errors.filter(function (error) {
         return error.name !== 'unauthorized' && error.name !== 'forbidden';
       });
+
+      docs.forEach(function(doc) {
+        var error = errorsById[doc._id];
+        if (error) {
+          returnValue.emit('denied', utils.clone(error));
+        } else {
+          returnValue.emit('replicated', utils.clone(doc));
+        }
+      });
+
       if (non403s.length > 0) {
         var error = new Error('bulkDocs error');
         error.other_errors = errors;

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -24,7 +24,7 @@ function sync(src, target, opts, callback) {
 function Sync(src, target, opts, callback) {
   var self = this;
   this.canceled = false;
-  
+
   var onChange, complete;
   if ('onChange' in opts) {
     onChange = opts.onChange;
@@ -60,6 +60,30 @@ function Sync(src, target, opts, callback) {
       change: change
     });
   }
+  function pushReplicated(doc) {
+    self.emit('replicated', {
+      direction: 'push',
+      doc: doc
+    });
+  }
+  function pullReplicated(doc) {
+    self.emit('replicated', {
+      direction: 'pull',
+      doc: doc
+    });
+  }
+  function pushDenied(doc) {
+    self.emit('denied', {
+      direction: 'push',
+      doc: doc
+    });
+  }
+  function pullDenied(doc) {
+    self.emit('denied', {
+      direction: 'pull',
+      doc: doc
+    });
+  }
   var listeners = {};
 
   var removed = {};
@@ -87,6 +111,12 @@ function Sync(src, target, opts, callback) {
     if (event === 'change') {
       self.pull.on('change', pullChange);
       self.push.on('change', pushChange);
+    } else if (event === 'replicated') {
+      self.pull.on('replicated', pullReplicated);
+      self.push.on('replicated', pushReplicated);
+    } else if (event === 'denied') {
+      self.pull.on('denied', pullDenied);
+      self.push.on('denied', pushDenied);
     } else if (event === 'cancel') {
       self.pull.on('cancel', onCancel);
       self.push.on('cancel', onCancel);


### PR DESCRIPTION
<del>@nolanlawson I've added tests for `db.sync` as well, to make sure that the `replicated` and `denied` events get triggered, but I didn't need to put in any extra code for proxying – or am I missing something</del> <ins>https://github.com/pouchdb/pouchdb/pull/3270#issuecomment-68217350</ins>
