### PR TITLE
(#3596) - fix inconsistent sub-headings

### DIFF
--- a/docs/_includes/api/create_document.html
+++ b/docs/_includes/api/create_document.html
@@ -148,7 +148,7 @@ db.post({
 {% endhighlight %}
 {% include code/end.html %}
 
-### Example Response:
+#### Example Response:
 {% highlight js %}
 {
   "ok" : true,

--- a/docs/_includes/api/replication.html
+++ b/docs/_includes/api/replication.html
@@ -89,7 +89,7 @@ db.replicate.to(remote).then(function (result) {
 
 For non-live replications, the returned object is also an event emitter as well as a promise, and you can use all the events described above (except for `'paused'` and `'active'`, which only apply to `retry` replications).
 
-#### Example response
+#### Example Response:
 
 Example response in the `'change'` listener:
 


### PR DESCRIPTION
The "example usage" and "example response" headings should look the same everywhere.