### PR TITLE
(#136) - Fix "Replicates deleted docs w/ delay" against CouchDB 2.0

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -1746,7 +1746,9 @@ adapters.forEach(function (adapters) {
       }).then(function (res) {
         res.rows.should.have.length(0, 'deleted locally');
       }).then(function () {
-        return waitForChange(remote, function (c) { return c.seq === 2; });
+        return waitForChange(remote, function (c) {
+          return c.id === doc._id && c.deleted;
+        });
       }).then(function () {
         return remote.allDocs();
       }).then(function (res) {


### PR DESCRIPTION
Alter "Replicates deleted docs w/ delay" to not depend upon an incremental database sequence number. Instead, test incoming changes against the specific document properties that we're interested in (in this case, id and deleted).