### PR TITLE
(#3516) - Blog RSS feed

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,6 @@
+name: PouchDB
+description: PouchDB, the JavaScript Database that Syncs!
+url: http://pouchdb.com
 highlighter: pygments
 markdown: redcarpet
 baseurl:

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ page.title }}</title>
+    <link rel="alternate" title="{{ site.description }}" type="application/rss+xml" href="/feed.xml">
     <link rel="stylesheet" href="{{ site.baseurl }}/static/css/pouchdb.css" />
     <script type="text/javascript">
       var _gaq = _gaq || [];

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -1,0 +1,27 @@
+---
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>{{ site.name | xml_escape }}</title>
+    <description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>
+    <link>{{ site.url }}</link>
+    <atom:link href="{{ site.url }}/feed.xml" rel="self" type="application/rss+xml" />
+    {% for post in site.posts limit:10 %}
+      <item>
+        <title>{{ post.title | xml_escape }}</title>
+        {% if post.author %}
+          <dc:creator>{{ post.author | xml_escape }}</dc:creator>
+        {% endif %}
+        {% if post.excerpt %}
+          <description>{{ post.excerpt | xml_escape }}</description>
+        {% else %}
+          <description>{{ post.content | xml_escape }}</description>
+        {% endif %}
+        <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+        <link>{{ site.url }}{{ post.url }}</link>
+        <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
+      </item>
+    {% endfor %}
+  </channel>
+</rss>


### PR DESCRIPTION
Uses https://github.com/snaptortoise/jekyll-rss-feeds to generate a RSS feed at /feed.xml with the latest 10 posts.

I've tested this with https://chrome.google.com/webstore/detail/rss-subscription-extensio/nlbjncdgjeocebhnmkbbbdekmmmcbfjd and the autodetection works, here's a sample:

```xml

<?xml version="1.0" encoding="UTF-8"?>
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
  <channel>
    <title>PouchDB</title>
    <description>PouchDB, the JavaScript Database that Syncs!</description>
    <link>http://pouchdb.com</link>
    <atom:link href="http://pouchdb.com/feed.xml" rel="self" type="application/rss+xml" />
    
      <item>
        <title>PouchDB 3.3.0&amp;#58; Fix Up, Look Sharp</title>
        
          <dc:creator>Dale Harvey</dc:creator>
        
        
          <description>&lt;p&gt;A new month means a new PouchDB release. Over the last month we have been looking around the rough edges and cleaning things up or chopping them off along with the usual slew of bugfixes and a lot of great news.&lt;/p&gt;
</description>
        
        <pubDate>Tue, 03 Feb 2015 00:00:00 +0000</pubDate>
        <link>http://pouchdb.com/2015/02/03/fix-up-look-sharp.html</link>
        <guid isPermaLink="true">http://pouchdb.com/2015/02/03/fix-up-look-sharp.html</guid>
      </item>
    
  </channel>
</rss>

```