### PR TITLE
(#3824) - WIP - fix live replication batch size

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -159,6 +159,7 @@ function replicate(repId, src, target, opts, returnValue, result) {
     docs_read: 0,
     docs_written: 0,
     doc_write_failures: 0,
+    live: continuous,
     errors: []
   };
 
@@ -481,7 +482,6 @@ function replicate(repId, src, target, opts, returnValue, result) {
       getChanges();
     } else {
       if (continuous) {
-        changesOpts.live = true;
         getChanges();
       } else {
         changesCompleted = true;


### PR DESCRIPTION
Fixes #3824 by actually using live changes from the get-go. Before,
we would do `changes()` once without `live`, then once again
without `live`, then finally the third time with `live`, leading
to the bug.

The reason this is untested is because it would be pretty much
impossible to write a test for. The only test I can think of would
be to check the exact number of times that `changes()` was called during
a live replication, but that seems flakey.

However, if you check the network tab during live replication, you'll
see we're doing far fewer HTTP requests than before. So this is a
win for replication performance (again).