### PR TITLE
(fix #3680) - Properly encode special document ids

### DIFF
--- a/lib/adapters/http/http.js
+++ b/lib/adapters/http/http.js
@@ -16,8 +16,11 @@ var isBrowser = typeof process === 'undefined' || process.browser;
 var buffer = require('../../deps/buffer');
 
 function encodeDocId(id) {
-  if (/^_(design|local)/.test(id)) {
-    return id;
+  if (/^_design/.test(id)) {
+    return '_design/' + encodeURIComponent(id.slice(8));
+  }
+  if (/^_local/.test(id)) {
+    return '_local/' + encodeURIComponent(id.slice(7));
   }
   return encodeURIComponent(id);
 }

--- a/tests/integration/test.http.js
+++ b/tests/integration/test.http.js
@@ -64,6 +64,20 @@ describe('test.http.js', function () {
     });
   });
 
+  it('handle ddocs with slashes', function (done) {
+    var ddoc = {
+      _id: '_design/foo/bar'
+    };
+    var db = new PouchDB(dbs.name);
+    db.bulkDocs({ docs: [ddoc] }, function (err, result) {
+      db.get(ddoc._id, function (err, doc) {
+        should.not.exist(err);
+        doc._id.should.equal(ddoc._id, 'Correct doc returned');
+        done();
+      });
+    });
+  });
+
   it('#2853 test uri parsing usernames/passwords', function () {
     var uri = PouchDB.utils.parseUri(
       'http://u%24ern%40me:p%26%24%24w%40rd@foo.com');


### PR DESCRIPTION
Correctly encode design and local document ids, like `_design/foo/bar` in http adapter.