### PR TITLE
(#136) - Fix "Test test of invalid open_revs parameter"

### DIFF
--- a/tests/integration/test.get.js
+++ b/tests/integration/test.get.js
@@ -724,7 +724,9 @@ adapters.forEach(function (adapter) {
             'not an array': 'or all string'
           }
         }, function (err, res) {
-          err.name.should.equal('unknown_error', 'correct error');
+          var acceptable_errors = ['unknown_error','function_clause'];
+          acceptable_errors.indexOf(err.name)
+            .should.not.equal(-1, 'correct error');
           // unfortunately!
           db.get('foo', {
             open_revs: [


### PR DESCRIPTION
(#136) - Fix "Test test of invalid open_revs parameter"

When giving an invalid parameter to ?open_revs, CouchDB 1.6 and 
CouchDB 2.0 provide different error messages. The former says 
"unknown_error" the latter "function_clause". I've modified the test to 
handle both scenarios.