### PR TITLE
Specify message in error object when abortReplication is called.

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -368,6 +368,9 @@ function replicate(repId, src, target, opts, returnValue, result) {
     if (replicationCompleted) {
       return;
     }
+    if (!err.message) {
+      err.message = reason;
+    }
     result.ok = false;
     result.status = 'aborting';
     result.errors.push(err);


### PR DESCRIPTION
If a message hasn't been specified, use the reason we're aborting.

Noticed that the message was empty, and the reason for aborting was getting lost.