### PR TITLE
(#3286) - test in Chrome 36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ env:
 
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome COMMAND=test
+  - CLIENT=saucelabs:chrome:36 COMMAND=test
   - CLIENT=saucelabs:chrome:37 COMMAND=test
   - CLIENT=saucelabs:safari:6 COMMAND=test
   - CLIENT="saucelabs:iphone:7.1:OS X 10.9" COMMAND=test


### PR DESCRIPTION
Chrome 36 had no blob support, 37 was when they added broken
support, and 38 was when it was finally fixed.

I would like to test in all three. Chrome is the most popular
desktop browser on the planet, and it's also very close
to what mobile Android users experience. Let's play it safe
and test all three versions.
