### PR TITLE
(#3382) - mark websql as invalid when errored

### DIFF
--- a/lib/adapters/websql/websql.js
+++ b/lib/adapters/websql/websql.js
@@ -993,7 +993,28 @@ function WebSqlPouch(opts, callback) {
 }
 
 WebSqlPouch.valid = function () {
-  return !!openDBFunction;
+  // Some environments (WKWebView, Chrome for iOS, Android WebView
+  // when mis-configured) will throw Security Exception 11 or
+  // Security Exception 18 here. We can catch that by opening
+  // up a test database.
+  if (!openDBFunction) {
+    return false;
+  }
+  // PhantomJS fails our tests for some baffling reason if we
+  // open up this extra DB: https://github.com/pouchdb/pouchdb/pull/3406
+  // Since this test is really just for Android WebView, iOS Chrome,
+  // and WKWebView, assume PhantomJS is fine.
+  if (/PhantomJS/.test(navigator.userAgent)) {
+    return true;
+  }
+  try {
+    var dbName = '__pouchdb_meta';
+    openDBFunction(dbName, 1, dbName, 1);
+    return true;
+  } catch (err) {
+    // ignore
+  }
+  return false;
 };
 
 WebSqlPouch.destroy = utils.toPromise(function (name, opts, callback) {


### PR DESCRIPTION
The hardest thing about this commit is figuring out what to call the stupid "test" database that we can never possibly delete.

I feel like the shortest possible name will confuse people the least. Seeing a database called `__pouchdb_meta` should not be too shocking or confusing (e.g. in phonegap this would become a `__pouchdb_meta.db` file).

This commit makes me sad, but let's do it.