### PR TITLE
Ignore changes feed include_docs conflicts from CSG

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -39,6 +39,10 @@ adapters.forEach(function (adapters) {
     // simplify for easier deep equality checks
     function simplifyChanges(res) {
       var changes = res.results.map(function (change) {
+        if (testUtils.isSyncGateway() &&
+          change.doc && change.doc._conflicts) {
+          delete change.doc._conflicts;
+        }
         return {
           id: change.id,
           deleted: change.deleted,
@@ -51,7 +55,7 @@ adapters.forEach(function (adapters) {
 
       // in CouchDB 2.0, changes is not guaranteed to be
       // ordered
-      if (testUtils.isCouchMaster()) {
+      if (testUtils.isCouchMaster() || testUtils.isSyncGateway()) {
         changes.sort(function (a, b) {
           return a.id > b.id;
         });


### PR DESCRIPTION
This just normalizes some of the Sync Gateway differences. (We don't list conflicts in the include_docs doc, just in the changes feed list, etc.)

Creating pull request to verify test run before committing. I really wish I could green button to commit, once it's passing.