### PR TITLE
(#3578) - confirm filtered replication works for deletion

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -3560,6 +3560,77 @@ adapters.forEach(function (adapters) {
       });
     });
 
+    it("#3578-2 ddoc repl, filter on field, put() _deleted=true", function() {
+      var db = new PouchDB(dbs.name);
+      var remote = new PouchDB(dbs.remote);
+
+      return remote.bulkDocs([{
+        _id: '_design/myddoc',
+        filters: {
+          myfilter: function (doc) {
+            return doc.name === 'barbara';
+          }.toString()
+        }
+      },
+        {_id: 'a', name: 'anna'},
+        {_id: 'b', name: 'barbara'},
+        {_id: 'c', name: 'charlie'}
+      ]).then(function () {
+        return remote.replicate.to(db, {filter: 'myddoc/myfilter'});
+      }).then(function() {
+        return db.allDocs();
+      }).then(function (res) {
+        res.rows.should.have.length(1);
+      }).then(function(){
+        return remote.get('b');
+      }).then(function(doc) {
+        doc._deleted = true;
+        return remote.put(doc);
+      }).then(function () {
+        return remote.replicate.to(db, {filter: 'myddoc/myfilter'});
+      }).then(function () {
+        return db.allDocs();
+      }).then(function (docs) {
+        docs.rows.should.have.length(0,
+          'deleted because _deleted=true was used');
+      });
+    });
+
+    it("#3578-2 ddoc repl, filter on field, remove()", function() {
+      var db = new PouchDB(dbs.name);
+      var remote = new PouchDB(dbs.remote);
+
+      return remote.bulkDocs([{
+        _id: '_design/myddoc',
+        filters: {
+          myfilter: function (doc) {
+            return doc.name === 'barbara';
+          }.toString()
+        }
+      },
+        {_id: 'a', name: 'anna'},
+        {_id: 'b', name: 'barbara'},
+        {_id: 'c', name: 'charlie'}
+      ]).then(function () {
+        return remote.replicate.to(db, {filter: 'myddoc/myfilter'});
+      }).then(function() {
+        return db.allDocs();
+      }).then(function (res) {
+        res.rows.should.have.length(1);
+      }).then(function(){
+        return remote.get('b');
+      }).then(function(doc) {
+        return remote.remove(doc);
+      }).then(function () {
+        return remote.replicate.to(db, {filter: 'myddoc/myfilter'});
+      }).then(function () {
+        return db.allDocs();
+      }).then(function (docs) {
+        docs.rows.should.have.length(1,
+          'not deleted because remove() was used');
+      });
+    });
+
     it('#3270 triggers "change" events with .docs property', function(done) {
       var replicatedDocs = [];
       var db = new PouchDB(dbs.name);


### PR DESCRIPTION
If you use `remove()`, then filtering on fields should no longer
work, because you have removed all fields.

If you use `put()` with `_deleted=true`, then filtering on fields
should continue to work, because the field is still there.

These tests confirm that CouchDB and PouchDB both exhibit the
correct behavior for this.