### PR TITLE
(#136) - Skip migration tests against CouchDB master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ env:
 
   # Test CouchDB master (aka bigcouch branch)
   - BAIL=0 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - BAIL=0 CLIENT=selenium:firefox SERVER=couchdb-master COMMAND=test
+  - BAIL=0 SKIP_MIGRATION=true CLIENT=selenium:firefox SERVER=couchdb-master COMMAND=test
 
   # Performance tests
   - CLIENT=selenium:firefox PERF=1 COMMAND=test
@@ -78,7 +78,7 @@ env:
 
 matrix:
  allow_failures:
- - env: BAIL=0 CLIENT=selenium:firefox SERVER=couchdb-master COMMAND=test
+ - env: BAIL=0 SKIP_MIGRATION=true CLIENT=selenium:firefox SERVER=couchdb-master COMMAND=test
  fast_finish: true
 
 branches:


### PR DESCRIPTION
The browser migration tests fail against CouchDB master because older versions of PouchDB (<=3.2.0) don't support replication against it. Given that migrations are well tested against other servers, skip them against CouchDB master for now.