### PR TITLE
(#3495) filter changes for CSG

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -56,7 +56,12 @@ adapters.forEach(function (adapters) {
           return a.id > b.id;
         });
       }
-
+      // CSG will send a change event when just the ACL changed
+      if (testUtils.isSyncGateway()) {
+        changes = changes.filter(function(change){
+          return change.id !== "_user/";
+        });
+      }
       return changes;
     }
 


### PR DESCRIPTION
CSG has extra entries in the changes feed, which we can ignore
in tests.