### PR TITLE
(#136) - Fix "Reporting write failures (#942)"

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -2482,6 +2482,7 @@ adapters.forEach(function (adapters) {
       var remote = new PouchDB(dbs.remote);
       db.bulkDocs({docs: docs}, {new_edits: false}, function (err, _) {
         var bulkDocs = remote.bulkDocs;
+        var bulkDocsCallCount = 0;
         remote.bulkDocs = function (content, opts, callback) {
           return new PouchDB.utils.Promise(function (fulfill, reject) {
             if (typeof callback !== 'function') {
@@ -2493,12 +2494,17 @@ adapters.forEach(function (adapters) {
                 }
               };
             }
-            var ids = content.docs.map(function (doc) { return doc._id; });
-            if (ids.indexOf('a') >= 0) {
-              callback(null, [{ok: true, id: 'a', rev: '1-a'}]);
-            } else if (ids.indexOf('b') >= 0) {
+
+            // mock a successful write for the first
+            // document and a failed write for the second
+            var doc = content.docs[0];
+            if (bulkDocsCallCount === 0) {
+              bulkDocsCallCount++;
+              callback(null, [{ok: true, id: doc._id, rev: doc._rev}]);
+            } else if (bulkDocsCallCount === 1) {
+              bulkDocsCallCount++;
               callback(null, [{
-                id: 'b',
+                id: doc._id,
                 error: 'internal server error',
                 reason: 'test document write error'
               }]);


### PR DESCRIPTION
Change the "Reporting write failures (#942)" test to avoid dependencies on the _changes feed order. This was failing against CouchDB 2.0 because sometimes document "b" would come before "a" in the feed. The mocking function would return a write error for document "b" which caused the replication to abort at which point the assertions around documents read / written fail.

The mocked bulk_docs endpoint now returns failure for the second document, regardless of the _id.