### PR TITLE
(#3517) - use debug 2.1.2 instead of master

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "argsarray": "0.0.1",
     "bluebird": "^1.2.4",
-    "debug": "git://github.com/visionmedia/debug.git",
+    "debug": "^2.1.2",
     "double-ended-queue": "^2.0.0-0",
     "es3ify": "^0.1.3",
     "express": "^4.10.4",


### PR DESCRIPTION
Looks like stuff should be fixed now.