### PR TITLE
(#3082) - fix for leveldb returning too many docs

### DIFF
--- a/lib/adapters/leveldb/leveldb.js
+++ b/lib/adapters/leveldb/leveldb.js
@@ -779,8 +779,6 @@ function LevelPouch(opts, callback) {
       var limit;
       if (typeof opts.limit === 'number') {
         limit = opts.limit;
-      } else {
-        limit = -1;
       }
       if (limit === 0 ||
           ('start' in readstreamOpts && 'end' in readstreamOpts &&
@@ -802,7 +800,7 @@ function LevelPouch(opts, callback) {
           if (skip-- > 0) {
             next();
             return;
-          } else if (limit-- === 0) {
+          } else if (typeof limit === 'number' && limit-- <= 0) {
             docstream.unpipe();
             docstream.destroy();
             next();


### PR DESCRIPTION
I'm not actually able to reproduce #3082, but if
there was a race condition in some version of LevelDOWN
that caused more than `limit` docs to be returned, I imagine
this would fix it. Even if not, this is a harmless change.