### PR TITLE
(#3707) - add bower install documentation

### DIFF
--- a/docs/learn.md
+++ b/docs/learn.md
@@ -18,6 +18,10 @@ To start using PouchDB in your website, simply [download][latest-min] it and inc
 <script src="pouchdb-{{ site.version }}.min.js"></script>
 {% endhighlight %}
 
+Or install it with Bower:
+
+{% highlight bash %}$ bower install --save pouchdb{% endhighlight %}
+
 Or install it as a Node.js module:
 
 {% highlight bash %}$ npm install --save pouchdb{% endhighlight %}


### PR DESCRIPTION
Just realized it's not clear that PouchDB is available from Bower. Many people are still using Bower (e.g. with Ionic).