### PR TITLE
verifyInfo for CSG

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -62,9 +62,18 @@ adapters.forEach(function (adapters) {
 
     function verifyInfo(info, expected) {
       if (!testUtils.isCouchMaster()) {
-        info.update_seq.should.equal(expected.update_seq, 'update_seq');
+        if (typeof info.doc_count === 'undefined') { 
+          // info is from Sync Gateway, which allocates an extra seqnum
+          // for user access control purposes.
+          info.update_seq.should.be.within(expected.update_seq, 
+            expected.update_seq + 1, 'update_seq');
+        } else {
+          info.update_seq.should.equal(expected.update_seq, 'update_seq');
+        }
       }
-      info.doc_count.should.equal(expected.doc_count, 'doc_count');
+      if (info.doc_count) { // info is NOT from Sync Gateway
+        info.doc_count.should.equal(expected.doc_count, 'doc_count');
+      }
     }
 
     it('Test basic pull replication', function (done) {


### PR DESCRIPTION
This duck types db infos from Sync Gateway and makes allowances
for things like access control sequences and lack of doc_count.

We don't switch on isSyncGateway() explicitly b/c we don't want
to drop these assertions for the whole environment, just when
the info is from Sync Gateway. If we want to make sure it's not
being lenient in other environments we could refactor the verifyInfo
function to look more like a switch statement. Maybe the time to
do this is on the NEXT environment that gets added. :)