### PR TITLE
(#3699) - don't leak complete/error events 

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -3,6 +3,7 @@
 var utils = require('./utils');
 var EE = require('events').EventEmitter;
 var Checkpointer = require('./checkpointer');
+var oncePerKey = utils.oncePerKey;
 
 var MAX_SIMULTANEOUS_REVS = 50;
 var RETRY_DEFAULT = false;
@@ -572,8 +573,8 @@ function replicate(repId, src, target, opts, returnValue, result) {
   }
 
   if (typeof opts.complete === 'function') {
-    returnValue.once('error', opts.complete);
-    returnValue.once('complete', function (result) {
+    oncePerKey(returnValue, 'error', 'error', opts.complete);
+    oncePerKey(returnValue, 'complete', 'complete', function (result) {
       opts.complete(null, result);
     });
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,6 +39,21 @@ exports.pick = function (obj, arr) {
   return res;
 };
 
+// just like emitter.once(event, listener), but doesn't
+// add additional listeners if any listeners with the
+// key are already attached
+exports.oncePerKey = function oncePerKey(emitter, event, key, listener) {
+  var listeners = emitter.listeners(event).filter(function (listener) {
+    return listener._key === key;
+  });
+  if (listeners.length) {
+    return;
+  }
+  emitter.once(event, listener);
+  listeners = emitter.listeners(event);
+  listeners[listeners.length - 1]._key = key;
+};
+
 exports.inherits = require('inherits');
 
 function isChromeApp() {


### PR DESCRIPTION
(Part 2 of fixing #3699).

Also checks paused/active events, even though
they weren't leaking before.