### PR TITLE
(#136) - Remove test of deprecated local_seq parameter

### DIFF
--- a/tests/integration/test.get.js
+++ b/tests/integration/test.get.js
@@ -102,21 +102,6 @@ adapters.forEach(function (adapter) {
       });
     });
 
-    it('Get local_seq of document', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.post({ test: 'somestuff' }, function (err, info1) {
-        db.get(info1.id, { local_seq: true }, function (err, res) {
-          res._local_seq.should.equal(1);
-          db.post({ test: 'someotherstuff' }, function (err, info2) {
-            db.get(info2.id, { local_seq: true }, function (err, res) {
-              res._local_seq.should.equal(2);
-              done();
-            });
-          });
-        });
-      });
-    });
-
     it('Get revisions of removed doc', function (done) {
       var db = new PouchDB(dbs.name, {auto_compaction: false});
       db.post({ test: 'somestuff' }, function (err, info) {


### PR DESCRIPTION
(#136) - Remove test of deprecated local_seq parameter

Removing a test that was using a ?local_seq=true parameter to ensure that local sequence numbers are sequential. It turns out, post CouchDB 2.0 that local_seq numbers are no longer sequential and become meaningless in a sharded environment.
 
CouchDB 2.0 is set to remove this parameter anyway (https://issues.apache.org/jira/browse/COUCHDB-2537) , so removing this test shouldn't do any harm.
