### PR TITLE
(#3817) - increase another test timeout

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -1928,7 +1928,6 @@ adapters.forEach(function (adapters) {
       if ('saucelabs' in testUtils.params()) {
         return done();
       }
-      this.timeout(15000);
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
       var docs = [];
@@ -2934,7 +2933,6 @@ adapters.forEach(function (adapters) {
     });
 
     it('issue #2342 update_seq after replication', function (done) {
-      this.timeout(30000);
       var docs = [];
       for (var i = 0; i < 10; i++) {
         docs.push({_id: i.toString()});


### PR DESCRIPTION
We're manually setting the timeout to 30s,
when the default is 60. This causes the test
to fail pretty frequently as I test on my local network.