### PR TITLE
(#3791) - fix leveldown test args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ env:
   # Test against pouchdb-server
   - CLIENT=node SERVER=pouchdb-server COMMAND=test
   - CLIENT=selenium:firefox SERVER=pouchdb-server COMMAND=test
-  - SERVER_ADAPTER=memory LEVEL_ADAPTER=memdown SERVER=pouchdb-server COMMAND=test
+  - SERVER_ADAPTER=memdown LEVEL_ADAPTER=memdown SERVER=pouchdb-server COMMAND=test
 
   # Test against pouchdb-express-router
   - CLIENT=node SERVER=pouchdb-express-router COMMAND=test

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -10,14 +10,16 @@ if [[ ! -z $SERVER ]]; then
       ln -s ../../.. ./node_modules/pouchdb-server/node_modules/pouchdb
     fi
     export COUCH_HOST='http://127.0.0.1:6984'
-    echo -e "Starting up pouchdb-server\n"
     TESTDIR=./tests/pouchdb_server
     rm -rf $TESTDIR && mkdir -p $TESTDIR
-    if [[ "$SERVER_ADAPTER" == "memory" ]]; then
-      FLAGS='--in-memory'
-    else
-      FLAGS="-d $TESTDIR"
+    FLAGS="--dir $TESTDIR"
+    if [[ ! -z $SERVER_ADAPTER ]]; then
+      FLAGS="$FLAGS --level-backend $SERVER_ADAPTER"
     fi
+    if [[ ! -z $SERVER_PREFIX ]]; then
+      FLAGS="$FLAGS --level-prefix $SERVER_PREFIX"
+    fi
+    echo -e "Starting up pouchdb-server with flags: $FLAGS \n"
     ./node_modules/.bin/pouchdb-server -p 6984 $FLAGS &
     export SERVER_PID=$!
     sleep 15 # give it a chance to start up


### PR DESCRIPTION
This adds correct SERVER_ADAPTER and
SERVER_PREFIX variables that can be used by
leveldown authors as described here:
https://gist.github.com/nolanlawson/f2f4d7e2e6f426502b94

It also fixes the MemDOWN Travis tests to use
the SERVER_ADAPTER variable. (Before it was hard-coded
to run the server with --in-memory, which does the
same thing.)