### PR TITLE
(#3350) - http compact() also returns {ok:true}

### DIFF
--- a/lib/adapters/http/http.js
+++ b/lib/adapters/http/http.js
@@ -223,7 +223,7 @@ function HttpPouch(opts, callback) {
       function ping() {
         api.info(function (err, res) {
           if (!res.compact_running) {
-            callback();
+            callback(null, {ok: true});
           } else {
             setTimeout(ping, opts.interval || 200);
           }

--- a/tests/integration/test.compaction.js
+++ b/tests/integration/test.compaction.js
@@ -19,6 +19,16 @@ adapters.forEach(function (adapter) {
     after(function (done) {
       testUtils.cleanup([dbs.name], done);
     });
+    
+    it('#3350 compact should return {ok: true}', function (done) {
+      var db = new PouchDB(dbs.name);
+      db.compact(function (err, result) {
+        should.not.exist(err);
+        result.should.eql({ok: true});
+
+        done();
+      });
+    });
 
     it('#2913 massively parallel compaction', function () {
       var db = new PouchDB(dbs.name);
@@ -1198,16 +1208,6 @@ adapters.forEach(function (adapter) {
         }, function (err) {
           err.status.should.equal(412);
         });
-      });
-    });
-
-    it('#3350 compact should return {ok: true}', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.compact(function (err, result) {
-        should.not.exist(err);
-        result.should.eql({ok: true});
-
-        done();
       });
     });
 


### PR DESCRIPTION
@marten-de-vries I noticed that the test wasn't being run for `http`. Also the `http` adapter needed a fix.