### PR TITLE
(#136) - Skip "issue #2393 update_seq after new_edits + replication"

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -2920,6 +2920,11 @@ adapters.forEach(function (adapters) {
     });
 
     it('issue #2393 update_seq after new_edits + replication', function (done) {
+      // the assertions below do not hold in a clustered CouchDB
+      if (testUtils.isCouchMaster()) {
+        return done();
+      }
+
       var docs = [{
         '_id': 'foo',
         '_rev': '1-x',


### PR DESCRIPTION
Skipping this test in CouchDB master because sequence numbers cannot be compared for equality (changes and info might return different encodings of the same data).