### PR TITLE
(#2676) Ignore _removed field

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,7 +43,9 @@ var reservedWords = toObject([
   '_replication_state',
   '_replication_state_time',
   '_replication_state_reason',
-  '_replication_stats'
+  '_replication_stats',
+  // Specific to Couchbase Sync Gateway
+  '_removed'
 ]);
 
 // List of reserved words that should end up the document


### PR DESCRIPTION
This is needed to support Couchbase Sync Gateway, which adds this field when a document previously accessible by a user in a channel isn’t accessible anymore.

A complete implementation of this feature would effectively delete the document locally and emit proper ```delete``` event.

I didn't add any test for this, since we would need in my opinion to run an integration test against a Couchbase Sync Gateway instance.