### PR TITLE
(#3220) - remove sequence number arithmetic in changes.js

### DIFF
--- a/lib/changes.js
+++ b/lib/changes.js
@@ -146,7 +146,7 @@ Changes.prototype.doChanges = function (opts) {
         callback(null, {status: 'cancelled'});
         return;
       }
-      opts.since = info.update_seq  - 1;
+      opts.since = info.update_seq;
       self.doChanges(opts);
     }, callback);
     return;
@@ -154,7 +154,7 @@ Changes.prototype.doChanges = function (opts) {
 
   if (opts.continuous && opts.since !== 'now') {
     this.db.info().then(function (info) {
-      self.startSeq = info.update_seq - 1;
+      self.startSeq = info.update_seq;
     }, function (err) {
       if (err.id === 'idbNull') {
         //db closed before this returned

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -2920,8 +2920,8 @@ adapters.forEach(function (adapters) {
           db.replicate.from(dbs.remote, function (err, _) {
             db.info(function (err, info) {
               db.changes({
-                since: 'latest',
-                live: true,
+                descending: true,
+                limit: 1,
                 onChange: function (change) {
                   change.changes.should.have.length(1);
 
@@ -2963,8 +2963,8 @@ adapters.forEach(function (adapters) {
           db.replicate.from(dbs.remote, function (err, _) {
             db.info(function (err, info) {
               var changes = db.changes({
-                since: 'latest',
-                live: true,
+                descending: true,
+                limit: 1,
                 onChange: function (change) {
                   change.changes.should.have.length(1);
                   change.seq.should.equal(info.update_seq);
@@ -2973,8 +2973,8 @@ adapters.forEach(function (adapters) {
                 complete: function() {
                   remote.info(function (err, info) {
                     var rchanges = remote.changes({
-                      since: 'latest',
-                      live: true,
+                      descending: true,
+                      limit: 1,
                       onChange: function (change) {
                         change.changes.should.have.length(1);
                         change.seq.should.equal(info.update_seq);


### PR DESCRIPTION
Remove the seq - 1 logic from since=now/latest and continuous changes implementation. This commit is just to observe/document the test failures.