### PR TITLE
(#3316) - more changes() documentation

### DIFF
--- a/docs/_guides/changes.md
+++ b/docs/_guides/changes.md
@@ -20,7 +20,8 @@ If you want to simply fetch all changes since the beginning of time, you can do:
 
 ```js
 db.changes({
-  since: 0
+  since: 0,
+  include_docs: true
 }).then(function (changes) {
   
 }).catch(function (err) {
@@ -35,6 +36,8 @@ Then you will have a list of all changes made to the database, in the order that
 One thing you will notice about the changes feed is that it actually omits non-leaf revisions to documents. For instance, in the live example, we skip from `seq` 1 immediately to `seq` 3.
 
 This is by design &ndash; the changes feed only tells us about leaf revisions. However, the order of those leaf revisions is determined by the order they were put in the database. So you may notice that `'firstDoc'` still appears before `'secondDoc'`, which appears before `'thirdDoc'`.
+
+Also notice the the option `{include_docs: true}`. By default, the documents themselves are not included in the changes feed; only the `id`s, `rev`s, and whether or not they were `deleted`. With `{include_docs: true}`, however, each non-deleted change will have a `doc` property containing the new or modified document.
 
 Changes pagination
 ------
@@ -92,6 +95,49 @@ db.changes({
 In the above example, we've also taken advantage of the quasi-magical `'now'` option for `since`, which will give us all changes from the moment we start listening.
 
 This can be very useful for scenarios where you want to update the UI whenever something in the database changes, such as for a real-time chat application.
+
+Understanding changes
+---------
+
+There are two types of changes:
+
+* Added or modified documents
+* Deleted documents
+
+To distinguish between the two types in a live `changes()` listener, 
+you can use the follow code:
+
+```js
+db.changes({
+  since: 'now',
+  live: true,
+  include_docs: true
+}).on('change', function (change) {
+  // change.id contains the doc id, change.doc contains the doc
+  if (change.deleted) {
+    // document was deleted
+  } else {
+    // document was added/modified
+  }
+}).on('error', function (err) {
+  // handle errors
+});
+```
+
+You can see a [live example](http://bl.ocks.org/nolanlawson/fa42662cdfeeaa7b78fc) of this code.
+
+Notice that `change.doc` contains the document (unless it's deleted), because we used `{include_docs: true}`.
+
+Also notice that new documents always have revisions starting with the string `'1-'`. Subsequent revisions start with `'2-'`, `'3-'`, `'4-'`, etc.
+
+{% include alert_start.html variant="info" %}
+
+<p><strong>How can I distinguish between added and modified documents?</strong> Checking if the revision starts with <code>'1-'</code> is a pretty good trick. However, this will not work for databases that are replication targets, because replication only sends the latest versions of documents. This means that the <code>'1-'</code> revision may get skipped entirely, and the local database will only receive the 2nd, 3rd or 4th (etc.) revision. Conflicting revisions will also appear in the changes feed.</p>
+
+<p>So the short answer is that you cannot. If you are trying to mirror changes in a non-Pouch structure (e.g. a list of DOM elements), then the best solution is to search all the DOM elements to see if the document already exists, or to re-run <code>allDocs()</code> for every change.</p>
+ 
+{% include alert_end.html %}
+
 
 Related API documentation
 --------


### PR DESCRIPTION
The `changes()` documentation was looking kind of weak, so I added this.

Although I'm becoming convinced that people should just use `changes()` as an indication that *something* changed, rather than trying to understand the changes feed itself. E.g. if you are trying to maintain an in-memory mirror of DOM elements, then just blow it away every time something changes and run `allDocs` all over again. I believe I am even screwing this up in the ember-pouch plugin, so I need to go back and rewrite what I already wrote over there.