### PR TITLE
(#3731) - upgrade browserify, use source maps

### DIFF
--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -44,13 +44,15 @@ var w = watchify(browserify(indexfile, {
   standalone: "PouchDB",
   cache: {},
   packageCache: {},
-  fullPaths: true
+  fullPaths: true,
+  debug: true
 })).on('update', bundle);
 var b = watchify(browserify({
     entries: perfRoot,
     cache: {},
     packageCache: {},
-    fullPaths: true
+    fullPaths: true,
+    debug: true
   })).on('update', bundlePerfTests);
 
 function bundle(callback) {

--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
     "replace": "^0.2.9",
     "es5-shim": "^3.1.1",
     "phantomjs": "^1.9.7-5",
-    "browserify": "^6.1.0",
-    "watchify": "^2.0.0",
+    "browserify": "^9.0.3",
+    "watchify": "^2.4.0",
     "derequire": "^2.0.0",
     "selenium-standalone": "3.0.2"
   },


### PR DESCRIPTION
Upgrades Browserify and adds source maps when running `npm run dev`. Makes it much much easier to work on PouchDB in dev mode.

![screenshot 2015-04-12 12 04 20](https://cloud.githubusercontent.com/assets/283842/7106380/7f8dcf04-e10c-11e4-90de-916f563f0a34.png)
