### PR TITLE
(#3688) - correctly es3ify

### DIFF
--- a/bin/build-plugin.sh
+++ b/bin/build-plugin.sh
@@ -16,4 +16,5 @@ DEREQUIRE=./node_modules/.bin/derequire
     -x pouchdb \
     -r ./lib/plugins/config-$LEVEL_BACKEND.js:adapter-config \
     -r ./lib/plugins/migrate-browser.js:migrate \
+    | ./bin/es3ify.js \
     | $DEREQUIRE > ./dist/$OUTPUT_FILENAME

--- a/bin/es3ify.js
+++ b/bin/es3ify.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+'use strict';
+var es3ify = require('es3ify');
+return process.stdin.pipe(es3ify()).pipe(process.stdout);

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "scripts": {
     "build-js": "npm run build-main-js && npm run min && npm run build-plugins",
-    "build-main-js": "browserify . -s PouchDB -p bundle-collapser/plugin | derequire > dist/pouchdb.js",
+    "build-main-js": "browserify . -s PouchDB -p bundle-collapser/plugin | ./bin/es3ify.js | derequire > dist/pouchdb.js",
     "min": "uglifyjs dist/pouchdb.js -mc > dist/pouchdb.min.js",
     "build-plugins": "sh bin/build-all-plugins.sh",
     "build": "npm run version && mkdirp dist && npm run build-js && npm run license",
@@ -112,10 +112,5 @@
     "./lib/deps/buffer.js": "./lib/deps/buffer-browser.js",
     "bluebird": "lie",
     "fs": false
-  },
-  "browserify": {
-    "transform": [
-      "es3ify"
-    ]
   }
 }


### PR DESCRIPTION
es3ify is not really doing what we want it to do. When used as a
browserify transform, it is unsafe, because it only applies to
OUR OWN code, not necessarily dependencies.

Furthermore, it's been causing problems from day one due to weirdnesses
where projects that depend on PouchDB and browserify it themselves
also need to require es3ify directly. That's not cool.

My fix is to use es3ify in the same way that we use derequire - i.e.
just as a command-line tool when building, which runs over the entire
file.

I've manually confirmed that this outputs es3ified code and fixes #3688.