### PR TITLE
remove listeners added per replicate() call on error

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -130,6 +130,13 @@ function genReplicationId(src, target, opts) {
 }
 
 function replicate(repId, src, target, opts, returnValue, result) {
+  // Remember per-replicate()-call listeners for later removal
+  var listeners = [];
+  var newListener = function(event, listener) {
+    listeners.push([event, listener]);
+  };
+  returnValue.on('newListener', newListener);
+
   var batches = [];               // list of batches to be processed
   var currentBatch;               // the batch currently being processed
   var pendingBatch = {
@@ -428,6 +435,10 @@ function replicate(repId, src, target, opts, returnValue, result) {
       if (allErrors.length > 0) {
         error.other_errors = allErrors;
       }
+      // backOff() will call replicate() again; remove leaky listeners
+      for (var i = 0; i < listeners.length; i++) {
+        returnValue.removeListener.apply(returnValue, listeners[i]);
+      }
       error.result = result;
       backOff(repId, src, target, opts, returnValue, result, error);
     } else {
@@ -582,6 +593,7 @@ function replicate(repId, src, target, opts, returnValue, result) {
       throw err;
     });
   }
+  returnValue.removeListener('newListener', newListener);
 }
 
 exports.toPouch = toPouch;

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -107,6 +107,9 @@ Replication.prototype.ready = function (src, target) {
     target.removeListener('destroyed', onDestroy);
   }
   this.then(cleanup, cleanup);
+
+  // avoid EventEmitter leaks by making second ready() call a no-op
+  this.ready = function () { };
 };
 
 


### PR DESCRIPTION
PouchDB's builtin replication with retry is useless if you actually go offline because backOff() will call replicate() repeatedly adding  the EventEmitter will soon fill up, and then replication will never be able to actually continue.

This pull request avoids the problem by removing all of the per-replicate()-call listeners before calling backOff().