### PR TITLE
(#3381) - remove useless md5 code

### DIFF
--- a/lib/deps/md5.js
+++ b/lib/deps/md5.js
@@ -95,9 +95,6 @@ module.exports = function (data, callback) {
   function loadNextChunk() {
     var start = currentChunk * chunkSize;
     var end = start + chunkSize;
-    if ((start + chunkSize) >= data.size) {
-      end = data.size;
-    }
     currentChunk++;
     if (currentChunk < chunks) {
       append(buffer, data, start, end);


### PR DESCRIPTION
Two things:

* `size` isn't correct; it's `length` or `byteLength`
* both `slice` and `substring` are clamped anyway, so
  this is useless