### PR TITLE
(#3557) - idb allDocs() refactor, perf improvements

### DIFF
--- a/lib/adapters/idb/idb-all-docs.js
+++ b/lib/adapters/idb/idb-all-docs.js
@@ -1,0 +1,184 @@
+'use strict';
+
+var merge = require('../../merge');
+var errors = require('../../deps/errors');
+var idbUtils = require('./idb-utils');
+var idbConstants = require('./idb-constants');
+
+var ATTACH_STORE = idbConstants.ATTACH_STORE;
+var BY_SEQ_STORE = idbConstants.BY_SEQ_STORE;
+var DOC_STORE = idbConstants.DOC_STORE;
+
+var decodeDoc = idbUtils.decodeDoc;
+var decodeMetadata = idbUtils.decodeMetadata;
+var fetchAttachmentsIfNecessary = idbUtils.fetchAttachmentsIfNecessary;
+var postProcessAttachments = idbUtils.postProcessAttachments;
+var openTransactionSafely = idbUtils.openTransactionSafely;
+
+function createKeyRange(start, end, inclusiveEnd, key, descending) {
+  try {
+    if (start && end) {
+      if (descending) {
+        return IDBKeyRange.bound(end, start, !inclusiveEnd, false);
+      } else {
+        return IDBKeyRange.bound(start, end, false, !inclusiveEnd);
+      }
+    } else if (start) {
+      if (descending) {
+        return IDBKeyRange.upperBound(start);
+      } else {
+        return IDBKeyRange.lowerBound(start);
+      }
+    } else if (end) {
+      if (descending) {
+        return IDBKeyRange.lowerBound(end, !inclusiveEnd);
+      } else {
+        return IDBKeyRange.upperBound(end, !inclusiveEnd);
+      }
+    } else if (key) {
+      return IDBKeyRange.only(key);
+    }
+  } catch (e) {
+    return {error: e};
+  }
+  return null;
+}
+
+function handleKeyRangeError(api, opts, err, callback) {
+  if (err.name === "DataError" && err.code === 0) {
+    // data error, start is less than end
+    return callback(null, {
+      total_rows: api._meta.docCount,
+      offset: opts.skip,
+      rows: []
+    });
+  }
+  callback(errors.error(errors.IDB_ERROR, err.name, err.message));
+}
+
+function idbAllDocs(opts, api, idb, callback) {
+
+  function allDocsQuery(opts, callback) {
+    var start = 'startkey' in opts ? opts.startkey : false;
+    var end = 'endkey' in opts ? opts.endkey : false;
+    var key = 'key' in opts ? opts.key : false;
+    var skip = opts.skip || 0;
+    var limit = typeof opts.limit === 'number' ? opts.limit : -1;
+    var inclusiveEnd = opts.inclusive_end !== false;
+    var descending = 'descending' in opts && opts.descending ? 'prev' : null;
+
+    var keyRange = createKeyRange(start, end, inclusiveEnd, key, descending);
+    if (keyRange && keyRange.error) {
+      return handleKeyRangeError(api, opts, keyRange.error, callback);
+    }
+
+    var stores = [DOC_STORE, BY_SEQ_STORE];
+
+    if (opts.attachments) {
+      stores.push(ATTACH_STORE);
+    }
+    var txnResult = openTransactionSafely(idb, stores, 'readonly');
+    if (txnResult.error) {
+      return callback(txnResult.error);
+    }
+    var txn = txnResult.txn;
+    var docStore = txn.objectStore(DOC_STORE);
+    var seqStore = txn.objectStore(BY_SEQ_STORE);
+    var cursor = descending ?
+      docStore.openCursor(keyRange, descending) :
+      docStore.openCursor(keyRange);
+    var docIdRevIndex = seqStore.index('_doc_id_rev');
+    var results = [];
+    var docCount = 0;
+
+    // if the user specifies include_docs=true, then we don't
+    // want to block the main cursor while we're fetching the doc
+    function fetchDocAsynchronously(metadata, row, winningRev) {
+      var key = metadata.id + "::" + winningRev;
+      docIdRevIndex.get(key).onsuccess =  function onGetDoc(e) {
+        row.doc = decodeDoc(e.target.result);
+        if (opts.conflicts) {
+          row.doc._conflicts = merge.collectConflicts(metadata);
+        }
+        fetchAttachmentsIfNecessary(row.doc, opts, txn);
+      };
+    }
+
+    function allDocsInner(cursor, winningRev, metadata) {
+      var row = {
+        id: metadata.id,
+        key: metadata.id,
+        value: {
+          rev: winningRev
+        }
+      };
+      var deleted = metadata.deleted;
+      if (opts.deleted === 'ok') {
+        results.push(row);
+        // deleted docs are okay with "keys" requests
+        if (deleted) {
+          row.value.deleted = true;
+          row.doc = null;
+        } else if (opts.include_docs) {
+          fetchDocAsynchronously(metadata, row, winningRev);
+        }
+      } else if (!deleted && skip-- <= 0) {
+        results.push(row);
+        if (opts.include_docs) {
+          fetchDocAsynchronously(metadata, row, winningRev);
+        }
+        if (--limit === 0) {
+          return;
+        }
+      }
+      cursor.continue();
+    }
+
+    function onGetCursor(e) {
+      docCount = api._meta.docCount; // do this within the txn for consistency
+      var cursor = e.target.result;
+      if (!cursor) {
+        return;
+      }
+      var metadata = decodeMetadata(cursor.value);
+      var winningRev = metadata.winningRev;
+
+      allDocsInner(cursor, winningRev, metadata);
+    }
+
+    function onResultsReady() {
+      callback(null, {
+        total_rows: docCount,
+        offset: opts.skip,
+        rows: results
+      });
+    }
+
+    function onTxnComplete() {
+      if (opts.attachments) {
+        postProcessAttachments(results).then(onResultsReady);
+      } else {
+        onResultsReady();
+      }
+    }
+
+    txn.oncomplete = onTxnComplete;
+    cursor.onsuccess = onGetCursor;
+  }
+
+  function allDocs(opts, callback) {
+
+    if (opts.limit === 0) {
+      return callback(null, {
+        total_rows: api._meta.docCount,
+        offset: opts.skip,
+        rows: []
+      });
+    }
+    allDocsQuery(opts, callback);
+  }
+
+  allDocs(opts, callback);
+}
+
+module.exports = idbAllDocs;

--- a/lib/adapters/idb/idb-bulk-docs.js
+++ b/lib/adapters/idb/idb-bulk-docs.js
@@ -26,6 +26,7 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
   var attachStore;
   var attachAndSeqStore;
   var docInfoError;
+  var docCountDelta = 0;
 
   for (var i = 0, len = docInfos.length; i < len; i++) {
     var doc = docInfos[i];
@@ -45,7 +46,7 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
   var results = new Array(docInfos.length);
   var fetchedDocs = new utils.Map();
   var preconditionErrored = false;
-  var blobType = api._blobSupport ? 'blob' : 'base64';
+  var blobType = api._meta.blobSupport ? 'blob' : 'base64';
 
   utils.preprocessAttachments(docInfos, blobType, function (err) {
     if (err) {
@@ -128,8 +129,8 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
       return;
     }
 
-    Changes.notify(api._name);
-    api._docCount = -1; // invalidate
+    Changes.notify(api._meta.name);
+    api._meta.docCount += docCountDelta;
     callback(null, results);
   }
 
@@ -186,6 +187,8 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
 
   function writeDoc(docInfo, winningRev, deleted, callback, isUpdate,
                     delta, resultsIdx) {
+
+    docCountDelta += delta;
 
     var doc = docInfo.data;
     doc._id = docInfo.metadata.id;

--- a/lib/adapters/idb/idb-utils.js
+++ b/lib/adapters/idb/idb-utils.js
@@ -63,7 +63,7 @@ exports.decodeMetadata = function (storedObject) {
   }
   var metadata = utils.safeJsonParse(storedObject.data);
   metadata.winningRev = storedObject.winningRev;
-  metadata.deletedOrLocal = storedObject.deletedOrLocal === '1';
+  metadata.deleted = storedObject.deletedOrLocal === '1';
   metadata.seq = storedObject.seq;
   return metadata;
 };

--- a/lib/adapters/idb/idb.js
+++ b/lib/adapters/idb/idb.js
@@ -6,6 +6,7 @@ var errors = require('../../deps/errors');
 var idbUtils = require('./idb-utils');
 var idbConstants = require('./idb-constants');
 var idbBulkDocs = require('./idb-bulk-docs');
+var idbAllDocs = require('./idb-all-docs');
 var checkBlobSupport = require('./idb-blob-support');
 
 var ADAPTER_VERSION = idbConstants.ADAPTER_VERSION;
@@ -46,14 +47,10 @@ function IdbPouch(opts, callback) {
 
 function init(api, opts, callback) {
 
-  var name = opts.name;
+  var dbName = opts.name;
 
-  var instanceId = null;
-  var idStored = false;
   var idb = null;
-  api._docCount = -1;
-  api._blobSupport = null;
-  api._name = name;
+  api._meta = null;
 
   // called when creating a fresh new database
   function createSchema(db) {
@@ -212,7 +209,7 @@ function init(api, opts, callback) {
     function decodeMetadataCompat(storedObject) {
       if (!storedObject.data) {
         // old format, when we didn't store it stringified
-        storedObject.deletedOrLocal = storedObject.deletedOrLocal === '1';
+        storedObject.deleted = storedObject.deletedOrLocal === '1';
         return storedObject;
       }
       return decodeMetadata(storedObject);
@@ -257,7 +254,7 @@ function init(api, opts, callback) {
 
       function onGetMetadataSeq() {
         var metadataToStore = encodeMetadata(metadata,
-          metadata.winningRev, metadata.deletedOrLocal);
+          metadata.winningRev, metadata.deleted);
 
         var req = docStore.put(metadataToStore);
         req.onsuccess = function () {
@@ -279,7 +276,7 @@ function init(api, opts, callback) {
   };
 
   api._id = utils.toPromise(function (callback) {
-    callback(null, instanceId);
+    callback(null, api._meta.instanceId);
   });
 
   api._bulkDocs = function idb_bulkDocs(req, opts, callback) {
@@ -367,229 +364,53 @@ function init(api, opts, callback) {
     };
   };
 
-  function createKeyRange(start, end, inclusiveEnd, key, descending) {
-    try {
-      if (start && end) {
-        if (descending) {
-          return IDBKeyRange.bound(end, start, !inclusiveEnd, false);
-        } else {
-          return IDBKeyRange.bound(start, end, false, !inclusiveEnd);
-        }
-      } else if (start) {
-        if (descending) {
-          return IDBKeyRange.upperBound(start);
-        } else {
-          return IDBKeyRange.lowerBound(start);
-        }
-      } else if (end) {
-        if (descending) {
-          return IDBKeyRange.lowerBound(end, !inclusiveEnd);
-        } else {
-          return IDBKeyRange.upperBound(end, !inclusiveEnd);
-        }
-      } else if (key) {
-        return IDBKeyRange.only(key);
-      }
-    } catch (e) {
-      return {error: e};
+  api._info = function idb_info(callback) {
+
+    if (idb === null || !cachedDBs[dbName]) {
+      var error = new Error('db isn\'t open');
+      error.id = 'idbNull';
+      return callback(error);
     }
-    return null;
-  }
+    var updateSeq;
+    var docCount;
 
-  function allDocsQuery(totalRows, opts, callback) {
-    var start = 'startkey' in opts ? opts.startkey : false;
-    var end = 'endkey' in opts ? opts.endkey : false;
-    var key = 'key' in opts ? opts.key : false;
-    var skip = opts.skip || 0;
-    var limit = typeof opts.limit === 'number' ? opts.limit : -1;
-    var inclusiveEnd = opts.inclusive_end !== false;
-    var descending = 'descending' in opts && opts.descending ? 'prev' : null;
-
-    var keyRange = createKeyRange(start, end, inclusiveEnd, key, descending);
-    if (keyRange && keyRange.error) {
-      var err = keyRange.error;
-      if (err.name === "DataError" && err.code === 0) {
-        // data error, start is less than end
-         return callback(null, {
-           total_rows : totalRows,
-           offset : opts.skip,
-           rows : []
-         });
-      }
-      return callback(errors.error(errors.IDB_ERROR, err.name, err.message));
-    }
-
-    var stores = [DOC_STORE, BY_SEQ_STORE];
-    if (opts.attachments) {
-      stores.push(ATTACH_STORE);
-    }
-    var txnResult = openTransactionSafely(idb, stores, 'readonly');
-    if (txnResult.error) {
-      return callback(txnResult.error);
-    }
-    var transaction = txnResult.txn;
-
-    function onResultsReady() {
-      callback(null, {
-        total_rows: totalRows,
-        offset: opts.skip,
-        rows: results
-      });
-    }
-
-    transaction.oncomplete = function () {
-      if (opts.attachments) {
-        postProcessAttachments(results).then(onResultsReady);
-      } else {
-        onResultsReady();
-      }
-    };
-
-    var oStore = transaction.objectStore(DOC_STORE);
-    var oCursor = descending ? oStore.openCursor(keyRange, descending)
-      : oStore.openCursor(keyRange);
-    var results = [];
-    oCursor.onsuccess = function (e) {
-      if (!e.target.result) {
-        return;
-      }
-      var cursor = e.target.result;
-      var metadata = decodeMetadata(cursor.value);
-      var winningRev = metadata.winningRev;
-
-      function allDocsInner(metadata, data) {
-        var doc = {
-          id: metadata.id,
-          key: metadata.id,
-          value: {
-            rev: winningRev
-          }
-        };
-        if (opts.include_docs) {
-          doc.doc = data;
-          if (opts.conflicts) {
-            doc.doc._conflicts = merge.collectConflicts(metadata);
-          }
-          fetchAttachmentsIfNecessary(doc.doc, opts, transaction);
-        }
-        var deleted = utils.isDeleted(metadata, winningRev);
-        if (opts.deleted === 'ok') {
-          // deleted docs are okay with keys_requests
-          if (deleted) {
-            doc.value.deleted = true;
-            doc.doc = null;
-          }
-          results.push(doc);
-        } else if (!deleted && skip-- <= 0) {
-          results.push(doc);
-          if (--limit === 0) {
-            return;
-          }
-        }
-        cursor.continue();
-      }
-
-      if (!opts.include_docs) {
-        allDocsInner(metadata);
-      } else {
-        var index = transaction.objectStore(BY_SEQ_STORE).index('_doc_id_rev');
-        var key = metadata.id + "::" + winningRev;
-        index.get(key).onsuccess = function (event) {
-          allDocsInner(decodeMetadata(cursor.value),
-            decodeDoc(event.target.result));
-        };
-      }
-    };
-  }
-
-  function countDocs(callback) {
-    if (api._docCount !== -1) {
-      return callback(null, api._docCount);
-    }
-
-    var count;
-    var txnResult = openTransactionSafely(idb, [DOC_STORE], 'readonly');
+    var txnResult = openTransactionSafely(idb, [BY_SEQ_STORE], 'readonly');
     if (txnResult.error) {
       return callback(txnResult.error);
     }
     var txn = txnResult.txn;
-    var index = txn.objectStore(DOC_STORE).index('deletedOrLocal');
-    index.count(IDBKeyRange.only("0")).onsuccess = function (e) {
-      count = e.target.result;
+    var cursor = txn.objectStore(BY_SEQ_STORE).openCursor(null, 'prev');
+    cursor.onsuccess = function (event) {
+      var cursor = event.target.result;
+      updateSeq = cursor ? cursor.key : 0;
+      // count within the same txn for consistency
+      docCount = api._meta.docCount;
     };
-    txn.onerror = idbError(callback);
+
     txn.oncomplete = function () {
-      api._docCount = count;
-      callback(null, api._docCount);
+      callback(null, {
+        doc_count: docCount,
+        update_seq: updateSeq,
+        // for debugging
+        idb_attachment_format: (api._meta.blobSupport ? 'binary' : 'base64')
+      });
     };
-  }
-
-  api._allDocs = function idb_allDocs(opts, callback) {
-
-    // first count the total_rows
-    countDocs(function (err, totalRows) {
-      if (err) {
-        return callback(err);
-      }
-      if (opts.limit === 0) {
-        return callback(null, {
-          total_rows : totalRows,
-          offset : opts.skip,
-          rows : []
-        });
-      }
-      allDocsQuery(totalRows, opts, callback);
-    });
   };
 
-  api._info = function idb_info(callback) {
-
-    countDocs(function (err, count) {
-      if (err) {
-        return callback(err);
-      }
-      if (idb === null || !cachedDBs[api._name]) {
-        var error = new Error('db isn\'t open');
-        error.id = 'idbNull';
-        return callback(error);
-      }
-      var updateSeq = 0;
-      var txnResult = openTransactionSafely(idb, [BY_SEQ_STORE], 'readonly');
-      if (txnResult.error) {
-        return callback(txnResult.error);
-      }
-      var txn = txnResult.txn;
-      txn.objectStore(BY_SEQ_STORE).openCursor(null, "prev").onsuccess =
-        function (event) {
-        var cursor = event.target.result;
-        if (cursor) {
-          updateSeq = cursor.key;
-        } else {
-          updateSeq = 0;
-        }
-      };
-
-      txn.oncomplete = function () {
-        callback(null, {
-          doc_count: count,
-          update_seq: updateSeq,
-          // for debugging
-          idb_attachment_format: (api._blobSupport ? 'binary' : 'base64')
-        });
-      };
-    });
+  api._allDocs = function idb_allDocs(opts, callback) {
+    idbAllDocs(opts, api, idb, callback);
   };
 
   api._changes = function (opts) {
     opts = utils.clone(opts);
 
     if (opts.continuous) {
-      var id = name + ':' + utils.uuid();
-      IdbPouch.Changes.addListener(name, id, api, opts);
-      IdbPouch.Changes.notify(name);
+      var id = dbName + ':' + utils.uuid();
+      IdbPouch.Changes.addListener(dbName, id, api, opts);
+      IdbPouch.Changes.notify(dbName);
       return {
         cancel: function () {
-          IdbPouch.Changes.removeListener(name, id);
+          IdbPouch.Changes.removeListener(dbName, id);
         }
       };
     }
@@ -761,7 +582,7 @@ function init(api, opts, callback) {
     // https://developer.mozilla.org/en-US/docs/IndexedDB/IDBDatabase#close
     // "Returns immediately and closes the connection in a separate thread..."
     idb.close();
-    delete cachedDBs[name];
+    delete cachedDBs[dbName];
     idb = null;
     callback();
   };
@@ -812,7 +633,7 @@ function init(api, opts, callback) {
       });
       compactRevs(revs, docId, txn);
       var winningRev = metadata.winningRev;
-      var deleted = metadata.deletedOrLocal;
+      var deleted = metadata.deleted;
       txn.objectStore(DOC_STORE).put(
         encodeMetadata(metadata, winningRev, deleted));
     };
@@ -936,24 +757,23 @@ function init(api, opts, callback) {
     };
   };
 
-  var cached = cachedDBs[name];
+  var cached = cachedDBs[dbName];
 
   if (cached) {
     idb = cached.idb;
-    instanceId = cached.instanceId;
-    api._blobSupport = cached.blobSupport;
+    api._meta = cached.global;
     process.nextTick(function () {
       callback(null, api);
     });
     return;
   }
 
-  var req = indexedDB.open(name, ADAPTER_VERSION);
+  var req = indexedDB.open(dbName, ADAPTER_VERSION);
 
   if (!('openReqList' in IdbPouch)) {
     IdbPouch.openReqList = {};
   }
-  IdbPouch.openReqList[name] = req;
+  IdbPouch.openReqList[dbName] = req;
 
   req.onupgradeneeded = function (e) {
     var db = e.target.result;
@@ -999,47 +819,66 @@ function init(api, opts, callback) {
 
     idb.onversionchange = function () {
       idb.close();
-      delete cachedDBs[name];
+      delete cachedDBs[dbName];
     };
     idb.onabort = function () {
       idb.close();
-      delete cachedDBs[name];
+      delete cachedDBs[dbName];
     };
 
-    var txn = idb.transaction([META_STORE, DETECT_BLOB_SUPPORT_STORE],
-      'readwrite');
+    var txn = idb.transaction([
+        META_STORE,
+        DETECT_BLOB_SUPPORT_STORE,
+        DOC_STORE
+      ], 'readwrite');
 
     var req = txn.objectStore(META_STORE).get(META_STORE);
+
+    var blobSupport = null;
+    var docCount = null;
+    var instanceId = null;
 
     req.onsuccess = function (e) {
 
       var checkSetupComplete = function () {
-        if (api._blobSupport === null || !idStored) {
+        if (blobSupport === null || docCount === null ||
+            instanceId === null) {
           return;
         } else {
-          cachedDBs[name] = {
-            idb: idb,
+          api._meta = {
+            name: dbName,
             instanceId: instanceId,
-            blobSupport: api._blobSupport,
-            loaded: true
+            blobSupport: blobSupport,
+            docCount: docCount
+          };
+
+          cachedDBs[dbName] = {
+            idb: idb,
+            global: api._meta
           };
           callback(null, api);
         }
       };
 
+      //
+      // fetch/store the id
+      //
+
       var meta = e.target.result || {id: META_STORE};
-      if (name  + '_id' in meta) {
-        instanceId = meta[name + '_id'];
-        idStored = true;
+      if (dbName  + '_id' in meta) {
+        instanceId = meta[dbName + '_id'];
         checkSetupComplete();
       } else {
         instanceId = utils.uuid();
-        meta[name + '_id'] = instanceId;
+        meta[dbName + '_id'] = instanceId;
         txn.objectStore(META_STORE).put(meta).onsuccess = function () {
-          idStored = true;
           checkSetupComplete();
         };
       }
+
+      //
+      // check blob support
+      //
 
       if (!blobSupportPromise) {
         // make sure blob support is only checked once
@@ -1047,9 +886,20 @@ function init(api, opts, callback) {
       }
 
       blobSupportPromise.then(function (val) {
-        api._blobSupport = val;
+        blobSupport = val;
         checkSetupComplete();
       });
+
+      //
+      // count docs
+      //
+
+      var index = txn.objectStore(DOC_STORE).index('deletedOrLocal');
+      index.count(IDBKeyRange.only('0')).onsuccess = function (e) {
+        docCount = e.target.result;
+        checkSetupComplete();
+      };
+
     };
   };
 

--- a/tests/performance/perf.basics.js
+++ b/tests/performance/perf.basics.js
@@ -102,6 +102,32 @@ module.exports = function (PouchDB, opts) {
           done();
         }, done);
       }
+    }, {
+      name: 'all-docs-include-docs',
+      assertions: 1,
+      iterations: 100,
+      setup: function (db, callback) {
+        var docs = [];
+        for (var i = 0; i < 1000; i++) {
+          docs.push({
+            _id: commonUtils.createDocId(i),
+            foo: 'bar',
+            baz: 'quux',
+            _deleted: i % 2 === 1
+          });
+        }
+        db.bulkDocs({docs: docs}, callback);
+      },
+      test: function (db, itr, docs, done) {
+        return db.allDocs({
+          include_docs: true,
+          limit: 100
+        }).then(function () {
+          return db.post({}); // to invalidate the doc count
+        }).then(function () {
+          done();
+        }, done);
+      }
     },
     {
       name: 'pull-replication-perf-skimdb',


### PR DESCRIPTION
- keep docCount in memory, ala leveldb.js
- use metadata.deleted instead of calculating
  with utils.isDeleted()
- fetch docs asynchronously for include_docs=true