### PR TITLE
(#2632) - remove leveldb from browserify build

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "./deps/buffer": false,
     "request": false,
     "crypto": false,
-    "./adapters/leveldb": false,
+    "./adapters/leveldb/leveldb": false,
     "./adapters/levelalt": false,
     "./lib/deps/ajax.js": "./lib/deps/ajax-browser.js",
     "./lib/version.js": "./lib/version-browser.js",


### PR DESCRIPTION
044761a504f3cb0493804c6cefdb90813de527fe caused us to start including all of `leveldb.js` in the browserify build, adding about 30KB, up to ~80KB total. Now it's back down to ~50KB minified+gzipped.