### PR TITLE
(#3656) - fix up jshint and promise test

### DIFF
--- a/lib/adapters/websql/websql-bulk-docs.js
+++ b/lib/adapters/websql/websql-bulk-docs.js
@@ -104,7 +104,8 @@ function websqlBulkDocs(req, opts, api, db, Changes, callback) {
 
     function finish() {
       var data = docInfo.data;
-      var deletedInt = deleted ? 1 : 0;
+      // #3646 deleted passed to writeDoc is not for BY_SEQ_STORE
+      var deletedInt = docInfo.metadata.deleted ? 1 : 0;
 
       var id = data._id;
       var rev = data._rev;

--- a/tests/integration/index.html
+++ b/tests/integration/index.html
@@ -45,6 +45,7 @@
     <script src='browser.info.js'></script>
     <script src='test.issue221.js'></script>
     <script src='test.issue3179.js'></script>
+    <script src='test.issue3646.js'></script>
     <script src='test.http.js'></script>
     <script src='test.compaction.js'></script>
     <script src='test.get.js'></script>

--- a/tests/integration/test.issue3646.js
+++ b/tests/integration/test.issue3646.js
@@ -1,0 +1,213 @@
+'use strict';
+
+describe('Issue #3646 WebSQL deleted documents bug', function () {
+  it('Should finish with 0 documents', function (done) {
+    new PouchDB('issue3646', function (err, db) {
+      Promise.all(data.forEach(docs) {
+        db.bulkDocs(docs, {new_edits: false});
+      }).then(function() {
+        db.info().then(function(info) {
+          info.doc_count.should.equal(0);
+          done();
+        });
+      });
+    });
+  });
+
+  var data = [
+   {
+    "docs": [
+     {
+      "_revisions": {
+       "start": 2, 
+       "ids": [
+        "4e16ac64356d4358bf1bdb4857fc299f", 
+        "aed67b17ea5ba6b78e704ad65d3fb5db"
+       ]
+      }, 
+      "_rev": "2-4e16ac64356d4358bf1bdb4857fc299f", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 2, 
+       "ids": [
+        "3757f03a178b34284361c89303cf8c35", 
+        "0593f4c87b24f0f9b620526433929bb0"
+       ]
+      }, 
+      "_rev": "2-3757f03a178b34284361c89303cf8c35", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 3, 
+       "ids": [
+        "f28d17ab990dcadd20ad38860fde9f11", 
+        "6cf4b9e2115d7e884292b97aa8765285", 
+        "dcfdf66ab61873ee512a9ccf3e3731a1"
+       ]
+      }, 
+      "_rev": "3-f28d17ab990dcadd20ad38860fde9f11", 
+      "_id": "b74e3b45"
+     }, 
+     {
+      "_revisions": {
+       "start": 3, 
+       "ids": [
+        "4d93920c00a4a7269095b22ff4329b3c", 
+        "7190eca51acb2b302a89ed1204ac2813", 
+        "017eba7ef1e4f529143f463779822627"
+       ]
+      }, 
+      "_rev": "3-4d93920c00a4a7269095b22ff4329b3c", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 3, 
+       "ids": [
+        "91b47d7b889feb36eaf9336c071f00cc", 
+        "0e3379b8f9128e6062d13eeb98ec538e", 
+        "1c006ce18b663e2a031ced4669797c28"
+       ]
+      }, 
+      "_rev": "3-91b47d7b889feb36eaf9336c071f00cc", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 4, 
+       "ids": [
+        "2c3c860d421fc9f6cc82e4fb811dc8e2", 
+        "4473170dcffa850aca381b4f644b2947", 
+        "3524a871600080f5e30e59a292b02a3f", 
+        "89eb0b5131800963bb7caf1fc83b6242"
+       ]
+      }, 
+      "_rev": "4-2c3c860d421fc9f6cc82e4fb811dc8e2", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 6, 
+       "ids": [
+        "441f43a31c89dc68a7cc934ce5779bf8", 
+        "4c7f8b00508144d049d18668d17e552a", 
+        "e8431fb3b448f3457c5b2d77012fa8b4", 
+        "f2e7dc8102123e13ca792a0a05ca6235", 
+        "37a13a5c1e2ce5926a3ffcda7e669106", 
+        "78739468c87b30f76d067a2d7f373803"
+       ]
+      }, 
+      "_rev": "6-441f43a31c89dc68a7cc934ce5779bf8", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }
+    ]
+   }, 
+   {
+    "docs": [
+     {
+      "_revisions": {
+       "start": 2, 
+       "ids": [
+        "3757f03a178b34284361c89303cf8c35", 
+        "0593f4c87b24f0f9b620526433929bb0"
+       ]
+      }, 
+      "_rev": "2-3757f03a178b34284361c89303cf8c35", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 2, 
+       "ids": [
+        "4e16ac64356d4358bf1bdb4857fc299f", 
+        "aed67b17ea5ba6b78e704ad65d3fb5db"
+       ]
+      }, 
+      "_rev": "2-4e16ac64356d4358bf1bdb4857fc299f", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 3, 
+       "ids": [
+        "91b47d7b889feb36eaf9336c071f00cc", 
+        "0e3379b8f9128e6062d13eeb98ec538e", 
+        "1c006ce18b663e2a031ced4669797c28"
+       ]
+      }, 
+      "_rev": "3-91b47d7b889feb36eaf9336c071f00cc", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 3, 
+       "ids": [
+        "4d93920c00a4a7269095b22ff4329b3c", 
+        "7190eca51acb2b302a89ed1204ac2813", 
+        "017eba7ef1e4f529143f463779822627"
+       ]
+      }, 
+      "_rev": "3-4d93920c00a4a7269095b22ff4329b3c", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 4, 
+       "ids": [
+        "2c3c860d421fc9f6cc82e4fb811dc8e2", 
+        "4473170dcffa850aca381b4f644b2947", 
+        "3524a871600080f5e30e59a292b02a3f", 
+        "89eb0b5131800963bb7caf1fc83b6242"
+       ]
+      }, 
+      "_rev": "4-2c3c860d421fc9f6cc82e4fb811dc8e2", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 4, 
+       "ids": [
+        "dbaa7e6c02381c2c0ec5259572387d7c", 
+        "f28d17ab990dcadd20ad38860fde9f11", 
+        "6cf4b9e2115d7e884292b97aa8765285", 
+        "dcfdf66ab61873ee512a9ccf3e3731a1"
+       ]
+      }, 
+      "_rev": "4-dbaa7e6c02381c2c0ec5259572387d7c", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 6, 
+       "ids": [
+        "441f43a31c89dc68a7cc934ce5779bf8", 
+        "4c7f8b00508144d049d18668d17e552a", 
+        "e8431fb3b448f3457c5b2d77012fa8b4", 
+        "f2e7dc8102123e13ca792a0a05ca6235", 
+        "37a13a5c1e2ce5926a3ffcda7e669106", 
+        "78739468c87b30f76d067a2d7f373803"
+       ]
+      }, 
+      "_rev": "6-441f43a31c89dc68a7cc934ce5779bf8", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }
+    ]
+   }
+  ];
+});

