### PR TITLE
(#3039) - WIP DON'T MERGE - use a bloomfilter for idb

### DIFF
--- a/lib/adapters/idb/idb-bulk-docs.js
+++ b/lib/adapters/idb/idb-bulk-docs.js
@@ -118,7 +118,13 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
         checkDone(); // skip local docs
         continue;
       }
-      var req = docStore.get(docInfo.metadata.id);
+      var id = docInfo.metadata.id;
+      if (!api._docIdsFilter.test(id)) { // doesn't exist
+        api._docIdsFilter.add(id); // for races with simultaneous bulkDocs
+        checkDone();
+        continue;
+      }
+      var req = docStore.get(id);
       req.onsuccess = readMetadata;
     }
   }
@@ -128,8 +134,8 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
       return;
     }
 
-    Changes.notify(api._name);
     api._docCount = -1; // invalidate
+    Changes.notify(api._name);
     callback(null, results);
   }
 

--- a/lib/adapters/idb/idb-utils.js
+++ b/lib/adapters/idb/idb-utils.js
@@ -241,3 +241,16 @@ exports.openTransactionSafely = function (idb, stores, mode) {
     };
   }
 };
+
+// simplified cursor API
+exports.openCursor = function (store, range, onGetCursor, onDone) {
+  var cursor = range ? store.openCursor(range) : store.openCursor();
+  cursor.onsuccess = function (e) {
+    cursor = e.target.result;
+    if (!cursor) {
+      return onDone();
+    }
+    onGetCursor(cursor);
+    cursor.continue();
+  };
+};

--- a/lib/adapters/idb/idb.js
+++ b/lib/adapters/idb/idb.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var BloomFilter = require('bloomfilter').BloomFilter;
 var utils = require('../../utils');
 var merge = require('../../merge');
 var errors = require('../../deps/errors');
@@ -28,6 +29,7 @@ var postProcessAttachments = idbUtils.postProcessAttachments;
 var readBlobData = idbUtils.readBlobData;
 var taskQueue = idbUtils.taskQueue;
 var openTransactionSafely = idbUtils.openTransactionSafely;
+var openCursor = idbUtils.openCursor;
 
 var cachedDBs = {};
 var blobSupportPromise;
