### PR TITLE
(#2597 #2632) - ccjs+uglifyify+bundle-collapser for smaller min

### DIFF
--- a/bin/min.sh
+++ b/bin/min.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+BROWSERIFY=./node_modules/.bin/browserify
+DEREQUIRE=./node_modules/.bin/derequire
+UGLIFY=./node_modules/.bin/uglifyjs
+CCJS=./node_modules/.bin/ccjs
+
+# use uglifyify and bundle-collapser for best compression
+# for the pre-minified bundle
+
+# then uglify, ccjs, then uglify again for best compression
+# (yes really)
+
+$BROWSERIFY \
+    -p bundle-collapser/plugin \
+    -p uglifyify \
+    -s PouchDB . \
+    | $DEREQUIRE \
+    | $UGLIFY - -mc \
+    | $CCJS - --warning_level=QUIET \
+    | $UGLIFY - -mc > dist/pouchdb.min.js

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "argsarray": "0.0.1",
     "bluebird": "^1.2.4",
     "double-ended-queue": "^2.0.0-0",
+    "closurecompiler": "^1.3.2",
     "es3ify": "^0.1.3",
     "inherits": "~2.0.1",
     "level-js": "^2.1.3",
@@ -70,12 +71,14 @@
     "phantomjs": "^1.9.7-5",
     "browserify": "^6.1.0",
     "watchify": "^2.0.0",
-    "derequire": "^1.2.0"
+    "derequire": "^1.2.0",
+    "bundle-collapser": "^1.1.1",
+    "uglifyify": "2.6.0"
   },
   "scripts": {
     "build-js": "npm run build-main-js && npm run min && npm run build-plugins",
     "build-main-js": "browserify . -s PouchDB | derequire > dist/pouchdb.js",
-    "min": "uglifyjs dist/pouchdb.js -mc > dist/pouchdb.min.js",
+    "min": "sh bin/min.sh",
     "build-plugins": "sh bin/build-all-plugins.sh",
     "build": "npm run version && mkdirp dist && npm run build-js && npm run license",
     "license": "node ./bin/add-license.js",


### PR DESCRIPTION
min+gzip size before: 86003.

After: 80828

Without using `ccjs` (i.e. just using uglifyify and bundle-transform): 82875

I think if `ccjs` is buying us 2 extra KB, then it's worth using.