### PR TITLE
(#136) - Fix "replication since" tests

### DIFF
--- a/lib/checkpointer.js
+++ b/lib/checkpointer.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var utils = require('./utils');
+var pouchCollate = require('pouchdb-collate');
+var collate = pouchCollate.collate;
 
 function updateCheckpoint(db, id, checkpoint, returnValue) {
   return db.get(id).catch(function (err) {
@@ -60,7 +62,7 @@ Checkpointer.prototype.getCheckpoint = function () {
   var self = this;
   return self.target.get(self.id).then(function (targetDoc) {
     return self.src.get(self.id).then(function (sourceDoc) {
-      if (targetDoc.last_seq === sourceDoc.last_seq) {
+      if (collate(targetDoc.last_seq, sourceDoc.last_seq) === 0) {
         return sourceDoc.last_seq;
       }
       return 0;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "debug": "^2.1.0",
     "pouchdb-express-router": "^0.0.2",
     "express": "^4.10.4",
-    "miller-rabin": "1.1.1"
+    "miller-rabin": "1.1.1",
+    "pouchdb-collate": "^1.2.0"
   },
   "optionalDependencies": {
     "leveldown": "~0.10.2"


### PR DESCRIPTION
Two fixes here:
1. Ensure we find checkpoint documents which match array-based sequence numbers.
2. Alter the "replication since" test to not assume incremental sequence numbers.