### PR TITLE
(#136) - Fix "changes to same doc are grouped" against CouchDB 2.0

### DIFF
--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -2099,10 +2099,10 @@ adapters.forEach(function (adapter) {
               include_docs: true,
               complete: function (err, changes) {
                 changes.results.length.should.equal(4);
-                changes.results[2].seq.should.equal(5);
-                changes.results[2].id.should.equal('2');
-                changes.results[2].changes.length.should.equal(1);
-                changes.results[2].doc.integer.should.equal(11);
+
+                var second = findById(changes.results, '2');
+                second.changes.length.should.equal(1);
+                second.doc.integer.should.equal(11);
                 done();
               }
             });


### PR DESCRIPTION
Do not assume ordering of _changes and remove the sequence number assertion. Sequence numbers in clustered CouchDB cannot be tested for equality without decoding them into the Erlang representation.
