### PR TITLE
(#3569) - catch 409s in checkpointer

### DIFF
--- a/lib/checkpointer.js
+++ b/lib/checkpointer.js
@@ -19,7 +19,13 @@ function updateCheckpoint(db, id, checkpoint, returnValue) {
       return;
     }
     doc.last_seq = checkpoint;
-    return db.put(doc);
+    return db.put(doc).catch(function (err) {
+      if (err.status === 409) {
+        // retry; someone is trying to write a checkpoint simultaneously
+        return updateCheckpoint(db, id, checkpoint, returnValue);
+      }
+      throw err;
+    });
   });
 }
 


### PR DESCRIPTION
Test fails before the fix, succeeds after.

I'm kinda surprised this bug has hung around for so long. I thought we were more diligent about catching 409s and retrying.