### PR TITLE
Be robust about changes entries which don't have documents

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -106,12 +106,16 @@ exports.filterChange = function filterChange(opts) {
   req.query = opts.query_params;
 
   return function filter(change) {
-    if (opts.filter && hasFilter && !opts.filter.call(this, change.doc, req)) {
+    if (!change.doc) {
+      change.doc = {};
+    }
+    if (opts.filter && hasFilter && 
+      !opts.filter.call(this, change.doc, req)) {
       return false;
     }
     if (!opts.include_docs) {
       delete change.doc;
-    } else if (!opts.attachments) {
+    } else if (!opts.attachments && change.doc) {
       for (var att in change.doc._attachments) {
         if (change.doc._attachments.hasOwnProperty(att)) {
           change.doc._attachments[att].stub = true;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -109,13 +109,12 @@ exports.filterChange = function filterChange(opts) {
     if (!change.doc) {
       change.doc = {};
     }
-    if (opts.filter && hasFilter && 
-      !opts.filter.call(this, change.doc, req)) {
+    if (opts.filter && hasFilter && !opts.filter.call(this, change.doc, req)) {
       return false;
     }
     if (!opts.include_docs) {
       delete change.doc;
-    } else if (!opts.attachments && change.doc) {
+    } else if (!opts.attachments) {
       for (var att in change.doc._attachments) {
         if (change.doc._attachments.hasOwnProperty(att)) {
           change.doc._attachments[att].stub = true;


### PR DESCRIPTION
Sync Gateway occasionally consumes a sequence number and sends a
changes entry that does not correspond to a document. It is safe
to ignore these. This patch prevents them from blowing up filters.