### PR TITLE
(#3640) - simplify md5sum for large binaries

### DIFF
--- a/lib/deps/md5.js
+++ b/lib/deps/md5.js
@@ -5,49 +5,6 @@ var Md5 = require('spark-md5');
 var setImmediateShim = global.setImmediate || global.setTimeout;
 var MD5_CHUNK_SIZE = 32768;
 
-function sliceShim(arrayBuffer, begin, end) {
-  if (typeof arrayBuffer.slice === 'function') {
-    if (!begin && !end) {
-      return arrayBuffer.slice();
-    } else if (!end) {
-      return arrayBuffer.slice(begin);
-    } else {
-      return arrayBuffer.slice(begin, end);
-    }
-  }
-  //
-  // shim for IE courtesy of http://stackoverflow.com/a/21440217
-  //
-
-  //If `begin`/`end` is unspecified, Chrome assumes 0, so we do the same
-  //Chrome also converts the values to integers via flooring
-  begin = Math.floor(begin || 0);
-  end = Math.floor(end || 0);
-
-  var len = arrayBuffer.byteLength;
-
-  //If either `begin` or `end` is negative, it refers to an
-  //index from the end of the array, as opposed to from the beginning.
-  //The range specified by the `begin` and `end` values is clamped to the
-  //valid index range for the current array.
-  begin = begin < 0 ? Math.max(begin + len, 0) : Math.min(len, begin);
-  end = end < 0 ? Math.max(end + len, 0) : Math.min(len, end);
-
-  //If the computed length of the new ArrayBuffer would be negative, it
-  //is clamped to zero.
-  if (end - begin <= 0) {
-    return new ArrayBuffer(0);
-  }
-
-  var result = new ArrayBuffer(end - begin);
-  var resultBytes = new Uint8Array(result);
-  var sourceBytes = new Uint8Array(arrayBuffer, begin, end - begin);
-
-  resultBytes.set(sourceBytes);
-
-  return result;
-}
-
 // convert a 64-bit int to a binary string
 function intToString(int) {
   var bytes = [
@@ -71,6 +28,23 @@ function rawToBase64(raw) {
   return btoa(res);
 }
 
+function appendBuffer(buffer, data, start, end) {
+  if (start > 0 || end < data.byteLength) {
+    // only create a subarray if we really need to
+    data = new Uint8Array(data, start,
+      Math.min(end, data.byteLength) - start);
+  }
+  buffer.append(data);
+}
+
+function appendString(buffer, data, start, end) {
+  if (start > 0 || end < data.length) {
+    // only create a substring if we really need to
+    data = data.substring(start, end);
+  }
+  buffer.appendBinary(data);
+}
+
 module.exports = function (data, callback) {
   if (!process.browser) {
     var base64 = crypto.createHash('md5').update(data).digest('base64');
@@ -84,13 +58,7 @@ module.exports = function (data, callback) {
   var currentChunk = 0;
   var buffer = inputIsString ? new Md5() : new Md5.ArrayBuffer();
 
-  function append(buffer, data, start, end) {
-    if (inputIsString) {
-      buffer.appendBinary(data.substring(start, end));
-    } else {
-      buffer.append(sliceShim(data, start, end));
-    }
-  }
+  var append = inputIsString ? appendString : appendBuffer;
 
   function loadNextChunk() {
     var start = currentChunk * chunkSize;


### PR DESCRIPTION
This doesn't fix the "crashiness" problem. (Interesting, Chrome seems to have solved that itself - it no longer crashes as of Chrome Canary when I try a very large file with the provided test.)

However, this does simplify the code, so that we can start actually fixing the root of the problem, which I believe is in SparkMD5, notably [these lines](https://github.com/satazor/SparkMD5/blob/0d8d2a772ab2ef1fd66fec41bb6cb3665e6e3ccc/spark-md5.js#L497-L499).