### PR TITLE
(#2632) - remove browserified Buffer from build

### DIFF
--- a/lib/adapters/http/http.js
+++ b/lib/adapters/http/http.js
@@ -13,6 +13,7 @@ var utils = require('../../utils');
 var errors = require('../../deps/errors');
 var log = require('debug')('pouchdb:http');
 var isBrowser = typeof process === 'undefined' || process.browser;
+var buffer = require('../../deps/buffer');
 
 function encodeDocId(id) {
   if (/^_(design|local)/.test(id)) {
@@ -470,7 +471,7 @@ function HttpPouch(opts, callback) {
       if (isBrowser) {
         blob = utils.createBlob([utils.fixBinary(binary)], {type: type});
       } else {
-        blob = binary ? new Buffer(binary, 'binary') : '';
+        blob = binary ? new buffer(binary, 'binary') : '';
       }
     }
 

--- a/lib/deps/buffer-browser.js
+++ b/lib/deps/buffer-browser.js
@@ -1,0 +1,2 @@
+// hey guess what, we don't need this in the browser
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "build-perf": "browserify tests/performance/*.js > tests/performance-bundle.js"
   },
   "browser": {
-    "./deps/buffer": false,
     "request": false,
     "crypto": false,
     "./adapters/leveldb/leveldb": false,
@@ -104,6 +103,7 @@
     "./lib/deps/ajax.js": "./lib/deps/ajax-browser.js",
     "./lib/version.js": "./lib/version-browser.js",
     "./lib/adapters/preferredAdapters.js": "./lib/adapters/preferredAdapters-browser.js",
+    "./lib/deps/buffer.js": "./lib/deps/buffer-browser.js",
     "bluebird": "lie",
     "leveldown": "level-js",
     "fs": false


### PR DESCRIPTION
So apparently Browserify does this thing where,
if you do `"./mydep": "false"`, you need to reference
all possible relative paths used to that dependency,
whereas if you just swap it out for an empty
implementation then it works regardless of the relative
path used.

This solution is dumb, but it cuts down the min+gz size
from 51185 to 46298.