### PR TITLE
136 enable blocked assertions

### DIFF
--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -2072,11 +2072,6 @@ adapters.forEach(function (adapter) {
     });
 
     it('#2569 Big non-live doc_ids filter', function () {
-      // blocked on https://issues.apache.org/jira/browse/COUCHDB-2530
-      if (testUtils.isCouchMaster()) {
-        return true;
-      }
-      
       var docs = [];
       for (var i = 0; i < 5; i++) {
         var id = '';
@@ -2132,11 +2127,6 @@ adapters.forEach(function (adapter) {
     });
 
     it('#2569 Big live doc_ids filter', function () {
-      // blocked on https://issues.apache.org/jira/browse/COUCHDB-2530
-      if (testUtils.isCouchMaster()) {
-        return true;
-      }
-
       var docs = [];
       for (var i = 0; i < 5; i++) {
         var id = '';

--- a/tests/integration/test.revs_diff.js
+++ b/tests/integration/test.revs_diff.js
@@ -102,11 +102,6 @@ adapters.forEach(function (adapter) {
     });
 
     it('Revs diff with empty revs', function () {
-      // blocked on COUCHDB-2531
-      if (testUtils.isCouchMaster()) {
-        return true;
-      }
-
       return new PouchDB(dbs.name).then(function (db) {
         return db.revsDiff({}).then(function (res) {
           should.exist(res);


### PR DESCRIPTION
Re-enable assertions against CouchDB master blocked on COUCHDB-2530 and COUCHDB-2531 (both now fixed).