### PR TITLE
(#3493) be robust about missing docs

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -106,6 +106,11 @@ exports.filterChange = function filterChange(opts) {
   req.query = opts.query_params;
 
   return function filter(change) {
+    if (!change.doc) {
+      // CSG sends events on the changes feed that don't have documents,
+      // this hack makes a whole lot of existing code robust.
+      change.doc = {};
+    }
     if (opts.filter && hasFilter && !opts.filter.call(this, change.doc, req)) {
       return false;
     }


### PR DESCRIPTION
Sync Gateway occasionally consumes a sequence number and sends a
changes entry that does not correspond to a document. It is safe
to ignore these. This patch prevents them from blowing up filters.

This is a redo of an earlier pull request. Now we have tests for
Sync Gateway.

However those tests won't start behaving correctly until we cut a new release
of Sync Gateway and point Travis at it.