### PR TITLE
(#3543) - allow set Auth headers in replications

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -575,7 +575,7 @@ exports.toPouch = toPouch;
 function toPouch(db, opts) {
   var PouchConstructor = opts.PouchConstructor;
   if (typeof db === 'string') {
-    return new PouchConstructor(db);
+    return new PouchConstructor(db, opts);
   } else if (db.then) {
     return db;
   } else {


### PR DESCRIPTION
This fix seems obviously correct to me, and I can't think of a test for it since we don't use authentication in our test CouchDB. So I'd be fine with merging it as-is (assuming it's green).