### PR TITLE
(#3845) - add xmlns:gap to cordova config

### DIFF
--- a/tests/integration/cordova/config.xml
+++ b/tests/integration/cordova/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="com.pouchdb.tests" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="com.pouchdb.tests" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
     <name>PouchDB Test Runner</name>
     <description>
       Runs the unit tests suite for the PouchDB project on Cordova.


### PR DESCRIPTION
As pointed out by @brodybits in
https://github.com/litehelpers/Cordova-sqlite-storage/issues/255.
To be honest, I don't even know how it was passing
in Blackberry when I added this. It's not valid XML without
this fix.