### PR TITLE
Change events with docs property

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -156,9 +156,11 @@ function replicate(repId, src, target, opts, returnValue, result) {
   };
   var checkpointer = new Checkpointer(src, target, repId, state);
   var outResult;
+  var allErrors = [];
 
   if (result) {
     result.docs = [];
+    result.errors = [];
     outResult = utils.clone(result);
   } else {
     outResult =  {
@@ -194,12 +196,14 @@ function replicate(repId, src, target, opts, returnValue, result) {
           errorsById[res.id] = res;
         }
       });
-      outResult.errors = outResult.errors.concat(errors);
+      outResult.errors = errors;
+      allErrors = allErrors.concat(errors);
       outResult.docs_written += currentBatch.docs.length - errors.length;
       var non403s = errors.filter(function (error) {
         return error.name !== 'unauthorized' && error.name !== 'forbidden';
       });
 
+      outResult.docs = [];
       docs.forEach(function(doc) {
         var error = errorsById[doc._id];
         if (error) {
@@ -393,6 +397,7 @@ function replicate(repId, src, target, opts, returnValue, result) {
     outResult.ok = false;
     outResult.status = 'aborting';
     outResult.errors.push(err);
+    allErrors = allErrors.concat(err);
     batches = [];
     pendingBatch = {
       seq: 0,
@@ -417,17 +422,19 @@ function replicate(repId, src, target, opts, returnValue, result) {
     outResult.end_time = new Date();
     outResult.last_seq = last_seq;
     replicationCompleted = state.cancelled = true;
-    var non403s = outResult.errors.filter(function (error) {
+    var non403s = allErrors.filter(function (error) {
       return error.name !== 'unauthorized' && error.name !== 'forbidden';
     });
     if (non403s.length > 0) {
-      var error = outResult.errors.pop();
-      if (outResult.errors.length > 0) {
-        error.other_errors = outResult.errors;
+      var error = allErrors.pop();
+      if (allErrors.length > 0) {
+        error.other_errors = allErrors;
       }
-      error.outResult = outResult;
+      error.result = outResult;
       backOff(repId, src, target, opts, returnValue, outResult, error);
     } else {
+      outResult.errors = allErrors;
+      delete outResult.docs; // it would be the last badge only
       returnValue.emit('complete', outResult);
       returnValue.removeAllListeners();
     }
@@ -536,8 +543,8 @@ function replicate(repId, src, target, opts, returnValue, result) {
 
   if (typeof opts.complete === 'function') {
     returnValue.once('error', opts.complete);
-    returnValue.once('complete', function (result) {
-      opts.complete(null, result);
+    returnValue.once('complete', function (outResult) {
+      opts.complete(null, outResult);
     });
   }
 

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -155,24 +155,17 @@ function replicate(repId, src, target, opts, returnValue, result) {
     cancelled: false
   };
   var checkpointer = new Checkpointer(src, target, repId, state);
-  var outResult;
   var allErrors = [];
+  var changedDocs = [];
 
-  if (result) {
-    result.docs = [];
-    result.errors = [];
-    outResult = utils.clone(result);
-  } else {
-    outResult =  {
-      ok: true,
-      start_time: new Date(),
-      docs_read: 0,
-      docs_written: 0,
-      doc_write_failures: 0,
-      errors: [],
-      docs: []
-    };
-  }
+  result = result || {
+    ok: true,
+    start_time: new Date(),
+    docs_read: 0,
+    docs_written: 0,
+    doc_write_failures: 0,
+    errors: []
+  };
 
   var changesOpts = {};
   returnValue.ready(src, target);
@@ -191,25 +184,25 @@ function replicate(repId, src, target, opts, returnValue, result) {
       var errorsById = {};
       res.forEach(function (res) {
         if (res.error) {
-          outResult.doc_write_failures++;
+          result.doc_write_failures++;
           errors.push(res);
           errorsById[res.id] = res;
         }
       });
-      outResult.errors = errors;
+      result.errors = errors;
       allErrors = allErrors.concat(errors);
-      outResult.docs_written += currentBatch.docs.length - errors.length;
+      result.docs_written += currentBatch.docs.length - errors.length;
       var non403s = errors.filter(function (error) {
         return error.name !== 'unauthorized' && error.name !== 'forbidden';
       });
 
-      outResult.docs = [];
+      changedDocs = [];
       docs.forEach(function(doc) {
         var error = errorsById[doc._id];
         if (error) {
           returnValue.emit('denied', utils.clone(error));
         } else {
-          outResult.docs = outResult.docs.concat(doc);
+          changedDocs.push(doc);
         }
       });
 
@@ -220,7 +213,7 @@ function replicate(repId, src, target, opts, returnValue, result) {
         throw new Error('bulkWrite partial failure');
       }
     }, function (err) {
-      outResult.doc_write_failures += docs.length;
+      result.doc_write_failures += docs.length;
       throw err;
     });
   }
@@ -247,7 +240,7 @@ function replicate(repId, src, target, opts, returnValue, result) {
             return completeReplication();
           }
           if (doc.ok) {
-            outResult.docs_read++;
+            result.docs_read++;
             currentBatch.pendingRevs++;
             currentBatch.docs.push(doc.ok);
           }
@@ -288,7 +281,7 @@ function replicate(repId, src, target, opts, returnValue, result) {
             Object.keys(row.doc._attachments).length === 0
           )
         ) {
-          outResult.docs_read++;
+          result.docs_read++;
           currentBatch.pendingRevs++;
           currentBatch.docs.push(row.doc);
           delete currentBatch.diffs[row.id];
@@ -309,7 +302,9 @@ function replicate(repId, src, target, opts, returnValue, result) {
         completeReplication();
         throw new Error('cancelled');
       }
-      outResult.last_seq = last_seq = currentBatch.seq;
+      result.last_seq = last_seq = currentBatch.seq;
+      var outResult = utils.clone(result);
+      outResult.docs = changedDocs;
       returnValue.emit('change', outResult);
       currentBatch = undefined;
       getChanges();
@@ -363,7 +358,7 @@ function replicate(repId, src, target, opts, returnValue, result) {
       if (batches.length === 0 && !currentBatch) {
         if ((continuous && changesOpts.live) || changesCompleted) {
           returnValue.emit('paused');
-          returnValue.emit('uptodate', outResult);
+          returnValue.emit('uptodate', result);
         }
         if (changesCompleted) {
           completeReplication();
@@ -394,9 +389,9 @@ function replicate(repId, src, target, opts, returnValue, result) {
     if (!err.message) {
       err.message = reason;
     }
-    outResult.ok = false;
-    outResult.status = 'aborting';
-    outResult.errors.push(err);
+    result.ok = false;
+    result.status = 'aborting';
+    result.errors.push(err);
     allErrors = allErrors.concat(err);
     batches = [];
     pendingBatch = {
@@ -413,14 +408,14 @@ function replicate(repId, src, target, opts, returnValue, result) {
       return;
     }
     if (state.cancelled) {
-      outResult.status = 'cancelled';
+      result.status = 'cancelled';
       if (writingCheckpoint) {
         return;
       }
     }
-    outResult.status = outResult.status || 'complete';
-    outResult.end_time = new Date();
-    outResult.last_seq = last_seq;
+    result.status = result.status || 'complete';
+    result.end_time = new Date();
+    result.last_seq = last_seq;
     replicationCompleted = state.cancelled = true;
     var non403s = allErrors.filter(function (error) {
       return error.name !== 'unauthorized' && error.name !== 'forbidden';
@@ -430,12 +425,11 @@ function replicate(repId, src, target, opts, returnValue, result) {
       if (allErrors.length > 0) {
         error.other_errors = allErrors;
       }
-      error.result = outResult;
-      backOff(repId, src, target, opts, returnValue, outResult, error);
+      error.result = result;
+      backOff(repId, src, target, opts, returnValue, result, error);
     } else {
-      outResult.errors = allErrors;
-      delete outResult.docs; // it would be the last badge only
-      returnValue.emit('complete', outResult);
+      result.errors = allErrors;
+      returnValue.emit('complete', result);
       returnValue.removeAllListeners();
     }
   }
@@ -450,7 +444,7 @@ function replicate(repId, src, target, opts, returnValue, result) {
       batches.length === 0 &&
       !currentBatch
     ) {
-      returnValue.emit('outofdate', outResult);
+      returnValue.emit('outofdate', result);
     }
     pendingBatch.seq = change.seq;
     pendingBatch.changes.push(change);
@@ -543,8 +537,8 @@ function replicate(repId, src, target, opts, returnValue, result) {
 
   if (typeof opts.complete === 'function') {
     returnValue.once('error', opts.complete);
-    returnValue.once('complete', function (outResult) {
-      opts.complete(null, outResult);
+    returnValue.once('complete', function (result) {
+      opts.complete(null, result);
     });
   }
 

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -155,15 +155,23 @@ function replicate(repId, src, target, opts, returnValue, result) {
     cancelled: false
   };
   var checkpointer = new Checkpointer(src, target, repId, state);
-  result = result || {
-    ok: true,
-    start_time: new Date(),
-    docs_read: 0,
-    docs_written: 0,
-    doc_write_failures: 0,
-    errors: [],
-    docs: []
-  };
+  var outResult;
+
+  if (result) {
+    result.docs = [];
+    outResult = utils.clone(result);
+  } else {
+    outResult =  {
+      ok: true,
+      start_time: new Date(),
+      docs_read: 0,
+      docs_written: 0,
+      doc_write_failures: 0,
+      errors: [],
+      docs: []
+    };
+  }
+
   var changesOpts = {};
   returnValue.ready(src, target);
 
@@ -181,24 +189,23 @@ function replicate(repId, src, target, opts, returnValue, result) {
       var errorsById = {};
       res.forEach(function (res) {
         if (res.error) {
-          result.doc_write_failures++;
+          outResult.doc_write_failures++;
           errors.push(res);
           errorsById[res.id] = res;
         }
       });
-      result.errors = result.errors.concat(errors);
-      result.docs_written += currentBatch.docs.length - errors.length;
+      outResult.errors = outResult.errors.concat(errors);
+      outResult.docs_written += currentBatch.docs.length - errors.length;
       var non403s = errors.filter(function (error) {
         return error.name !== 'unauthorized' && error.name !== 'forbidden';
       });
 
-      result.docs = [];
       docs.forEach(function(doc) {
         var error = errorsById[doc._id];
         if (error) {
           returnValue.emit('denied', utils.clone(error));
         } else {
-          result.docs = result.docs.concat(doc);
+          outResult.docs = outResult.docs.concat(doc);
         }
       });
 
@@ -209,7 +216,7 @@ function replicate(repId, src, target, opts, returnValue, result) {
         throw new Error('bulkWrite partial failure');
       }
     }, function (err) {
-      result.doc_write_failures += docs.length;
+      outResult.doc_write_failures += docs.length;
       throw err;
     });
   }
@@ -236,7 +243,7 @@ function replicate(repId, src, target, opts, returnValue, result) {
             return completeReplication();
           }
           if (doc.ok) {
-            result.docs_read++;
+            outResult.docs_read++;
             currentBatch.pendingRevs++;
             currentBatch.docs.push(doc.ok);
           }
@@ -277,7 +284,7 @@ function replicate(repId, src, target, opts, returnValue, result) {
             Object.keys(row.doc._attachments).length === 0
           )
         ) {
-          result.docs_read++;
+          outResult.docs_read++;
           currentBatch.pendingRevs++;
           currentBatch.docs.push(row.doc);
           delete currentBatch.diffs[row.id];
@@ -298,8 +305,8 @@ function replicate(repId, src, target, opts, returnValue, result) {
         completeReplication();
         throw new Error('cancelled');
       }
-      result.last_seq = last_seq = currentBatch.seq;
-      returnValue.emit('change', utils.clone(result));
+      outResult.last_seq = last_seq = currentBatch.seq;
+      returnValue.emit('change', outResult);
       currentBatch = undefined;
       getChanges();
     }).catch(function (err) {
@@ -352,7 +359,7 @@ function replicate(repId, src, target, opts, returnValue, result) {
       if (batches.length === 0 && !currentBatch) {
         if ((continuous && changesOpts.live) || changesCompleted) {
           returnValue.emit('paused');
-          returnValue.emit('uptodate', utils.clone(result));
+          returnValue.emit('uptodate', outResult);
         }
         if (changesCompleted) {
           completeReplication();
@@ -383,9 +390,9 @@ function replicate(repId, src, target, opts, returnValue, result) {
     if (!err.message) {
       err.message = reason;
     }
-    result.ok = false;
-    result.status = 'aborting';
-    result.errors.push(err);
+    outResult.ok = false;
+    outResult.status = 'aborting';
+    outResult.errors.push(err);
     batches = [];
     pendingBatch = {
       seq: 0,
@@ -401,27 +408,27 @@ function replicate(repId, src, target, opts, returnValue, result) {
       return;
     }
     if (state.cancelled) {
-      result.status = 'cancelled';
+      outResult.status = 'cancelled';
       if (writingCheckpoint) {
         return;
       }
     }
-    result.status = result.status || 'complete';
-    result.end_time = new Date();
-    result.last_seq = last_seq;
+    outResult.status = outResult.status || 'complete';
+    outResult.end_time = new Date();
+    outResult.last_seq = last_seq;
     replicationCompleted = state.cancelled = true;
-    var non403s = result.errors.filter(function (error) {
+    var non403s = outResult.errors.filter(function (error) {
       return error.name !== 'unauthorized' && error.name !== 'forbidden';
     });
     if (non403s.length > 0) {
-      var error = result.errors.pop();
-      if (result.errors.length > 0) {
-        error.other_errors = result.errors;
+      var error = outResult.errors.pop();
+      if (outResult.errors.length > 0) {
+        error.other_errors = outResult.errors;
       }
-      error.result = result;
-      backOff(repId, src, target, opts, returnValue, result, error);
+      error.outResult = outResult;
+      backOff(repId, src, target, opts, returnValue, outResult, error);
     } else {
-      returnValue.emit('complete', result);
+      returnValue.emit('complete', outResult);
       returnValue.removeAllListeners();
     }
   }
@@ -436,7 +443,7 @@ function replicate(repId, src, target, opts, returnValue, result) {
       batches.length === 0 &&
       !currentBatch
     ) {
-      returnValue.emit('outofdate', utils.clone(result));
+      returnValue.emit('outofdate', outResult);
     }
     pendingBatch.seq = change.seq;
     pendingBatch.changes.push(change);

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -161,7 +161,8 @@ function replicate(repId, src, target, opts, returnValue, result) {
     docs_read: 0,
     docs_written: 0,
     doc_write_failures: 0,
-    errors: []
+    errors: [],
+    docs: []
   };
   var changesOpts = {};
   returnValue.ready(src, target);
@@ -195,6 +196,8 @@ function replicate(repId, src, target, opts, returnValue, result) {
         var error = errorsById[doc._id];
         if (error) {
           returnValue.emit('denied', utils.clone(error));
+        } else {
+          result.docs = result.docs.concat(doc);
         }
       });
 

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -192,6 +192,7 @@ function replicate(repId, src, target, opts, returnValue, result) {
         return error.name !== 'unauthorized' && error.name !== 'forbidden';
       });
 
+      result.docs = [];
       docs.forEach(function(doc) {
         var error = errorsById[doc._id];
         if (error) {

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -3462,6 +3462,29 @@ adapters.forEach(function (adapters) {
         }).catch(done);
       });
     });
+
+    it.only('#XXXX triggers "replicated" events', function(done) {
+      var replicatedDocs = [];
+      var db = new PouchDB(dbs.name);
+      db.bulkDocs({ docs: docs }, {})
+      .then(function(results) {
+        var replication = db.replicate.to(dbs.remote);
+        replication.on('change', function(change) {
+          console.log('\n"change" Event ===')
+          console.log(change)
+          replicatedDocs = replicatedDocs.concat(change.docs);
+        });
+        return replication;
+      })
+      .then(function() {
+        replicatedDocs.length.should.equal(3);
+        replicatedDocs[0]._id.should.equal('0');
+        replicatedDocs[1]._id.should.equal('1');
+        replicatedDocs[2]._id.should.equal('2');
+        done();
+      })
+      .catch(done);
+    });
   });
 });
 

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -3463,15 +3463,13 @@ adapters.forEach(function (adapters) {
       });
     });
 
-    it.only('#XXXX triggers "replicated" events', function(done) {
+    it('#3270 triggers "change" events with .docs property', function(done) {
       var replicatedDocs = [];
       var db = new PouchDB(dbs.name);
       db.bulkDocs({ docs: docs }, {})
       .then(function(results) {
         var replication = db.replicate.to(dbs.remote);
         replication.on('change', function(change) {
-          console.log('\n"change" Event ===')
-          console.log(change)
           replicatedDocs = replicatedDocs.concat(change.docs);
         });
         return replication;

--- a/tests/integration/test.sync.js
+++ b/tests/integration/test.sync.js
@@ -403,5 +403,32 @@ adapters.forEach(function (adapters) {
         .then(done, done);
       });
     });
+
+    it('#3270 triggers "change" events with .docs property', function(done) {
+      var syncedDocs = [];
+      var db = new PouchDB(dbs.name);
+      var docs = [
+        {_id: '1'},
+        {_id: '2'},
+        {_id: '3'}
+      ];
+
+      db.bulkDocs({ docs: docs }, {})
+      .then(function(results) {
+        var sync = db.sync(dbs.remote);
+        sync.on('change', function(change) {
+          syncedDocs = syncedDocs.concat(change.change.docs);
+        });
+        return sync;
+      })
+      .then(function() {
+        syncedDocs.length.should.equal(3);
+        syncedDocs[0]._id.should.equal('1');
+        syncedDocs[1]._id.should.equal('2');
+        syncedDocs[2]._id.should.equal('3');
+        done();
+      })
+      .catch(done);
+    });
   });
 });


### PR DESCRIPTION
adds `event.docs` property to `change` events of replications.

```js
var docs = [{_id: '0'}, {_id: '1'}, {_id: '2'}];
db.bulkDocs({ docs: docs }, {})
.then(function(results) {
  var replication = db.replicate.to(dbs.remote);
  replication.on('change', function(change) {
    console.log('replicated:', change.docs);
  });
})
// replicated: [{_id: '0'}]
// replicated: [{_id: '1'}]
// replicated: [{_id: '2'}]
```

Once it's good to go, I'll squash and rebase the commits.