### PR TITLE
add androidDatabaseImplementation option for websql

### DIFF
--- a/lib/adapters/websql/websql.js
+++ b/lib/adapters/websql/websql.js
@@ -105,7 +105,8 @@ function WebSqlPouch(opts, callback) {
     description: api._name,
     size: size,
     location: opts.location,
-    createFromLocation: opts.createFromLocation
+    createFromLocation: opts.createFromLocation,
+    androidDatabaseImplementation: opts.androidDatabaseImplementation
   });
   if (!db) {
     return callback(errors.error(errors.UNKNOWN_ERROR));


### PR DESCRIPTION
this option has been added to the cordova sqlite plugin to fallback to an older sqlite implementation; https://github.com/litehelpers/Cordova-sqlite-storage#android-sqlite-implementation