### PR TITLE
call db.removeListener() before emit

### DIFF
--- a/lib/changes.js
+++ b/lib/changes.js
@@ -15,13 +15,13 @@ function Changes(db, opts, callback) {
   opts = opts ? utils.clone(opts) : {};
   var oldComplete = callback || opts.complete || function () {};
   var complete = opts.complete = utils.once(function (err, resp) {
+    db.removeListener('destroyed', onDestroy);
     if (err) {
       self.emit('error', err);
     } else {
       self.emit('complete', resp);
     }
     self.removeAllListeners();
-    db.removeListener('destroyed', onDestroy);
   });
   if (oldComplete) {
     self.on('complete', function (resp) {


### PR DESCRIPTION
The Changes object's event listeners can add listeners to db; remove our listener before that happens.