### PR TITLE
Ignore CSG "_user" entries in the changes feed.

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -319,6 +319,7 @@ function replicate(repId, src, target, opts, returnValue, result) {
   function getDiffs() {
     var diff = {};
     currentBatch.changes.forEach(function (change) {
+      if (change.id === "_user/") {return;}
       diff[change.id] = change.changes.map(function (x) {
         return x.rev;
       });


### PR DESCRIPTION
This is the last bug that needs to be fixed before I was able to get CSG and PouchDB's TodoMVC example syncing.

This depends on applying my [CORS pull request to SG master](https://github.com/couchbase/sync_gateway/pull/695) before it will work.