### PR TITLE
(#3739) - fix http events, remove undocumented events

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -98,55 +98,7 @@ utils.inherits(AbstractPouchDB, EventEmitter);
 module.exports = AbstractPouchDB;
 
 function AbstractPouchDB() {
-  var self = this;
   EventEmitter.call(this);
-
-  var listeners = 0, changes;
-  var eventNames = ['change', 'delete', 'create', 'update'];
-  this.on('newListener', function (eventName) {
-    if (~eventNames.indexOf(eventName)) {
-      if (listeners) {
-        listeners++;
-        return;
-      } else {
-        listeners++;
-      }
-    } else {
-      return;
-    }
-    var lastChange = 0;
-    changes = this.changes({
-      conflicts: true,
-      include_docs: true,
-      continuous: true,
-      since: 'now',
-      onChange: function (change) {
-        if (change.seq <= lastChange) {
-          return;
-        }
-        lastChange = change.seq;
-        self.emit('change', change);
-        if (change.doc._deleted) {
-          self.emit('delete', change);
-        } else if (change.doc._rev.split('-')[0] === '1') {
-          self.emit('create', change);
-        } else {
-          self.emit('update', change);
-        }
-      }
-    });
-  });
-  this.on('removeListener', function (eventName) {
-    if (~eventNames.indexOf(eventName)) {
-      listeners--;
-      if (listeners) {
-        return;
-      }
-    } else {
-      return;
-    }
-    changes.cancel();
-  });
 }
 
 AbstractPouchDB.prototype.post =

--- a/lib/adapters/http/http.js
+++ b/lib/adapters/http/http.js
@@ -1036,6 +1036,7 @@ function HttpPouch(opts, callback) {
         callback(err);
       } else {
         api.emit('destroyed');
+        api.constructor.emit('destroyed', opts.name);
         callback(null, resp);
       }
     });

--- a/tests/integration/test.defaults.js
+++ b/tests/integration/test.defaults.js
@@ -117,5 +117,69 @@ if (!process.env.LEVEL_ADAPTER &&
         });
       });
     });
+
+    it('constructor emits destroyed when using defaults', function () {
+      var CustomPouch = PouchDB.defaults({db: require('memdown')});
+
+      return new CustomPouch('mydb').then(function (db) {
+        return new PouchDB.utils.Promise(function (resolve) {
+          CustomPouch.once('destroyed', function (name) {
+            name.should.equal('mydb');
+            resolve();
+          });
+          db.destroy();
+        });
+      });
+    });
+
+    it('db emits destroyed when using defaults', function () {
+      var CustomPouch = PouchDB.defaults({db: require('memdown')});
+
+      return new CustomPouch('mydb').then(function (db) {
+        return new PouchDB.utils.Promise(function (resolve) {
+          db.once('destroyed', resolve);
+          db.destroy();
+        });
+      });
+    });
+
+    it('constructor emits creation event', function (done) {
+      var CustomPouch = PouchDB.defaults({db: require('memdown')});
+
+      CustomPouch.once('created', function (name) {
+        name.should.equal('mydb', 'should be same thing');
+        done();
+      });
+      new PouchDB('mydb');
+    });
+
+    // somewhat odd behavior (CustomPouch constructor always mirrors PouchDB),
+    // but better to test it explicitly
+    it('PouchDB emits destroyed when using defaults', function () {
+      var CustomPouch = PouchDB.defaults({db: require('memdown')});
+
+      return new CustomPouch('mydb').then(function (db) {
+        return new PouchDB.utils.Promise(function (resolve) {
+          PouchDB.once('destroyed', function (name) {
+            name.should.equal('mydb');
+            resolve();
+          });
+          db.destroy();
+        });
+      });
+    });
+
+    // somewhat odd behavior (CustomPouch constructor always mirrors PouchDB),
+    // but better to test it explicitly
+    it('PouchDB emits created when using defaults', function (done) {
+      var CustomPouch = PouchDB.defaults({db: require('memdown')});
+
+      PouchDB.once('created', function (name) {
+        name.should.equal('mydb', 'should be same thing');
+        done();
+      });
+      new CustomPouch('mydb');
+    });
+
   });
 }


### PR DESCRIPTION
I added a lot of new tests, especially around `PouchDB.defaults` and `destroy()`, because this is where i first noticed the bug.

Also note that I'm proposing we remove the undocumented `db.on('change'/'delete'/'update'/'create')` events. A few reasons:

* It creates unnecessary event emitters for every `PouchDB` created. And I doubt any of our users are even using it, because it's been undocumented.
* Users can create explicit `changes()` listeners if they really want.
* Most importantly, I couldn't figure out how to get the newly-enabled `http` tests to pass for those events. :confused: Trust me, I tried.

There's one slightly unrelated, weird thing I noticed: `PouchDB` and `CustomPouch` always emit the same `'created'`/`'destroyed'` events, regardless of whether it's a `PouchDB` or a `CustomPouch` that was created/destroyed. This should probably be fixed eventually, but for now I'm noting it by adding tests to confirm it.