### PR TITLE
(#136) - Skip large doc_ids tests against CouchDB 2.0

### DIFF
--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -1878,6 +1878,11 @@ adapters.forEach(function (adapter) {
     });
 
     it('#2569 Big non-live doc_ids filter', function () {
+      // blocked on https://issues.apache.org/jira/browse/COUCHDB-2530
+      if (testUtils.isCouchMaster()) {
+        return true;
+      }
+      
       var docs = [];
       for (var i = 0; i < 5; i++) {
         var id = '';
@@ -1933,6 +1938,11 @@ adapters.forEach(function (adapter) {
     });
 
     it('#2569 Big live doc_ids filter', function () {
+      // blocked on https://issues.apache.org/jira/browse/COUCHDB-2530
+      if (testUtils.isCouchMaster()) {
+        return true;
+      }
+
       var docs = [];
       for (var i = 0; i < 5; i++) {
         var id = '';


### PR DESCRIPTION
CouchDB 2.0 does not (yet) support POST requests to _changes. We should re-enable these tests when https://issues.apache.org/jira/browse/COUCHDB-2530 is fixed.
