### PR TITLE
(#3804) - Replication: Include rev-1 attachments

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -262,17 +262,23 @@ function replicate(repId, src, target, opts, returnValue, result) {
     }
     return src.allDocs({
       keys: ids,
-      include_docs: true
+      include_docs: true,
+      attachments: true
     }).then(function (res) {
       if (state.cancelled) {
         completeReplication();
         throw (new Error('cancelled'));
       }
       res.rows.forEach(function (row) {
+        var hasAttachments = row.doc && row.doc._attachments &&
+          Object.keys(row.doc._attachments).length > 0;
+        var hasAttachmentData = hasAttachments &&
+          !row.doc._attachments[Object.keys(row.doc._attachments)[0]].stub;
+
         if (row.doc && !row.deleted &&
           row.value.rev.slice(0, 2) === '1-' && (
-            !row.doc._attachments ||
-            Object.keys(row.doc._attachments).length === 0
+            !hasAttachments ||
+            hasAttachmentData
           )
         ) {
           result.docs_read++;


### PR DESCRIPTION
Include attachments when fetching generation one docs during replication.
The ability to include attachments on a view result was added in CouchDB 1.6.

Add `attachments=true` to the query and examine the result wheather it has
attachment data. If yes, use it.