### PR TITLE
(#136) - Skip "Revs diff with empty revs" / CouchDB 2.0

### DIFF
--- a/tests/integration/test.revs_diff.js
+++ b/tests/integration/test.revs_diff.js
@@ -102,6 +102,11 @@ adapters.forEach(function (adapter) {
     });
 
     it('Revs diff with empty revs', function () {
+      // blocked on COUCHDB-2531
+      if (testUtils.isCouchMaster()) {
+        return true;
+      }
+
       return new PouchDB(dbs.name).then(function (db) {
         return db.revsDiff({}).then(function (res) {
           should.exist(res);


### PR DESCRIPTION
CouchDB 2.0 currently fails to respond when an empty revision set is passed to _revs_diff (COUCHDB-2531). Until this is fixed, skip the test.