### PR TITLE
(#136) - Fix taskqueue / Info test against CouchDB 2.0

### DIFF
--- a/tests/integration/test.taskqueue.js
+++ b/tests/integration/test.taskqueue.js
@@ -62,7 +62,9 @@ adapters.forEach(function (adapter) {
       var db = new PouchDB(dbs.name);
       db.info(function (err, info) {
         info.doc_count.should.equal(0);
-        info.update_seq.should.equal(0);
+        if (!testUtils.isCouchMaster()) {
+          info.update_seq.should.equal(0);
+        }
         done();
       });
     });


### PR DESCRIPTION
Initial update_seq is deterministic for a new CouchDB 2.0 database. Skip this assertion when running this test against it.