### PR TITLE
(#3664) - update docs on chrome blobs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -86,6 +86,7 @@ Here are the strategies used by various browsers in PouchDB:
 	<th><img src="static/img/browser-logos/internet-explorer_32x32.png" alt="IE"/></th>
 	<th><img src="static/img/browser-logos/firefox_32x32.png" alt="Firefox"/></th>
 	<th><img src="static/img/browser-logos/chrome_32x32.png" alt="Chrome"/></th>
+	<th><img src="static/img/browser-logos/chrome_32x32.png" alt="Chrome"/></th>
 	<th><img src="static/img/browser-logos/safari_32x32.png" alt="Safari"/></th>
 	<th><img src="static/img/browser-logos/safari_32x32.png" alt="Safari"/></th>
 </tr>
@@ -93,15 +94,17 @@ Here are the strategies used by various browsers in PouchDB:
     <th>Adapter</th>
 	<th>IE (10+)</th>
 	<th>Firefox</th>
-	<th>Chrome, Android</th>
-	<th>Safari < 7.1 <br/>iOS < 8</th>	
-	<th>Safari >= 7.1, <br/>iOS >= 8</th>
+	<th>Chrome < 43,<br/>Android</th>
+	<th>Chrome >= 43</th>
+	<th>Safari < 7.1,<br/>iOS < 8</th>	
+	<th>Safari >= 7.1,<br/>iOS >= 8</th>
 </tr>
 <tr>
     <td>IndexedDB</td>
 	<td>Blob</td>
 	<td>Blob</td>
 	<td>Base-64</td>
+	<td>Blob</td>
 	<td></td>
 	<td></td>
 </tr>
@@ -109,6 +112,7 @@ Here are the strategies used by various browsers in PouchDB:
 	<td>WebSQL</td>
 	<td></td>
 	<td></td>
+	<td>Blob</td>
 	<td>Blob</td>
 	<td>UTF-16 Blob</td>
 	<td>Blob</td>


### PR DESCRIPTION
I've tested and can confirm that Chrome
has finally resolved all the blob issues
as of Chrome v43 (currently Canary). This
will eventually make it into Android Lollipop,
and we can update the docs again when that
happens.