### PR TITLE
(#136) - Skip taskqueue "Query" test

### DIFF
--- a/tests/integration/test.taskqueue.js
+++ b/tests/integration/test.taskqueue.js
@@ -25,6 +25,11 @@ adapters.forEach(function (adapter) {
     });
 
     it('Query', function (done) {
+      // temp views are not supported in CouchDB 2.0
+      if (testUtils.isCouchMaster()) {
+        return done();
+      }
+
       var db = new PouchDB(dbs.name);
       var queryFun = {
         map: function (doc) {


### PR DESCRIPTION
CouchDB 2.0 doesn't support temporary views so skip this test against it.