### PR TITLE
(#3586) - use mapreduce 2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "pouchdb-collate": "^1.2.0",
     "pouchdb-collections": "^1.0.0",
     "pouchdb-extend": "^0.1.2",
-    "pouchdb-mapreduce": "~2.3.0",
+    "pouchdb-mapreduce": "~2.3.2",
     "pouchdb-upsert": "^1.0.2",
     "request": "~2.28.0",
     "spark-md5": "0.0.5",


### PR DESCRIPTION
This is a sanity check to make sure we didn't break anything in 2.3.2.