### PR TITLE
(#136) - Skip compaction tests against CouchDB 2.0

### DIFF
--- a/tests/integration/test.compaction.js
+++ b/tests/integration/test.compaction.js
@@ -5,6 +5,9 @@ var autoCompactionAdapters = ['local'];
 
 adapters.forEach(function (adapter) {
   describe('test.compaction.js-' + adapter, function () {
+    if (testUtils.isCouchMaster()) {
+      return true;
+    }
 
     var dbs = {};
 


### PR DESCRIPTION
CouchDB 2.0 does not expose the _compact endpoint via the public interface. Instead, compaction can be triggered via the backdoor admin
port. In future we may want to test against this but skip for now.