### PR TITLE
(#136) - call done() when skipping changes last seq

### DIFF
--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -678,7 +678,7 @@ adapters.forEach(function (adapter) {
       // not equal the last seq in the _changes feed (although it
       // should evaluate to the same thing on the server).
       if (testUtils.isCouchMaster()) {
-        return true;
+        return done();
       }
 
       var docs = [
@@ -721,7 +721,7 @@ adapters.forEach(function (adapter) {
       // not equal the last seq in the _changes feed (although it
       // should evaluate to the same thing on the server).
       if (testUtils.isCouchMaster()) {
-        return true;
+        return done();
       }
 
       var docs = [


### PR DESCRIPTION
When skipping the "changes last seq" test against CouchDB 2.0 (see #3271) call done() instead of returning true. Without this, the test never completes.