### PR TITLE
(#3379) - prefer readAsArrayBuffer to BinaryString

### DIFF
--- a/lib/deps/md5.js
+++ b/lib/deps/md5.js
@@ -7,7 +7,7 @@ var MD5_CHUNK_SIZE = 32768;
 
 function sliceShim(arrayBuffer, begin, end) {
   if (typeof arrayBuffer.slice === 'function') {
-    if (!begin) {
+    if (!begin && !end) {
       return arrayBuffer.slice();
     } else if (!end) {
       return arrayBuffer.slice(begin);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -459,6 +459,16 @@ exports.readAsBinaryString = function (blob, callback) {
   }
 };
 
+// simplified API. universal browser support is assumed
+exports.readAsArrayBuffer = function (blob, callback) {
+  var reader = new FileReader();
+  reader.onloadend = function (e) {
+    var result = e.target.result || new ArrayBuffer(0);
+    callback(result);
+  };
+  reader.readAsArrayBuffer(blob);
+};
+
 exports.once = function (fun) {
   var called = false;
   return exports.getArguments(function (args) {
@@ -869,15 +879,15 @@ exports.preprocessAttachments = function preprocessAttachments(
         callback();
       });
     } else { // input is a blob
-      exports.readAsBinaryString(att.data, function (binary) {
+      exports.readAsArrayBuffer(att.data, function (buff) {
         if (blobType === 'binary') {
-          att.data = binary;
+          att.data = exports.arrayBufferToBinaryString(buff);
         } else if (blobType === 'base64') {
-          att.data = exports.btoa(binary);
+          att.data = exports.btoa(exports.arrayBufferToBinaryString(buff));
         }
-        exports.MD5(binary).then(function (result) {
+        exports.MD5(buff).then(function (result) {
           att.digest = 'md5-' + result;
-          att.length = binary.length;
+          att.length = buff.byteLength;
           callback();
         });
       });

--- a/tests/performance/index.js
+++ b/tests/performance/index.js
@@ -11,6 +11,7 @@ function runTestSuites(PouchDB) {
 
   require('./perf.basics')(PouchDB, opts);
   require('./perf.views')(PouchDB, opts);
+  require('./perf.attachments')(PouchDB, opts);
 }
 var startNow = true;
 if (global.window && global.window.location && global.window.location.search) {

--- a/tests/performance/perf.attachments.js
+++ b/tests/performance/perf.attachments.js
@@ -1,0 +1,60 @@
+'use strict';
+
+function randomBrowserBlob(size) {
+  var buff = new ArrayBuffer(size);
+  var arr = new Uint8Array(buff);
+  for (var i = 0; i < size; i++) {
+    arr[i] = Math.floor(65535 * Math.random());
+  }
+  return new Blob([buff], {type: 'application/octet-stream'});
+}
+
+function randomBuffer(size) {
+  var buff = new Buffer(size);
+  for (var i = 0; i < size; i++) {
+    buff.write(
+      String.fromCharCode(Math.floor(65535 * Math.random())),
+      i, 1, 'binary');
+  }
+  return buff;
+}
+
+
+function randomBlob(size) {
+  if (process.browser) {
+    return randomBrowserBlob(size);
+  } else { // node
+    return randomBuffer(size);
+  }
+}
+
+module.exports = function (PouchDB, opts) {
+
+  // need to use bluebird for promises everywhere, so we're comparing
+  // apples to apples
+  require('bluebird'); // var Promise = require('bluebird');
+  var utils = require('./utils');
+
+  var testCases = [
+    {
+      name: 'basic-attachments',
+      assertions: 1,
+      iterations: 1000,
+      setup: function (db, callback) {
+
+        var blob = randomBlob(50000);
+        db._blob = blob;
+        callback();
+      },
+      test: function (db, itr, doc, done) {
+        db.putAttachment(Math.random().toString(), 'foo.txt', db._blob,
+          'application/octet-stream').then(function () {
+          done();
+        }, done);
+      }
+    }
+  ];
+
+  utils.runTests(PouchDB, 'views', testCases, opts);
+
+};


### PR DESCRIPTION
I have no evidence that this produces better
performance, but my intuition tells me so.

It just seems silly to convert a Blob to a binary string
just for the purposes of MD5 hashing. Presumably
ArrayBuffers are better at memory management.