### PR TITLE
(#136) - Fix _changes ordering assertions in replication tests

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -36,6 +36,30 @@ adapters.forEach(function (adapters) {
       {_id: '2', integer: 2, string: '2'}
     ];
 
+    // simplify for easier deep equality checks
+    function simplifyChanges(res) {
+      var changes = res.results.map(function (change) {
+        return {
+          id: change.id,
+          deleted: change.deleted,
+          changes: change.changes.map(function (x) {
+            return x.rev;
+          }).sort(),
+          doc: change.doc
+        };
+      });
+
+      // in CouchDB 2.0, changes is not guaranteed to be
+      // ordered
+      if (testUtils.isCouchMaster()) {
+        changes.sort(function (a, b) {
+          return a.id > b.id;
+        });
+      }
+
+      return changes;
+    }
+
     it('Test basic pull replication', function (done) {
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
@@ -760,19 +784,6 @@ adapters.forEach(function (adapters) {
         ]
       ];
 
-      // simplify for easier deep equality checks
-      function simplifyChanges(res) {
-        return res.results.map(function (change) {
-          return {
-            id: change.id,
-            deleted: change.deleted,
-            changes: change.changes.map(function (x) {
-              return x.rev;
-            }).sort()
-          };
-        });
-      }
-
       var chain = PouchDB.utils.Promise.resolve();
       tree.forEach(function (docs) {
         chain = chain.then(function () {
@@ -800,21 +811,6 @@ adapters.forEach(function (adapters) {
     });
 
     it('#3136 style=all_docs with conflicts', function () {
-
-      // simplify for easier deep equality checks
-      function simplifyChanges(res) {
-        return res.results.map(function (change) {
-          return {
-            id: change.id,
-            deleted: change.deleted,
-            changes: change.changes.map(function (x) {
-              return x.rev;
-            }).sort(),
-            doc: change.doc
-          };
-        });
-      }
-
       var docs1 = [
         {_id: '0', integer: 0},
         {_id: '1', integer: 1},
@@ -886,21 +882,6 @@ adapters.forEach(function (adapters) {
     });
 
     it('#3136 style=all_docs with conflicts reversed', function () {
-
-      // simplify for easier deep equality checks
-      function simplifyChanges(res) {
-        return res.results.map(function (change) {
-          return {
-            id: change.id,
-            deleted: change.deleted,
-            changes: change.changes.map(function (x) {
-              return x.rev;
-            }).sort(),
-            doc: change.doc
-          };
-        });
-      }
-
       var docs1 = [
         {_id: '0', integer: 0},
         {_id: '1', integer: 1},


### PR DESCRIPTION
In CouchDB 2.0, _changes is not guaranteed to be ordered. Sort the response before making assertions on the contents.

I've also removed duplicate definitions of the simplifyChanges function so this sort only occurs in one place.