### PR TITLE
(#136) - Fix "change entry for a deleted doc" against CouchDB 2.0

### DIFF
--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -2206,9 +2206,11 @@ adapters.forEach(function (adapter) {
             include_docs: true,
             complete: function (err, changes) {
               changes.results.length.should.equal(4);
-              var ch = changes.results[3];
-              ch.id.should.equal('3');
-              ch.seq.should.equal(5);
+              var ch = findById(changes.results, '3');
+              // sequence numbers are not incremental in CouchDB 2.0
+              if (!testUtils.isCouchMaster()) {
+                ch.seq.should.equal(5);
+              }
               ch.deleted.should.equal(true);
               done();
             }


### PR DESCRIPTION
Do not assume _changes are ordered or that sequence numbers are incremental when testing against CouchDB 2.0.
