### PR TITLE
(#3528) - fix memory/localstorage plugins

### DIFF
--- a/bin/build-plugin.sh
+++ b/bin/build-plugin.sh
@@ -12,7 +12,7 @@ fi
 DEREQUIRE=./node_modules/.bin/derequire
 
 ./node_modules/.bin/browserify lib/plugins/index.js \
-    -r $LEVEL_BACKEND:leveldown \
+    -r $LEVEL_BACKEND \
     -x pouchdb \
     -r ./lib/plugins/config-$LEVEL_BACKEND.js:adapter-config \
     -r ./lib/plugins/migrate-browser.js:migrate \

--- a/lib/plugins/config-level-js.js
+++ b/lib/plugins/config-level-js.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   name: 'idb-alt',
+  require: 'level-js',
   valid: function () {
     var PouchDB = global.PouchDB || require('pouchdb');
     return 'idb' in PouchDB.adapters &&

--- a/lib/plugins/config-localstorage-down.js
+++ b/lib/plugins/config-localstorage-down.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   name: 'localstorage',
+  require: 'localstorage-down',
   valid: function () {
     return typeof localStorage !== 'undefined';
   },

--- a/lib/plugins/config-memdown.js
+++ b/lib/plugins/config-memdown.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   name: 'memory',
+  require: 'memdown',
   valid: function () {
     return true;
   },

--- a/lib/plugins/levelalt.js
+++ b/lib/plugins/levelalt.js
@@ -1,10 +1,11 @@
 'use strict';
 
 var LevelPouch = require('../adapters/leveldb/leveldb');
-var leveldown = require('leveldown');
 var utils = require('../utils');
 module.exports = altFactory;
 function altFactory(adapterConfig) {
+  var leveldown = require(adapterConfig.require);
+
   function LevelPouchAlt(opts, callback) {
     var _opts = utils.extend({
       db: leveldown

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "./lib/adapters/preferredAdapters.js": "./lib/adapters/preferredAdapters-browser.js",
     "./lib/deps/buffer.js": "./lib/deps/buffer-browser.js",
     "bluebird": "lie",
-    "leveldown": "level-js",
     "fs": false
   },
   "browserify": {


### PR DESCRIPTION
This is sort of a nasty hack, but it works.

I can confirm that this doesn't include anything we don't want (e.g. level-js in the built `pouchdb.js`, or memdown in `pouchdb.localstorage.js` etc.), and I can also confirm that the plugins are actually using in-memory/localstorage/level.js as they should.