### PR TITLE
(#3285 #3326) - refactor idb, fix blob support in Chrome

### DIFF
--- a/lib/adapters/idb/idb-bulk-docs.js
+++ b/lib/adapters/idb/idb-bulk-docs.js
@@ -17,7 +17,7 @@ var decodeMetadata = idbUtils.decodeMetadata;
 var encodeMetadata = idbUtils.encodeMetadata;
 var idbError = idbUtils.idbError;
 
-function idbBulkDocs(req, opts, api, idb, Changes, callback) {
+function idbBulkDocs(req, opts, api, Changes, callback) {
   var docInfos = req.docs;
   var txn;
   var docStore;
@@ -60,7 +60,7 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
       ATTACH_STORE, META_STORE,
       LOCAL_STORE, ATTACH_AND_SEQ_STORE
     ];
-    txn = idb.transaction(stores, 'readwrite');
+    txn = api._idb.transaction(stores, 'readwrite');
     txn.onerror = idbError(callback);
     txn.ontimeout = idbError(callback);
     txn.oncomplete = complete;

--- a/lib/adapters/idb/idb-changes.js
+++ b/lib/adapters/idb/idb-changes.js
@@ -1,0 +1,184 @@
+'use strict';
+
+var utils = require('../../utils');
+var idbUtils = require('./idb-utils');
+var idbConstants = require('./idb-constants');
+
+var ATTACH_STORE = idbConstants.ATTACH_STORE;
+var BY_SEQ_STORE = idbConstants.BY_SEQ_STORE;
+var DOC_STORE = idbConstants.DOC_STORE;
+
+var decodeDoc = idbUtils.decodeDoc;
+var decodeMetadata = idbUtils.decodeMetadata;
+var fetchAttachmentsIfNecessary = idbUtils.fetchAttachmentsIfNecessary;
+var idbError = idbUtils.idbError;
+var postProcessAttachments = idbUtils.postProcessAttachments;
+
+function idbChanges(opts, api, Changes) {
+  opts = utils.clone(opts);
+
+  if (opts.continuous) {
+    var id = api._name + ':' + utils.uuid();
+    Changes.addListener(api._name, id, api, opts);
+    Changes.notify(api._name);
+    return {
+      cancel: function () {
+        Changes.removeListener(api._name, id);
+      }
+    };
+  }
+
+  var docIds = opts.doc_ids && new utils.Set(opts.doc_ids);
+  var descending = opts.descending ? 'prev' : null;
+
+  opts.since = opts.since || 0;
+  var lastSeq = opts.since;
+
+  var limit = 'limit' in opts ? opts.limit : -1;
+  if (limit === 0) {
+    limit = 1; // per CouchDB _changes spec
+  }
+  var returnDocs;
+  if ('returnDocs' in opts) {
+    returnDocs = opts.returnDocs;
+  } else {
+    returnDocs = true;
+  }
+
+  var results = [];
+  var numResults = 0;
+  var filter = utils.filterChange(opts);
+  var docIdsToMetadata = new utils.Map();
+
+  var txn;
+  var bySeqStore;
+  var docStore;
+  var docIdRevIndex;
+
+  function onGetCursor(cursor) {
+
+    var doc = decodeDoc(cursor.value);
+    var seq = cursor.key;
+
+    lastSeq = seq;
+
+    if (docIds && !docIds.has(doc._id)) {
+      return cursor.continue();
+    }
+
+    var metadata;
+
+    function onGetMetadata() {
+      if (metadata.seq !== seq) {
+        // some other seq is later
+        return cursor.continue();
+      }
+
+      if (metadata.winningRev === doc._rev) {
+        return onGetWinningDoc(doc);
+      }
+
+      fetchWinningDoc();
+    }
+
+    function fetchWinningDoc() {
+      var docIdRev = doc._id + '::' + metadata.winningRev;
+      var req = docIdRevIndex.get(docIdRev);
+      req.onsuccess = function (e) {
+        onGetWinningDoc(decodeDoc(e.target.result));
+      };
+    }
+
+    function onGetWinningDoc(winningDoc) {
+
+      var change = opts.processChange(winningDoc, metadata, opts);
+      change.seq = metadata.seq;
+      if (filter(change)) {
+        numResults++;
+        if (returnDocs) {
+          results.push(change);
+        }
+        // process the attachment immediately
+        // for the benefit of live listeners
+        if (opts.attachments && opts.include_docs) {
+          fetchAttachmentsIfNecessary(winningDoc, opts, txn, function () {
+            postProcessAttachments([change]).then(function () {
+              opts.onChange(change);
+            });
+          });
+        } else {
+          opts.onChange(change);
+        }
+      }
+      if (numResults !== limit) {
+        cursor.continue();
+      }
+    }
+
+    metadata = docIdsToMetadata.get(doc._id);
+    if (metadata) { // cached
+      return onGetMetadata();
+    }
+    // metadata not cached, have to go fetch it
+    docStore.get(doc._id).onsuccess = function (event) {
+      metadata = decodeMetadata(event.target.result);
+      docIdsToMetadata.set(doc._id, metadata);
+      onGetMetadata();
+    };
+  }
+
+  function onsuccess(event) {
+    var cursor = event.target.result;
+
+    if (!cursor) {
+      return;
+    }
+    onGetCursor(cursor);
+  }
+
+  function fetchChanges() {
+    var objectStores = [DOC_STORE, BY_SEQ_STORE];
+    if (opts.attachments) {
+      objectStores.push(ATTACH_STORE);
+    }
+    txn = api._idb.transaction(objectStores, 'readonly');
+    txn.onerror = idbError(opts.complete);
+    txn.oncomplete = onTxnComplete;
+
+    bySeqStore = txn.objectStore(BY_SEQ_STORE);
+    docStore = txn.objectStore(DOC_STORE);
+    docIdRevIndex = bySeqStore.index('_doc_id_rev');
+
+    var req;
+
+    if (descending) {
+      req = bySeqStore.openCursor(null, descending);
+    } else {
+      req = bySeqStore.openCursor(IDBKeyRange.lowerBound(opts.since, true));
+    }
+
+    req.onsuccess = onsuccess;
+  }
+
+  fetchChanges();
+
+  function onTxnComplete() {
+
+    function finish() {
+      opts.complete(null, {
+        results: results,
+        last_seq: lastSeq
+      });
+    }
+
+    if (!opts.continuous && opts.attachments) {
+      // cannot guarantee that postProcessing was already done,
+      // so do it again
+      postProcessAttachments(results).then(finish);
+    } else {
+      finish();
+    }
+  }
+}
+
+module.exports = idbChanges;

--- a/lib/adapters/idb/idb-setup.js
+++ b/lib/adapters/idb/idb-setup.js
@@ -322,18 +322,24 @@ function idbSetup(api, callback) {
 
         function createBlobSupportPromise() {
           // make sure blob support is only checked one
-          return new utils.Promise(function (resolve) {
-            var blob = utils.createBlob([''], {type: 'image/png'});
+          return new utils.Promise(function (resolve, reject) {
+            // 1x1 transparent PNG
+            var blob = utils.createBlob([utils.fixBinary(utils.atob(
+              'iVBORw0KGgoAAAANSUhEUgAAAAEAAAA' +
+              'BCAQAAAC1HAwCAAAAC0lEQVQYV2NgYA' +
+              'AAAAMAAWgmWQ0AAAAASUVORK5CYII='
+            ))], {type: 'image/png'});
             txn.objectStore(DETECT_BLOB_SUPPORT_STORE).put(blob, 'key');
             txn.oncomplete = function () {
               // have to do it in a separate transaction, else the correct
               // content type is always returned
-              txn = api._idb.transaction([META_STORE, DETECT_BLOB_SUPPORT_STORE],
+              var blobTxn = api._idb.transaction([DETECT_BLOB_SUPPORT_STORE],
                 'readwrite');
-              var getBlobReq = txn.objectStore(
+              var getBlobReq = blobTxn.objectStore(
                 DETECT_BLOB_SUPPORT_STORE).get('key');
-              getBlobReq.onsuccess = function (e) {
 
+              getBlobReq.onerror = reject;
+              getBlobReq.onsuccess = function (e) {
                 var storedBlob = e.target.result;
                 var url = URL.createObjectURL(storedBlob);
 
@@ -348,10 +354,6 @@ function idbSetup(api, callback) {
                     resolve(true);
                   } else {
                     resolve(!!(res && res.type === 'image/png'));
-                    if (err && err.status === 404) {
-                      utils.explain404(
-                        'PouchDB is just detecting blob URL support.');
-                    }
                   }
                   URL.revokeObjectURL(url);
                 });

--- a/lib/adapters/idb/idb-setup.js
+++ b/lib/adapters/idb/idb-setup.js
@@ -1,0 +1,422 @@
+'use strict';
+
+var utils = require('../../utils');
+var merge = require('../../merge');
+var idbUtils = require('./idb-utils');
+var idbConstants = require('./idb-constants');
+
+var ADAPTER_VERSION = idbConstants.ADAPTER_VERSION;
+var ATTACH_AND_SEQ_STORE = idbConstants.ATTACH_AND_SEQ_STORE;
+var ATTACH_STORE = idbConstants.ATTACH_STORE;
+var BY_SEQ_STORE = idbConstants.BY_SEQ_STORE;
+var DETECT_BLOB_SUPPORT_STORE = idbConstants.DETECT_BLOB_SUPPORT_STORE;
+var DOC_STORE = idbConstants.DOC_STORE;
+var LOCAL_STORE = idbConstants.LOCAL_STORE;
+var META_STORE = idbConstants.META_STORE;
+
+var decodeMetadata = idbUtils.decodeMetadata;
+var encodeMetadata = idbUtils.encodeMetadata;
+var idbError = idbUtils.idbError;
+var cachedDBs = idbUtils.cachedDBs;
+var openReqList = idbUtils.openReqList;
+
+var blobSupportPromise;
+
+// called when creating a fresh new database
+function createSchema(db) {
+  var docStore = db.createObjectStore(DOC_STORE, {keyPath : 'id'});
+  db.createObjectStore(BY_SEQ_STORE, {autoIncrement: true})
+    .createIndex('_doc_id_rev', '_doc_id_rev', {unique: true});
+  db.createObjectStore(ATTACH_STORE, {keyPath: 'digest'});
+  db.createObjectStore(META_STORE, {keyPath: 'id', autoIncrement: false});
+  db.createObjectStore(DETECT_BLOB_SUPPORT_STORE);
+
+  // added in v2
+  docStore.createIndex('deletedOrLocal', 'deletedOrLocal', {unique : false});
+
+  // added in v3
+  db.createObjectStore(LOCAL_STORE, {keyPath: '_id'});
+
+  // added in v4
+  var attAndSeqStore = db.createObjectStore(ATTACH_AND_SEQ_STORE,
+    {autoIncrement: true});
+  attAndSeqStore.createIndex('seq', 'seq');
+  attAndSeqStore.createIndex('digestSeq', 'digestSeq', {unique: true});
+}
+
+// migration to version 2
+// unfortunately "deletedOrLocal" is a misnomer now that we no longer
+// store local docs in the main doc-store, but whaddyagonnado
+function addDeletedOrLocalIndex(txn, callback) {
+  var docStore = txn.objectStore(DOC_STORE);
+  docStore.createIndex('deletedOrLocal', 'deletedOrLocal', {unique : false});
+
+  docStore.openCursor().onsuccess = function (event) {
+    var cursor = event.target.result;
+    if (cursor) {
+      var metadata = cursor.value;
+      var deleted = utils.isDeleted(metadata);
+      metadata.deletedOrLocal = deleted ? "1" : "0";
+      docStore.put(metadata);
+      cursor.continue();
+    } else {
+      callback();
+    }
+  };
+}
+
+// migration to version 3 (part 1)
+function createLocalStoreSchema(db) {
+  db.createObjectStore(LOCAL_STORE, {keyPath: '_id'})
+    .createIndex('_doc_id_rev', '_doc_id_rev', {unique: true});
+}
+
+// migration to version 3 (part 2)
+function migrateLocalStore(txn, cb) {
+  var localStore = txn.objectStore(LOCAL_STORE);
+  var docStore = txn.objectStore(DOC_STORE);
+  var seqStore = txn.objectStore(BY_SEQ_STORE);
+
+  var cursor = docStore.openCursor();
+  cursor.onsuccess = function (event) {
+    var cursor = event.target.result;
+    if (cursor) {
+      var metadata = cursor.value;
+      var docId = metadata.id;
+      var local = utils.isLocalId(docId);
+      var rev = merge.winningRev(metadata);
+      if (local) {
+        var docIdRev = docId + "::" + rev;
+        // remove all seq entries
+        // associated with this docId
+        var start = docId + "::";
+        var end = docId + "::~";
+        var index = seqStore.index('_doc_id_rev');
+        var range = IDBKeyRange.bound(start, end, false, false);
+        var seqCursor = index.openCursor(range);
+        seqCursor.onsuccess = function (e) {
+          seqCursor = e.target.result;
+          if (!seqCursor) {
+            // done
+            docStore.delete(cursor.primaryKey);
+            cursor.continue();
+          } else {
+            var data = seqCursor.value;
+            if (data._doc_id_rev === docIdRev) {
+              localStore.put(data);
+            }
+            seqStore.delete(seqCursor.primaryKey);
+            seqCursor.continue();
+          }
+        };
+      } else {
+        cursor.continue();
+      }
+    } else if (cb) {
+      cb();
+    }
+  };
+}
+
+// migration to version 4 (part 1)
+function addAttachAndSeqStore(db) {
+  var attAndSeqStore = db.createObjectStore(ATTACH_AND_SEQ_STORE,
+    {autoIncrement: true});
+  attAndSeqStore.createIndex('seq', 'seq');
+  attAndSeqStore.createIndex('digestSeq', 'digestSeq', {unique: true});
+}
+
+// migration to version 4 (part 2)
+function migrateAttsAndSeqs(txn, callback) {
+  var seqStore = txn.objectStore(BY_SEQ_STORE);
+  var attStore = txn.objectStore(ATTACH_STORE);
+  var attAndSeqStore = txn.objectStore(ATTACH_AND_SEQ_STORE);
+
+  // need to actually populate the table. this is the expensive part,
+  // so as an optimization, check first that this database even
+  // contains attachments
+  var req = attStore.count();
+  req.onsuccess = function (e) {
+    var count = e.target.result;
+    if (!count) {
+      return callback(); // done
+    }
+
+    seqStore.openCursor().onsuccess = function (e) {
+      var cursor = e.target.result;
+      if (!cursor) {
+        return callback(); // done
+      }
+      var doc = cursor.value;
+      var seq = cursor.primaryKey;
+      var atts = Object.keys(doc._attachments || {});
+      var digestMap = {};
+      for (var j = 0; j < atts.length; j++) {
+        var att = doc._attachments[atts[j]];
+        digestMap[att.digest] = true; // uniq digests, just in case
+      }
+      var digests = Object.keys(digestMap);
+      for (j = 0; j < digests.length; j++) {
+        var digest = digests[j];
+        attAndSeqStore.put({
+          seq: seq,
+          digestSeq: digest + '::' + seq
+        });
+      }
+      cursor.continue();
+    };
+  };
+}
+
+// migration to version 5
+// Instead of relying on on-the-fly migration of metadata,
+// this brings the doc-store to its modern form:
+// - metadata.winningrev
+// - metadata.seq
+// - stringify the metadata when storing it
+function migrateMetadata(txn) {
+
+  function decodeMetadataCompat(storedObject) {
+    if (!storedObject.data) {
+      // old format, when we didn't store it stringified
+      storedObject.deletedOrLocal = storedObject.deletedOrLocal === '1';
+      return storedObject;
+    }
+    return decodeMetadata(storedObject);
+  }
+
+  // ensure that every metadata has a winningRev and seq,
+  // which was previously created on-the-fly but better to migrate
+  var bySeqStore = txn.objectStore(BY_SEQ_STORE);
+  var docStore = txn.objectStore(DOC_STORE);
+  var cursor = docStore.openCursor();
+  cursor.onsuccess = function (e) {
+    var cursor = e.target.result;
+    if (!cursor) {
+      return; // done
+    }
+    var metadata = decodeMetadataCompat(cursor.value);
+
+    metadata.winningRev = metadata.winningRev || merge.winningRev(metadata);
+
+    function fetchMetadataSeq() {
+      // metadata.seq was added post-3.2.0, so if it's missing,
+      // we need to fetch it manually
+      var start = metadata.id + '::';
+      var end = metadata.id + '::\uffff';
+      var req = bySeqStore.index('_doc_id_rev').openCursor(
+        IDBKeyRange.bound(start, end));
+
+      var metadataSeq = 0;
+      req.onsuccess = function (e) {
+        var cursor = e.target.result;
+        if (!cursor) {
+          metadata.seq = metadataSeq;
+          return onGetMetadataSeq();
+        }
+        var seq = cursor.primaryKey;
+        if (seq > metadataSeq) {
+          metadataSeq = seq;
+        }
+        cursor.continue();
+      };
+    }
+
+    function onGetMetadataSeq() {
+      var metadataToStore = encodeMetadata(metadata,
+        metadata.winningRev, metadata.deletedOrLocal);
+
+      var req = docStore.put(metadataToStore);
+      req.onsuccess = function () {
+        cursor.continue();
+      };
+    }
+
+    if (metadata.seq) {
+      return onGetMetadataSeq();
+    }
+
+    fetchMetadataSeq();
+  };
+}
+
+function idbSetup(api, callback) {
+
+  function initIdb() {
+
+    function onUpgradeNeeded(e) {
+      var db = e.target.result;
+      if (e.oldVersion < 1) {
+        return createSchema(db); // new db, initial schema
+      }
+      // do migrations
+
+      var txn = e.currentTarget.transaction;
+      // these migrations have to be done in this function, before
+      // control is returned to the event loop, because IndexedDB
+
+      if (e.oldVersion < 3) {
+        createLocalStoreSchema(db); // v2 -> v3
+      }
+      if (e.oldVersion < 4) {
+        addAttachAndSeqStore(db); // v3 -> v4
+      }
+
+      var migrations = [
+        addDeletedOrLocalIndex, // v1 -> v2
+        migrateLocalStore,      // v2 -> v3
+        migrateAttsAndSeqs,     // v3 -> v4
+        migrateMetadata         // v4 -> v5
+      ];
+
+      var i = e.oldVersion;
+
+      function next() {
+        var migration = migrations[i - 1];
+        i++;
+        if (migration) {
+          migration(txn, next);
+        }
+      }
+
+      next();
+    }
+
+    function onOpenSuccess(e) {
+      api._idb = e.target.result;
+
+      api._idb.onversionchange = function () {
+        api._idb.close();
+        cachedDBs.delete(api._name);
+      };
+      api._idb.onabort = function () {
+        api._idb.close();
+        cachedDBs.delete(api._name);
+      };
+
+      var txn = api._idb.transaction([META_STORE, DETECT_BLOB_SUPPORT_STORE],
+        'readwrite');
+
+      var req = txn.objectStore(META_STORE).get(META_STORE);
+
+      req.onsuccess = function (e) {
+        var meta = e.target.result || {id: META_STORE};
+        onGetMetadata(meta);
+      };
+
+      function onGetMetadata(meta) {
+
+        function checkSetupComplete() {
+          if (api._blobSupport === null || !api._instanceId) {
+            return;
+          } else {
+            cachedDBs.set(api._name, {
+              idb: api._idb,
+              instanceId: api._instanceId,
+              blobSupport: api._blobSupport,
+              loaded: true
+            });
+            callback(null, api);
+          }
+        }
+
+        function createBlobSupportPromise() {
+          // make sure blob support is only checked one
+          return new utils.Promise(function (resolve) {
+            var blob = utils.createBlob([''], {type: 'image/png'});
+            txn.objectStore(DETECT_BLOB_SUPPORT_STORE).put(blob, 'key');
+            txn.oncomplete = function () {
+              // have to do it in a separate transaction, else the correct
+              // content type is always returned
+              txn = api._idb.transaction([META_STORE, DETECT_BLOB_SUPPORT_STORE],
+                'readwrite');
+              var getBlobReq = txn.objectStore(
+                DETECT_BLOB_SUPPORT_STORE).get('key');
+              getBlobReq.onsuccess = function (e) {
+
+                var storedBlob = e.target.result;
+                var url = URL.createObjectURL(storedBlob);
+
+                utils.ajax({
+                  url: url,
+                  cache: true,
+                  binary: true
+                }, function (err, res) {
+                  if (err && err.status === 405) {
+                    // firefox won't let us do that. but firefox doesn't
+                    // have the blob type bug that Chrome does, so that's ok
+                    resolve(true);
+                  } else {
+                    resolve(!!(res && res.type === 'image/png'));
+                    if (err && err.status === 404) {
+                      utils.explain404(
+                        'PouchDB is just detecting blob URL support.');
+                    }
+                  }
+                  URL.revokeObjectURL(url);
+                });
+              };
+            };
+          }).catch(function (err) {
+            return false; // error, so assume unsupported
+          });
+        }
+
+        function storeId() {
+          var idKey = api._name + '_id';
+          if (idKey in meta) {
+            api._instanceId = meta[idKey];
+            checkSetupComplete();
+          } else {
+            var instanceId = utils.uuid();
+            meta[idKey] = instanceId;
+            txn.objectStore(META_STORE).put(meta).onsuccess = function () {
+              api._instanceId = instanceId;
+              checkSetupComplete();
+            };
+          }
+        }
+
+        function checkBlobSupport() {
+          // Detect blob support. Chrome didn't support it until version 38.
+          // in version 37 they had a broken version where PNGs (and possibly
+          // other binary types) aren't stored correctly.
+          if (!blobSupportPromise) {
+            blobSupportPromise = createBlobSupportPromise();
+          }
+
+          blobSupportPromise.then(function (val) {
+            api._blobSupport = val;
+            checkSetupComplete();
+          });
+        }
+
+        storeId();
+        checkBlobSupport();
+      }
+    }
+
+    var openReq = indexedDB.open(api._name, ADAPTER_VERSION);
+
+    openReqList.set(api._name, openReq);
+
+    openReq.onupgradeneeded = onUpgradeNeeded;
+    openReq.onsuccess = onOpenSuccess;
+    openReq.onerror = idbError(callback);
+  }
+
+  var cached = cachedDBs.get(api._name);
+
+  if (cached) {
+    api._idb = cached.idb;
+    api._instanceId = cached.instanceId;
+    api._blobSupport = cached.blobSupport;
+    process.nextTick(function () {
+      callback(null, api);
+    });
+  } else {
+    initIdb();
+  }
+}
+
+module.exports = idbSetup;

--- a/lib/adapters/idb/idb-utils.js
+++ b/lib/adapters/idb/idb-utils.js
@@ -229,3 +229,6 @@ exports.compactRevs = function (revs, docId, txn) {
     };
   });
 };
+
+exports.cachedDBs = new utils.Map();
+exports.openReqList = new utils.Map();

--- a/lib/adapters/idb/idb.js
+++ b/lib/adapters/idb/idb.js
@@ -6,15 +6,14 @@ var errors = require('../../deps/errors');
 var idbUtils = require('./idb-utils');
 var idbConstants = require('./idb-constants');
 var idbBulkDocs = require('./idb-bulk-docs');
+var idbChanges = require('./idb-changes');
+var idbSetup = require('./idb-setup');
 
-var ADAPTER_VERSION = idbConstants.ADAPTER_VERSION;
 var ATTACH_AND_SEQ_STORE = idbConstants.ATTACH_AND_SEQ_STORE;
 var ATTACH_STORE = idbConstants.ATTACH_STORE;
 var BY_SEQ_STORE = idbConstants.BY_SEQ_STORE;
-var DETECT_BLOB_SUPPORT_STORE = idbConstants.DETECT_BLOB_SUPPORT_STORE;
 var DOC_STORE = idbConstants.DOC_STORE;
 var LOCAL_STORE = idbConstants.LOCAL_STORE;
-var META_STORE = idbConstants.META_STORE;
 
 var applyNext = idbUtils.applyNext;
 var compactRevs = idbUtils.compactRevs;
@@ -26,9 +25,8 @@ var idbError = idbUtils.idbError;
 var postProcessAttachments = idbUtils.postProcessAttachments;
 var readBlobData = idbUtils.readBlobData;
 var taskQueue = idbUtils.taskQueue;
-
-var cachedDBs = {};
-var blobSupportPromise;
+var cachedDBs = idbUtils.cachedDBs;
+var openReqList = idbUtils.openReqList;
 
 function IdbPouch(opts, callback) {
   var api = this;
@@ -44,244 +42,20 @@ function IdbPouch(opts, callback) {
 
 function init(api, opts, callback) {
 
-  var name = opts.name;
-
-  var instanceId = null;
-  var idStored = false;
-  var idb = null;
   api._docCount = -1;
   api._blobSupport = null;
-  api._name = name;
-
-  // called when creating a fresh new database
-  function createSchema(db) {
-    var docStore = db.createObjectStore(DOC_STORE, {keyPath : 'id'});
-    db.createObjectStore(BY_SEQ_STORE, {autoIncrement: true})
-      .createIndex('_doc_id_rev', '_doc_id_rev', {unique: true});
-    db.createObjectStore(ATTACH_STORE, {keyPath: 'digest'});
-    db.createObjectStore(META_STORE, {keyPath: 'id', autoIncrement: false});
-    db.createObjectStore(DETECT_BLOB_SUPPORT_STORE);
-
-    // added in v2
-    docStore.createIndex('deletedOrLocal', 'deletedOrLocal', {unique : false});
-
-    // added in v3
-    db.createObjectStore(LOCAL_STORE, {keyPath: '_id'});
-
-    // added in v4
-    var attAndSeqStore = db.createObjectStore(ATTACH_AND_SEQ_STORE,
-      {autoIncrement: true});
-    attAndSeqStore.createIndex('seq', 'seq');
-    attAndSeqStore.createIndex('digestSeq', 'digestSeq', {unique: true});
-  }
-
-  // migration to version 2
-  // unfortunately "deletedOrLocal" is a misnomer now that we no longer
-  // store local docs in the main doc-store, but whaddyagonnado
-  function addDeletedOrLocalIndex(txn, callback) {
-    var docStore = txn.objectStore(DOC_STORE);
-    docStore.createIndex('deletedOrLocal', 'deletedOrLocal', {unique : false});
-
-    docStore.openCursor().onsuccess = function (event) {
-      var cursor = event.target.result;
-      if (cursor) {
-        var metadata = cursor.value;
-        var deleted = utils.isDeleted(metadata);
-        metadata.deletedOrLocal = deleted ? "1" : "0";
-        docStore.put(metadata);
-        cursor.continue();
-      } else {
-        callback();
-      }
-    };
-  }
-
-  // migration to version 3 (part 1)
-  function createLocalStoreSchema(db) {
-    db.createObjectStore(LOCAL_STORE, {keyPath: '_id'})
-      .createIndex('_doc_id_rev', '_doc_id_rev', {unique: true});
-  }
-
-  // migration to version 3 (part 2)
-  function migrateLocalStore(txn, cb) {
-    var localStore = txn.objectStore(LOCAL_STORE);
-    var docStore = txn.objectStore(DOC_STORE);
-    var seqStore = txn.objectStore(BY_SEQ_STORE);
-
-    var cursor = docStore.openCursor();
-    cursor.onsuccess = function (event) {
-      var cursor = event.target.result;
-      if (cursor) {
-        var metadata = cursor.value;
-        var docId = metadata.id;
-        var local = utils.isLocalId(docId);
-        var rev = merge.winningRev(metadata);
-        if (local) {
-          var docIdRev = docId + "::" + rev;
-          // remove all seq entries
-          // associated with this docId
-          var start = docId + "::";
-          var end = docId + "::~";
-          var index = seqStore.index('_doc_id_rev');
-          var range = IDBKeyRange.bound(start, end, false, false);
-          var seqCursor = index.openCursor(range);
-          seqCursor.onsuccess = function (e) {
-            seqCursor = e.target.result;
-            if (!seqCursor) {
-              // done
-              docStore.delete(cursor.primaryKey);
-              cursor.continue();
-            } else {
-              var data = seqCursor.value;
-              if (data._doc_id_rev === docIdRev) {
-                localStore.put(data);
-              }
-              seqStore.delete(seqCursor.primaryKey);
-              seqCursor.continue();
-            }
-          };
-        } else {
-          cursor.continue();
-        }
-      } else if (cb) {
-        cb();
-      }
-    };
-  }
-
-  // migration to version 4 (part 1)
-  function addAttachAndSeqStore(db) {
-    var attAndSeqStore = db.createObjectStore(ATTACH_AND_SEQ_STORE,
-      {autoIncrement: true});
-    attAndSeqStore.createIndex('seq', 'seq');
-    attAndSeqStore.createIndex('digestSeq', 'digestSeq', {unique: true});
-  }
-
-  // migration to version 4 (part 2)
-  function migrateAttsAndSeqs(txn, callback) {
-    var seqStore = txn.objectStore(BY_SEQ_STORE);
-    var attStore = txn.objectStore(ATTACH_STORE);
-    var attAndSeqStore = txn.objectStore(ATTACH_AND_SEQ_STORE);
-
-    // need to actually populate the table. this is the expensive part,
-    // so as an optimization, check first that this database even
-    // contains attachments
-    var req = attStore.count();
-    req.onsuccess = function (e) {
-      var count = e.target.result;
-      if (!count) {
-        return callback(); // done
-      }
-
-      seqStore.openCursor().onsuccess = function (e) {
-        var cursor = e.target.result;
-        if (!cursor) {
-          return callback(); // done
-        }
-        var doc = cursor.value;
-        var seq = cursor.primaryKey;
-        var atts = Object.keys(doc._attachments || {});
-        var digestMap = {};
-        for (var j = 0; j < atts.length; j++) {
-          var att = doc._attachments[atts[j]];
-          digestMap[att.digest] = true; // uniq digests, just in case
-        }
-        var digests = Object.keys(digestMap);
-        for (j = 0; j < digests.length; j++) {
-          var digest = digests[j];
-          attAndSeqStore.put({
-            seq: seq,
-            digestSeq: digest + '::' + seq
-          });
-        }
-        cursor.continue();
-      };
-    };
-  }
-
-  // migration to version 5
-  // Instead of relying on on-the-fly migration of metadata,
-  // this brings the doc-store to its modern form:
-  // - metadata.winningrev
-  // - metadata.seq
-  // - stringify the metadata when storing it
-  function migrateMetadata(txn) {
-
-    function decodeMetadataCompat(storedObject) {
-      if (!storedObject.data) {
-        // old format, when we didn't store it stringified
-        storedObject.deletedOrLocal = storedObject.deletedOrLocal === '1';
-        return storedObject;
-      }
-      return decodeMetadata(storedObject);
-    }
-
-    // ensure that every metadata has a winningRev and seq,
-    // which was previously created on-the-fly but better to migrate
-    var bySeqStore = txn.objectStore(BY_SEQ_STORE);
-    var docStore = txn.objectStore(DOC_STORE);
-    var cursor = docStore.openCursor();
-    cursor.onsuccess = function (e) {
-      var cursor = e.target.result;
-      if (!cursor) {
-        return; // done
-      }
-      var metadata = decodeMetadataCompat(cursor.value);
-
-      metadata.winningRev = metadata.winningRev || merge.winningRev(metadata);
-
-      function fetchMetadataSeq() {
-        // metadata.seq was added post-3.2.0, so if it's missing,
-        // we need to fetch it manually
-        var start = metadata.id + '::';
-        var end = metadata.id + '::\uffff';
-        var req = bySeqStore.index('_doc_id_rev').openCursor(
-          IDBKeyRange.bound(start, end));
-
-        var metadataSeq = 0;
-        req.onsuccess = function (e) {
-          var cursor = e.target.result;
-          if (!cursor) {
-            metadata.seq = metadataSeq;
-            return onGetMetadataSeq();
-          }
-          var seq = cursor.primaryKey;
-          if (seq > metadataSeq) {
-            metadataSeq = seq;
-          }
-          cursor.continue();
-        };
-      }
-
-      function onGetMetadataSeq() {
-        var metadataToStore = encodeMetadata(metadata,
-          metadata.winningRev, metadata.deletedOrLocal);
-
-        var req = docStore.put(metadataToStore);
-        req.onsuccess = function () {
-          cursor.continue();
-        };
-      }
-
-      if (metadata.seq) {
-        return onGetMetadataSeq();
-      }
-
-      fetchMetadataSeq();
-    };
-
-  }
+  api._name = opts.name;
 
   api.type = function () {
     return 'idb';
   };
 
   api._id = utils.toPromise(function (callback) {
-    callback(null, instanceId);
+    callback(null, api._instanceId);
   });
 
   api._bulkDocs = function idb_bulkDocs(req, opts, callback) {
-    idbBulkDocs(req, opts, api, idb, IdbPouch.Changes, callback);
+    idbBulkDocs(req, opts, api, IdbPouch.Changes, callback);
   };
 
   // First we look up the metadata in the ids database, then we fetch the
@@ -295,8 +69,8 @@ function init(api, opts, callback) {
     if (opts.ctx) {
       txn = opts.ctx;
     } else {
-      txn =
-        idb.transaction([DOC_STORE, BY_SEQ_STORE, ATTACH_STORE], 'readonly');
+      txn = api._idb.transaction(
+        [DOC_STORE, BY_SEQ_STORE, ATTACH_STORE], 'readonly');
     }
 
     function finish() {
@@ -343,8 +117,8 @@ function init(api, opts, callback) {
     if (opts.ctx) {
       txn = opts.ctx;
     } else {
-      txn =
-        idb.transaction([DOC_STORE, BY_SEQ_STORE, ATTACH_STORE], 'readonly');
+      txn = api._idb.transaction(
+        [DOC_STORE, BY_SEQ_STORE, ATTACH_STORE], 'readonly');
     }
     var digest = attachment.digest;
     var type = attachment.content_type;
@@ -411,7 +185,7 @@ function init(api, opts, callback) {
     if (opts.attachments) {
       stores.push(ATTACH_STORE);
     }
-    var transaction = idb.transaction(stores, 'readonly');
+    var transaction = api._idb.transaction(stores, 'readonly');
 
     function onResultsReady() {
       callback(null, {
@@ -499,7 +273,7 @@ function init(api, opts, callback) {
     }
 
     var count;
-    var txn = idb.transaction([DOC_STORE], 'readonly');
+    var txn = api._idb.transaction([DOC_STORE], 'readonly');
     var index = txn.objectStore(DOC_STORE).index('deletedOrLocal');
     index.count(IDBKeyRange.only("0")).onsuccess = function (e) {
       count = e.target.result;
@@ -535,13 +309,13 @@ function init(api, opts, callback) {
       if (err) {
         return callback(err);
       }
-      if (idb === null) {
+      if (api._idb === null) {
         var error = new Error('db isn\'t open');
         error.id = 'idbNull';
         return callback(error);
       }
       var updateSeq = 0;
-      var txn = idb.transaction([BY_SEQ_STORE], 'readonly');
+      var txn = api._idb.transaction([BY_SEQ_STORE], 'readonly');
       txn.objectStore(BY_SEQ_STORE).openCursor(null, "prev").onsuccess =
         function (event) {
         var cursor = event.target.result;
@@ -562,189 +336,24 @@ function init(api, opts, callback) {
   };
 
   api._changes = function (opts) {
-    opts = utils.clone(opts);
-
-    if (opts.continuous) {
-      var id = name + ':' + utils.uuid();
-      IdbPouch.Changes.addListener(name, id, api, opts);
-      IdbPouch.Changes.notify(name);
-      return {
-        cancel: function () {
-          IdbPouch.Changes.removeListener(name, id);
-        }
-      };
-    }
-
-    var docIds = opts.doc_ids && new utils.Set(opts.doc_ids);
-    var descending = opts.descending ? 'prev' : null;
-
-    opts.since = opts.since || 0;
-    var lastSeq = opts.since;
-
-    var limit = 'limit' in opts ? opts.limit : -1;
-    if (limit === 0) {
-      limit = 1; // per CouchDB _changes spec
-    }
-    var returnDocs;
-    if ('returnDocs' in opts) {
-      returnDocs = opts.returnDocs;
-    } else {
-      returnDocs = true;
-    }
-
-    var results = [];
-    var numResults = 0;
-    var filter = utils.filterChange(opts);
-    var docIdsToMetadata = new utils.Map();
-
-    var txn;
-    var bySeqStore;
-    var docStore;
-
-    function onGetCursor(cursor) {
-
-      var doc = decodeDoc(cursor.value);
-      var seq = cursor.key;
-
-      lastSeq = seq;
-
-      if (docIds && !docIds.has(doc._id)) {
-        return cursor.continue();
-      }
-
-      var metadata;
-
-      function onGetMetadata() {
-        if (metadata.seq !== seq) {
-          // some other seq is later
-          return cursor.continue();
-        }
-
-        if (metadata.winningRev === doc._rev) {
-          return onGetWinningDoc(doc);
-        }
-
-        fetchWinningDoc();
-      }
-
-      function fetchWinningDoc() {
-        var docIdRev = doc._id + '::' + metadata.winningRev;
-        var req = bySeqStore.index('_doc_id_rev').openCursor(
-          IDBKeyRange.bound(docIdRev, docIdRev + '\uffff'));
-        req.onsuccess = function (e) {
-          onGetWinningDoc(decodeDoc(e.target.result.value));
-        };
-      }
-
-      function onGetWinningDoc(winningDoc) {
-
-        var change = opts.processChange(winningDoc, metadata, opts);
-        change.seq = metadata.seq;
-        if (filter(change)) {
-          numResults++;
-          if (returnDocs) {
-            results.push(change);
-          }
-          // process the attachment immediately
-          // for the benefit of live listeners
-          if (opts.attachments && opts.include_docs) {
-            fetchAttachmentsIfNecessary(winningDoc, opts, txn, function () {
-              postProcessAttachments([change]).then(function () {
-                opts.onChange(change);
-              });
-            });
-          } else {
-            opts.onChange(change);
-          }
-        }
-        if (numResults !== limit) {
-          cursor.continue();
-        }
-      }
-
-      metadata = docIdsToMetadata.get(doc._id);
-      if (metadata) { // cached
-        return onGetMetadata();
-      }
-      // metadata not cached, have to go fetch it
-      docStore.get(doc._id).onsuccess = function (event) {
-        metadata = decodeMetadata(event.target.result);
-        docIdsToMetadata.set(doc._id, metadata);
-        onGetMetadata();
-      };
-    }
-
-    function onsuccess(event) {
-      var cursor = event.target.result;
-
-      if (!cursor) {
-        return;
-      }
-      onGetCursor(cursor);
-    }
-
-    function fetchChanges() {
-      var objectStores = [DOC_STORE, BY_SEQ_STORE];
-      if (opts.attachments) {
-        objectStores.push(ATTACH_STORE);
-      }
-      txn = idb.transaction(objectStores, 'readonly');
-      txn.onerror = idbError(opts.complete);
-      txn.oncomplete = onTxnComplete;
-
-      bySeqStore = txn.objectStore(BY_SEQ_STORE);
-      docStore = txn.objectStore(DOC_STORE);
-
-      var req;
-
-      if (descending) {
-        req = bySeqStore.openCursor(
-
-          null, descending);
-      } else {
-        req = bySeqStore.openCursor(
-          IDBKeyRange.lowerBound(opts.since, true));
-      }
-
-      req.onsuccess = onsuccess;
-    }
-
-    fetchChanges();
-
-    function onTxnComplete() {
-
-      function finish() {
-        opts.complete(null, {
-          results: results,
-          last_seq: lastSeq
-        });
-      }
-
-      if (!opts.continuous && opts.attachments) {
-        // cannot guarantee that postProcessing was already done,
-        // so do it again
-        postProcessAttachments(results).then(finish);
-      } else {
-        finish();
-      }
-    }
+    idbChanges(opts, api, IdbPouch.Changes);
   };
 
   api._close = function (callback) {
-    if (idb === null) {
+    if (api._idb === null) {
       return callback(errors.error(errors.NOT_OPEN));
     }
 
     // https://developer.mozilla.org/en-US/docs/IndexedDB/IDBDatabase#close
     // "Returns immediately and closes the connection in a separate thread..."
-    idb.close();
-    delete cachedDBs[name];
-    idb = null;
+    api._idb.close();
+    cachedDBs.delete(api._name);
+    api._idb = null;
     callback();
   };
 
   api._getRevisionTree = function (docId, callback) {
-    var txn = idb.transaction([DOC_STORE], 'readonly');
+    var txn = api._idb.transaction([DOC_STORE], 'readonly');
     var req = txn.objectStore(DOC_STORE).get(docId);
     req.onsuccess = function (event) {
       var doc = decodeMetadata(event.target.result);
@@ -760,7 +369,7 @@ function init(api, opts, callback) {
   // which are listed in revs and sets this document
   // revision to to rev_tree
   api._doCompaction = function (docId, revs, callback) {
-    var txn = idb.transaction([
+    var txn = api._idb.transaction([
       DOC_STORE,
       BY_SEQ_STORE,
       ATTACH_STORE,
@@ -792,7 +401,7 @@ function init(api, opts, callback) {
 
 
   api._getLocal = function (id, callback) {
-    var tx = idb.transaction([LOCAL_STORE], 'readonly');
+    var tx = api._idb.transaction([LOCAL_STORE], 'readonly');
     var req = tx.objectStore(LOCAL_STORE).get(id);
 
     req.onerror = idbError(callback);
@@ -824,7 +433,7 @@ function init(api, opts, callback) {
     var tx = opts.ctx;
     var ret;
     if (!tx) {
-      tx = idb.transaction([LOCAL_STORE], 'readwrite');
+      tx = api._idb.transaction([LOCAL_STORE], 'readwrite');
       tx.onerror = idbError(callback);
       tx.oncomplete = function () {
         if (ret) {
@@ -869,7 +478,7 @@ function init(api, opts, callback) {
   };
 
   api._removeLocal = function (doc, callback) {
-    var tx = idb.transaction([LOCAL_STORE], 'readwrite');
+    var tx = api._idb.transaction([LOCAL_STORE], 'readwrite');
     var ret;
     tx.oncomplete = function () {
       if (ret) {
@@ -892,166 +501,7 @@ function init(api, opts, callback) {
     };
   };
 
-  var cached = cachedDBs[name];
-
-  if (cached) {
-    idb = cached.idb;
-    instanceId = cached.instanceId;
-    api._blobSupport = cached.blobSupport;
-    process.nextTick(function () {
-      callback(null, api);
-    });
-    return;
-  }
-
-  var req = indexedDB.open(name, ADAPTER_VERSION);
-
-  if (!('openReqList' in IdbPouch)) {
-    IdbPouch.openReqList = {};
-  }
-  IdbPouch.openReqList[name] = req;
-
-  req.onupgradeneeded = function (e) {
-    var db = e.target.result;
-    if (e.oldVersion < 1) {
-      return createSchema(db); // new db, initial schema
-    }
-    // do migrations
-
-    var txn = e.currentTarget.transaction;
-    // these migrations have to be done in this function, before
-    // control is returned to the event loop, because IndexedDB
-
-    if (e.oldVersion < 3) {
-      createLocalStoreSchema(db); // v2 -> v3
-    }
-    if (e.oldVersion < 4) {
-      addAttachAndSeqStore(db); // v3 -> v4
-    }
-
-    var migrations = [
-      addDeletedOrLocalIndex, // v1 -> v2
-      migrateLocalStore,      // v2 -> v3
-      migrateAttsAndSeqs,     // v3 -> v4
-      migrateMetadata         // v4 -> v5
-    ];
-
-    var i = e.oldVersion;
-
-    function next() {
-      var migration = migrations[i - 1];
-      i++;
-      if (migration) {
-        migration(txn, next);
-      }
-    }
-
-    next();
-  };
-
-  req.onsuccess = function (e) {
-
-    idb = e.target.result;
-
-    idb.onversionchange = function () {
-      idb.close();
-      delete cachedDBs[name];
-    };
-    idb.onabort = function () {
-      idb.close();
-      delete cachedDBs[name];
-    };
-
-    var txn = idb.transaction([META_STORE, DETECT_BLOB_SUPPORT_STORE],
-      'readwrite');
-
-    var req = txn.objectStore(META_STORE).get(META_STORE);
-
-    req.onsuccess = function (e) {
-
-      var checkSetupComplete = function () {
-        if (api._blobSupport === null || !idStored) {
-          return;
-        } else {
-          cachedDBs[name] = {
-            idb: idb,
-            instanceId: instanceId,
-            blobSupport: api._blobSupport,
-            loaded: true
-          };
-          callback(null, api);
-        }
-      };
-
-      var meta = e.target.result || {id: META_STORE};
-      if (name  + '_id' in meta) {
-        instanceId = meta[name + '_id'];
-        idStored = true;
-        checkSetupComplete();
-      } else {
-        instanceId = utils.uuid();
-        meta[name + '_id'] = instanceId;
-        txn.objectStore(META_STORE).put(meta).onsuccess = function () {
-          idStored = true;
-          checkSetupComplete();
-        };
-      }
-
-      // Detect blob support. Chrome didn't support it until version 38.
-      // in version 37 they had a broken version where PNGs (and possibly
-      // other binary types) aren't stored correctly.
-      if (!blobSupportPromise) {
-
-        // make sure blob support is only checked one
-        blobSupportPromise = new utils.Promise(function (resolve) {
-          var blob = utils.createBlob([''], {type: 'image/png'});
-          txn.objectStore(DETECT_BLOB_SUPPORT_STORE).put(blob, 'key');
-          txn.oncomplete = function () {
-            // have to do it in a separate transaction, else the correct
-            // content type is always returned
-            txn = idb.transaction([META_STORE, DETECT_BLOB_SUPPORT_STORE],
-              'readwrite');
-            var getBlobReq = txn.objectStore(
-              DETECT_BLOB_SUPPORT_STORE).get('key');
-            getBlobReq.onsuccess = function (e) {
-
-              var storedBlob = e.target.result;
-              var url = URL.createObjectURL(storedBlob);
-
-              utils.ajax({
-                url: url,
-                cache: true,
-                binary: true
-              }, function (err, res) {
-                if (err && err.status === 405) {
-                  // firefox won't let us do that. but firefox doesn't
-                  // have the blob type bug that Chrome does, so that's ok
-                  resolve(true);
-                } else {
-                  resolve(!!(res && res.type === 'image/png'));
-                  if (err && err.status === 404) {
-                    utils.explain404(
-                      'PouchDB is just detecting blob URL support.');
-                  }
-                }
-                URL.revokeObjectURL(url);
-              });
-            };
-          };
-        }).catch(function (err) {
-          return false; // error, so assume unsupported
-        });
-      }
-
-      blobSupportPromise.then(function (val) {
-        api._blobSupport = val;
-        checkSetupComplete();
-      });
-    };
-  };
-
-  req.onerror = idbError(callback);
-
+  idbSetup(api, callback);
 }
 
 IdbPouch.valid = function () {
@@ -1069,26 +519,24 @@ IdbPouch.valid = function () {
 };
 
 function destroy(name, opts, callback) {
-  if (!('openReqList' in IdbPouch)) {
-    IdbPouch.openReqList = {};
-  }
   IdbPouch.Changes.removeAllListeners(name);
 
   //Close open request for "name" database to fix ie delay.
-  if (IdbPouch.openReqList[name] && IdbPouch.openReqList[name].result) {
-    IdbPouch.openReqList[name].result.close();
+  var openReq = openReqList.get(name);
+  if (openReq && openReq.result) {
+    openReq.result.close();
   }
   var req = indexedDB.deleteDatabase(name);
 
   req.onsuccess = function () {
     //Remove open request from the list.
-    if (IdbPouch.openReqList[name]) {
-      IdbPouch.openReqList[name] = null;
+    if (openReqList.has(name)) {
+      openReqList.delete(name);
     }
     if (utils.hasLocalStorage() && (name in localStorage)) {
       delete localStorage[name];
     }
-    delete cachedDBs[name];
+    cachedDBs.delete(name);
     callback(null, { 'ok': true });
   };
 


### PR DESCRIPTION
This PR is a two-for-one.

The old 404 we were getting for blobs in Chrome was due to using an empty PNG. I switched to using a transparent 1x1 transparent PNG as originally advised by @ssured (but stupidly ignored by me).

Why a transparent PNG? Because an empty PNG causes the 404 in Chrome, whereas we have to use a PNG because apparently plaintext doesn't suss out the error in Chrome 37.

I verified manually that the 404 is no longer thrown in Chrome 39 and that `blobSupport` is set to true.

**Please wait for a green in IE10 before merging.**