### PR TITLE
(#3797) - consistently use utils.btoa/utils.atob

### DIFF
--- a/lib/adapters/websql/websql.js
+++ b/lib/adapters/websql/websql.js
@@ -842,7 +842,7 @@ function WebSqlPouch(opts, callback) {
       var data = item.escaped ? websqlUtils.unescapeBlob(item.body) :
         parseHexString(item.body, encoding);
       if (opts.encode) {
-        res = btoa(data);
+        res = utils.btoa(data);
       } else {
         data = utils.fixBinary(data);
         res = utils.createBlob([data], {type: type});

--- a/lib/deps/base64.js
+++ b/lib/deps/base64.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var buffer = require('./buffer');
+
+if (typeof atob === 'function') {
+  exports.atob = function (str) {
+    return atob(str);
+  };
+} else {
+  exports.atob = function (str) {
+    var base64 = new buffer(str, 'base64');
+    // Node.js will just skip the characters it can't encode instead of
+    // throwing and exception
+    if (base64.toString('base64') !== str) {
+      throw ("Cannot base64 encode full string");
+    }
+    return base64.toString('binary');
+  };
+}
+
+if (typeof btoa === 'function') {
+  exports.btoa = function (str) {
+    return btoa(str);
+  };
+} else {
+  exports.btoa = function (str) {
+    return new buffer(str, 'binary').toString('base64');
+  };
+}

--- a/lib/deps/md5.js
+++ b/lib/deps/md5.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var base64 = require('./base64');
 var crypto = require('crypto');
 var Md5 = require('spark-md5');
 var setImmediateShim = global.setImmediate || global.setTimeout;
@@ -25,7 +26,7 @@ function rawToBase64(raw) {
   for (var i = 0; i < raw.length; i++) {
     res += intToString(raw[i]);
   }
-  return btoa(res);
+  return base64.btoa(res);
 }
 
 function appendBuffer(buffer, data, start, end) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,7 +6,6 @@ exports.ajax = require('./deps/ajax');
 exports.createBlob = require('./deps/blob');
 exports.uuid = require('./deps/uuid');
 exports.getArguments = require('argsarray');
-var buffer = require('./deps/buffer');
 var errors = require('./deps/errors');
 var EventEmitter = require('events').EventEmitter;
 var collections = require('pouchdb-collections');
@@ -248,31 +247,9 @@ Changes.prototype.notify = function (dbName) {
   this.notifyLocalWindows(dbName);
 };
 
-if (typeof atob === 'function') {
-  exports.atob = function (str) {
-    return atob(str);
-  };
-} else {
-  exports.atob = function (str) {
-    var base64 = new buffer(str, 'base64');
-    // Node.js will just skip the characters it can't encode instead of
-    // throwing and exception
-    if (base64.toString('base64') !== str) {
-      throw ("Cannot base64 encode full string");
-    }
-    return base64.toString('binary');
-  };
-}
-
-if (typeof btoa === 'function') {
-  exports.btoa = function (str) {
-    return btoa(str);
-  };
-} else {
-  exports.btoa = function (str) {
-    return new buffer(str, 'binary').toString('base64');
-  };
-}
+var base64 = require('./deps/base64');
+exports.atob = base64.atob;
+exports.btoa = base64.btoa;
 
 // From http://stackoverflow.com/questions/14967647/ (continues on next line)
 // encode-decode-image-with-base64-breaks-image (2013-04-21)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "pouchdb"
   ],
   "dependencies": {
+    "Base64": "^0.3.0",
     "argsarray": "0.0.1",
     "bluebird": "^1.2.4",
     "debug": "^2.1.2",


### PR DESCRIPTION
Also move them to their own file outside of utils.
This is just code cleanup and doesn't change the
functionality at all.