### PR TITLE
(#3787) - fix adapter prefix logic

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -43,9 +43,12 @@ PouchDB.parseAdapter = function (name, opts) {
     utils.hasLocalStorage() &&
     localStorage['_pouch__websqldb_' + PouchDB.prefix + name];
 
-  if (typeof opts !== 'undefined' && opts.db) {
+
+  if (opts.adapter) {
+    adapterName = opts.adapter;
+  } else if (typeof opts !== 'undefined' && opts.db) {
     adapterName = 'leveldb';
-  } else {
+  } else { // automatically determine adapter
     for (var i = 0; i < PouchDB.preferredAdapters.length; ++i) {
       adapterName = PouchDB.preferredAdapters[i];
       if (adapterName in PouchDB.adapters) {
@@ -61,16 +64,15 @@ PouchDB.parseAdapter = function (name, opts) {
   }
 
   adapter = PouchDB.adapters[adapterName];
-  if (adapterName && adapter) {
-    var use_prefix = 'use_prefix' in adapter ? adapter.use_prefix : true;
 
-    return {
-      name: use_prefix ? PouchDB.prefix + name : name,
-      adapter: adapterName
-    };
-  }
+  // if adapter is invalid, then an error will be thrown later
+  var usePrefix = (adapter && 'use_prefix' in adapter) ?
+      adapter.use_prefix : true;
 
-  throw 'No valid adapter found';
+  return {
+    name: usePrefix ? (PouchDB.prefix + name) : name,
+    adapter: adapterName
+  };
 };
 
 PouchDB.destroy = utils.toPromise(function (name, opts, callback) {


### PR DESCRIPTION
This bug had no real impact, except that custom adapters
couldn't specify use_prefix or not.

Since this is a really subtle and uncommon use case,
and it doesn't have any impact other than when people use
e.g. LocalStorage/IndexedDB directly alongside PouchDB,
I don't think it's worth adding a test for it.

Suffice it to say that, before this commit, all adapters
in the browser were having their `use_prefix` set to true,
because IDB was being chosen for its `use_prefix`. The correct
adapter will still eventually chosen; but the `use_prefix`
always came from IDB.

This was not really a big issue, since our
other browserified adapters all have `use_prefix` set to true
anyway, but this commit makes the code more correct. Thanks to
@davidpfahler for reporting it!