### PR TITLE
(#3646) - fix deleted conflicts in all 3 adapters

### DIFF
--- a/lib/adapters/idb/idb-bulk-docs.js
+++ b/lib/adapters/idb/idb-bulk-docs.js
@@ -185,8 +185,8 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
     });
   }
 
-  function writeDoc(docInfo, winningRev, deleted, callback, isUpdate,
-                    delta, resultsIdx) {
+  function writeDoc(docInfo, winningRev, winningRevIsDeleted, newRevIsDeleted,
+                    isUpdate, delta, resultsIdx, callback) {
 
     docCountDelta += delta;
 
@@ -194,19 +194,19 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
     doc._id = docInfo.metadata.id;
     doc._rev = docInfo.metadata.rev;
 
-    if (deleted) {
+    if (newRevIsDeleted) {
       doc._deleted = true;
     }
 
     var hasAttachments = doc._attachments &&
       Object.keys(doc._attachments).length;
     if (hasAttachments) {
-      return writeAttachments(docInfo, winningRev, deleted,
-        callback, isUpdate, resultsIdx);
+      return writeAttachments(docInfo, winningRev, winningRevIsDeleted,
+        isUpdate, resultsIdx, callback);
     }
 
-    finishDoc(docInfo, winningRev, deleted,
-      callback, isUpdate, resultsIdx);
+    finishDoc(docInfo, winningRev, winningRevIsDeleted,
+      isUpdate, resultsIdx, callback);
   }
 
   function autoCompact(docInfo) {
@@ -215,8 +215,8 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
     compactRevs(revsToDelete, docInfo.metadata.id, txn);
   }
 
-  function finishDoc(docInfo, winningRev, deleted, callback, isUpdate,
-                     resultsIdx) {
+  function finishDoc(docInfo, winningRev, winningRevIsDeleted,
+                     isUpdate, resultsIdx, callback) {
 
     var doc = docInfo.data;
     var metadata = docInfo.metadata;
@@ -232,7 +232,8 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
       metadata.seq = e.target.result;
       // Current _rev is calculated from _rev_tree on read
       delete metadata.rev;
-      var metadataToStore = encodeMetadata(metadata, winningRev, deleted);
+      var metadataToStore = encodeMetadata(metadata, winningRev,
+        winningRevIsDeleted);
       var metaDataReq = docStore.put(metadataToStore);
       metaDataReq.onsuccess = afterPutMetadata;
     }
@@ -265,8 +266,8 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
     putReq.onerror = afterPutDocError;
   }
 
-  function writeAttachments(docInfo, winningRev, deleted, callback,
-                            isUpdate, resultsIdx) {
+  function writeAttachments(docInfo, winningRev, winningRevIsDeleted,
+                            isUpdate, resultsIdx, callback) {
 
 
     var doc = docInfo.data;
@@ -276,8 +277,8 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
 
     function collectResults() {
       if (numDone === attachments.length) {
-        finishDoc(docInfo, winningRev, deleted, callback, isUpdate,
-          resultsIdx);
+        finishDoc(docInfo, winningRev, winningRevIsDeleted,
+          isUpdate, resultsIdx, callback);
       }
     }
 

--- a/lib/adapters/leveldb/leveldb.js
+++ b/lib/adapters/leveldb/leveldb.js
@@ -498,22 +498,22 @@ function LevelPouch(opts, callback) {
       return complete();
     }
 
-    function writeDoc(doc, winningRev, deleted, callback2,
-                      isUpdate, delta, index) {
+    function writeDoc(docInfo, winningRev, winningRevIsDeleted, newRevIsDeleted,
+                      isUpdate, delta, resultsIdx, callback2) {
       docCountDelta += delta;
 
       var err = null;
       var recv = 0;
 
-      doc.data._id = doc.metadata.id;
-      doc.data._rev = doc.metadata.rev;
+      docInfo.data._id = docInfo.metadata.id;
+      docInfo.data._rev = docInfo.metadata.rev;
 
-      if (deleted) {
-        doc.data._deleted = true;
+      if (newRevIsDeleted) {
+        docInfo.data._deleted = true;
       }
 
-      var attachments = doc.data._attachments ?
-        Object.keys(doc.data._attachments) :
+      var attachments = docInfo.data._attachments ?
+        Object.keys(docInfo.data._attachments) :
         [];
 
       function attachmentSaved(attachmentErr) {
@@ -544,12 +544,12 @@ function LevelPouch(opts, callback) {
 
       for (var i = 0; i < attachments.length; i++) {
         var key = attachments[i];
-        var att = doc.data._attachments[key];
+        var att = docInfo.data._attachments[key];
 
         if (att.stub) {
           // still need to update the refs mapping
-          var id = doc.data._id;
-          var rev = doc.data._rev;
+          var id = docInfo.data._id;
+          var rev = docInfo.data._rev;
           saveAttachmentRefs(id, rev, att.digest, attachmentSaved);
           continue;
         }
@@ -566,44 +566,45 @@ function LevelPouch(opts, callback) {
           data = att.data;
         } else { // browser
           utils.readAsBinaryString(att.data,
-            onLoadEnd(doc, key, attachmentSaved));
+            onLoadEnd(docInfo, key, attachmentSaved));
           continue;
         }
         utils.MD5(data).then(
-          onMD5Load(doc, key, data, attachmentSaved)
+          onMD5Load(docInfo, key, data, attachmentSaved)
         );
       }
 
       function finish() {
-        var seq = doc.metadata.rev_map[doc.metadata.rev];
+        var seq = docInfo.metadata.rev_map[docInfo.metadata.rev];
         if (seq) {
           // check that there aren't any existing revisions with the same
           // revision id, else we shouldn't do anything
           return callback2();
         }
         seq = ++newUpdateSeq;
-        doc.metadata.rev_map[doc.metadata.rev] = doc.metadata.seq = seq;
+        docInfo.metadata.rev_map[docInfo.metadata.rev] =
+          docInfo.metadata.seq = seq;
         var seqKey = formatSeq(seq);
         var batch = [{
           key: seqKey,
-          value: doc.data,
+          value: docInfo.data,
           prefix: stores.bySeqStore,
           type: 'put',
           valueEncoding: 'json'
         }, {
-          key: doc.metadata.id,
-          value: doc.metadata,
+          key: docInfo.metadata.id,
+          value: docInfo.metadata,
           prefix: stores.docStore,
           type: 'put',
           valueEncoding: safeJsonEncoding
         }];
         txn.batch(batch);
-        results[index] = {
+        results[resultsIdx] = {
           ok: true,
-          id: doc.metadata.id,
+          id: docInfo.metadata.id,
           rev: winningRev
         };
-        fetchedDocs.set(doc.metadata.id, doc.metadata);
+        fetchedDocs.set(docInfo.metadata.id, docInfo.metadata);
         callback2();
       }
 

--- a/lib/adapters/websql/websql-bulk-docs.js
+++ b/lib/adapters/websql/websql-bulk-docs.js
@@ -104,7 +104,8 @@ function websqlBulkDocs(req, opts, api, db, Changes, callback) {
 
     function finish() {
       var data = docInfo.data;
-      var deletedInt = deleted ? 1 : 0;
+      // #3646 deleted passed to writeDoc is not for BY_SEQ_STORE
+      var deletedInt = docInfo.metadata.deleted ? 1 : 0;
 
       var id = data._id;
       var rev = data._rev;

--- a/lib/adapters/websql/websql-bulk-docs.js
+++ b/lib/adapters/websql/websql-bulk-docs.js
@@ -98,14 +98,12 @@ function websqlBulkDocs(req, opts, api, db, Changes, callback) {
     });
   }
 
-
-  function writeDoc(docInfo, winningRev, deleted, callback, isUpdate,
-                    docCount, resultsIdx) {
+  function writeDoc(docInfo, winningRev, winningRevIsDeleted, newRevIsDeleted,
+                    isUpdate, delta, resultsIdx, callback) {
 
     function finish() {
       var data = docInfo.data;
-      // #3646 deleted passed to writeDoc is not for BY_SEQ_STORE
-      var deletedInt = docInfo.metadata.deleted ? 1 : 0;
+      var deletedInt = newRevIsDeleted ? 1 : 0;
 
       var id = data._id;
       var rev = data._rev;
@@ -186,7 +184,7 @@ function websqlBulkDocs(req, opts, api, db, Changes, callback) {
     var attachments = Object.keys(docInfo.data._attachments || {});
 
 
-    if (deleted) {
+    if (newRevIsDeleted) {
       docInfo.data._deleted = true;
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -557,13 +557,16 @@ exports.updateDoc = function updateDoc(prev, docInfo, results,
     return cb();
   }
 
-  var previouslyDeleted = exports.isDeleted(prev);
+  // TODO: some of these can be pre-calculated, but it's safer to just
+  // call merge.winningRev() and exports.isDeleted() all over again
+  var previousWinningRev = merge.winningRev(prev);
+  var previouslyDeleted = exports.isDeleted(prev, previousWinningRev);
   var deleted = exports.isDeleted(docInfo.metadata);
   var isRoot = /^1-/.test(docInfo.metadata.rev);
 
   if (previouslyDeleted && !deleted && newEdits && isRoot) {
     var newDoc = docInfo.data;
-    newDoc._rev = merge.winningRev(prev);
+    newDoc._rev = previousWinningRev;
     newDoc._id = docInfo.metadata.id;
     docInfo = exports.parseDoc(newDoc, newEdits);
   }
@@ -588,18 +591,17 @@ exports.updateDoc = function updateDoc(prev, docInfo, results,
 
   // recalculate
   var winningRev = merge.winningRev(docInfo.metadata);
-  deleted = exports.isDeleted(docInfo.metadata, winningRev);
+  var winningRevIsDeleted = exports.isDeleted(docInfo.metadata, winningRev);
 
-  var delta = 0;
-  if (newEdits || winningRev === newRev) {
-    // if newEdits==false and we're pushing existing revisions,
-    // then the only thing that matters is whether this revision
-    // is the winning one, and thus replaces an old one
-    delta = (previouslyDeleted === deleted) ? 0 :
-      previouslyDeleted < deleted ? -1 : 1;
-  }
+  // calculate the total number of documents that were added/removed,
+  // from the perspective of total_rows/doc_count
+  var delta = (previouslyDeleted === winningRevIsDeleted) ? 0 :
+      previouslyDeleted < winningRevIsDeleted ? -1 : 1;
 
-  writeDoc(docInfo, winningRev, deleted, cb, true, delta, i);
+  var newRevIsDeleted = exports.isDeleted(docInfo.metadata, newRev);
+
+  writeDoc(docInfo, winningRev, winningRevIsDeleted, newRevIsDeleted,
+    true, delta, i, cb);
 };
 
 exports.processDocs = function processDocs(docInfos, api, fetchedDocs,
@@ -621,7 +623,8 @@ exports.processDocs = function processDocs(docInfos, api, fetchedDocs,
 
     var delta = deleted ? 0 : 1;
 
-    writeDoc(docInfo, winningRev, deleted, callback, false, delta, resultsIdx);
+    writeDoc(docInfo, winningRev, deleted, deleted, false,
+      delta, resultsIdx, callback);
   }
 
   var newEdits = opts.new_edits;

--- a/tests/integration/index.html
+++ b/tests/integration/index.html
@@ -45,6 +45,7 @@
     <script src='browser.info.js'></script>
     <script src='test.issue221.js'></script>
     <script src='test.issue3179.js'></script>
+    <script src='test.issue3646.js'></script>
     <script src='test.http.js'></script>
     <script src='test.compaction.js'></script>
     <script src='test.get.js'></script>

--- a/tests/integration/test.issue3646.js
+++ b/tests/integration/test.issue3646.js
@@ -1,213 +1,245 @@
 'use strict';
 
-describe('Issue #3646 WebSQL deleted documents bug', function () {
-  it('Should finish with 0 documents', function (done) {
-    new PouchDB('issue3646', function (err, db) {
-      Promise.all(data.forEach(docs) {
-        db.bulkDocs(docs, {new_edits: false});
-      }).then(function() {
-        db.info().then(function(info) {
-          info.doc_count.should.equal(0);
-          done();
-        });
+var adapters = ['local', 'http'];
+
+adapters.forEach(function (adapter) {
+  describe('#3646 WebSQL deleted documents - ' + adapter, function () {
+
+    var dbs = {};
+
+    beforeEach(function (done) {
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
+      testUtils.cleanup([dbs.name], done);
+    });
+
+    after(function (done) {
+      testUtils.cleanup([dbs.name], done);
+    });
+
+    it('Should finish with 0 documents', function () {
+      var db = new PouchDB(dbs.name);
+
+      return db.bulkDocs(data[0], {new_edits: false}).then(function () {
+        return db.bulkDocs(data[1], {new_edits: false});
+      }).then(function () {
+        return db.allDocs();
+      }).then(function (res) {
+        res.rows.should.have.length(0, 'all docs length is 0');
+        res.total_rows.should.equal(0);
+        return db.allDocs({keys: ['b74e3b45'], include_docs: true});
+      }).then(function (res) {
+        var first = res.rows[0];
+        should.equal(first.value.deleted, true, 'all docs value.deleted');
+        first.value.rev.should.equal('6-441f43a31c89dc68a7cc934ce5779bf8');
+        res.total_rows.should.equal(0);
+        return db.info();
+      }).then(function (info) {
+        info.doc_count.should.equal(0, 'doc_count is 0');
+        return db.changes({include_docs: true});
+      }).then(function (changes) {
+        changes.results.should.have.length(1);
+        var first = changes.results[0];
+        first.doc._rev.should.equal('6-441f43a31c89dc68a7cc934ce5779bf8');
+        should.equal(first.deleted, true, 'changes metadata.deleted');
+        should.equal(first.doc._deleted, true, 'changes doc._deleted');
       });
     });
-  });
 
-  var data = [
-   {
-    "docs": [
-     {
-      "_revisions": {
-       "start": 2, 
-       "ids": [
-        "4e16ac64356d4358bf1bdb4857fc299f", 
-        "aed67b17ea5ba6b78e704ad65d3fb5db"
-       ]
-      }, 
-      "_rev": "2-4e16ac64356d4358bf1bdb4857fc299f", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 2, 
-       "ids": [
-        "3757f03a178b34284361c89303cf8c35", 
-        "0593f4c87b24f0f9b620526433929bb0"
-       ]
-      }, 
-      "_rev": "2-3757f03a178b34284361c89303cf8c35", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 3, 
-       "ids": [
-        "f28d17ab990dcadd20ad38860fde9f11", 
-        "6cf4b9e2115d7e884292b97aa8765285", 
-        "dcfdf66ab61873ee512a9ccf3e3731a1"
-       ]
-      }, 
-      "_rev": "3-f28d17ab990dcadd20ad38860fde9f11", 
-      "_id": "b74e3b45"
-     }, 
-     {
-      "_revisions": {
-       "start": 3, 
-       "ids": [
-        "4d93920c00a4a7269095b22ff4329b3c", 
-        "7190eca51acb2b302a89ed1204ac2813", 
-        "017eba7ef1e4f529143f463779822627"
-       ]
-      }, 
-      "_rev": "3-4d93920c00a4a7269095b22ff4329b3c", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 3, 
-       "ids": [
-        "91b47d7b889feb36eaf9336c071f00cc", 
-        "0e3379b8f9128e6062d13eeb98ec538e", 
-        "1c006ce18b663e2a031ced4669797c28"
-       ]
-      }, 
-      "_rev": "3-91b47d7b889feb36eaf9336c071f00cc", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 4, 
-       "ids": [
-        "2c3c860d421fc9f6cc82e4fb811dc8e2", 
-        "4473170dcffa850aca381b4f644b2947", 
-        "3524a871600080f5e30e59a292b02a3f", 
-        "89eb0b5131800963bb7caf1fc83b6242"
-       ]
-      }, 
-      "_rev": "4-2c3c860d421fc9f6cc82e4fb811dc8e2", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 6, 
-       "ids": [
-        "441f43a31c89dc68a7cc934ce5779bf8", 
-        "4c7f8b00508144d049d18668d17e552a", 
-        "e8431fb3b448f3457c5b2d77012fa8b4", 
-        "f2e7dc8102123e13ca792a0a05ca6235", 
-        "37a13a5c1e2ce5926a3ffcda7e669106", 
-        "78739468c87b30f76d067a2d7f373803"
-       ]
-      }, 
-      "_rev": "6-441f43a31c89dc68a7cc934ce5779bf8", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }
-    ]
-   }, 
-   {
-    "docs": [
-     {
-      "_revisions": {
-       "start": 2, 
-       "ids": [
-        "3757f03a178b34284361c89303cf8c35", 
-        "0593f4c87b24f0f9b620526433929bb0"
-       ]
-      }, 
-      "_rev": "2-3757f03a178b34284361c89303cf8c35", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 2, 
-       "ids": [
-        "4e16ac64356d4358bf1bdb4857fc299f", 
-        "aed67b17ea5ba6b78e704ad65d3fb5db"
-       ]
-      }, 
-      "_rev": "2-4e16ac64356d4358bf1bdb4857fc299f", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 3, 
-       "ids": [
-        "91b47d7b889feb36eaf9336c071f00cc", 
-        "0e3379b8f9128e6062d13eeb98ec538e", 
-        "1c006ce18b663e2a031ced4669797c28"
-       ]
-      }, 
-      "_rev": "3-91b47d7b889feb36eaf9336c071f00cc", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 3, 
-       "ids": [
-        "4d93920c00a4a7269095b22ff4329b3c", 
-        "7190eca51acb2b302a89ed1204ac2813", 
-        "017eba7ef1e4f529143f463779822627"
-       ]
-      }, 
-      "_rev": "3-4d93920c00a4a7269095b22ff4329b3c", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 4, 
-       "ids": [
-        "2c3c860d421fc9f6cc82e4fb811dc8e2", 
-        "4473170dcffa850aca381b4f644b2947", 
-        "3524a871600080f5e30e59a292b02a3f", 
-        "89eb0b5131800963bb7caf1fc83b6242"
-       ]
-      }, 
-      "_rev": "4-2c3c860d421fc9f6cc82e4fb811dc8e2", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 4, 
-       "ids": [
-        "dbaa7e6c02381c2c0ec5259572387d7c", 
-        "f28d17ab990dcadd20ad38860fde9f11", 
-        "6cf4b9e2115d7e884292b97aa8765285", 
-        "dcfdf66ab61873ee512a9ccf3e3731a1"
-       ]
-      }, 
-      "_rev": "4-dbaa7e6c02381c2c0ec5259572387d7c", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }, 
-     {
-      "_revisions": {
-       "start": 6, 
-       "ids": [
-        "441f43a31c89dc68a7cc934ce5779bf8", 
-        "4c7f8b00508144d049d18668d17e552a", 
-        "e8431fb3b448f3457c5b2d77012fa8b4", 
-        "f2e7dc8102123e13ca792a0a05ca6235", 
-        "37a13a5c1e2ce5926a3ffcda7e669106", 
-        "78739468c87b30f76d067a2d7f373803"
-       ]
-      }, 
-      "_rev": "6-441f43a31c89dc68a7cc934ce5779bf8", 
-      "_id": "b74e3b45", 
-      "_deleted": true
-     }
-    ]
-   }
-  ];
+    var data = [
+      {
+        "docs": [
+          {
+            "_revisions": {
+              "start": 2,
+              "ids": [
+                "4e16ac64356d4358bf1bdb4857fc299f",
+                "aed67b17ea5ba6b78e704ad65d3fb5db"
+              ]
+            },
+            "_rev": "2-4e16ac64356d4358bf1bdb4857fc299f",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 2,
+              "ids": [
+                "3757f03a178b34284361c89303cf8c35",
+                "0593f4c87b24f0f9b620526433929bb0"
+              ]
+            },
+            "_rev": "2-3757f03a178b34284361c89303cf8c35",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 3,
+              "ids": [
+                "f28d17ab990dcadd20ad38860fde9f11",
+                "6cf4b9e2115d7e884292b97aa8765285",
+                "dcfdf66ab61873ee512a9ccf3e3731a1"
+              ]
+            },
+            "_rev": "3-f28d17ab990dcadd20ad38860fde9f11",
+            "_id": "b74e3b45"
+          },
+          {
+            "_revisions": {
+              "start": 3,
+              "ids": [
+                "4d93920c00a4a7269095b22ff4329b3c",
+                "7190eca51acb2b302a89ed1204ac2813",
+                "017eba7ef1e4f529143f463779822627"
+              ]
+            },
+            "_rev": "3-4d93920c00a4a7269095b22ff4329b3c",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 3,
+              "ids": [
+                "91b47d7b889feb36eaf9336c071f00cc",
+                "0e3379b8f9128e6062d13eeb98ec538e",
+                "1c006ce18b663e2a031ced4669797c28"
+              ]
+            },
+            "_rev": "3-91b47d7b889feb36eaf9336c071f00cc",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 4,
+              "ids": [
+                "2c3c860d421fc9f6cc82e4fb811dc8e2",
+                "4473170dcffa850aca381b4f644b2947",
+                "3524a871600080f5e30e59a292b02a3f",
+                "89eb0b5131800963bb7caf1fc83b6242"
+              ]
+            },
+            "_rev": "4-2c3c860d421fc9f6cc82e4fb811dc8e2",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 6,
+              "ids": [
+                "441f43a31c89dc68a7cc934ce5779bf8",
+                "4c7f8b00508144d049d18668d17e552a",
+                "e8431fb3b448f3457c5b2d77012fa8b4",
+                "f2e7dc8102123e13ca792a0a05ca6235",
+                "37a13a5c1e2ce5926a3ffcda7e669106",
+                "78739468c87b30f76d067a2d7f373803"
+              ]
+            },
+            "_rev": "6-441f43a31c89dc68a7cc934ce5779bf8",
+            "_id": "b74e3b45",
+            "_deleted": true
+          }
+        ]
+      },
+      {
+        "docs": [
+          {
+            "_revisions": {
+              "start": 2,
+              "ids": [
+                "3757f03a178b34284361c89303cf8c35",
+                "0593f4c87b24f0f9b620526433929bb0"
+              ]
+            },
+            "_rev": "2-3757f03a178b34284361c89303cf8c35",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 2,
+              "ids": [
+                "4e16ac64356d4358bf1bdb4857fc299f",
+                "aed67b17ea5ba6b78e704ad65d3fb5db"
+              ]
+            },
+            "_rev": "2-4e16ac64356d4358bf1bdb4857fc299f",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 3,
+              "ids": [
+                "91b47d7b889feb36eaf9336c071f00cc",
+                "0e3379b8f9128e6062d13eeb98ec538e",
+                "1c006ce18b663e2a031ced4669797c28"
+              ]
+            },
+            "_rev": "3-91b47d7b889feb36eaf9336c071f00cc",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 3,
+              "ids": [
+                "4d93920c00a4a7269095b22ff4329b3c",
+                "7190eca51acb2b302a89ed1204ac2813",
+                "017eba7ef1e4f529143f463779822627"
+              ]
+            },
+            "_rev": "3-4d93920c00a4a7269095b22ff4329b3c",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 4,
+              "ids": [
+                "2c3c860d421fc9f6cc82e4fb811dc8e2",
+                "4473170dcffa850aca381b4f644b2947",
+                "3524a871600080f5e30e59a292b02a3f",
+                "89eb0b5131800963bb7caf1fc83b6242"
+              ]
+            },
+            "_rev": "4-2c3c860d421fc9f6cc82e4fb811dc8e2",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 4,
+              "ids": [
+                "dbaa7e6c02381c2c0ec5259572387d7c",
+                "f28d17ab990dcadd20ad38860fde9f11",
+                "6cf4b9e2115d7e884292b97aa8765285",
+                "dcfdf66ab61873ee512a9ccf3e3731a1"
+              ]
+            },
+            "_rev": "4-dbaa7e6c02381c2c0ec5259572387d7c",
+            "_id": "b74e3b45",
+            "_deleted": true
+          },
+          {
+            "_revisions": {
+              "start": 6,
+              "ids": [
+                "441f43a31c89dc68a7cc934ce5779bf8",
+                "4c7f8b00508144d049d18668d17e552a",
+                "e8431fb3b448f3457c5b2d77012fa8b4",
+                "f2e7dc8102123e13ca792a0a05ca6235",
+                "37a13a5c1e2ce5926a3ffcda7e669106",
+                "78739468c87b30f76d067a2d7f373803"
+              ]
+            },
+            "_rev": "6-441f43a31c89dc68a7cc934ce5779bf8",
+            "_id": "b74e3b45",
+            "_deleted": true
+          }
+        ]
+      }
+    ];
+  });
 });

--- a/tests/integration/test.issue3646.js
+++ b/tests/integration/test.issue3646.js
@@ -1,0 +1,213 @@
+'use strict';
+
+describe('Issue #3646 WebSQL deleted documents bug', function () {
+  it('Should finish with 0 documents', function (done) {
+    new PouchDB('issue3646', function (err, db) {
+      Promise.all(data.forEach(docs) {
+        db.bulkDocs(docs, {new_edits: false});
+      }).then(function() {
+        db.info().then(function(info) {
+          info.doc_count.should.equal(0);
+          done();
+        });
+      });
+    });
+  });
+
+  var data = [
+   {
+    "docs": [
+     {
+      "_revisions": {
+       "start": 2, 
+       "ids": [
+        "4e16ac64356d4358bf1bdb4857fc299f", 
+        "aed67b17ea5ba6b78e704ad65d3fb5db"
+       ]
+      }, 
+      "_rev": "2-4e16ac64356d4358bf1bdb4857fc299f", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 2, 
+       "ids": [
+        "3757f03a178b34284361c89303cf8c35", 
+        "0593f4c87b24f0f9b620526433929bb0"
+       ]
+      }, 
+      "_rev": "2-3757f03a178b34284361c89303cf8c35", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 3, 
+       "ids": [
+        "f28d17ab990dcadd20ad38860fde9f11", 
+        "6cf4b9e2115d7e884292b97aa8765285", 
+        "dcfdf66ab61873ee512a9ccf3e3731a1"
+       ]
+      }, 
+      "_rev": "3-f28d17ab990dcadd20ad38860fde9f11", 
+      "_id": "b74e3b45"
+     }, 
+     {
+      "_revisions": {
+       "start": 3, 
+       "ids": [
+        "4d93920c00a4a7269095b22ff4329b3c", 
+        "7190eca51acb2b302a89ed1204ac2813", 
+        "017eba7ef1e4f529143f463779822627"
+       ]
+      }, 
+      "_rev": "3-4d93920c00a4a7269095b22ff4329b3c", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 3, 
+       "ids": [
+        "91b47d7b889feb36eaf9336c071f00cc", 
+        "0e3379b8f9128e6062d13eeb98ec538e", 
+        "1c006ce18b663e2a031ced4669797c28"
+       ]
+      }, 
+      "_rev": "3-91b47d7b889feb36eaf9336c071f00cc", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 4, 
+       "ids": [
+        "2c3c860d421fc9f6cc82e4fb811dc8e2", 
+        "4473170dcffa850aca381b4f644b2947", 
+        "3524a871600080f5e30e59a292b02a3f", 
+        "89eb0b5131800963bb7caf1fc83b6242"
+       ]
+      }, 
+      "_rev": "4-2c3c860d421fc9f6cc82e4fb811dc8e2", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 6, 
+       "ids": [
+        "441f43a31c89dc68a7cc934ce5779bf8", 
+        "4c7f8b00508144d049d18668d17e552a", 
+        "e8431fb3b448f3457c5b2d77012fa8b4", 
+        "f2e7dc8102123e13ca792a0a05ca6235", 
+        "37a13a5c1e2ce5926a3ffcda7e669106", 
+        "78739468c87b30f76d067a2d7f373803"
+       ]
+      }, 
+      "_rev": "6-441f43a31c89dc68a7cc934ce5779bf8", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }
+    ]
+   }, 
+   {
+    "docs": [
+     {
+      "_revisions": {
+       "start": 2, 
+       "ids": [
+        "3757f03a178b34284361c89303cf8c35", 
+        "0593f4c87b24f0f9b620526433929bb0"
+       ]
+      }, 
+      "_rev": "2-3757f03a178b34284361c89303cf8c35", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 2, 
+       "ids": [
+        "4e16ac64356d4358bf1bdb4857fc299f", 
+        "aed67b17ea5ba6b78e704ad65d3fb5db"
+       ]
+      }, 
+      "_rev": "2-4e16ac64356d4358bf1bdb4857fc299f", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 3, 
+       "ids": [
+        "91b47d7b889feb36eaf9336c071f00cc", 
+        "0e3379b8f9128e6062d13eeb98ec538e", 
+        "1c006ce18b663e2a031ced4669797c28"
+       ]
+      }, 
+      "_rev": "3-91b47d7b889feb36eaf9336c071f00cc", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 3, 
+       "ids": [
+        "4d93920c00a4a7269095b22ff4329b3c", 
+        "7190eca51acb2b302a89ed1204ac2813", 
+        "017eba7ef1e4f529143f463779822627"
+       ]
+      }, 
+      "_rev": "3-4d93920c00a4a7269095b22ff4329b3c", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 4, 
+       "ids": [
+        "2c3c860d421fc9f6cc82e4fb811dc8e2", 
+        "4473170dcffa850aca381b4f644b2947", 
+        "3524a871600080f5e30e59a292b02a3f", 
+        "89eb0b5131800963bb7caf1fc83b6242"
+       ]
+      }, 
+      "_rev": "4-2c3c860d421fc9f6cc82e4fb811dc8e2", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 4, 
+       "ids": [
+        "dbaa7e6c02381c2c0ec5259572387d7c", 
+        "f28d17ab990dcadd20ad38860fde9f11", 
+        "6cf4b9e2115d7e884292b97aa8765285", 
+        "dcfdf66ab61873ee512a9ccf3e3731a1"
+       ]
+      }, 
+      "_rev": "4-dbaa7e6c02381c2c0ec5259572387d7c", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }, 
+     {
+      "_revisions": {
+       "start": 6, 
+       "ids": [
+        "441f43a31c89dc68a7cc934ce5779bf8", 
+        "4c7f8b00508144d049d18668d17e552a", 
+        "e8431fb3b448f3457c5b2d77012fa8b4", 
+        "f2e7dc8102123e13ca792a0a05ca6235", 
+        "37a13a5c1e2ce5926a3ffcda7e669106", 
+        "78739468c87b30f76d067a2d7f373803"
+       ]
+      }, 
+      "_rev": "6-441f43a31c89dc68a7cc934ce5779bf8", 
+      "_id": "b74e3b45", 
+      "_deleted": true
+     }
+    ]
+   }
+  ];
+});


### PR DESCRIPTION
This bug appears when a deleted revision is added, which is not the winning
revision. It caused errors both in how `doc_count`/`total_rows` was
calculated, as well as how the winning doc was returned.

The bug appeared in all three adapters.

The test captures both failures. I can confirm that the test fails before
the fix and succeeds afterwards.