### PR TITLE
(#2352 #2158) - clone object before inserting in IDB

### DIFF
--- a/lib/adapters/idb/idb-bulk-docs.js
+++ b/lib/adapters/idb/idb-bulk-docs.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var collate = require('pouchdb-collate');
 var utils = require('../../utils');
 var errors = require('../../deps/errors');
 var idbUtils = require('./idb-utils');
@@ -17,6 +18,13 @@ var decodeMetadata = idbUtils.decodeMetadata;
 var encodeMetadata = idbUtils.encodeMetadata;
 var idbError = idbUtils.idbError;
 var openTransactionSafely = idbUtils.openTransactionSafely;
+
+// recursively normalize the document so that it doesn't store
+// e.g. Dates/ArrayBuffers as their native object type
+function normalize(doc) {
+  // basically equivalent to JSON.parse(JSON.stringify(doc)) but faster
+  return collate.normalizeKey(doc);
+}
 
 function idbBulkDocs(req, opts, api, idb, Changes, callback) {
   var docInfos = req.docs;
@@ -241,7 +249,7 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
       var index = bySeqStore.index('_doc_id_rev');
       var getKeyReq = index.getKey(doc._doc_id_rev);
       getKeyReq.onsuccess = function (e) {
-        var putReq = bySeqStore.put(doc, e.target.result);
+        var putReq = bySeqStore.put(normalize(doc), e.target.result);
         putReq.onsuccess = afterPutDoc;
       };
     }
@@ -256,7 +264,7 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
       insertAttachmentMappings(docInfo, metadata.seq, callback);
     }
 
-    var putReq = bySeqStore.put(doc);
+    var putReq = bySeqStore.put(normalize(doc));
 
     putReq.onsuccess = afterPutDoc;
     putReq.onerror = afterPutDocError;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "pouchdb-collections": "^1.0.0",
     "pouchdb-extend": "^0.1.2",
     "pouchdb-mapreduce": "~2.3.0",
+    "pouchdb-collate": "^1.2.0",
     "pouchdb-upsert": "^1.0.2",
     "request": "~2.28.0",
     "spark-md5": "0.0.5",

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -937,6 +937,38 @@ adapters.forEach(function (adapter) {
       db.put({_id: 'bar', _zing: 'zing'}, cb);
     });
 
+    it('should not store raw Dates', function () {
+      var date = new Date();
+      var date2 = new Date();
+      var date3 = new Date();
+      var origDocs = [
+        { _id: '1', mydate: date },
+        { _id: '2', array: [date2] },
+        { _id: '3', deep: { deeper: { deeperstill: date3 } }
+        }
+      ];
+      return new PouchDB(dbs.name).then(function (db) {
+        return db.bulkDocs(origDocs).then(function () {
+          return db.allDocs({include_docs: true});
+        }).then(function (res) {
+          var docs = res.rows.map(function (row) {
+            delete row.doc._rev;
+            return row.doc;
+          });
+          docs.should.deep.equal([
+            { _id: '1', mydate: date.toJSON() },
+            { _id: '2', array: [date2.toJSON()] },
+            { _id: '3', deep: { deeper: { deeperstill: date3.toJSON() } }
+            }
+          ]);
+          origDocs[0].mydate.should.be.instanceof(Date, 'date not modified');
+          origDocs[1].array[0].should.be.instanceof(Date, 'date not modified');
+          origDocs[2].deep.deeper.deeperstill.should.be.instanceof(Date,
+            'date not modified');
+        });
+      });
+    });
+
     if (adapter === 'local') {
       // TODO: this test fails in the http adapter in Chrome
       it('should allow unicode doc ids', function (done) {


### PR DESCRIPTION
Revival of 6c6d95a, which used cloning via pouchdb-collate
to make sure that Dates become strings, etc. This also
has the benefit of cloning the doc, so we avoid weird errors
due to global Object prototype mangling.