### PR TITLE
(#3405) - remove pouchdb-express-router test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,6 @@ env:
   - CLIENT=selenium:firefox SERVER=pouchdb-server COMMAND=test
   - SERVER_ADAPTER=memory LEVEL_ADAPTER=memdown SERVER=pouchdb-server COMMAND=test
 
-  # Test against pouchdb-express-router
-  - CLIENT=node SERVER=pouchdb-express-router COMMAND=test
-
   # Test in firefox/phantomjs running on travis
   - CLIENT=selenium:firefox COMMAND=test
   - CLIENT=selenium:phantomjs ES5_SHIM=true COMMAND=test


### PR DESCRIPTION
So now that we have the `minimumForPouchDB` mode
in express-pouchdb, I think we can deprecate
pouchdb-express-router. Having two parallel
codebases always made me nervous anyway.