### PR TITLE
(#3818) - fix cordova tests for blackberry10

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -72,10 +72,14 @@ Run the tests against a connected Android device, using the given COUCH_HOST
 Run the tests against the FirefoxOS simulator:
 
     $ CLIENT=firefoxos npm run cordova
+    
+Run the tests against a BlackBerry 10 device:
+
+    $ CLIENT=blackberry10 DEVICE=true npm run cordova
 
 Use a custom Couch host:
 
-    $ COUCH_HOST=http://myurl:2020 npm run cordova
+    $ COUCH_HOST=http://myurl:5984 npm run cordova
 
 Grep some tests:    
 

--- a/tests/integration/cordova/config.xml
+++ b/tests/integration/cordova/config.xml
@@ -9,4 +9,5 @@
     </author>
     <content src="tests/integration/index.html" />
     <access origin="*" />
+    <preference name="websecurity" value="disable" gap:platform="blackberry10" />
 </widget>


### PR DESCRIPTION
I actually managed to get the tests running on a Blackberry
10 device, but I had to add this configuration to
allow remote access to CouchDB in the app.

Also updated TESTING.md with some info for blackberry.