### PR TITLE
(#3689) - Add ajax override to GET

### DIFF
--- a/lib/adapters/http/http.js
+++ b/lib/adapters/http/http.js
@@ -136,7 +136,7 @@ function HttpPouch(opts, callback) {
   var ajaxOpts = opts.ajax || {};
   opts = utils.clone(opts);
   function ajax(options, callback) {
-    var reqOpts = utils.extend({}, ajaxOpts, options);
+    var reqOpts = utils.extend(true, utils.clone(ajaxOpts), options);
     log(reqOpts.method + ' ' + reqOpts.url);
     return utils.ajax(reqOpts, callback);
   }
@@ -338,6 +338,8 @@ function HttpPouch(opts, callback) {
       method: 'GET',
       url: genDBUrl(host, id + params)
     };
+    var getRequestAjaxOpts = opts.ajax || {};
+    utils.extend(true, options, getRequestAjaxOpts);
 
     // If the given id contains at least one '/' and the part before the '/'
     // is NOT "_design" and is NOT "_local"

--- a/tests/component/test.headers.js
+++ b/tests/component/test.headers.js
@@ -2,7 +2,10 @@
 
 var http = require('http');
 var PouchDB = require('../../lib');
-var assert = require("assert");
+var should = require("chai").should();
+require('bluebird').onPossiblyUnhandledRejection(function (e, promise) {
+  throw e;
+});
 
 describe('test.headers.js', function () {
 
@@ -19,25 +22,40 @@ describe('test.headers.js', function () {
     server.listen(PORT, done);
   });
 
-  after(function (done) {
-    server.close(done);
+  after(function () {
+    return server.close();
   });
 
-
-  it('Test headers are sent correctly', function (done) {
+  it('Test headers are sent correctly', function () {
     var opts = {ajax: {headers: {foo: 'bar'}}};
-    new PouchDB('http://127.0.0.1:' + PORT, opts, function() {
-      assert.equal(headers.foo, 'bar');
-      done();
+    return new PouchDB('http://127.0.0.1:' + PORT, opts).then(function() {
+      should.equal(headers.foo, 'bar');
     });
   });
 
-  it('Test auth params are sent correctly', function (done) {
+  it('Test auth params are sent correctly', function () {
     var opts = {auth: {username: 'foo', password: 'bar'}};
-    new PouchDB('http://127.0.0.1:' + PORT, opts, function() {
-      assert.equal(typeof headers.authorization, 'string');
-      done();
+    return new PouchDB('http://127.0.0.1:' + PORT, opts).then(function() {
+      should.equal(typeof headers.authorization, 'string');
     });
   });
 
+  it('Test headers are sent correctly on GET request', function() {
+    var db = new PouchDB('http://127.0.0.1:' + PORT);
+    var opts = { ajax: { headers: { ick: "slick" } } };
+    return db.get('fake', opts).then(function() {
+      should.equal(headers.ick, 'slick');
+    });
+  });
+
+  it('Test that we combine ajax options both globally and locally on GET',
+     function() {
+    var opts = { ajax: { headers: { aheader: 'whyyes' } } };
+    var db = new PouchDB('http://127.0.0.1:' + PORT, opts);
+    var getOpts = {ajax: { headers: { ick: "slick", aheader: "override!" } } };
+    return db.get('fake', getOpts).then(function() {
+      should.equal(headers.ick, 'slick');
+      should.equal(headers.aheader, 'override!');
+    });
+  });
 });


### PR DESCRIPTION
Needed the ability to actually use the advertised support for ajax on GET
requests.

test.headers.js - Fixed it up to use promises for the tests. This was
important for after() because otherwise for some reason done never
got called. Also added tests for new GET functionality.