### PR TITLE
test undeletion

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -283,8 +283,14 @@ adapters.forEach(function (adapters) {
       }).then(function () {
         return db.allDocs({keys: ['foo']});
       }).then(function (res) {
-        rev = res.rows[0].value.rev;
-        return db.put({_id: 'foo', _rev: rev});
+        if (testUtils.isSyncGateway() && !res.rows[0].value) {
+          return remote.get('foo', {open_revs:'all'}).then(function(doc){
+            return db.put({_id: 'foo', _rev: doc[0].ok._rev});
+          })
+        } else {
+          rev = res.rows[0].value.rev;
+          return db.put({_id: 'foo', _rev: rev});
+        }
       }).then(function () {
         return db.replicate.to(remote);
       }).then(function () {

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -286,7 +286,7 @@ adapters.forEach(function (adapters) {
         if (testUtils.isSyncGateway() && !res.rows[0].value) {
           return remote.get('foo', {open_revs:'all'}).then(function(doc){
             return db.put({_id: 'foo', _rev: doc[0].ok._rev});
-          })
+          });
         } else {
           rev = res.rows[0].value.rev;
           return db.put({_id: 'foo', _rev: rev});


### PR DESCRIPTION
sync gateway doesn't include deleted docs in all docs view responses, so in that case the test can fetch the doc via another API and continue running.