### PR TITLE
(#3687) - return to pending state when live replication pauses

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -97,12 +97,6 @@ Replication.prototype.cancel = function () {
 
 Replication.prototype.ready = function (src, target) {
   var self = this;
-  this.once('change', function () {
-    if (this.state === 'pending' || this.state === 'stopped') {
-      self.state = 'active';
-      self.emit('active');
-    }
-  });
   function onDestroy() {
     self.cancel();
   }
@@ -362,6 +356,7 @@ function replicate(repId, src, target, opts, returnValue, result) {
     if (pendingBatch.changes.length === 0) {
       if (batches.length === 0 && !currentBatch) {
         if ((continuous && changesOpts.live) || changesCompleted) {
+          returnValue.state = 'pending';
           returnValue.emit('paused');
           returnValue.emit('uptodate', result);
         }
@@ -382,6 +377,10 @@ function replicate(repId, src, target, opts, returnValue, result) {
         changes: [],
         docs: []
       };
+      if (returnValue.state === 'pending' || returnValue.state === 'stopped') {
+        returnValue.state = 'active';
+        returnValue.emit('active');
+      }
       startNextBatch();
     }
   }


### PR DESCRIPTION
Fixes #3687.  As a side effect, though, it also slightly changes the order of events triggered by live replication: now 'active' always comes first, before the first 'change' of the replication batch (it used to be fired in a "once('change')" handler, so it was trigger just after).