### PR TITLE
(pouchdb/express-pouchdb#194) - fix callback called twice

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -425,44 +425,34 @@ AbstractPouchDB.prototype.compact =
   });
 });
 AbstractPouchDB.prototype._compact = function (opts, callback) {
-  var done = false;
-  var started = 0;
-  var copts = {
-    returnDocs: false
-  };
   var self = this;
-  var lastSeq;
-  function finish() {
-    upsert(self, '_local/compaction', function (doc) {
-      if (!doc.last_seq || doc.last_seq < lastSeq) {
-        doc.last_seq = lastSeq;
-        return doc;
-      }
-      return false; // somebody else got here first, don't update
-    }, function () {
-      callback(null, {ok: true});
-    });
-  }
-  if (opts.last_seq) {
-    copts.since = opts.last_seq;
-  }
-  function afterCompact() {
-    started--;
-    if (!started && done) {
-      finish();
-    }
-  }
+  var changesOpts = {
+    returnDocs: false,
+    last_seq: opts.last_seq || 0
+  };
+  var promises = [];
+
   function onChange(row) {
-    started++;
-    self.compactDocument(row.id, 0).then(afterCompact, callback);
+    promises.push(self.compactDocument(row.id, 0));
   }
-  self.changes(copts).on('change', onChange).on('complete', function (resp) {
-    done = true;
-    lastSeq = resp.last_seq;
-    if (!started) {
-      finish();
-    }
-  }).on('error', callback);
+  function onComplete(resp) {
+    var lastSeq = resp.last_seq;
+    Promise.all(promises).then(function () {
+      return upsert(self, '_local/compaction', function deltaFunc(doc) {
+        if (!doc.last_seq || doc.last_seq < lastSeq) {
+          doc.last_seq = lastSeq;
+          return doc;
+        }
+        return false; // somebody else got here first, don't update
+      });
+    }).then(function () {
+      callback(null, {ok: true});
+    }).catch(callback);
+  }
+  self.changes(changesOpts)
+    .on('change', onChange)
+    .on('complete', onComplete)
+    .on('error', callback);
 };
 /* Begin api wrappers. Specific functionality to storage belongs in the 
    _[method] */

--- a/lib/adapters/leveldb/leveldb.js
+++ b/lib/adapters/leveldb/leveldb.js
@@ -1113,7 +1113,7 @@ function LevelPouch(opts, callback) {
         }
         if (++numDone === revs.length) { // done
           if (overallErr) {
-            return callback(err);
+            return callback(overallErr);
           }
           deleteOrphanedAttachments();
         }
@@ -1192,9 +1192,6 @@ function LevelPouch(opts, callback) {
 
       revs.forEach(function (rev) {
         var seq = seqs[rev];
-        if (!seq) {
-          return;
-        }
         batch.push({
           key: formatSeq(seq),
           type: 'del',


### PR DESCRIPTION
The `leveldb.js` fixes are actually unrelated; I was just doing some code cleanup over there.