### PR TITLE
Fix a comment

### DIFF
--- a/lib/adapters/http/http.js
+++ b/lib/adapters/http/http.js
@@ -623,9 +623,9 @@ function HttpPouch(opts, callback) {
     var body;
     var method = 'GET';
 
-    // TODO I don't see conflicts as a valid parameter for a
-    // _all_docs request 
-    // (see http://wiki.apache.org/couchdb/HTTP_Document_API#all_docs)
+    // Supported only by Couchbase
+    // http://developer.couchbase.com/mobile/develop/references/couchbase-lite/
+    // rest-api/database/get-all-docs/index.html
     if (opts.conflicts) {
       params.push('conflicts=true');
     }


### PR DESCRIPTION
The ```conflicts``` option is actually supported by Couchbase.