### PR TITLE
(#3319) - set leveldown to false to fix webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "./lib/adapters/preferredAdapters.js": "./lib/adapters/preferredAdapters-browser.js",
     "./lib/deps/buffer.js": "./lib/deps/buffer-browser.js",
     "bluebird": "lie",
-    "fs": false
+    "fs": false,
+    "leveldown": false
   }
 }


### PR DESCRIPTION
Webpack does not like that `leveldown` is trying to use
`fs`. We can harmlessly set it to `false` in the package.json.

For `levelup`, the issue is that it's trying to directly load
its own package.json file, which is apparently a big contentious
issue in Webpack, and the standard solution is that app devs add their
own json loader, which is what Webpack devs themselves advocate (see
[here](https://github.com/webpack/webpack/issues/378#issuecomment-50258332) and [here](http://mattdesl.svbtle.com/browserify-vs-webpack)).

We can add a note about this Webpack config fix to our own wiki,
or we can just trust that Webpack-using devs will find it themselves
after 5 minutes of googling the JSON issue (I found it in about
as much time). In any case, the bare minimum we need to do is
set `leveldown` to `false`.