### PR TITLE
(#3755) - Faster replicate from down server test

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -3901,8 +3901,11 @@ downAdapters.map(function (adapter) {
     });
 
     it('replicate from down server test', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.replicate.to('http://infiniterequest.com', function (err, changes) {
+      var source = new PouchDB('http://infiniterequest.com', {
+        ajax: {timeout: 10}
+      });
+      var target = new PouchDB(dbs.name);
+      source.replicate.to(target, function (err, changes) {
         should.exist(err);
         done();
       });


### PR DESCRIPTION
By configuring a `10ms` ajax timeout.