### PR TITLE
(#136) - Fix "Changes with conflicts are handled correctly" against CouchDB 2.0

### DIFF
--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -2162,8 +2162,7 @@ adapters.forEach(function (adapter) {
                         }).on('error', testDone)
                         .then(function (changes) {
                             changes.results.length.should.equal(4);
-                            var ch = changes.results[3];
-                            ch.id.should.equal('3');
+                            var ch = findById(changes.results, '3');
                             ch.changes.length.should.equal(2);
                             ch.doc.integer.should.equal(30);
                             ch.doc._rev.should.equal(rev4local);
@@ -2171,6 +2170,12 @@ adapters.forEach(function (adapter) {
                               { rev: rev4local },
                               { rev: remoterev }
                             ]);
+
+                            // Blocked on COUCHDB-2518
+                            if (testUtils.isCouchMaster()) {
+                              return;
+                            }
+
                             ch.doc.should.have.property('_conflicts');
                             ch.doc._conflicts.length.should.equal(1);
                             ch.doc._conflicts[0].should.equal(remoterev);


### PR DESCRIPTION
Do not assume ordering of _changes in the test. CouchDB 2.0 does not currently handle ?conflicts=true when fetching _changes (COUCHDB-2518) so skip these assertions for now when testing against CouchDB master.
