### PR TITLE
(#136) - Skip assertions which compare update_seq / CouchDB 2.0

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -333,10 +333,14 @@ adapters.forEach(function (adapters) {
             db.allDocs(function (err, result) {
               result.rows.length.should.equal(docs.length);
               db.info(function (err, info) {
-                info.update_seq.should.be.above(2, 'update_seq local');
+                if (!testUtils.isCouchMaster()) {
+                  info.update_seq.should.be.above(2, 'update_seq local');
+                }
                 info.doc_count.should.equal(3, 'doc_count local');
                 remote.info(function (err, info) {
-                  info.update_seq.should.be.above(2, 'update_seq remote');
+                  if (!testUtils.isCouchMaster()) {
+                    info.update_seq.should.be.above(2, 'update_seq remote');
+                  }
                   info.doc_count.should.equal(3, 'doc_count remote');
                   done();
                 });
@@ -1800,7 +1804,9 @@ adapters.forEach(function (adapters) {
           result.docs_written.should.equal(3);
           result.docs_read.should.equal(3);
           db.info(function (err, info) {
-            info.update_seq.should.be.above(0);
+            if (!testUtils.isCouchMaster()) {
+              info.update_seq.should.be.above(0);
+            }
             info.doc_count.should.equal(1);
             done();
           });


### PR DESCRIPTION
CouchDB 2.0 represents sequence numbers as arrays and they are not incremental. When testing against CouchDB master, skip assertions
that the update_seq should be above a specific integer.