### PR TITLE
(#3750) - fix typo in replication test

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -192,7 +192,7 @@ adapters.forEach(function (adapters) {
     });
 
     it('pull replication with many changes + a conflict (#2543)', function () {
-      var db = new PouchDB(dbs.remote);
+      var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
       // simulate 5000 normal commits with two conflicts at the very end
       function uuid() {
@@ -234,7 +234,7 @@ adapters.forEach(function (adapters) {
         return remote.replicate.to(db);
       }).then(function (result) {
         result.ok.should.equal(true);
-        result.docs_written.should.equal(0, 'correct # docs written (1)');
+        result.docs_written.should.equal(1, 'correct # docs written (1)');
         return db.info();
       }).then(function (info) {
         if (!testUtils.isSyncGateway() || info.doc_count) {
@@ -249,7 +249,7 @@ adapters.forEach(function (adapters) {
         return remote.replicate.to(db);
       }).then(function (result) {
         result.ok.should.equal(true);
-        result.docs_written.should.equal(0, 'correct # docs written (2)');
+        result.docs_written.should.equal(1, 'correct # docs written (2)');
         return db.info();
       }).then(function (info) {
         if (!testUtils.isSyncGateway() || info.doc_count) {


### PR DESCRIPTION
This was a pretty dumb mistake, noticed by @jo here:
https://github.com/pouchdb/pouchdb/commit/c2ef4055d3b227150f724f3314d309b759c21c10#commitcomment-10801263

The point of the test was to cause a stack overflow, which it did
before #2543 was fixed, so in a sense the test was fine. But I think
it's way less confusing now.