### PR TITLE
(#3155) - spellcheck/document retry

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -503,10 +503,11 @@ Replication is an event emiter like `changes()` and emits the `'complete'`, `'ac
 
 All options default to `false` unless otherwise specified.
 
+* `options.live`: If `true`, starts subscribing to future changes in the `source` database and continue replicating them.
+* `options.retry`: If `true`, replication will be retried when an error occurs (e.g. when the user goes offline). Only used during `live` replication: if you don't also set `{live: true}`, then `retry` will be considered `false`.
 * `options.filter`: Reference a filter function from a design document to selectively get updates.
 * `options.query_params`: Query params sent to the filter function.
 * `options.doc_ids`: Only replicate docs with these ids (array of strings).
-* `options.live`: If `true`, starts subscribing to future changes in the `source` database and continue replicating them.
 * `options.since`: Replicate changes after the given sequence number.
 * `options.create_target`: Create target database if it does not exist. Only for server replications.
 * `options.batch_size`: Number of documents to process at a time. Defaults to 100. This affects the number of docs held in memory and the number sent at a time to the target server. You may need to adjust downward if targeting devices with low amounts of memory (e.g. phones) or if the documents are large in size (e.g. with attachments). If your documents are small in size, then increasing this number will probably speed replication up.
@@ -536,13 +537,13 @@ db.replicate.from(remoteDB, [options]);
 
 ### Replication events
 
-* `change` - The change event fires when the replication has written a new document.
-* `complete` - The complete event fires when replication is completed or cancelled, in a live replication only cancelling the replication should trigger this event.
-* `active` - This event fires when the replication is actively processing changes.
-* `paused(error)` - This event fires when the replication is paused, this is because it is a live replication waiting for changes, or it is waiting to retry a request due to an error.
+* `change` - This event fires when the replication has written a new document.
+* `complete` - This event fires when replication is completed or cancelled. In a live replication, only cancelling the replication should trigger this event.
+* `paused` - This event fires when the replication is paused, either because a live replication is waiting for changes, or because a live+retry replication is waiting to retry a request due to an error.
+* `active` - This event fires when the replication starts actively processing changes; e.g. when it recovers from an error during live+retry replication.
 * `denied` - This event fires if a document failed to replicate due to validation or authorization errors.
 * `error`` - This event is fired when the replication is stopped due to an unrecoverable failure.
-* `uptodate` *DEPRECATED* - This event fires when a live replication has caught up and is waiting on future changes, this should be replaced by using the `paused` event.
+* `uptodate` (*DEPRECATED*) - This event fires when a live replication has caught up and is waiting on future changes. This should be replaced by using the `paused` event.
 
 #### Example Response:
 


### PR DESCRIPTION
Added documentation for `retry` itself, and also fixed some comma splices, etc.

One thing that's still unclear to me is this line:

> * `paused` - This event fires when the replication is paused, either because a live replication is waiting for changes, or because a live+retry replication is waiting to retry a request due to an error.

It seems to me that it would be clearer to keep `uptodate` for live replication and reserve `paused` for live+retry replication, unless there is some technical reason against it. I find it confusing that `paused` applies to two somewhat different events, and that we need to deprecate `uptodate` to do so.