### PR TITLE
(#136) - Fix "Test pull replication with many changes"

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -440,6 +440,10 @@ function replicate(repId, src, target, opts, returnValue, result) {
     if (state.cancelled) {
       return completeReplication();
     }
+    var filter = utils.filterChange(opts)(change);
+    if (!filter) {
+      return;
+    }
     if (
       pendingBatch.changes.length === 0 &&
       batches.length === 0 &&
@@ -458,7 +462,10 @@ function replicate(repId, src, target, opts, returnValue, result) {
     if (state.cancelled) {
       return completeReplication();
     }
-    if (changesOpts.since < changes.last_seq) {
+
+    // if no results were returned then we're done,
+    // else fetch more
+    if (changes.results.length > 0) {
       changesOpts.since = changes.last_seq;
       getChanges();
     } else {
@@ -515,10 +522,11 @@ function replicate(repId, src, target, opts, returnValue, result) {
         batch_size: batch_size,
         style: 'all_docs',
         doc_ids: doc_ids,
-        returnDocs: false
+        returnDocs: true // required so we know when we're done
       };
       if (opts.filter) {
-        changesOpts.filter = opts.filter;
+        // required for the client-side filter in onChange
+        changesOpts.include_docs = true;
       }
       if (opts.query_params) {
         changesOpts.query_params = opts.query_params;

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -137,8 +137,10 @@ adapters.forEach(function (adapters) {
             result.ok.should.equal(true);
             result.docs_written.should.equal(docs.length);
             new PouchDB(dbs.name).info(function (err, info) {
-              info.update_seq.should.equal(numDocs, 'update_seq');
-              info.doc_count.should.equal(numDocs, 'doc_count');
+              verifyInfo(info, {
+                update_seq: numDocs,
+                doc_count: numDocs
+              });
               done();
             });
           }


### PR DESCRIPTION
CouchDB 2.0 represents sequence numbers as arrays which should be treated as opaque blobs. This prevents us using simple comparison operators on them (e.g. last_seq < current_seq).

Previously we were using a similar test to determine whether new changes were returned in a call to _changes (if params.since < result.last_seq, fetch more changes). This no longer holds so, instead, I've added a new field to the onChangesComplete callback, "finished", which indicates that the _changes call returned no results (i.e. we're finished).