### PR TITLE
allow _security docs to be put w/out an error

### DIFF
--- a/lib/deps/parse-doc.js
+++ b/lib/deps/parse-doc.js
@@ -53,7 +53,7 @@ exports.invalidIdError = function (id) {
     err = errors.error(errors.MISSING_ID);
   } else if (typeof id !== 'string') {
     err = errors.error(errors.INVALID_ID);
-  } else if (/^_/.test(id) && !(/^_(design|local)/).test(id)) {
+  } else if (/^_/.test(id) && !(/^_(design|local|security)/).test(id)) {
     err = errors.error(errors.RESERVED_ID);
   }
   if (err) {


### PR DESCRIPTION
previously, I was getting a "Only reserved document ids may start with underscore." error whenever I tried to `put` a `_security` doc