### PR TITLE
(#3543) - fix filtered replication with a ddoc

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -525,8 +525,12 @@ function replicate(repId, src, target, opts, returnValue, result) {
         returnDocs: true // required so we know when we're done
       };
       if (opts.filter) {
-        // required for the client-side filter in onChange
-        changesOpts.include_docs = true;
+        if (typeof opts.filter !== 'string') {
+          // required for the client-side filter in onChange
+          changesOpts.include_docs = true;
+        } else { // ddoc filter
+          changesOpts.filter = opts.filter;
+        }
       }
       if (opts.query_params) {
         changesOpts.query_params = opts.query_params;

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -3508,6 +3508,32 @@ adapters.forEach(function (adapters) {
       })
       .catch(done);
     });
+
+    it('#3543 replication with a ddoc filter', function () {
+      var db = new PouchDB(dbs.name);
+      var remote = new PouchDB(dbs.remote);
+
+      return remote.bulkDocs([{
+        _id: '_design/myddoc',
+        filters: {
+          myfilter: function (doc) {
+            return doc._id === 'a';
+          }.toString()
+        }
+      },
+        {_id: 'a'},
+        {_id: 'b'},
+        {_id: 'c'}
+      ]).then(function () {
+        return remote.replicate.to(db, {filter: 'myddoc/myfilter'});
+      }).then(function () {
+        return db.allDocs();
+      }).then(function (res) {
+        res.rows.should.have.length(1);
+        res.rows[0].id.should.equal('a');
+      });
+    });
+
   });
 });
 


### PR DESCRIPTION
This should fix the problem where filtered replication
with a ddoc was being ignored. Apparently we had no tests
for ddoc-filtering in `replicate()`.

I tested this against Cloudant and it passed, so hoping it will
pass against Couch master as well.