### PR TITLE
(#3573) - avoid setting Content-Type for GETs

### DIFF
--- a/lib/deps/request-browser.js
+++ b/lib/deps/request-browser.js
@@ -27,7 +27,9 @@ module.exports = function(options, callback) {
   xhr.open(options.method, options.url);
   xhr.withCredentials = true;
 
-  if (options.json) {
+  if (options.method === 'GET') {
+    delete options.headers['Content-Type'];
+  } else if (options.json) {
     options.headers.Accept = 'application/json';
     options.headers['Content-Type'] = options.headers['Content-Type'] ||
       'application/json';


### PR DESCRIPTION
This avoids extra OPTIONS requests for GETs
in the case of CORS requests. If this PR does
what I think it does, then even the Travis tests
should be significantly faster this time around.