### PR TITLE
(#3369) - disable blobSupport in Chrome, fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,9 @@ env:
   - AUTO_COMPACTION=true CLIENT=selenium:phantomjs ES5_SHIM=true COMMAND=test
 
   # Testing in saucelabs
-  - CLIENT=saucelabs:chrome COMMAND=test
   - CLIENT=saucelabs:chrome:36 COMMAND=test
   - CLIENT=saucelabs:chrome:37 COMMAND=test
+  - CLIENT=saucelabs:chrome:39 COMMAND=test
   - CLIENT=saucelabs:safari:6 COMMAND=test
   - CLIENT="saucelabs:iphone:7.1:OS X 10.9" COMMAND=test
   - CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test

--- a/lib/adapters/idb/idb-blob-support.js
+++ b/lib/adapters/idb/idb-blob-support.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var utils = require('../../utils');
+var idbConstants = require('./idb-constants');
+var DETECT_BLOB_SUPPORT_STORE = idbConstants.DETECT_BLOB_SUPPORT_STORE;
+
+//
+// Detect blob support. Chrome didn't support it until version 38.
+// In version 37 they had a broken version where PNGs (and possibly
+// other binary types) aren't stored correctly, because when you fetch
+// them, the content type is always null.
+//
+// Furthermore, they have some outstanding bugs where blobs occasionally
+// are read by FileReader as null, or by ajax as 404s.
+//
+// Sadly we use the 404 bug to detect the FileReader bug, so if they
+// get fixed independently and released in different versions of Chrome,
+// then the bug could come back. So it's worthwhile to watch these issues:
+// 404 bug: https://code.google.com/p/chromium/issues/detail?id=447916
+// FileReader bug: https://code.google.com/p/chromium/issues/detail?id=447836
+//
+function checkBlobSupport(txn, idb) {
+  return new utils.Promise(function (resolve, reject) {
+    var blob = utils.createBlob([''], {type: 'image/png'});
+    txn.objectStore(DETECT_BLOB_SUPPORT_STORE).put(blob, 'key');
+    txn.oncomplete = function () {
+      // have to do it in a separate transaction, else the correct
+      // content type is always returned
+      var blobTxn = idb.transaction([DETECT_BLOB_SUPPORT_STORE],
+        'readwrite');
+      var getBlobReq = blobTxn.objectStore(
+        DETECT_BLOB_SUPPORT_STORE).get('key');
+      getBlobReq.onerror = reject;
+      getBlobReq.onsuccess = function (e) {
+
+        var storedBlob = e.target.result;
+        var url = URL.createObjectURL(storedBlob);
+
+        utils.ajax({
+          url: url,
+          cache: true,
+          binary: true
+        }, function (err, res) {
+          if (err && err.status === 405) {
+            // firefox won't let us do that. but firefox doesn't
+            // have the blob type bug that Chrome does, so that's ok
+            resolve(true);
+          } else {
+            resolve(!!(res && res.type === 'image/png'));
+            if (err && err.status === 404) {
+              utils.explain404('PouchDB is just detecting blob URL support.');
+            }
+          }
+          URL.revokeObjectURL(url);
+        });
+      };
+    };
+  }).catch(function () {
+    return false; // error, so assume unsupported
+  });
+}
+
+module.exports = checkBlobSupport;

--- a/lib/adapters/idb/idb.js
+++ b/lib/adapters/idb/idb.js
@@ -6,6 +6,7 @@ var errors = require('../../deps/errors');
 var idbUtils = require('./idb-utils');
 var idbConstants = require('./idb-constants');
 var idbBulkDocs = require('./idb-bulk-docs');
+var checkBlobSupport = require('./idb-blob-support');
 
 var ADAPTER_VERSION = idbConstants.ADAPTER_VERSION;
 var ATTACH_AND_SEQ_STORE = idbConstants.ATTACH_AND_SEQ_STORE;
@@ -997,52 +998,9 @@ function init(api, opts, callback) {
         };
       }
 
-      // Detect blob support. Chrome didn't support it until version 38.
-      // in version 37 they had a broken version where PNGs (and possibly
-      // other binary types) aren't stored correctly.
       if (!blobSupportPromise) {
-
-        // make sure blob support is only checked one
-        blobSupportPromise = new utils.Promise(function (resolve, reject) {
-          // 1x1 transparent PNG
-          var blob = utils.createBlob([utils.fixBinary(utils.atob(
-            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAA' +
-            'BCAQAAAC1HAwCAAAAC0lEQVQYV2NgYA' +
-            'AAAAMAAWgmWQ0AAAAASUVORK5CYII='
-          ))], {type: 'image/png'});
-          txn.objectStore(DETECT_BLOB_SUPPORT_STORE).put(blob, 'key');
-          txn.oncomplete = function () {
-            // have to do it in a separate transaction, else the correct
-            // content type is always returned
-            var blobTxn = idb.transaction([DETECT_BLOB_SUPPORT_STORE],
-              'readwrite');
-            var getBlobReq = blobTxn.objectStore(
-              DETECT_BLOB_SUPPORT_STORE).get('key');
-            getBlobReq.onerror = reject;
-            getBlobReq.onsuccess = function (e) {
-
-              var storedBlob = e.target.result;
-              var url = URL.createObjectURL(storedBlob);
-
-              utils.ajax({
-                url: url,
-                cache: true,
-                binary: true
-              }, function (err, res) {
-                if (err && err.status === 405) {
-                  // firefox won't let us do that. but firefox doesn't
-                  // have the blob type bug that Chrome does, so that's ok
-                  resolve(true);
-                } else {
-                  resolve(!!(res && res.type === 'image/png'));
-                }
-                URL.revokeObjectURL(url);
-              });
-            };
-          };
-        }).catch(function () {
-          return false; // error, so assume unsupported
-        });
+        // make sure blob support is only checked once
+        blobSupportPromise = checkBlobSupport(txn, idb);
       }
 
       blobSupportPromise.then(function (val) {


### PR DESCRIPTION
This essentially reverts fce1c97, meaning we're back to
using the 404 test to disable blob support in Chrome/Android/Opera.

This is somewhat flakey because we're using one bug to detect
another, but I'm really hoping to avoid UA sniffing here.

I also moved `idb-blob-support.js` to its own file and changed
the Travis tests so that we test Chrome 39 explicitly. I confirmed
that 38 and 39 are currently failing in master, so I don't know
which version Sauce is giving us when we don't specify the version. It
seems pointless to test it without the version, if we aren't actually
getting the latest stable.