### PR TITLE
Update create_database.html documentation to match API on authentication

### DIFF
--- a/docs/_includes/api/create_database.html
+++ b/docs/_includes/api/create_database.html
@@ -20,7 +20,7 @@ This method creates a database or opens an existing one. If you use a URL like `
 * `ajax`: (Remote databases only.) Ajax requester options. For instance, passing in the options `{ajax: {timeout: 10000}}` will allow you to set the max timeout for an HTTP request. These are passed ver batim to [request][] (in Node.js) or  [a request shim](https://github.com/pouchdb/pouchdb/blob/master/lib/deps/request-browser.js) (in the browser), with the exception of:
 * `ajax.cache`: Appends a random string to the end of all HTTP GET requests to avoid them being cached on IE. Set this to `true` to prevent this happening.
 * `ajax.headers`: The `ajax.headers` option allows you to customise headers that are sent to the remote HTTP Server.
-* `ajax.username` + `ajax.password`: You can specify HTTP auth parameters either by using a database with a name in the form `http://user:pass@host/name` or via the `username` + `password` options.
+* `auth.username` + `auth.password`: You can specify HTTP auth parameters either by using a database with a name in the form `http://user:pass@host/name` or via the `auth.username` + `auth.password` options.
   
 **WebSQL-only options:**
 
@@ -73,6 +73,8 @@ var db = new PouchDB('http://example.com/dbname', {
     headers: {
       'X-Some-Special-Header': 'foo'
     },
+  },
+  auth: {
     username: 'mysecretusername',
     password: 'mysecretpassword'
   }


### PR DESCRIPTION
Username and password credentials for remote http databases are not defined (anymore?) inside options.ajax, but options.auth. Updated documentation to account for that.