### PR TITLE
(#136) - Fix '#3270 triggers "change" events with .docs property'

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -3482,6 +3482,9 @@ adapters.forEach(function (adapters) {
         return replication;
       })
       .then(function() {
+        replicatedDocs.sort(function (a, b) {
+          return a._id > b._id ? 1 : -1;
+        });
         replicatedDocs.length.should.equal(3);
         replicatedDocs[0]._id.should.equal('0');
         replicatedDocs[1]._id.should.equal('1');

--- a/tests/integration/test.sync.js
+++ b/tests/integration/test.sync.js
@@ -422,6 +422,10 @@ adapters.forEach(function (adapters) {
         return sync;
       })
       .then(function() {
+        syncedDocs.sort(function (a, b) {
+          return a._id > b._id ? 1 : -1;
+        });
+
         syncedDocs.length.should.equal(3);
         syncedDocs[0]._id.should.equal('1');
         syncedDocs[1]._id.should.equal('2');


### PR DESCRIPTION
Changes might not be ordered in CouchDB 2.0 / Cloudant. Sort the results before making assertions on the content.