### PR TITLE
(#136) - Fix "#2342 update_seq after replication"

### DIFF
--- a/lib/changes.js
+++ b/lib/changes.js
@@ -141,20 +141,32 @@ Changes.prototype.doChanges = function (opts) {
     opts.since = 0;
   }
   if (opts.since === 'now') {
-    this.db.info().then(function (info) {
+    this.db.changes({
+      descending: true,
+      limit: 2
+    }).then(function (resp) {
       if (self.isCancelled) {
         callback(null, {status: 'cancelled'});
         return;
       }
-      opts.since = info.update_seq  - 1;
+      opts.since = resp.results.length > 1 ?
+        resp.last_seq : 0;
       self.doChanges(opts);
     }, callback);
     return;
   }
 
   if (opts.continuous && opts.since !== 'now') {
-    this.db.info().then(function (info) {
-      self.startSeq = info.update_seq - 1;
+    this.db.changes({
+      descending: true,
+      limit: 2
+    }).then(function (resp) {
+      if (self.isCancelled) {
+        callback(null, {status: 'cancelled'});
+        return;
+      }
+      self.startSeq = resp.results.length > 1 ?
+        resp.last_seq : 0;
     }, function (err) {
       if (err.id === 'idbNull') {
         //db closed before this returned


### PR DESCRIPTION
Do not use sequence number arithmetic when calculating the sequence number for use with since=now/latest or continuous changes feeds.

CouchDB 2.0 represents sequence numbers as opaque blobs so the previous approach would fail. Rather than deduct 1 from the current sequence number, this commit fetches the latest 2 results from the changes feed and uses the second as the starting point for the original call. If less than two results are returned then we start from 0.

This also fixes most issues identified in #3220.