### PR TITLE
(#3395) - Return 404 when open_revs is requested for missing doc

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -510,9 +510,7 @@ AbstractPouchDB.prototype.get =
     if (opts.open_revs === "all") {
       this._getRevisionTree(id, function (err, rev_tree) {
         if (err) {
-          // if there's no such document we should treat this
-          // situation the same way as if revision tree was empty
-          rev_tree = [];
+          return callback(err);
         }
         leaves = merge.collectLeaves(rev_tree).map(function (leaf) {
           return leaf.rev;

--- a/tests/integration/test.get.js
+++ b/tests/integration/test.get.js
@@ -694,8 +694,16 @@ adapters.forEach(function (adapter) {
         res.length.should.equal(1, 'just one result');
         res[0].missing.should.equal('2-whatever', 'just one result');
         db.get('nonexistent', { open_revs: 'all' }, function (err, res) {
-          res.length.should.equal(0, 'no open revisions');
-          done();
+          // CouchDB 1.X doesn't handle this situation correctly
+          // CouchDB 2.0 fixes it (see COUCHDB-2517)
+          testUtils.isCouchDB(function (isCouchDB) {
+            if (isCouchDB && !testUtils.isCouchMaster()) {
+              return done();
+            }
+
+            err.status.should.equal(404);
+            done();
+          });
         });
       });
     });


### PR DESCRIPTION
CouchDB 1.X crashes and returns a 200 response when a request for open_revs on a non-existent document is made. In CouchDB 2.0 this is
fixed (COUCHDB-2517) and it now returns a 404 which seems like the correct response.

We were previously matching the CouchDB 1.X behaviour and hiding this error condition. This commit allows the error to propagate up, matching the new CouchDB behaviour.

The fix in the tests is a little ugly as we need to skip the assertion when testing against CouchDB 1.X.