### PR TITLE
(pouchdb/express-pouchdb#203) - Deprecate PouchDB.destroy() properly.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -744,3 +744,40 @@ AbstractPouchDB.prototype.registerDependentDatabase =
     return callback(null, {db: depDB});
   });
 });
+
+AbstractPouchDB.prototype.destroy =
+  utils.adapterFun('destroy', function (callback) {
+
+  var self = this;
+  var usePrefix = 'use_prefix' in self ? self.use_prefix : true;
+
+  function destroyDb() {
+    // call destroy method of the particular adaptor
+    self._destroy(function (err, resp) {
+      if (err) {
+        return callback(err);
+      }
+      self.emit('destroyed');
+      callback(null, resp || { 'ok': true });
+    });
+  }
+  self.get('_local/_pouch_dependentDbs', function (err, localDoc) {
+    if (err) {
+      if (err.status !== 404) {
+        return callback(err);
+      } else { // no dependencies
+        return destroyDb();
+      }
+    }
+    var dependentDbs = localDoc.dependentDbs;
+    var PouchDB = self.constructor;
+    var deletedMap = Object.keys(dependentDbs).map(function (name) {
+      var trueName = usePrefix ?
+        name.replace(new RegExp('^' + PouchDB.prefix), '') : name;
+      return new PouchDB(trueName, self.__opts).destroy();
+    });
+    Promise.all(deletedMap).then(destroyDb, function (error) {
+      callback(error);
+    });
+  });
+});

--- a/lib/adapters/http/http.js
+++ b/lib/adapters/http/http.js
@@ -1025,7 +1025,7 @@ function HttpPouch(opts, callback) {
     callback();
   };
 
-  api.destroy = utils.adapterFun('destroy', function (callback) {
+  api._destroy = function (callback) {
     ajax({
       url: genDBUrl(host, ''),
       method: 'DELETE',
@@ -1040,25 +1040,8 @@ function HttpPouch(opts, callback) {
         callback(null, resp);
       }
     });
-  });
+  };
 }
-
-// Delete the HttpPouch specified by the given name.
-HttpPouch.destroy = utils.toPromise(function (name, opts, callback) {
-  var host = getHost(name, opts);
-  opts = opts || {};
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-  opts = utils.clone(opts);
-  opts.headers = host.headers;
-  opts.method = 'DELETE';
-  opts.url = genDBUrl(host, '');
-  var ajaxOpts = opts.ajax || {};
-  opts = utils.extend({}, opts, ajaxOpts);
-  utils.ajax(opts, callback);
-});
 
 // HttpPouch is a valid adapter.
 HttpPouch.valid = function () {

--- a/lib/adapters/idb/idb.js
+++ b/lib/adapters/idb/idb.js
@@ -757,6 +757,30 @@ function init(api, opts, callback) {
     };
   };
 
+  api._destroy = function (callback) {
+    IdbPouch.Changes.removeAllListeners(dbName);
+
+    //Close open request for "dbName" database to fix ie delay.
+    if (IdbPouch.openReqList[dbName] && IdbPouch.openReqList[dbName].result) {
+      IdbPouch.openReqList[dbName].result.close();
+      delete cachedDBs[dbName];
+    }
+    var req = indexedDB.deleteDatabase(dbName);
+
+    req.onsuccess = function () {
+      //Remove open request from the list.
+      if (IdbPouch.openReqList[dbName]) {
+        IdbPouch.openReqList[dbName] = null;
+      }
+      if (utils.hasLocalStorage() && (dbName in localStorage)) {
+        delete localStorage[dbName];
+      }
+      callback(null, { 'ok': true });
+    };
+
+    req.onerror = idbError(callback);
+  };
+
   var cached = cachedDBs[dbName];
 
   if (cached) {
@@ -920,43 +944,6 @@ IdbPouch.valid = function () {
   return !isSafari && typeof indexedDB !== 'undefined' &&
     typeof IDBKeyRange !== 'undefined';
 };
-
-function destroy(name, opts, callback) {
-  if (!('openReqList' in IdbPouch)) {
-    IdbPouch.openReqList = {};
-  }
-  IdbPouch.Changes.removeAllListeners(name);
-
-  //Close open request for "name" database to fix ie delay.
-  if (IdbPouch.openReqList[name] && IdbPouch.openReqList[name].result) {
-    IdbPouch.openReqList[name].result.close();
-    delete cachedDBs[name];
-  }
-  var req = indexedDB.deleteDatabase(name);
-
-  req.onsuccess = function () {
-    //Remove open request from the list.
-    if (IdbPouch.openReqList[name]) {
-      IdbPouch.openReqList[name] = null;
-    }
-    if (utils.hasLocalStorage() && (name in localStorage)) {
-      delete localStorage[name];
-    }
-    callback(null, { 'ok': true });
-  };
-
-  req.onerror = idbError(callback);
-}
-
-IdbPouch.destroy = utils.toPromise(function (name, opts, callback) {
-  taskQueue.queue.push({
-    action: function (thisCallback) {
-      destroy(name, opts, thisCallback);
-    },
-    callback: callback
-  });
-  applyNext();
-});
 
 IdbPouch.Changes = new utils.Changes();
 

--- a/lib/adapters/leveldb/leveldb.js
+++ b/lib/adapters/leveldb/leveldb.js
@@ -1330,44 +1330,39 @@ function LevelPouch(opts, callback) {
       });
     });
   };
