### PR TITLE
(#3361) - remove PouchDB.extend

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,6 @@ var PouchDB = require('./setup');
 module.exports = PouchDB;
 
 PouchDB.ajax = require('./deps/ajax');
-PouchDB.extend = require('pouchdb-extend');
 PouchDB.utils = require('./utils');
 PouchDB.Errors = require('./deps/errors');
 PouchDB.replicate = require('./replicate').replicate;

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -127,7 +127,7 @@ testUtils.cleanup = function (dbs, done) {
 // in rev_tree). Doc must have _rev. If prevRev is not specified
 // just insert doc with correct _rev (new_edits=false!)
 testUtils.putAfter = function (db, doc, prevRev, callback) {
-  var newDoc = PouchDB.extend({}, doc);
+  var newDoc = PouchDB.utils.extend({}, doc);
   if (!prevRev) {
     db.put(newDoc, { new_edits: false }, callback);
     return;


### PR DESCRIPTION
`PouchDB.extend` was never an official API, and `extend`
is already exposed in `utils`. Looks like this was
only ever used in the integration tests.