### PR TITLE
(#3505) - fix sqlite plugin support

### DIFF
--- a/lib/adapters/websql/websql-utils.js
+++ b/lib/adapters/websql/websql-utils.js
@@ -174,6 +174,33 @@ function getSize(opts) {
   return isAndroid ? 5000000 : 1; // in PhantomJS, if you use 0 it will crash
 }
 
+var cachedDatabases = {};
+
+function openDB(name, version, desc, size) {
+  var sqlitePluginOpenDBFunction =
+    typeof sqlitePlugin !== 'undefined' &&
+    sqlitePlugin.openDatabase &&
+    sqlitePlugin.openDatabase.bind(sqlitePlugin);
+
+  var openDBFunction = sqlitePluginOpenDBFunction ||
+    (typeof openDatabase !== 'undefined' && openDatabase);
+
+  var db = cachedDatabases[name];
+  if (!db) {
+    db = cachedDatabases[name] = openDBFunction(name, version, desc, size);
+    db._sqlitePlugin = !!sqlitePluginOpenDBFunction;
+  }
+  return db;
+}
+
+function valid() {
+  // SQLitePlugin leaks this global object, which we can use
+  // to detect if it's installed or not. The benefit is that it's
+  // declared immediately, before the 'deviceready' event has fired.
+  return typeof openDatabase !== 'undefined' ||
+    typeof SQLitePlugin !== 'undefined';
+}
+
 module.exports = {
   escapeBlob: escapeBlob,
   unescapeBlob: unescapeBlob,
@@ -183,5 +210,7 @@ module.exports = {
   select: select,
   compactRevs: compactRevs,
   unknownError: unknownError,
-  getSize: getSize
+  getSize: getSize,
+  openDB: openDB,
+  valid: valid
 };

--- a/lib/adapters/websql/websql.js
+++ b/lib/adapters/websql/websql.js
@@ -24,6 +24,7 @@ var select = websqlUtils.select;
 var compactRevs = websqlUtils.compactRevs;
 var unknownError = websqlUtils.unknownError;
 var getSize = websqlUtils.getSize;
+var openDB = websqlUtils.openDB;
 
 function fetchAttachmentsIfNecessary(doc, opts, api, txn, cb) {
   var attachments = Object.keys(doc._attachments || {});
@@ -58,28 +59,6 @@ function fetchAttachmentsIfNecessary(doc, opts, api, txn, cb) {
       checkDone();
     }
   });
-}
-
-var cachedDatabases = {};
-
-var sqlitePluginOpenDBFunction =
-  ((typeof navigator !== 'undefined' &&
-    navigator.sqlitePlugin &&
-    navigator.sqlitePlugin.openDatabase) &&
-    navigator.sqlitePlugin.openDatabase.bind(navigator.sqlitePlugin)) ||
-  ((typeof sqlitePlugin !== 'undefined' &&
-    sqlitePlugin.openDatabase) &&
-    sqlitePlugin.openDatabase.bind(sqlitePlugin));
-
-var openDBFunction = sqlitePluginOpenDBFunction ||
-  (typeof openDatabase !== 'undefined' && openDatabase);
-
-function openDB(name, version, desc, size) {
-  var db = cachedDatabases[name];
-  if (!db) {
-    db = cachedDatabases[name] = openDBFunction(name, version, desc, size);
-  }
-  return db;
 }
 
 var POUCH_VERSION = 1;
@@ -536,7 +515,7 @@ function WebSqlPouch(opts, callback) {
             doc_count: docCount,
             update_seq: updateSeq,
             // for debugging
-            sqlite_plugin: !!sqlitePluginOpenDBFunction,
+            sqlite_plugin: db._sqlitePlugin,
             websql_encoding: encoding
           });
         });
@@ -997,9 +976,7 @@ function WebSqlPouch(opts, callback) {
   };
 }
 
-WebSqlPouch.valid = function () {
-  return !!openDBFunction;
-};
+WebSqlPouch.valid = websqlUtils.valid;
 
 WebSqlPouch.destroy = utils.toPromise(function (name, opts, callback) {
   WebSqlPouch.Changes.removeAllListeners(name);


### PR DESCRIPTION
My goal: to get PouchDB to use the SQLite Plugin without any manual intervention from the user.

I succeeded! There were just a few things to change:

* `window.sqlitePlugin` is not declared until after Cordova's `deviceready` event has fired, so we cannot use it to detect `valid()`. (I.e. because of Windows Phone 8, which has sqlitePlugin support but not `openDatabase`.) But luckily the SQLitePlugin leaks a global `SQLitePlugin` variable, so we can use that to detect SQLitePlugin support. Flakey, but it fixes Windows Phone 8.
* the `openDB` function has to be re-generated every time a new database is created, because the global variables might have changed post-`deviceready`, in which case we want to use the SQLite plugin instead of `openDatabase`.

So basically what this requires users to do is to not call `new PouchDB()` until after the `deviceready` event (which they are probably accustomed to doing. I verified in [my sample app](https://github.com/nolanlawson/pouchdb-cordova-hello-world-with-sqlite-plugin) that it was actually working and actually using the SQLite Plugin.