### PR TITLE
(#3689) - Add ajax to GET and fix npm run dev on Windows

### DIFF
--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -2,6 +2,10 @@
 
 : ${CLIENT:="node"}
 
+if [[ "$#" == "1" ]]; then
+  CLIENT="$1"
+fi
+
 if [[ ! -z $SERVER ]]; then
   if [ "$SERVER" == "pouchdb-server" ]; then
     if [[ "$TRAVIS_REPO_SLUG" == "pouchdb/pouchdb" ]]; then

--- a/lib/adapters/http/http.js
+++ b/lib/adapters/http/http.js
@@ -133,7 +133,7 @@ function HttpPouch(opts, callback) {
   var ajaxOpts = opts.ajax || {};
   opts = utils.clone(opts);
   function ajax(options, callback) {
-    var reqOpts = utils.extend({}, ajaxOpts, options);
+    var reqOpts = utils.extend(true, utils.clone(ajaxOpts), options);
     log(reqOpts.method + ' ' + reqOpts.url);
     return utils.ajax(reqOpts, callback);
   }
@@ -335,6 +335,8 @@ function HttpPouch(opts, callback) {
       method: 'GET',
       url: genDBUrl(host, id + params)
     };
+    var getRequestAjaxOpts = opts.ajax || {};
+    utils.extend(true, options, getRequestAjaxOpts);
 
     // If the given id contains at least one '/' and the part before the '/'
     // is NOT "_design" and is NOT "_local"

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "test-browser": "mkdirp dist && npm run build-js && node ./bin/test-browser.js",
     "cordova": "npm run build && sh bin/run-cordova.sh",
     "jshint": "jshint -c .jshintrc bin/ lib/ tests/",
-    "dev": "npm run version && CLIENT=dev bash bin/run-test.sh",
+    "dev": "npm run version && bash bin/run-test.sh dev",
     "launch-dev-server": "npm run version && node ./bin/dev-server.js",
     "test": "npm run version && npm run jshint && bash bin/run-test.sh",
     "release": "sh bin/release.sh",


### PR DESCRIPTION
Fixes #3689.

Needed the ability to actually use the advertised support for ajax on GET
requests.

test.headers.js - Fixed it up to use promises for the tests. This was
important for after() because otherwise for some reason done never
got called. Also added tests for new GET functionality.

npm run dev - The package.json was edited to use an environment variable
to set the client variable to 'dev'. But this doesn't work on Windows.
So I edited bin/run-test.sh to support an optional command line argument
and then edited package.json to use that argument to pass in 'dev'