### PR TITLE
(#3325) - fix blob support w/ duplicate idbs

### DIFF
--- a/lib/adapters/idb/idb.js
+++ b/lib/adapters/idb/idb.js
@@ -897,7 +897,7 @@ function init(api, opts, callback) {
   if (cached) {
     idb = cached.idb;
     instanceId = cached.instanceId;
-    idStored = cached.idStored;
+    api._blobSupport = cached.blobSupport;
     process.nextTick(function () {
       callback(null, api);
     });
@@ -976,7 +976,7 @@ function init(api, opts, callback) {
           cachedDBs[name] = {
             idb: idb,
             instanceId: instanceId,
-            idStored: idStored,
+            blobSupport: api._blobSupport,
             loaded: true
           };
           callback(null, api);
@@ -1039,8 +1039,7 @@ function init(api, opts, callback) {
             };
           };
         }).catch(function (err) {
-          api._blobSupport = false;
-          checkSetupComplete();
+          return false; // error, so assume unsupported
         });
       }
 

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -980,6 +980,22 @@ adapters.forEach(function (adapter) {
           }, done);
         });
       });
+
+      // this test only really makes sense for IDB
+      it('should have same blob support for 2 dbs', function () {
+        var db1 = new PouchDB(dbs.name);
+        return db1.info().then(function () {
+          var db2 = new PouchDB(dbs.name);
+          return db2.info().then(function () {
+            if (typeof db1._blobSupport !== 'undefined') {
+              db1._blobSupport.should.equal(db2._blobSupport,
+                'same blob support');
+            } else {
+              true.should.equal(true);
+            }
+          });
+        });
+      });
     }
   });
 });


### PR DESCRIPTION
Just fixing this dumb bug, since my big refactor might not end up working in IE10.

FWIW, in Chrome 39 blobSupport is still false for some reason. Should probably investigate that separately.

Test fails before the fix, succeeds after.