### PR TITLE
(#3754) - fix cordova tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -59,29 +59,51 @@ or you can append it as `?es5shim=true` if you manually opened a browser window.
 
 ### Cordova tests
 
-You may need to install `ant` in order for the Android tests to run (e.g. `brew install ant`).
+You may need to install `ant` in order for the Android tests to run (e.g. `brew install ant`). You'll also need the Android SDK, and to make sure your `$ANDROID_HOME` is set.
 
-You will also need to run the dev test `npm run dev` simultaneously, so that
-the CORS server is available on port 2020.
+Run the tests against an iOS simulator:
 
     $ CLIENT=ios npm run cordova
-    $ CLIENT=android DEVICE=true npm run cordova. Also available: `CLIENT=firefoxos`.
+    
+Run the tests against a connected Android device, using the given COUCH_HOST    
+    
+    $ CLIENT=android DEVICE=true COUCH_HOST=http://example.com:5984
+
+Run the tests against the FirefoxOS simulator:
+
+    $ CLIENT=firefoxos npm run cordova
+
+Use a custom Couch host:
+
     $ COUCH_HOST=http://myurl:2020 npm run cordova
+
+Grep some tests:    
+
     $ GREP=basics npm run cordova
+    
+Test against the [SQLite Plugin](https://github.com/brodysoft/Cordova-SQLitePlugin):
+
     $ SQLITE_PLUGIN=true ADAPTERS=websql npm run cordova
 
+**Notes:**
+
 * `CLIENT=ios` will run on iOS, default is `CLIENT=android`
-* `DEVICE=true` will run on a device connected via USB, else on an emulator
-* `SQLITE_PLUGIN=true` will install and use the [SQLite Plugin](https://github.com/brodysoft/Cordova-SQLitePlugin) in lieu of the `'websql'` adapter.
-* `ADAPTERS=websql` should be used if you want to skip using IndexedDB on Android 4.4+ and iOS 8+.
+* `DEVICE=true` will run on a device connected via USB, else on an emulator (default is the emulator)
+* `SQLITE_PLUGIN=true` will install and use the [SQLite Plugin](https://github.com/brodysoft/Cordova-SQLitePlugin).
+* `ADAPTERS=websql` should be used if you want to skip using IndexedDB on Android 4.4+ or if you want to force the SQLite Plugin.
 * `COUCH_HOST` should be the full URL; you can only omit this is in the Android emulator due to the magic `10.0.2.2` route to `localhost`.
 * `ES5_SHIM=true` should be used on devices that don't support ES5 (e.g. Android 2.x).
+
+**WEINRE debugging:**
 
 You can also debug with Weinre by doing:
 
     $ npm install -g weinre
     $ weinre --boundHost=0.0.0.0
-    $ WEINRE_HOST=http://route.to.my.weinre:8080
+    
+Then run the tests with:
+
+    $ WEINRE_HOST=http://route.to.my.weinre:8080 npm run cordova
 
 ### Testing against PouchDB server
 

--- a/bin/run-cordova.sh
+++ b/bin/run-cordova.sh
@@ -33,7 +33,7 @@ mkdir -p $TESTS_DIR/www/dist
 cp dist/pouchdb*js $TESTS_DIR/www/dist
 
 ./node_modules/replace/bin/replace.js '<body>' \
-  '<body><script src="../cordova.js"></script>' \
+  '<body><script src="../../cordova.js"></script>' \
   $TESTS_DIR/www/tests/integration/index.html
 
 if [[ ! -z $GREP ]]; then
@@ -81,9 +81,9 @@ CORDOVA=../../../node_modules/cordova/bin/cordova
 
 $CORDOVA platform add $CLIENT
 if [[ $($CORDOVA plugin list | grep sqlite) ]]; then 
-  $CORDOVA plugin rm com.phonegap.plugins.sqlite
+  $CORDOVA plugin rm io.litehelpers.cordova.sqlite
 fi
 if [[ $SQLITE_PLUGIN == 'true' ]]; then 
-  $CORDOVA plugin add https://github.com/brodysoft/Cordova-SQLitePlugin
+  $CORDOVA plugin add https://github.com/litehelpers/Cordova-sqlite-storage.git
 fi
 $CORDOVA $ACTION $CLIENT

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -43,8 +43,9 @@ testUtils.couchHost = function () {
   } else if (window && window.COUCH_HOST) {
     return window.COUCH_HOST;
   } else if (window && window.cordova) {
-    // magic route to localhost on android emulator
-    return 'http://10.0.2.2:2020';
+    // magic route to localhost on android emulator,
+    // cors not needed because cordova
+    return 'http://10.0.2.2:5984';
   }
   // In the browser we default to the CORS server, in future will change
   return 'http://localhost:2020';


### PR DESCRIPTION
We still don't have automated Appium tests, but this at least
fixes the Cordova tests so that they're running again. I can confirm
that I can run the tests on both Android and iOS simulators,
with and without the SQLite Plugin. It also runs in FirefoxOS.