+
+  // close and delete open leveldb stores
+  api._destroy = function (callback) {
+    var dbStore;
+    if (dbStores.has(leveldown.name)) {
+      dbStore = dbStores.get(leveldown.name);
+    } else {
+      return callDestroy(name, callback);
+    }
+
+    if (dbStore.has(name)) {
+      LevelPouch.Changes.removeAllListeners(name);
+
+      dbStore.get(name).close(function () {
+        dbStore.delete(name);
+        callDestroy(name, callback);
+      });
+    } else {
+      callDestroy(name, callback);
+    }
+  };
+  function callDestroy(name, cb) {
+    if (typeof leveldown.destroy === 'function') {
+      leveldown.destroy(name, cb);
+    } else {
+      process.nextTick(cb);
+    }
+  }
 }
 
 LevelPouch.valid = function () {
   return process && !process.browser;
 };
-
-// close and delete open leveldb stores
-LevelPouch.destroy = utils.toPromise(function (name, opts, callback) {
-  opts = utils.clone(opts);
-
-  var leveldown = opts.db || originalLeveldown;
-  function callDestroy(name, cb) {
-    if (typeof leveldown.destroy === 'function') {
-      leveldown.destroy(name, cb);
-    } else {
-      process.nextTick(callback);
-    }
-  }
-
-  var dbStore;
-  if (dbStores.has(leveldown.name)) {
-    dbStore = dbStores.get(leveldown.name);
-  } else {
-    return callDestroy(name, callback);
-  }
-
-  if (dbStore.has(name)) {
-
-    LevelPouch.Changes.removeAllListeners(name);
-
-    dbStore.get(name).close(function () {
-      dbStore.delete(name);
-      callDestroy(name, callback);
-    });
-  } else {
-    callDestroy(name, callback);
-  }
-});
 
 LevelPouch.use_prefix = false;
 

--- a/lib/adapters/websql/websql.js
+++ b/lib/adapters/websql/websql.js
@@ -981,35 +981,26 @@ function WebSqlPouch(opts, callback) {
       }
     });
   };
+
+  api._destroy = function (callback) {
+    WebSqlPouch.Changes.removeAllListeners(api._name);
+    db.transaction(function (tx) {
+      var stores = [DOC_STORE, BY_SEQ_STORE, ATTACH_STORE, META_STORE,
+        LOCAL_STORE, ATTACH_AND_SEQ_STORE];
+      stores.forEach(function (store) {
+        tx.executeSql('DROP TABLE IF EXISTS ' + store, []);
+      });
+    }, unknownError(callback), function () {
+      if (utils.hasLocalStorage()) {
+        delete window.localStorage['_pouch__websqldb_' + api._name];
+        delete window.localStorage[api._name];
+      }
+      callback(null, {'ok': true});
+    });
+  };
 }
 
 WebSqlPouch.valid = websqlUtils.valid;
-
-WebSqlPouch.destroy = utils.toPromise(function (name, opts, callback) {
-  WebSqlPouch.Changes.removeAllListeners(name);
-  var size = getSize(opts);
-  var db = openDB({
-    name: name,
-    version: POUCH_VERSION,
-    description: name,
-    size: size,
-    location: opts.location,
-    createFromLocation: opts.createFromLocation
-  });
-  db.transaction(function (tx) {
-    var stores = [DOC_STORE, BY_SEQ_STORE, ATTACH_STORE, META_STORE,
-      LOCAL_STORE, ATTACH_AND_SEQ_STORE];
-    stores.forEach(function (store) {
-      tx.executeSql('DROP TABLE IF EXISTS ' + store, []);
-    });
-  }, unknownError(callback), function () {
-    if (utils.hasLocalStorage()) {
-      delete window.localStorage['_pouch__websqldb_' + name];
-      delete window.localStorage[name];
-    }
-    callback(null, {'ok': true});
-  });
-});
 
 WebSqlPouch.Changes = new utils.Changes();
 

