### PR TITLE
(#3585) - highlight ES6 when building too

### DIFF
--- a/bin/build-site.js
+++ b/bin/build-site.js
@@ -53,7 +53,7 @@ function highlightEs6() {
   // 'async' and 'await' to highlight correctly
   // in this blog post.
   replace({
-    regex: '<span class="nx">(await|async)</span>',
+    regex: '<span class="nx">(await|async|of)</span>',
     replacement: '<span class="kd">$1</span>',
     paths: [path],
     recursive: true
@@ -67,4 +67,5 @@ if (!process.env.BUILD) {
   console.log('Server address: http://0.0.0.0:4000');
 } else {
   execSync('jekyll build');
+  highlightEs6();
 }

--- a/docs/_posts/2015-03-05-taming-the-async-beast-with-es7.md
+++ b/docs/_posts/2015-03-05-taming-the-async-beast-with-es7.md
@@ -22,7 +22,7 @@ console.log(localStorage.foo);
 
 To work with LocalStorage, you simply treat it like a magical JavaScript object that happens to persist your data. It uses the same synchronous toolset that you're already used to from working with JavaScript itself.
 
-For all of [LocalStorage's](http://www.html5rocks.com/en/tutorials/offline/quota-research/) [faults](https://blog.mozilla.org/tglek/2012/02/22/psa-dom-local-storage-considered-harmful/), the ergonomics of this API go a long way to explain its continuing popularity. People keep using LocalStorage because it's simple, and it works exactly as you'd expect.
+For all of [LocalStorage's](http://www.html5rocks.com/en/tutorials/offline/quota-research/) [faults](https://blog.mozilla.org/tglek/2012/02/22/psa-dom-local-storage-considered-harmful/), the ergonomics of this API go a long way to explain its continuing popularity. People keep using LocalStorage, because it's simple and works exactly as expected.
 
 ### Promises aren't a panacea
 


### PR DESCRIPTION
Forgot to add this for when we're building the site, too. I think it's important that works like `await` and `yield` get syntax-highlighted.