@@ -54,6 +56,7 @@ function init(api, opts, callback) {
   api._docCount = -1;
   api._blobSupport = null;
   api._name = name;
+  api._docIdsFilter = null;
 
   // called when creating a fresh new database
   function createSchema(db) {
@@ -294,6 +297,12 @@ function init(api, opts, callback) {
     var err;
     var txn;
     opts = utils.clone(opts);
+
+    // check the cache first for perf
+    if (!api._docIdsFilter.test(id)) {
+      return callback(errors.error(errors.MISSING_DOC, 'missing'));
+    }
+
     if (opts.ctx) {
       txn = opts.ctx;
     } else {
@@ -827,6 +836,12 @@ function init(api, opts, callback) {
 
 
   api._getLocal = function (id, callback) {
+
+    // check the cache first for perf
+    if (!api._docIdsFilter.test(id)) {
+      return callback(errors.error(errors.MISSING_DOC));
+    }
+
     var txnResult = openTransactionSafely(idb, [LOCAL_STORE], 'readonly');
     if (txnResult.error) {
       return callback(txnResult.error);
@@ -858,7 +873,12 @@ function init(api, opts, callback) {
       doc._rev = '0-1';
     } else {
       doc._rev = '0-' + (parseInt(oldRev.split('-')[1], 10) + 1);
+      if (!api._docIdsFilter.test(doc._id)) {
+        // doc doesn't exist
+        return callback(errors.error(errors.REV_CONFLICT));
+      }
     }
+    api._docIdsFilter.add(doc._id); // prevent from using cache later
 
     var tx = opts.ctx;
     var ret;
@@ -945,6 +965,7 @@ function init(api, opts, callback) {
     idb = cached.idb;
     instanceId = cached.instanceId;
     api._blobSupport = cached.blobSupport;
+    api._docIdsFilter = cached.docIdsFilter;
     process.nextTick(function () {
       callback(null, api);
     });
@@ -1009,50 +1030,83 @@ function init(api, opts, callback) {
       delete cachedDBs[name];
     };
 
-    var txn = idb.transaction([META_STORE, DETECT_BLOB_SUPPORT_STORE],
+    var txn = idb.transaction([
+        META_STORE,
+        DETECT_BLOB_SUPPORT_STORE,
+        DOC_STORE,
+        LOCAL_STORE
+      ],
       'readwrite');
 
     var req = txn.objectStore(META_STORE).get(META_STORE);
 
     req.onsuccess = function (e) {
 
-      var checkSetupComplete = function () {
-        if (api._blobSupport === null || !idStored) {
+      function checkSetupComplete() {
+        if (api._blobSupport === null || !idStored || !api._docIdsFilter) {
           return;
         } else {
           cachedDBs[name] = {
             idb: idb,
             instanceId: instanceId,
             blobSupport: api._blobSupport,
+            docIdsFilter:  api._docIdsFilter,
             loaded: true
           };
           callback(null, api);
         }
-      };
+      }
 
-      var meta = e.target.result || {id: META_STORE};
-      if (name  + '_id' in meta) {
-        instanceId = meta[name + '_id'];
-        idStored = true;
-        checkSetupComplete();
-      } else {
-        instanceId = utils.uuid();
-        meta[name + '_id'] = instanceId;
-        txn.objectStore(META_STORE).put(meta).onsuccess = function () {
+      function storeId() {
+        var meta = e.target.result || {id: META_STORE};
+        if (name  + '_id' in meta) {
+          instanceId = meta[name + '_id'];
           idStored = true;
           checkSetupComplete();
-        };
+        } else {
+          instanceId = utils.uuid();
+          meta[name + '_id'] = instanceId;
+          txn.objectStore(META_STORE).put(meta).onsuccess = function () {
+            idStored = true;
+            checkSetupComplete();
+          };
+        }
       }
 
-      if (!blobSupportPromise) {
-        // make sure blob support is only checked once
-        blobSupportPromise = checkBlobSupport(txn, idb);
+      function doCheckBlobSupport() {
+        if (!blobSupportPromise) {
+          // make sure blob support is only checked once
+          blobSupportPromise = checkBlobSupport(txn, idb);
+        }
+
+        blobSupportPromise.then(function (val) {
+          api._blobSupport = val;
+          checkSetupComplete();
+        });
       }
 
-      blobSupportPromise.then(function (val) {
-        api._blobSupport = val;
-        checkSetupComplete();
-      });
+      function fetchDocIds() {
+        var docIds = new BloomFilter(8192, 16);
+        var numDone = 0;
+
+        function onGetCursor(cursor) {
+          docIds.add(cursor.primaryKey);
+        }
+
+        function checkDone() {
+          if (++numDone === 2) {
+            api._docIdsFilter = docIds;
+            checkSetupComplete();
+          }
+        }
+
+        openCursor(txn.objectStore(DOC_STORE), null, onGetCursor, checkDone);
+        openCursor(txn.objectStore(LOCAL_STORE), null, onGetCursor, checkDone);
+      }
+
+      storeId();
+      doCheckBlobSupport();
+      fetchDocIds();
     };
   };
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "pouchdb"
   ],
   "dependencies": {
+    "bloomfilter": "^0.0.14",
     "pouchdb-upsert": "^1.0.2",
     "pouchdb-collections": "^1.0.0",
     "argsarray": "0.0.1",

--- a/tests/integration/test.bulk_docs.js
+++ b/tests/integration/test.bulk_docs.js
@@ -685,6 +685,12 @@ adapters.forEach(function (adapter) {
     });
 
     it('handles simultaneous writes', function (done) {
+      if (testUtils.isCouchMaster()) {
+        // couch might give a 201 for both writes
+        true.should.equal(true);
+        return done();
+      }
+
       var db1 = new PouchDB(dbs.name);
       var db2 = new PouchDB(dbs.name);
       var id = 'fooId';
@@ -701,6 +707,36 @@ adapters.forEach(function (adapter) {
         if (++numDone === 2) {
           errorNames.should.deep.equal(['conflict']);
           ids.should.deep.equal([id]);
+          done();
+        }
+      }
+      db1.bulkDocs({docs : [{_id : id}]}, callback);
+      db2.bulkDocs({docs : [{_id : id}]}, callback);
+    });
+
+    it('handles simultaneous _local writes', function (done) {
+      if (testUtils.isCouchMaster()) {
+        // couch might give a 201 for both writes
+        true.should.equal(true);
+        return done();
+      }
+
+      var db1 = new PouchDB(dbs.name);
+      var db2 = new PouchDB(dbs.name);
+      var id = '_local/fooId';
+      var errorNames = [];
+      var ids = [];
+      var numDone = 0;
+      function callback(err, res) {
+        should.not.exist(err);
+        if (res[0].error) {
+          errorNames.push(res[0].name);
+        } else {
+          ids.push(res[0].ok);
+        }
+        if (++numDone === 2) {
+          errorNames.should.deep.equal(['conflict']);
+          ids.should.deep.equal([true]);
           done();
         }
       }

--- a/tests/integration/test.events.js
+++ b/tests/integration/test.events.js
@@ -47,7 +47,7 @@ adapters.forEach(function (adapter) {
     });
 
     it('emit creation event', function (done) {
-      var db = new PouchDB(dbs.name).on('created', function (newDB) {
+      var db = new PouchDB(dbs.name).once('created', function (newDB) {
         db.should.equal(newDB, 'should be same thing');
         done();
       });


### PR DESCRIPTION
When we're doing `bulkDocs`, one of the things that slows us down a lot is checking for existing documents by id. This is especially unfortunate for generation-1 docs, because the docs don't exist and so the `get()` is pointless.

This adds a bloom filter to keep track of doc ids, so that we can bail out early if we know a document has never been inserted before. 

Performance impact (temp-views test, 5 iterations):

    Firefox 37: 52444ms -> 49611ms (5% improvement)
    Chrome 40: 65949ms -> 46770ms (29% improvement)
    IE 11: 57911ms -> 54317ms (6% improvement)

Footprint size change:  46170 before, 47136 after (min+gz)

I can eventually implement this for WebSQL and LevelDB as well. Opening this PR early for feedback.