### PR TITLE
(#3608) - clarify filtered replication/changes

### DIFF
--- a/docs/_includes/api/changes.html
+++ b/docs/_includes/api/changes.html
@@ -13,18 +13,24 @@ It is an [event emitter][event emitter] and will emit a `'change'` event on each
 
 All options default to `false` unless otherwise specified.
 
+* `options.live`: Does "live" changes, using CouchDB's  `_longpoll_` feed if remote.
 * `options.include_docs`: Include the associated document with each change.
   * `options.conflicts`: Include conflicts.
   * `options.attachments`: Include attachments.
 * `options.descending`: Reverse the order of the output documents.
-* `options.since`: Start the results from the change immediately after the given sequence number. You can also pass 'now' if you want only new changes (when `live` is `true`).
-* `options.live`: Uses the  `_longpoll_` feed.
-* `options.timeout`: Request timeout (in milliseconds).
+* `options.since`: Start the results from the change immediately after the given sequence number. You can also pass `'now'` if you want only new changes (when `live` is `true`).
 * `options.limit`: Limit the number of results to this number.
+* `options.timeout`: Request timeout (in milliseconds).
+
+**Filtering Options:**
+
+* `options.filter`: Reference a filter function from a design document to selectively get updates. To use a view function, pass `_view` here and provide a reference to the view function in `options.view`. See [filtered changes](#filtered-changes) for details.
 * `options.doc_ids`: Only show changes for docs with these ids (array of strings).
-* `options.filter`: Reference a filter function from a design document to selectively get updates. To use a view function, pass `_view` here and provide a reference to the view function in `options.view`.
 * `options.query_params`: Object containing properties that are passed to the filter function, e.g. `{"foo:"bar"}`, where `"bar"` will be available in the filter function as `params.query.foo`. To access the `params`, define your filter function like `function (doc, params) {/* ... */}`.
 * `options.view`: Specify a view function (e.g. `'design_doc_name/view_name'`) to act as a filter. Documents counted as "passed" for a view filter if a map function emits at least one record for them. **Note**: `options.filter` must be set to `'_view'` for this option to work.
+
+**Advanced Options:**
+
 * `options.returnDocs`: Is available for non-http databases and defaults to `true`. Passing `false` prevents the changes feed from keeping all the documents in memory &ndash; in other words complete always has an empty results array, and the `change` event is the only way to get the event. Useful for large change sets where otherwise you would run out of memory.
 * `options.batch_size`: Only available for http databases, this configures how many changes to fetch at a time. Increasing this can reduce the number of requests made. Default is 25.
 * `options.style`: Specifies how many revisions are returned in the changes array. The default, `'main_only'`, will only return the current "winning" revision; `'all_docs'` will return all leaf revisions (including conflicts and deleted former conflicts). Most likely you won't need this unless you're writing a replicator.
@@ -196,3 +202,134 @@ When `live` is `false`, the returned object is also an event emitter as well as 
 and will fire the `'complete'` event when the results are ready.
 
 Note that this `'complete'` event only fires when you aren't doing live changes. With live changes, use the `'paused'` event instead.
+
+#### Filtered changes
+
+As with [replicate()](#replication), you can filter using:
+
+* an ad-hoc `filter` function
+* an array of `doc_ids`
+* a `filter` function inside of a design document
+* a `filter` function inside of a design document, with `query_params`
+* a `view` function inside of a design document
+
+If you are running `changes()` on a remote CouchDB, then the first method will run client-side, whereas the last four will filter on the server side. Therefore the last four should be preferred, especially if the database is large, because you want to send as few documents over the wire as possible.
+
+If you are running `changes()` on a local PouchDB, then obviously all five methods will run client-side. There are also no performance benefits to using any of the five, so can also just filter yourself, in your own `on('change')` handler. These methods are implemented in PouchDB purely for consistency with CouchDB.
+
+#### Filtering examples
+
+In these examples, we'll work with some mammals. Let's imagine our docs are:
+
+{% highlight js %}
+[
+  {_id: 'a', name: 'Kangaroo', type: 'marsupial'},
+  {_id: 'b', name: 'Koala', type: 'marsupial'},
+  {_id: 'c', name: 'Platypus', type: 'monotreme'}
+]
+{% endhighlight %}
+
+Here are 5 examples using the 5 different systems.
+
+**Example 1: Ad-hoc `filter` function**
+
+*Warning*: this runs client-side, if the database is remote.
+
+Filter by `type === 'marsupial'`:
+
+{% highlight js %}
+db.changes({
+  filter: function (doc) {
+    return doc.type === 'marsupial';
+  }
+});
+{% endhighlight %}
+
+**Example 2: Array of `doc_ids`**
+
+Filter documents with `_id`s `['a', 'c']`.
+
+{% highlight js %}
+db.changes({
+  doc_ids: ['a', 'c']
+});
+{% endhighlight %}
+
+**Example 3: `filter` function inside of a design document**
+
+First `put()` a design document:
+
+{% highlight js %}
+{
+  _id: '_design/mydesign',
+  filters: {
+    myfilter: function (doc) {
+      return doc.type === 'marsupial';
+    }.toString()
+  }
+}
+{% endhighlight %}
+
+Then filter by `type === 'marsupial'`:
+
+{% highlight js %}
+db.changes({
+  filter: 'mydesign/myfilter'
+});
+{% endhighlight %}
+
+**Example 4: `filter` function inside of a design document, with `query_params`**
+
+This is the most powerful way to filter, because it allows you to pass in arbitrary options to your filter function.
+
+First `put()` a design document:
+
+{% highlight js %}
+{
+  _id: '_design/mydesign',
+  filters: {
+    myfilter: function (doc, req) {
+      return doc.type === req.query.type;
+    }.toString()
+  }
+}
+{% endhighlight %}
+
+Then filter by `type === 'marsupial'`:
+
+{% highlight js %}
+db.changes({
+  filter: 'mydesign/myfilter',
+  query_params: {type: 'marsupial'}
+});
+{% endhighlight %}
+
+**Example 5: `view` function inside of a design document**
+
+This doesn't really offer any advantages compared to the previous two methods, unless you are already using a `view` for map/reduce queries, and you want to reuse it.
+
+Any documents that `emit()` anything will be considered to have passed this filter method.
+
+First `put()` a design document:
+
+{% highlight js %}
+{
+  _id: '_design/mydesign',
+  views: {
+    myview: function (doc) {
+      if (doc.type === 'marsupial') {
+        emit(doc._id);
+      }
+    }.toString()
+  }
+}
+{% endhighlight %}
+
+Then filter by `type === 'marsupial'`:
+
+{% highlight js %}
+db.changes({
+  filter: '_view',
+  view: 'mydesign/myview'
+});
+{% endhighlight %}

--- a/docs/_includes/api/replication.html
+++ b/docs/_includes/api/replication.html
@@ -14,11 +14,17 @@ All options default to `false` unless otherwise specified.
 
 * `options.live`: If `true`, starts subscribing to future changes in the `source` database and continue replicating them.
 * `options.retry`: If `true` will attempt to retry replications in the case of failure (due to being offline), using a backoff algorithm that retries at longer and longer intervals until a connection is re-established. Only applicable if `options.live` is also `true`.
-* `options.filter`: Reference a filter function from a design document to selectively get updates.
-* `options.query_params`: Query params sent to the filter function.
-* `options.doc_ids`: Only replicate docs with these ids (array of strings).
 * `options.since`: Replicate changes after the given sequence number.
-* `options.create_target`: Create target database if it does not exist. Only for server replications.
+
+**Filtering Options:**
+
+* `options.filter`: Reference a filter function from a design document to selectively get updates. To use a view function, pass `_view` here and provide a reference to the view function in `options.view`. See [filtered replication](#filtered-replication) for details.
+* `options.doc_ids`: Only show changes for docs with these ids (array of strings).
+* `options.query_params`: Object containing properties that are passed to the filter function, e.g. `{"foo:"bar"}`, where `"bar"` will be available in the filter function as `params.query.foo`. To access the `params`, define your filter function like `function (doc, params) {/* ... */}`.
+* `options.view`: Specify a view function (e.g. `'design_doc_name/view_name'`) to act as a filter. Documents counted as "passed" for a view filter if a map function emits at least one record for them. **Note**: `options.filter` must be set to `'_view'` for this option to work.
+
+**Advanced Options:**
+
 * `options.batch_size`: Number of documents to process at a time. Defaults to 100. This affects the number of docs held in memory and the number sent at a time to the target server. You may need to adjust downward if targeting devices with low amounts of memory (e.g. phones) or if the documents are large in size (e.g. with attachments). If your documents are small in size, then increasing this number will probably speed replication up.
 * `options.batches_limit`: Number of batches to process at a time. Defaults to 10. This (along wtih `batch_size`) controls how many docs are kept in memory at a time, so the maximum docs in memory at once would equal `batch_size` &times; `batches_limit`.
 
@@ -124,3 +130,144 @@ Example response in the `'complete'` listener:
 Note that replication is supported for both local and remote databases. So you can replicate from local to local or from remote to remote.
 
 However, if you replicate from remote to remote, then the changes will flow through PouchDB. If you want to trigger a server-initiated replication, please use regular ajax to POST to the CouchDB `_replicate` endpoint, as described [in the CouchDB docs](https://wiki.apache.org/couchdb/Replication).
+
+#### Filtered replication
+
+As with [changes()](#changes), you can filter from the source database using:
+
+* an ad-hoc `filter` function
+* an array of `doc_ids`
+* a `filter` function inside of a design document
+* a `filter` function inside of a design document, with `query_params`
+* a `view` function inside of a design document
+
+If you are replicating from a remote CouchDB, then the first method will run client-side, whereas the last four will filter on the server side. Therefore the last four should be preferred, especially if the database is large, because you want to send as few documents over the wire as possible.
+
+You should also beware trying to use filtered replication to enforce security, e.g. to partition a database per user. A better strategy is the ["one database per user" method](https://github.com/nolanlawson/pouchdb-authentication#couchdb-authentication-recipes).
+
+{% include alert/start.html variant="warning" %}
+
+{% markdown %}
+
+**Deleting filtered docs**: When you use filtered replication, you should avoid using `remove()` to delete documents, because that removes all their fields as well, which means means they might not pass the filter function anymore, causing the deleted revision to not be replicated. Instead, set the `doc._deleted` flag to `true` and then use `put()` or `bulkDocs()`.
+
+{% endmarkdown %}
+
+{% include alert/end.html %}
+
+#### Filtering examples
+
+In these examples, we'll work with some mammals. Let's imagine our docs are:
+
+{% highlight js %}
+[
+  {_id: 'a', name: 'Kangaroo', type: 'marsupial'},
+  {_id: 'b', name: 'Koala', type: 'marsupial'},
+  {_id: 'c', name: 'Platypus', type: 'monotreme'}
+]
+{% endhighlight %}
+
+Here are 5 examples using the 5 different systems.
+
+**Example 1: Ad-hoc `filter` function**
+
+*Warning*: this runs client-side, if you are replicating from a remote database.
+
+Filter by `type === 'marsupial'`:
+
+{% highlight js %}
+remote.replicate.to(local, {
+  filter: function (doc) {
+    return doc.type === 'marsupial';
+  }
+});
+{% endhighlight %}
+
+**Example 2: Array of `doc_ids`**
+
+Filter documents with `_id`s `['a', 'c']`.
+
+{% highlight js %}
+remote.replicate.to(local, {
+  doc_ids: ['a', 'c']
+});
+{% endhighlight %}
+
+**Example 3: `filter` function inside of a design document**
+
+First `put()` a design document in the remote database:
+
+{% highlight js %}
+{
+  _id: '_design/mydesign',
+  filters: {
+    myfilter: function (doc) {
+      return doc.type === 'marsupial';
+    }.toString()
+  }
+}
+{% endhighlight %}
+
+Then filter by `type === 'marsupial'`:
+
+{% highlight js %}
+remote.replicate.to(local, {
+  filter: 'mydesign/myfilter'
+});
+{% endhighlight %}
+
+**Example 4: `filter` function inside of a design document, with `query_params`**
+
+This is the most powerful way to filter, because it allows you to pass in arbitrary options to your filter function.
+
+First `put()` a design document in the remote database:
+
+{% highlight js %}
+{
+  _id: '_design/mydesign',
+  filters: {
+    myfilter: function (doc, req) {
+      return doc.type === req.query.type;
+    }.toString()
+  }
+}
+{% endhighlight %}
+
+Then filter by `type === 'marsupial'`:
+
+{% highlight js %}
+remote.replicate.to(local, {
+  filter: 'mydesign/myfilter',
+  query_params: {type: 'marsupial'}
+});
+{% endhighlight %}
+
+**Example 5: `view` function inside of a design document**
+
+This doesn't really offer any advantages compared to the previous two methods, unless you are already using a `view` for map/reduce queries, and you want to reuse it.
+
+Any documents that `emit()` anything will be considered to have passed this filter method.
+
+First `put()` a design document in the remote database:
+
+{% highlight js %}
+{
+  _id: '_design/mydesign',
+  views: {
+    myview: function (doc) {
+      if (doc.type === 'marsupial') {
+        emit(doc._id);
+      }
+    }.toString()
+  }
+}
+{% endhighlight %}
+
+Then filter by `type === 'marsupial'`:
+
+{% highlight js %}
+remote.replicate.to(local, {
+  filter: '_view',
+  view: 'mydesign/myview'
+});
+{% endhighlight %}


### PR DESCRIPTION
Filtered replication is way too complicated. Our goal is consistency with CouchDB, though, so I'm glad we implemented all these different options.

But golly, there are a lot.