### PR TITLE
(#3577) - edit intro docs

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -250,7 +250,7 @@ var pouch = new PouchDB('riak://localhost:8087/somebucket', {db: require('riakdo
 
 #### More LevelDOWN adapters
 
-There are many other LevelDOWN-based plugins &ndash; far too many to list here. You can find a [mostly-complete list on Github](https://github.com/rvagg/node-levelup/wiki/Modules) that includes implementations on top of MySQL, Windows Azure Table Storage, and SQLite.
+There are many other LevelDOWN-based plugins &ndash; far too many to list here. You can find a [mostly-complete list on Github](https://github.com/rvagg/node-levelup/wiki/Modules#storage-back-ends) that includes implementations on top of MySQL, Windows Azure Table Storage, and SQLite.
 
 
 {% include alert/start.html variant="warning"%}

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -4,53 +4,87 @@ title: About PouchDB
 sidebar: nav.html
 ---
 
-PouchDB was written to help web developers build applications that work offline as well as they do online. Applications save data locally, so the user can use all the features of an app even when they're offline. Plus, the data is synchronized between clients, so the user has up-to-date data wherever they go.
+PouchDB is an **in-browser database** that allows applications to save data locally, so that users can enjoy all the features of an app even when they're offline. Plus, the data is synchronized between clients, so users can stay up-to-date wherever they go.
 
-PouchDB is a free open-source project, written in JavaScript by these [wonderful contributors](https://github.com/pouchdb/pouchdb/graphs/contributors) and inspired by <a href="http://couchdb.apache.org/">Apache CouchDB</a>. If you want to get involved then check out the [contributing guide](https://github.com/pouchdb/pouchdb/blob/master/CONTRIBUTING.md).
+PouchDB also runs in **Node.js** and can be used as a direct interface to **CouchDB**-compatible servers. The API works the same in every environment, so you can spend less time worrying about browser differences, and more time writing clean, consistent code.
 
-{% include anchor.html class="h3" title="Browser Support" hash="browser_support" %}
-
-PouchDB uses various backends so it can work across different browsers and in Node.js. It uses IndexedDB in Firefox/Chrome/Opera/IE, WebSQL in Safari and most mobile browsers, and LevelDB in Node.js. It is currently tested and fully supported in:
-
- * Firefox latest stable (v29+)
- * Chrome latest stable (v34+)
- * Desktop Safari latest stable (v6+)
- * Internet Explorer (v10+)
- * Opera latest stable (v21+)
- * Android 4.0+
- * iOS Safari latest stable (v7.1+)
- * [Node.js](http://nodejs.org/)
-
-PouchDB is experimental on Android 2.x and various mobile browsers and environments including [Apache Cordova](http://cordova.apache.org/). It is known to work, but you may run into issues. As we resolve these issues we will update the fully supported list.
-
-PouchDB requires an ES5 environment. If your browser does not support this (IE <= 9, Android < 4.0, Opera Mini), then you will need to include the [es5-shim](https://github.com/es-shims/es5-shim) library.
+PouchDB is a free open-source project, written in JavaScript and driven by our [wonderful  community](https://github.com/pouchdb/pouchdb/graphs/contributors). If you want to get involved, then check out the [contributing guide](https://github.com/pouchdb/pouchdb/blob/master/CONTRIBUTING.md).
 
 {% include anchor.html class="h3" title="Installing" hash="installing" %}
 
-PouchDB is designed to be a minimal library that is suitable for mobile devices, tablets, desktops &mdash; anything that runs Javascript. To start using PouchDB in your website, you simply [download][latest] it and include it in your webpage.
-
-  [latest]: https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb-{{ site.version }}.min.js
+To start using PouchDB in your website, simply [download][latest-min] it and include it in your page:
 
 {% highlight html %}
 <script src="pouchdb-{{ site.version }}.min.js"></script>
 {% endhighlight %}
 
-#### Downloads
+Or install it as a Node.js module:
 
-Latest and greatest: [pouchdb-{{ site.version }}.min.js][latest]
+{% highlight bash %}$ npm install --save pouchdb{% endhighlight %}
+
+{% include anchor.html class="h3" title="Using PouchDB" hash="using_pouchdb" %}
+
+In the browser, getting started is as simple as:
+
+{% highlight javascript %}
+var db = new PouchDB('my_database');
+{% endhighlight %}
+
+In Node.js, you'll need to `require()` it first:
+
+{% highlight javascript %}
+var PouchDB = require('pouchdb');
+var db = new PouchDB('my_database');
+{% endhighlight %}
+
+Or, to use PouchDB as a direct client to CouchDB, simply pass in a URL:
+
+{% highlight javascript %}
+var db = new PouchDB('http://localhost:5984/my_database');
+{% endhighlight %}
+
+All of these `db`s share the same API, regardless of where they're storing data!
+
+To learn more about how to use PouchDB, check out our [Getting Started Tutorial](getting-started.html), [Guides](/guides/) and the [API Documentation](api.html).
+
+{% include anchor.html class="h3" title="Browser Support" hash="browser_support" %}
+
+PouchDB supports all modern browsers, using [IndexedDB][] under the hood and falling back to [WebSQL][] where IndexedDB isn't supported. It is [fully tested](https://travis-ci.org/pouchdb/pouchdb/) and supported in:
+
+ * Firefox 29+
+ * Chrome 30+
+ * Safari 5+
+ * Internet Explorer 10+
+ * Opera 21+
+ * Android 4.0+
+ * iOS 7.1+
+ * Windows Phone 8+
+
+PouchDB also runs in [Cordova/PhoneGap](https://github.com/nolanlawson/pouchdb-phonegap-cordova), [NW.js](https://github.com/nolanlawson/pouchdb-nw), [Atom Shell](pouchdb-atom-shell), and [Chrome apps](https://github.com/nolanlawson/pouchdb-chrome-app). It is framework-agnostic, and you can use it with Angular, React, Ember, Backbone, or your framework of choice. There are [many adapters](http://pouchdb.com/external.html#framework_adapters), or you can just use PouchDB as-is.
+
+PouchDB requires a modern ES5 environment, so if you need to support older browsers (IE <10, Android <4.0, Opera Mini), then you should include the [es5-shim](https://github.com/es-shims/es5-shim) library.  You can also use the [LocalStorage and in-memory adapters](/adapters.html#pouchdb_in_the_browser), or fall back to a live CouchDB.
+
+{% include anchor.html class="h3" title="Node.js" hash="node_js" %}
+
+In Node.js, PouchDB uses [LevelDB][] under the hood, and also supports [many other backends](/adapters.html#pouchdb_in_node_js) via the [LevelUP ecosystem](https://github.com/rvagg/node-levelup).
+
+PouchDB can also run as its own CouchDB-compatible web server, using [PouchDB Server](https://github.com/pouchdb/pouchdb-server).
+
+{% include anchor.html class="h3" title="Downloads" hash="downloads" %}
+
+Latest and greatest: 
+
+* [pouchdb-{{ site.version }}.min.js][latest-min] (compressed for production)
+* [pouchdb-{{ site.version }}.js][latest] (uncompressed for debugging)
 
 PouchDB is also hosted on [jsdelivr](http://www.jsdelivr.com/#!pouchdb) and [cdnjs](https://cdnjs.com/libraries/pouchdb).
 
 For past releases and changelog, check out the [Github releases page](https://github.com/pouchdb/pouchdb/releases).
 
-#### Node.js
+For plugins, see the [plugins page](/external.html).
 
-If you are using Node.js then run
-
-{% highlight bash %}$ npm install pouchdb{% endhighlight %}
-
-For an HTTP API to PouchDB check out [PouchDB Server](https://github.com/nick-thompson/pouchdb-server).
-
-{% include anchor.html class="h3" title="Using PouchDB" hash="using_pouchdb" %}
-
-To get started using PouchDB, check out our [Getting Started Tutorial](getting-started.html), [Guides](/guides/) and the [API Documentation](api.html).
+[IndexedDB]: http://caniuse.com/#feat=indexeddb
+[WebSQL]: http://caniuse.com/#feat=sql-storage
+[LevelDB]: http://leveldb.org/
+[latest]: https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb-{{ site.version }}.js
+[latest-min]: https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb-{{ site.version }}.min.js


### PR DESCRIPTION
The "Learn" page is probably the first place where
users will land after the home page, and I wanted to
clean it up and update the description a bit.

As for the API, I cleaned up some small inconsistencies
and added a longer intro section on promises/callbacks.
At some point, I would like to go in there and just remove
the callback examples entirely. I think we should deprecate
the callback API.