### PR TITLE
(#3815) - increase "retry stuff" test timeout

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -3051,6 +3051,7 @@ adapters.forEach(function (adapters) {
     });
 
     it('retry stuff', function (done) {
+      this.timeout(2000000);
 
       var remote = new PouchDB(dbs.remote);
       var Promise = PouchDB.utils.Promise;


### PR DESCRIPTION
When running the tests, I often see this one time out.
I think the test itself is fine; the timeout is just
too low. E.g. in pouchtest.com it will often fail
because the remote database is slow.