### PR TITLE
(#3350) - make compact return {ok: true}

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1021,6 +1021,13 @@ Also see [auto-compaction](#create_database), which runs compaction automaticall
 
 * `options.interval`: Number of milliseconds to wait before asking again if compaction is already done. Defaults to 200. (Only applies to remote databases.)
 
+#### Example Response:
+{% highlight js %}
+{
+  "ok" : "true"
+}
+{% endhighlight %}
+
 {% include anchor.html title="Document revisions diff" hash="revisions_diff" %}
 
 {% highlight js %}

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -440,8 +440,7 @@ AbstractPouchDB.prototype._compact = function (opts, callback) {
       }
       return false; // somebody else got here first, don't update
     }, function () {
-      // wrapped so no arguments are being passed on. (#3111)
-      callback();
+      callback(null, {ok: true});
     });
   }
   if (opts.last_seq) {

--- a/tests/integration/test.compaction.js
+++ b/tests/integration/test.compaction.js
@@ -1201,11 +1201,11 @@ adapters.forEach(function (adapter) {
       });
     });
 
-    it('#3111 compact should return a falsy value', function (done) {
+    it('#3350 compact should return {ok: true}', function (done) {
       var db = new PouchDB(dbs.name);
       db.compact(function (err, result) {
         should.not.exist(err);
-        should.not.exist(result);
+        result.should.eql({ok: true});
 
         done();
       });


### PR DESCRIPTION
As discussed in #3350 do what CouchDB does.