### PR TITLE
Worker blob attachment

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -246,7 +246,11 @@ Changes.prototype.notify = function (dbName) {
   this.notifyLocalWindows(dbName);
 };
 
-if (typeof window === 'undefined' || typeof window.atob !== 'function') {
+if (typeof atob === 'function' || typeof window !== 'undefined') {
+  exports.atob = function (str) {
+    return atob(str);
+  };
+} else {
   exports.atob = function (str) {
     var base64 = new buffer(str, 'base64');
     // Node.js will just skip the characters it can't encode instead of
@@ -255,10 +259,6 @@ if (typeof window === 'undefined' || typeof window.atob !== 'function') {
       throw ("Cannot base64 encode full string");
     }
     return base64.toString('binary');
-  };
-} else {
-  exports.atob = function (str) {
-    return atob(str);
   };
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -246,7 +246,7 @@ Changes.prototype.notify = function (dbName) {
   this.notifyLocalWindows(dbName);
 };
 
-if (typeof atob === 'function' || typeof window !== 'undefined') {
+if (typeof atob === 'function') {
   exports.atob = atob;
 } else {
   exports.atob = function (str) {
@@ -260,7 +260,7 @@ if (typeof atob === 'function' || typeof window !== 'undefined') {
   };
 }
 
-if (typeof btoa === 'function' || typeof window !== 'undefined') {
+if (typeof btoa === 'function') {
   exports.btoa = btoa;
 } else {
   exports.btoa = function (str) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -247,7 +247,9 @@ Changes.prototype.notify = function (dbName) {
 };
 
 if (typeof atob === 'function') {
-  exports.atob = atob;
+  exports.atob = function (str) {
+    return atob(str);
+  };
 } else {
   exports.atob = function (str) {
     var base64 = new buffer(str, 'base64');
@@ -261,7 +263,9 @@ if (typeof atob === 'function') {
 }
 
 if (typeof btoa === 'function') {
-  exports.btoa = btoa;
+  exports.btoa = function (str) {
+    return btoa(str);
+  };
 } else {
   exports.btoa = function (str) {
     return new buffer(str, 'binary').toString('base64');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -262,13 +262,13 @@ if (typeof window === 'undefined' || typeof window.atob !== 'function') {
   };
 }
 
-if (typeof window === 'undefined' || typeof window.btoa !== 'function') {
+if (typeof btoa === 'function' || typeof window !== 'undefined') {
   exports.btoa = function (str) {
-    return new buffer(str, 'binary').toString('base64');
+    return btoa(str);
   };
 } else {
   exports.btoa = function (str) {
-    return btoa(str);
+    return new buffer(str, 'binary').toString('base64');
   };
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -247,9 +247,7 @@ Changes.prototype.notify = function (dbName) {
 };
 
 if (typeof atob === 'function' || typeof window !== 'undefined') {
-  exports.atob = function (str) {
-    return atob(str);
-  };
+  exports.atob = atob;
 } else {
   exports.atob = function (str) {
     var base64 = new buffer(str, 'base64');
@@ -263,9 +261,7 @@ if (typeof atob === 'function' || typeof window !== 'undefined') {
 }
 
 if (typeof btoa === 'function' || typeof window !== 'undefined') {
-  exports.btoa = function (str) {
-    return btoa(str);
-  };
+  exports.btoa = btoa;
 } else {
   exports.btoa = function (str) {
     return new buffer(str, 'binary').toString('base64');

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
     "pouchdb"
   ],
   "dependencies": {
-    "pouchdb-upsert": "^1.0.2",
-    "pouchdb-collections": "^1.0.0",
     "argsarray": "0.0.1",
     "bluebird": "^1.2.4",
+    "debug": "git://github.com/visionmedia/debug.git",
     "double-ended-queue": "^2.0.0-0",
     "es3ify": "^0.1.3",
+    "express": "^4.10.4",
     "inherits": "~2.0.1",
     "level-js": "^2.1.3",
     "level-sublevel": "~5.2.0",
@@ -29,16 +29,16 @@
     "lie": "^2.6.0",
     "localstorage-down": "^0.6.2",
     "memdown": "^1.0.0",
+    "miller-rabin": "1.1.1",
+    "pouchdb-collate": "^1.2.0",
+    "pouchdb-collections": "^1.0.0",
     "pouchdb-extend": "^0.1.2",
     "pouchdb-mapreduce": "~2.3.0",
+    "pouchdb-upsert": "^1.0.2",
     "request": "~2.28.0",
     "spark-md5": "0.0.5",
     "through2": "^0.4.1",
-    "vuvuzela": "^1.0.0",
-    "debug": "^2.1.0",
-    "express": "^4.10.4",
-    "miller-rabin": "1.1.1",
-    "pouchdb-collate": "^1.2.0"
+    "vuvuzela": "^1.0.0"
   },
   "optionalDependencies": {
     "leveldown": "~0.10.2"

--- a/tests/integration/browser.worker.js
+++ b/tests/integration/browser.worker.js
@@ -28,6 +28,20 @@ function runTests() {
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });
 
+    it('add doc with blob attachemnt', function (done) {
+      var worker = new Worker('worker.js');
+      worker.addEventListener('error', function (e) {
+        throw e;
+      });
+      worker.addEventListener('message', function (e) {
+        e.data.title.should.equal('lalaa');
+        worker.terminate();
+        done();
+      });
+      worker.postMessage(sourceFile);
+      worker.postMessage(['allDocs', 'testdb']);
+    });
+
     it('create it', function (done) {
       var worker = new Worker('worker.js');
       worker.addEventListener('message', function (e) {
@@ -91,6 +105,5 @@ function runTests() {
         worker.postMessage(['create', dbs.name]);
       });
     }
-
   });
 }

--- a/tests/integration/browser.worker.js
+++ b/tests/integration/browser.worker.js
@@ -28,7 +28,7 @@ function runTests() {
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });
 
-    it.skip('create it', function (done) {
+    it('create it', function (done) {
       var worker = new Worker('worker.js');
       worker.addEventListener('message', function (e) {
         e.data.should.equal('pong');
@@ -39,7 +39,7 @@ function runTests() {
       worker.postMessage('ping');
     });
 
-    it.skip('check pouch version', function (done) {
+    it('check pouch version', function (done) {
       var worker = new Worker('worker.js');
       worker.addEventListener('message', function (e) {
         PouchDB.version.should.equal(e.data);
@@ -55,7 +55,7 @@ function runTests() {
 
     // does not work in NodeWebkit
     if (!isNodeWebkit) {
-      it.skip('create remote db', function (done) {
+      it('create remote db', function (done) {
         var worker = new Worker('worker.js');
         worker.addEventListener('error', function (e) {
           throw e;
@@ -77,7 +77,7 @@ function runTests() {
     if (!('mozIndexedDB' in window) &&
         !('msIndexedDB' in window) &&
         !isNodeWebkit) {
-      it.skip('create local db', function (done) {
+      it('create local db', function (done) {
         var worker = new Worker('worker.js');
         worker.addEventListener('error', function (e) {
           throw e;

--- a/tests/integration/browser.worker.js
+++ b/tests/integration/browser.worker.js
@@ -8,7 +8,7 @@ if (!sourceFile) {
   sourceFile = '../../dist/' + sourceFile[1];
 }
 
-if (typeof window.Worker === 'function') {
+if (typeof window.Worker === 'function' && window.chrome) {
   runTests();
 }
 

--- a/tests/integration/worker.js
+++ b/tests/integration/worker.js
@@ -24,6 +24,32 @@ function bigTest(name) {
   });
 }
 
+function allDocs(name) {
+  new PouchDB(name, function (err, db) {
+    if (err) {
+      throw err;
+    }
+    db.post({
+      _id: 'blah',
+      title: 'lalaa',
+      _attachments: {
+        'test': {
+          data: new Blob(),
+          content_type: ''
+        }
+      }
+    }, function(err, doc) {
+      db.get(doc.id, function (err, doc) {
+        if (err) {
+          throw err;
+        }
+        self.postMessage(doc);
+        db.destroy();
+      });
+    });
+  });
+}
+
 self.addEventListener('message', function (e) {
   if (typeof e.data === 'string' && e.data.indexOf('/dist/') > -1) {
     importScripts(e.data);
@@ -36,5 +62,8 @@ self.addEventListener('message', function (e) {
   }
   if (Array.isArray(e.data) && e.data[0] === 'create') {
     bigTest(e.data[1]);
+  }
+  if (Array.isArray(e.data) && e.data[0] === 'allDocs') {
+    allDocs(e.data[1]);
   }
 });


### PR DESCRIPTION
## Problem:
When inside of a web worker and adding a blob attachment, pouchDB assumes `btoa` does not exist globally and so tries to user `Buffer` which is available in Node/IO.

## Solution:
Check if `btoa` exists in the global scope first and if so, use it.
Align `atob` logic along with the logic for `btoa` to avoid using the polyfill.

## Warning: 
This PR also edits the version of the debug module to pull from the master branch on github. This was to get the tests for web working running.