### PR TITLE
(pouchdb/express-pouchdb#164) - adds SERVER=express-pouchdb-minimum

### DIFF
--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -30,6 +30,10 @@ if [[ ! -z $SERVER ]]; then
     node ./tests/misc/pouchdb-express-router.js &
     sleep 5
     export COUCH_HOST='http://127.0.0.1:3000'
+  elif [ "$SERVER" == "express-pouchdb-minimum" ]; then
+    node ./tests/misc/express-pouchdb-minimum-for-pouchdb.js &
+    sleep 5
+    export COUCH_HOST='http://127.0.0.1:3000'
   else
     # I mistype pouchdb-server a lot
     echo -e "Unknown SERVER $SERVER. Did you mean pouchdb-server?\n"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "devDependencies": {
     "bundle-collapser": "^1.1.1",
     "rimraf": "2.2.8",
-    "pouchdb-server": "^0.5.1",
+    "pouchdb-server": "^0.6.1",
+    "express-pouchdb": "^0.13.0",
     "commander": "~2.1.0",
     "uglify-js": "~2.4.6",
     "jshint": "~2.5.10",

--- a/tests/misc/express-pouchdb-minimum-for-pouchdb.js
+++ b/tests/misc/express-pouchdb-minimum-for-pouchdb.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var PouchDB = require('../../');
+
+var app = require('express-pouchdb')(PouchDB, {
+  mode: 'minimumForPouchDB'
+});
+app.listen(3000);


### PR DESCRIPTION
Adds support for the SERVER=express-pouchdb-minimum environment variable in the test code. The resulting server uses express-pouchdb in ``minimumForPouchDB`` mode. The implementation
is very much like pouchdb-express-router's.

I didn't enable this in Travis because I'm not sure if it's worth it - the chances of breaking it but not the normal pouchdb-server test by changing pouchdb code is very small I think. I do plan to run this in Travis for express-pouchdb though. A PR for that will follow.