### PR TITLE
3176 - fix changes/last_seq in local storage adapters

### DIFF
--- a/lib/adapters/idb/idb.js
+++ b/lib/adapters/idb/idb.js
@@ -628,8 +628,6 @@ function init(api, opts, callback) {
       var doc = decodeDoc(cursor.value);
       var seq = cursor.key;
 
-      lastSeq = seq;
-
       if (docIds && !docIds.has(doc._id)) {
         return cursor.continue();
       }
@@ -641,6 +639,8 @@ function init(api, opts, callback) {
           // some other seq is later
           return cursor.continue();
         }
+
+        lastSeq = seq;
 
         if (metadata.winningRev === doc._rev) {
           return onGetWinningDoc(doc);

--- a/lib/adapters/leveldb/leveldb.js
+++ b/lib/adapters/leveldb/leveldb.js
@@ -952,8 +952,6 @@ function LevelPouch(opts, callback) {
         return next();
       }
 
-      lastSeq = seq;
-
       if (docIds && !docIds.has(doc._id)) {
         return next();
       }
@@ -992,6 +990,8 @@ function LevelPouch(opts, callback) {
           // some other seq is later
           return next();
         }
+
+        lastSeq = seq;
 
         if (winningRev === doc._rev) {
           return onGetWinningDoc(doc);


### PR DESCRIPTION
Matching CouchDB behaviour, the last_seq field in _changes should represent the last active change processed.
    
The previous implementation was correct for the WebSQL adapter. However, the IndexedDB and LevelDB adapters would update last_seq for each change regardless of whether there was a more recent version of the document in the database (which would subsequently be filtered out of the feed).
This worked for ascending changes but when querying the feed in descending order, the bug was exposed.

In this commit, we increment last_seq after checking that the current change represents the max revision of the current document.

TODO: check the behaviour when conflicts are present - possibly we need to set last_seq for the winning revision rather than the max revision?
