### PR TITLE
Fix for BlackBerry 10 selecting WebSQL backend instead of IndexedDB

### DIFF
--- a/lib/adapters/idb/idb.js
+++ b/lib/adapters/idb/idb.js
@@ -913,7 +913,8 @@ IdbPouch.valid = function () {
   // to our knees.
   var isSafari = typeof openDatabase !== 'undefined' &&
     /(Safari|iPhone|iPad|iPod)/.test(navigator.userAgent) &&
-    !/Chrome/.test(navigator.userAgent);
+    !/Chrome/.test(navigator.userAgent) &&
+    !/BlackBerry/.test(navigator.platform);
 
   // some outdated implementations of IDB that appear on Samsung
   // and HTC Android devices <4.4 are missing IDBKeyRange


### PR DESCRIPTION
Apparently the BlackBerry 10 browser identifies itself as Mobile Safari, which causes the WebSQL adapter to be selected instead of IndexedDB, even though the BlackBerry 10 browser has a modern IndexedDB implementation.

This fix simply causes the IndexedDB backend to identify itself as valid on the BlackBerry 10 platform.

Thanks!