--- a/tests/integration/test.issue3646.js
+++ b/tests/integration/test.issue3646.js
@@ -1,213 +1,216 @@
 'use strict';
 
-describe('Issue #3646 WebSQL deleted documents bug', function () {
-  it('Should finish with 0 documents', function (done) {
-    new PouchDB('issue3646', function (err, db) {
-      Promise.all(data.forEach(docs) {
-        db.bulkDocs(docs, {new_edits: false});
-      }).then(function() {
-        db.info().then(function(info) {
-          info.doc_count.should.equal(0);
-          done();
-        });
+var adapters = ['local', 'http'];
+
+adapters.forEach(function (adapter) {
+  describe('#3646 WebSQL deleted documents - ' + adapter, function () {
+    it('Should finish with 0 documents', function () {
+      var Promise = PouchDB.utils.Promise;
+      var db = new PouchDB('issue3646');
+      return Promise.all(data.map(function (docs) {
+        return db.bulkDocs(docs, {new_edits: false});
+      })).then(function () {
+        return db.info();
+      }).then(function (info) {
+        info.doc_count.should.equal(0);
       });
     });
-  });
 
-  var data = [
-   {
-    "docs": [
-     {
-      "_revisions": {
-       "start": 2, 
-       "ids": [
-        "4e16ac64356d4358bf1bdb4857fc299f", 
-        "aed67b17ea5ba6b78e704ad65d3fb5db"
-       ]
-      }, 
-      "_rev": "2-4e16ac64356d4358bf1bdb4857fc299f", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 2, 
-       "ids": [
-        "3757f03a178b34284361c89303cf8c35", 
-        "0593f4c87b24f0f9b620526433929bb0"
-       ]
-      }, 
-      "_rev": "2-3757f03a178b34284361c89303cf8c35", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 3, 
-       "ids": [
-        "f28d17ab990dcadd20ad38860fde9f11", 
-        "6cf4b9e2115d7e884292b97aa8765285", 
-        "dcfdf66ab61873ee512a9ccf3e3731a1"
-       ]
-      }, 
-      "_rev": "3-f28d17ab990dcadd20ad38860fde9f11", 
-      "_id": "b74e3b45"
-     }, 
-     {
-      "_revisions": {
-       "start": 3, 
-       "ids": [
-        "4d93920c00a4a7269095b22ff4329b3c", 
-        "7190eca51acb2b302a89ed1204ac2813", 
-        "017eba7ef1e4f529143f463779822627"
-       ]
-      }, 
-      "_rev": "3-4d93920c00a4a7269095b22ff4329b3c", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 3, 
-       "ids": [
-        "91b47d7b889feb36eaf9336c071f00cc", 
-        "0e3379b8f9128e6062d13eeb98ec538e", 
-        "1c006ce18b663e2a031ced4669797c28"
-       ]
-      }, 
-      "_rev": "3-91b47d7b889feb36eaf9336c071f00cc", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 4, 
-       "ids": [
-        "2c3c860d421fc9f6cc82e4fb811dc8e2", 
-        "4473170dcffa850aca381b4f644b2947", 
-        "3524a871600080f5e30e59a292b02a3f", 
-        "89eb0b5131800963bb7caf1fc83b6242"
-       ]
-      }, 
-      "_rev": "4-2c3c860d421fc9f6cc82e4fb811dc8e2", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 6, 
-       "ids": [
-        "441f43a31c89dc68a7cc934ce5779bf8", 
-        "4c7f8b00508144d049d18668d17e552a", 
-        "e8431fb3b448f3457c5b2d77012fa8b4", 
-        "f2e7dc8102123e13ca792a0a05ca6235", 
-        "37a13a5c1e2ce5926a3ffcda7e669106", 
-        "78739468c87b30f76d067a2d7f373803"
-       ]
-      }, 
-      "_rev": "6-441f43a31c89dc68a7cc934ce5779bf8", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }
-    ]
-   }, 
-   {
-    "docs": [
-     {
-      "_revisions": {
-       "start": 2, 
-       "ids": [
-        "3757f03a178b34284361c89303cf8c35", 
-        "0593f4c87b24f0f9b620526433929bb0"
-       ]
-      }, 
-      "_rev": "2-3757f03a178b34284361c89303cf8c35", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 2, 
-       "ids": [
-        "4e16ac64356d4358bf1bdb4857fc299f", 
-        "aed67b17ea5ba6b78e704ad65d3fb5db"
-       ]
-      }, 
-      "_rev": "2-4e16ac64356d4358bf1bdb4857fc299f", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 3, 
-       "ids": [
-        "91b47d7b889feb36eaf9336c071f00cc", 
-        "0e3379b8f9128e6062d13eeb98ec538e", 
-        "1c006ce18b663e2a031ced4669797c28"
-       ]
-      }, 
-      "_rev": "3-91b47d7b889feb36eaf9336c071f00cc", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 3, 
-       "ids": [
-        "4d93920c00a4a7269095b22ff4329b3c", 
-        "7190eca51acb2b302a89ed1204ac2813", 
-        "017eba7ef1e4f529143f463779822627"
-       ]
-      }, 
-      "_rev": "3-4d93920c00a4a7269095b22ff4329b3c", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 4, 
-       "ids": [
-        "2c3c860d421fc9f6cc82e4fb811dc8e2", 
-        "4473170dcffa850aca381b4f644b2947", 
-        "3524a871600080f5e30e59a292b02a3f", 
-        "89eb0b5131800963bb7caf1fc83b6242"
-       ]
-      }, 
-      "_rev": "4-2c3c860d421fc9f6cc82e4fb811dc8e2", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 4, 
-       "ids": [
-        "dbaa7e6c02381c2c0ec5259572387d7c", 
-        "f28d17ab990dcadd20ad38860fde9f11", 
-        "6cf4b9e2115d7e884292b97aa8765285", 
-        "dcfdf66ab61873ee512a9ccf3e3731a1"
-       ]
-      }, 
-      "_rev": "4-dbaa7e6c02381c2c0ec5259572387d7c", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 6, 
-       "ids": [
-        "441f43a31c89dc68a7cc934ce5779bf8", 
-        "4c7f8b00508144d049d18668d17e552a", 
-        "e8431fb3b448f3457c5b2d77012fa8b4", 
-        "f2e7dc8102123e13ca792a0a05ca6235", 
-        "37a13a5c1e2ce5926a3ffcda7e669106", 
-        "78739468c87b30f76d067a2d7f373803"
-       ]
-      }, 
-      "_rev": "6-441f43a31c89dc68a7cc934ce5779bf8", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }
-    ]
-   }
-  ];
+    var data = [
+      {
+        "docs": [
+          {
+            "_revisions": {
+              "start": 2,
+              "ids": [
+                "4e16ac64356d4358bf1bdb4857fc299f",
+                "aed67b17ea5ba6b78e704ad65d3fb5db"
+              ]
+            },
+            "_rev": "2-4e16ac64356d4358bf1bdb4857fc299f",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 2,
+              "ids": [
+                "3757f03a178b34284361c89303cf8c35",
+                "0593f4c87b24f0f9b620526433929bb0"
+              ]
+            },
+            "_rev": "2-3757f03a178b34284361c89303cf8c35",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 3,
+              "ids": [
+                "f28d17ab990dcadd20ad38860fde9f11",
+                "6cf4b9e2115d7e884292b97aa8765285",
+                "dcfdf66ab61873ee512a9ccf3e3731a1"
+              ]
+            },
+            "_rev": "3-f28d17ab990dcadd20ad38860fde9f11",
+            "_id": "b74e3b45"
+          },
+          {
+            "_revisions": {
+              "start": 3,
+              "ids": [
+                "4d93920c00a4a7269095b22ff4329b3c",
+                "7190eca51acb2b302a89ed1204ac2813",
+                "017eba7ef1e4f529143f463779822627"
+              ]
+            },
+            "_rev": "3-4d93920c00a4a7269095b22ff4329b3c",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 3,
+              "ids": [
+                "91b47d7b889feb36eaf9336c071f00cc",
+                "0e3379b8f9128e6062d13eeb98ec538e",
+                "1c006ce18b663e2a031ced4669797c28"
+              ]
+            },
+            "_rev": "3-91b47d7b889feb36eaf9336c071f00cc",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 4,
+              "ids": [
+                "2c3c860d421fc9f6cc82e4fb811dc8e2",
+                "4473170dcffa850aca381b4f644b2947",
+                "3524a871600080f5e30e59a292b02a3f",
+                "89eb0b5131800963bb7caf1fc83b6242"
+              ]
+            },
+            "_rev": "4-2c3c860d421fc9f6cc82e4fb811dc8e2",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 6,
+              "ids": [
+                "441f43a31c89dc68a7cc934ce5779bf8",
+                "4c7f8b00508144d049d18668d17e552a",
+                "e8431fb3b448f3457c5b2d77012fa8b4",
+                "f2e7dc8102123e13ca792a0a05ca6235",
+                "37a13a5c1e2ce5926a3ffcda7e669106",
+                "78739468c87b30f76d067a2d7f373803"
+              ]
+            },
+            "_rev": "6-441f43a31c89dc68a7cc934ce5779bf8",
+            "_id": "b74e3b45",
+            "_deleted": true
+          }
+        ]
+      },
+      {
+        "docs": [
+          {
+            "_revisions": {
+              "start": 2,
+              "ids": [
+                "3757f03a178b34284361c89303cf8c35",
+                "0593f4c87b24f0f9b620526433929bb0"
+              ]
+            },
+            "_rev": "2-3757f03a178b34284361c89303cf8c35",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 2,
+              "ids": [
+                "4e16ac64356d4358bf1bdb4857fc299f",
+                "aed67b17ea5ba6b78e704ad65d3fb5db"
+              ]
+            },
+            "_rev": "2-4e16ac64356d4358bf1bdb4857fc299f",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 3,
+              "ids": [
+                "91b47d7b889feb36eaf9336c071f00cc",
+                "0e3379b8f9128e6062d13eeb98ec538e",
+                "1c006ce18b663e2a031ced4669797c28"
+              ]
+            },
+            "_rev": "3-91b47d7b889feb36eaf9336c071f00cc",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 3,
+              "ids": [
+                "4d93920c00a4a7269095b22ff4329b3c",
+                "7190eca51acb2b302a89ed1204ac2813",
+                "017eba7ef1e4f529143f463779822627"
+              ]
+            },
+            "_rev": "3-4d93920c00a4a7269095b22ff4329b3c",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 4,
+              "ids": [
+                "2c3c860d421fc9f6cc82e4fb811dc8e2",
+                "4473170dcffa850aca381b4f644b2947",
+                "3524a871600080f5e30e59a292b02a3f",
+                "89eb0b5131800963bb7caf1fc83b6242"
+              ]
+            },
+            "_rev": "4-2c3c860d421fc9f6cc82e4fb811dc8e2",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 4,
+              "ids": [
+                "dbaa7e6c02381c2c0ec5259572387d7c",
+                "f28d17ab990dcadd20ad38860fde9f11",
+                "6cf4b9e2115d7e884292b97aa8765285",
+                "dcfdf66ab61873ee512a9ccf3e3731a1"
+              ]
+            },
+            "_rev": "4-dbaa7e6c02381c2c0ec5259572387d7c",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 6,
+              "ids": [
+                "441f43a31c89dc68a7cc934ce5779bf8",
+                "4c7f8b00508144d049d18668d17e552a",
+                "e8431fb3b448f3457c5b2d77012fa8b4",
+                "f2e7dc8102123e13ca792a0a05ca6235",
+                "37a13a5c1e2ce5926a3ffcda7e669106",
+                "78739468c87b30f76d067a2d7f373803"
+              ]
+            },
+            "_rev": "6-441f43a31c89dc68a7cc934ce5779bf8",
+            "_id": "b74e3b45",
+            "_deleted": true
+          }
+        ]
+      }
+    ];
+  });
 });


### PR DESCRIPTION
@dholth I made some corrections to https://github.com/pouchdb/pouchdb/pull/3656, please take a look. I understand that our test suite is kinda complicated, but basically:

* tests should test both the http and local adapters, so that we can know what CouchDB says is the truth :)
* the Mocha promise format is waaay easier to work with than the callback format (i.e. "done")

I have good new and bad news. The good news is that your test is passing in CouchDB, IndexedDB, and WebSQL. The bad news is that it is failing in LevelDB, and that it doesn't actually capture the change you made to `websql-bulk-docs`, because it succeeds in WebSQL before and after the commit. :( And unfortunately I don't have time today to look into the LevelDB issue, but it seems you may have found some other bug in there.

Let me know if you need help with this; I'll be on IRC all day today. And thanks again for your help trying to track it down; it is *much much* appreciated.