--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -115,18 +115,6 @@ function PouchDB(name, opts, callback) {
 
     self.replicate.sync = self.sync;
 
-    self.destroy = utils.adapterFun('destroy', function (callback) {
-      var self = this;
-      var opts = this.__opts;
-      self.info(function (err, info) {
-        if (err) {
-          return callback(err);
-        }
-        opts.internal = true;
-        self.constructor.destroy(info.db_name, opts, callback);
-      });
-    });
-
     PouchDB.adapters[opts.adapter].call(self, opts, function (err) {
       if (err) {
         if (callback) {
@@ -135,13 +123,13 @@ function PouchDB(name, opts, callback) {
         }
         return;
       }
-      function destructionListener(event) {
-        if (event === 'destroyed') {
-          self.emit('destroyed');
-          PouchDB.removeListener(originalName, destructionListener);
-        }
+      function destructionListener() {
+        PouchDB.emit('destroyed', opts.originalName);
+        //so we don't have to sift through all dbnames
+        PouchDB.emit(opts.originalName, 'destroyed');
+        self.removeListener('destroyed', destructionListener);
       }
-      PouchDB.on(originalName, destructionListener);
+      self.on('destroyed', destructionListener);
       self.emit('created', self);
       PouchDB.emit('created', opts.originalName);
       self.taskqueue.ready(self);

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -2,7 +2,6 @@
 
 var PouchDB = require("./constructor");
 var utils = require('./utils');
-var Promise = utils.Promise;
 var EventEmitter = require('events').EventEmitter;
 PouchDB.adapters = {};
 PouchDB.preferredAdapters = require('./adapters/preferredAdapters.js');
@@ -75,6 +74,8 @@ PouchDB.parseAdapter = function (name, opts) {
 };
 
 PouchDB.destroy = utils.toPromise(function (name, opts, callback) {
+  console.log('PouchDB.destroy() is deprecated and will be removed. ' +
+              'Please use db.destroy() instead.');
 
   if (typeof opts === 'function' || typeof opts === 'undefined') {
     callback = opts;
@@ -85,56 +86,11 @@ PouchDB.destroy = utils.toPromise(function (name, opts, callback) {
     name = undefined;
   }
 
-  if (!opts.internal) {
-    console.log('PouchDB.destroy() is deprecated and will be removed. ' +
-                'Please use db.destroy() instead.');
-  }
-
-  var backend = PouchDB.parseAdapter(opts.name || name, opts);
-  var dbName = backend.name;
-  var adapter = PouchDB.adapters[backend.adapter];
-  var usePrefix = 'use_prefix' in adapter ? adapter.use_prefix : true;
-  var baseName = usePrefix ?
-    dbName.replace(new RegExp('^' + PouchDB.prefix), '') : dbName;
-  var fullName = (backend.adapter === 'http' || backend.adapter === 'https' ?
-      '' : (opts.prefix || '')) + dbName;
-  function destroyDb() {
-    // call destroy method of the particular adaptor
-    adapter.destroy(fullName, opts, function (err, resp) {
-      if (err) {
-        callback(err);
-      } else {
-        PouchDB.emit('destroyed', name);
-        //so we don't have to sift through all dbnames
-        PouchDB.emit(name, 'destroyed');
-        callback(null, resp || { 'ok': true });
-      }
-    });
-  }
-
-  var createOpts = utils.extend(true, {}, opts, {adapter : backend.adapter});
-  new PouchDB(baseName, createOpts, function (err, db) {
+  new PouchDB(name, opts, function (err, db) {
     if (err) {
       return callback(err);
     }
-    db.get('_local/_pouch_dependentDbs', function (err, localDoc) {
-      if (err) {
-        if (err.status !== 404) {
-          return callback(err);
-        } else { // no dependencies
-          return destroyDb();
-        }
-      }
-      var dependentDbs = localDoc.dependentDbs;
-      var deletedMap = Object.keys(dependentDbs).map(function (name) {
-        var trueName = usePrefix ?
-          name.replace(new RegExp('^' + PouchDB.prefix), '') : name;
-        return db.constructor.destroy(trueName, db.__opts);
-      });
-      Promise.all(deletedMap).then(destroyDb, function (error) {
-        callback(error);
-      });
-    });
+    db.destroy(callback);
   });
 });
 

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -937,6 +937,20 @@ adapters.forEach(function (adapter) {
       db.put({_id: 'bar', _zing: 'zing'}, cb);
     });
 
+    it('replace PouchDB.destroy() (express-pouchdb#203)', function (done) {
+      var old = PouchDB.destroy;
+      PouchDB.destroy = function (name, callback) {
+        var db = new PouchDB(name);
+        return db.destroy(callback);
+      };
+      // delete a non-existing db, should be fine.
+      PouchDB.destroy(dbs.name, function (err, resp) {
+        PouchDB.destroy = old;
+
+        done(err, resp);
+      });
+    });
+
     if (adapter === 'local') {
       // TODO: this test fails in the http adapter in Chrome
       it('should allow unicode doc ids', function (done) {


### PR DESCRIPTION
Does the heavy lifting for when ``PouchDB.destroy()`` is actually going to be removed. That should be as easy as just removing the ``PouchDB.destroy()``/``PouchAlt.destroy()`` code now. This also makes it possible to properly remove the deprecation notice in ``pouchdb-wrappers`` (background: pouchdb/express-pouchdb#203).

I think this is the first time I actually modified adapter-specific code, so a cautious review would be prudent.