### PR TITLE
(#136) - Fix "#3136 style=all_docs" against CouchDB 2.0

### DIFF
--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -1201,7 +1201,7 @@ adapters.forEach(function (adapter) {
       db.post({ test: 'adoc' });
     });
 
-    it('#3136 style=all_docs, right order', function () {
+    it('#3136 style=all_docs', function () {
 
       var db = new PouchDB(dbs.name);
 
@@ -1221,7 +1221,7 @@ adapters.forEach(function (adapter) {
         var ids = res.results.map(function (x) {
           return x.id;
         });
-        ids.should.deep.equal(docIds);
+        ids.should.include.members(docIds);
       });
     });
 


### PR DESCRIPTION
The _changes feed does not guarantee order so remove this assertion.
