### PR TITLE
(#3500) - Enable assertions blocked on CouchDB 2 bugs

### DIFF
--- a/tests/integration/test.all_docs.js
+++ b/tests/integration/test.all_docs.js
@@ -241,12 +241,10 @@ adapters.forEach(function (adapter) {
                   result.doc._rev.should.equal(conflictDoc2._rev);
                   result.doc._id.should.equal('3', 'correct doc id');
                   winRev._rev.should.equal(result.doc._rev);
-                  // blocked on COUCHDB-2518
-                  if (!testUtils.isCouchMaster()) {
-                    result.doc._conflicts.should.be.instanceof(Array);
-                    result.doc._conflicts.should.have.length(2);
-                    conflictDoc1._rev.should.equal(result.doc._conflicts[0]);
-                  }
+                  result.doc._conflicts.should.be.instanceof(Array);
+                  result.doc._conflicts.should.have.length(2);
+                  conflictDoc1._rev.should.equal(result.doc._conflicts[0]);
+
                   db.allDocs({
                     include_docs: true,
                     conflicts: true

--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -2295,11 +2295,6 @@ adapters.forEach(function (adapter) {
                               { rev: remoterev }
                             ]);
 
-                            // Blocked on COUCHDB-2518
-                            if (testUtils.isCouchMaster()) {
-                              return;
-                            }
-
                             ch.doc.should.have.property('_conflicts');
                             ch.doc._conflicts.length.should.equal(1);
                             ch.doc._conflicts[0].should.equal(remoterev);

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -848,11 +848,6 @@ adapters.forEach(function (adapters) {
     });
 
     it('#3136 style=all_docs with conflicts', function () {
-      // blocked on COUCHDB-2518
-      if (testUtils.isCouchMaster()) {
-        return true;
-      }
-
       var docs1 = [
         {_id: '0', integer: 0},
         {_id: '1', integer: 1},
@@ -924,11 +919,6 @@ adapters.forEach(function (adapters) {
     });
 
     it('#3136 style=all_docs with conflicts reversed', function () {
-      // blocked on COUCHDB-2518
-      if (testUtils.isCouchMaster()) {
-        return true;
-      }
-
       var docs1 = [
         {_id: '0', integer: 0},
         {_id: '1', integer: 1},


### PR DESCRIPTION
COUCHDB-2518 and COUCHDB-2522 are now fixed. Re-enable the assertions which they previously blocked.