### PR TITLE
(#3326) - fix blob support in chrome

### DIFF
--- a/lib/adapters/idb/idb.js
+++ b/lib/adapters/idb/idb.js
@@ -1003,16 +1003,22 @@ function init(api, opts, callback) {
       if (!blobSupportPromise) {
 
         // make sure blob support is only checked one
-        blobSupportPromise = new utils.Promise(function (resolve) {
-          var blob = utils.createBlob([''], {type: 'image/png'});
+        blobSupportPromise = new utils.Promise(function (resolve, reject) {
+          // 1x1 transparent PNG
+          var blob = utils.createBlob([utils.fixBinary(utils.atob(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAA' +
+            'BCAQAAAC1HAwCAAAAC0lEQVQYV2NgYA' +
+            'AAAAMAAWgmWQ0AAAAASUVORK5CYII='
+          ))], {type: 'image/png'});
           txn.objectStore(DETECT_BLOB_SUPPORT_STORE).put(blob, 'key');
           txn.oncomplete = function () {
             // have to do it in a separate transaction, else the correct
             // content type is always returned
-            txn = idb.transaction([META_STORE, DETECT_BLOB_SUPPORT_STORE],
+            var blobTxn = idb.transaction([DETECT_BLOB_SUPPORT_STORE],
               'readwrite');
-            var getBlobReq = txn.objectStore(
+            var getBlobReq = blobTxn.objectStore(
               DETECT_BLOB_SUPPORT_STORE).get('key');
+            getBlobReq.onerror = reject;
             getBlobReq.onsuccess = function (e) {
 
               var storedBlob = e.target.result;
@@ -1029,10 +1035,6 @@ function init(api, opts, callback) {
                   resolve(true);
                 } else {
                   resolve(!!(res && res.type === 'image/png'));
-                  if (err && err.status === 404) {
-                    utils.explain404(
-                      'PouchDB is just detecting blob URL support.');
-                  }
                 }
                 URL.revokeObjectURL(url);
               });


### PR DESCRIPTION
Verified manually that `api._blobSupport` is true in Chrome 39 and Firefox 36. Also the 404 is gone from Chrome, so there's no need for the info message any more.

Please wait for a green in IE10 to be safe.