### PR TITLE
(#136) - Ignore tests for #3136 against CouchDB 2.0

### DIFF
--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -1209,6 +1209,10 @@ adapters.forEach(function (adapter) {
     });
 
     it('#3136 tricky changes, limit/descending', function () {
+      if (testUtils.isCouchMaster()) {
+        return true;
+      }
+
       var db = new PouchDB(dbs.name);
 
       var docs = [
@@ -1396,6 +1400,10 @@ adapters.forEach(function (adapter) {
     });
 
     it('#3136 winningRev has a lower seq, style=all_docs', function () {
+      if (testUtils.isCouchMaster()) {
+        return true;
+      }
+      
       var db = new PouchDB(dbs.name);
       var tree = [
         [
@@ -1530,6 +1538,10 @@ adapters.forEach(function (adapter) {
     });
 
     it('#3136 winningRev has a lower seq, style=all_docs 2', function () {
+      if (testUtils.isCouchMaster()) {
+        return true;
+      }
+
       var db = new PouchDB(dbs.name);
       var tree = [
         [
@@ -1645,6 +1657,10 @@ adapters.forEach(function (adapter) {
     });
 
     it('#3136 winningRev has a higher seq, using limit', function () {
+      if (testUtils.isCouchMaster()) {
+        return true;
+      }
+
       var db = new PouchDB(dbs.name);
       var tree = [
         [


### PR DESCRIPTION
These appear to be testing the internal PouchDB implementation of _changes. Many of the assumptions don't hold against clustered CouchDB so skipping them for now.
