### PR TITLE
(#136) - Fix "issue #2342 update_seq after replication"

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -2916,7 +2916,11 @@ adapters.forEach(function (adapters) {
                 live: true,
                 onChange: function (change) {
                   change.changes.should.have.length(1);
-                  change.seq.should.equal(info.update_seq);
+
+                  // not a valid assertion in CouchDB 2.0
+                  if (!testUtils.isCouchMaster()) {
+                    change.seq.should.equal(info.update_seq);
+                  }
                   done();
                 }
               });


### PR DESCRIPTION
Do not assume that the update_seq and change seq are equal (not true in CouchDB 2.0).