### PR TITLE
(#3765) - checkpointer should browserify smaller

### DIFF
--- a/lib/checkpointer.js
+++ b/lib/checkpointer.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var utils = require('./utils');
+var Promise = require('./deps/promise');
+var explain404 = require('./deps/explain404');
 var pouchCollate = require('pouchdb-collate');
 var collate = pouchCollate.collate;
 
@@ -8,7 +9,7 @@ function updateCheckpoint(db, id, checkpoint, returnValue) {
   return db.get(id).catch(function (err) {
     if (err.status === 404) {
       if (db.type() === 'http') {
-        utils.explain404(
+        explain404(
           'PouchDB is just checking if a remote checkpoint exists.');
       }
       return {_id: id};
@@ -50,7 +51,7 @@ Checkpointer.prototype.updateTarget = function (checkpoint) {
 Checkpointer.prototype.updateSource = function (checkpoint) {
   var self = this;
   if (this.readOnlySource) {
-    return utils.Promise.resolve(true);
+    return Promise.resolve(true);
   }
   return updateCheckpoint(this.src, this.id, checkpoint, this.returnValue)
     .catch(function (err) {

--- a/lib/deps/explain404.js
+++ b/lib/deps/explain404.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// designed to give info to browser users, who are disturbed
+// when they see 404s in the console
+function explain404(str) {
+  if (process.browser && 'console' in global && 'info' in console) {
+    console.info('The above 404 is totally normal. ' + str);
+  }
+}
+
+module.exports = explain404;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -525,13 +525,7 @@ exports.cancellableFun = function (fun, self, opts) {
 
 exports.MD5 = exports.toPromise(require('./deps/md5'));
 
-// designed to give info to browser users, who are disturbed
-// when they see 404s in the console
-exports.explain404 = function (str) {
-  if (process.browser && 'console' in global && 'info' in console) {
-    console.info('The above 404 is totally normal. ' + str);
-  }
-};
+exports.explain404 = require('./deps/explain404');
 
 exports.info = function (str) {
   if (typeof console !== 'undefined' && 'info' in console) {


### PR DESCRIPTION
When the checkpointer is required externally from
`'pouchdb/extras/checkpointer'`, it's too big because
it pulls in all of utils. This makes it smaller.