### PR TITLE
(#136) - Fix "Reporting write failures if whole saving fails"

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -2562,7 +2562,6 @@ adapters.forEach(function (adapters) {
               .equal(0, 'second replication, doc_write_failures');
             result.docs_written.should
               .equal(2, 'second replication, docs_written');
-            result.last_seq.should.equal(2, 'second replication, last_seq');
             done();
           });
         });


### PR DESCRIPTION
Removed the assertion on last_seq. I'm not sure what this adds to the test and we have other coverage which ensures last_seq is set correctly.

In CouchDB 2.0 this assertion is invalid because sequence numbers are not integers.