### PR TITLE
(#3338) - expose ajax/checkpointer/promise

### DIFF
--- a/docs/_includes/api/plugins.html
+++ b/docs/_includes/api/plugins.html
@@ -22,4 +22,38 @@ PouchDB.plugin({
 new PouchDB('foobar').sayHello(); // prints "Hello!"
 {% endhighlight %}
 
+### Extra APIs
 
+In order to reduce code size when your plugin is browserified/webpacked, PouchDB exposes some of its internal modules to plugin authors.
+
+To use them, you should save PouchDB as a required npm dependency (`npm install --save pouchdb`) and then require them like so:
+
+#### Ajax
+
+{% highlight js %}
+var ajax = require('pouchdb/extras/ajax');
+{% endhighlight %}
+
+The `ajax()` function as used by PouchDB. Essentially a shim in the style of `jQuery.ajax`.
+
+#### Checkpointer
+
+{% highlight js %}
+var Checkpointer = require('pouchdb/extras/checkpointer');
+{% endhighlight %}
+
+The `Checkpointer` function as used by PouchDB's replicator. Writes checkpoints as `_local` docs so that replication can resume where it last left off.
+
+#### Promise
+
+{% highlight js %}
+var Promise = require('pouchdb/extras/promise');
+{% endhighlight %}
+
+The ES6 `Promise` shim as used by PouchDB. Expect this to be `bluebird` in Node, `lie` in browsers without Promise support, and the global `Promise` in browsers with Promise support.
+
+#### Caveats
+
+These "extras" should not be considered stable parts of the API, and may change unpredictably between PouchDB versions. Refer to the [source code](https://github.com/pouchdb/pouchdb/tree/master/extras) for the details of the API.
+
+If your plugin depends on a particular version of PouchDB, please notify your users. Unless you like to live dangerously, you should also nail down the version of PouchDB you are using in your `package.json`. And if you need any other internal modules, please submit a pull request.

--- a/extras/ajax.js
+++ b/extras/ajax.js
@@ -1,0 +1,4 @@
+'use strict';
+
+// allow external plugins to require('pouchdb/extras/ajax')
+module.exports = require('../lib/deps/ajax');

--- a/extras/checkpointer.js
+++ b/extras/checkpointer.js
@@ -1,0 +1,4 @@
+'use strict';
+
+// allow external plugins to require('pouchdb/extras/checkpointer')
+module.exports = require('../lib/checkpointer');

--- a/extras/promise.js
+++ b/extras/promise.js
@@ -1,0 +1,4 @@
+'use strict';
+
+// allow external plugins to require('pouchdb/extras/promise')
+module.exports = require('../lib/deps/promise');

--- a/lib/deps/promise.js
+++ b/lib/deps/promise.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (typeof global.Promise === 'function') {
+  module.exports = global.Promise;
+} else {
+  module.exports = require('bluebird');
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,12 +14,8 @@ exports.Map = collections.Map;
 exports.Set = collections.Set;
 var parseDoc = require('./deps/parse-doc');
 
-if (typeof global.Promise === 'function') {
-  exports.Promise = global.Promise;
-} else {
-  exports.Promise = require('bluebird');
-}
-var Promise = exports.Promise;
+var Promise = require('./deps/promise');
+exports.Promise = Promise;
 
 exports.lastIndexOf = function (str, char) {
   for (var i = str.length - 1; i >= 0; i--) {
@@ -419,7 +415,7 @@ exports.adapterFun = function (name, callback) {
     var self = this;
     logApiCall(self, name, args);
     if (!this.taskqueue.isReady) {
-      return new exports.Promise(function (fulfill, reject) {
+      return new Promise(function (fulfill, reject) {
         self.taskqueue.addTask(function (failed) {
           if (failed) {
             reject(failed);

--- a/tests/unit/test.extras.js
+++ b/tests/unit/test.extras.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var should = require('chai').should();
+
+describe('test.extras.js', function () {
+
+  it('extras/ajax should exist', function () {
+    var ajax = require('../../extras/ajax');
+    should.exist(ajax);
+    ajax.should.be.a('function');
+    ajax.name.should.equal('ajax');
+  });
+
+  it('extras/checkpointer should exist', function () {
+    var checkpointer = require('../../extras/checkpointer');
+    should.exist(checkpointer);
+    checkpointer.should.be.a('function');
+    checkpointer.name.should.equal('Checkpointer');
+  });
+
+  it('extras/promise should exist', function () {
+    var promise = require('../../extras/promise');
+    should.exist(promise);
+    promise.should.be.a('function');
+    promise.name.should.equal('Promise');
+  });
+
+});


### PR DESCRIPTION
This is my proposed solution to the problem of exposing
internal modules to plugin authors. I think this fix is
cleaner than publishing as separate npm modules.

Basically, plugin authors can require whatever they want
by using e.g. `require('pouchdb/extras/ajax')`. I did an
audit of current plugins, and I think the only things we
need are:

* `ajax` (pouchdb-authentication, pouchdb-load, Hoodie)
* `Promise` (just about every plugin)
* `Checkpointer` (pouchdb-load)

If I missed anything, please let me know.