### PR TITLE
(#3853) remove exec-sync to support 0.12

### DIFF
--- a/bin/build-site.js
+++ b/bin/build-site.js
@@ -2,51 +2,52 @@
 
 'use strict';
 
-var fs = require('fs');
-
 var http_server = require('http-server');
-var execSync = require('exec-sync');
-var mkdirp = require('mkdirp');
+var bluebird = require('bluebird');
+var fs = bluebird.promisifyAll(require('fs'));
 var watchGlob = require('watch-glob');
 var replace = require('replace');
+var exec = require('child-process-promise').exec;
+var mkdirp = bluebird.promisify(require('mkdirp'));
 
 var POUCHDB_CSS = __dirname + '/../docs/static/css/pouchdb.css';
 var POUCHDB_LESS = __dirname + '/../docs/static/less/pouchdb/pouchdb.less';
 
-if (!execSync('gem list jekyll -i')) {
-  console.log('Install Jekyll');
-  process.exit(1);
-}
+process.chdir('docs');
 
-mkdirp.sync(__dirname + '/../docs/static/css');
+function checkJekyll() {
+  return exec('gem list jekyll -i').then(function (result) {
+    if (!/true/.test(result.stdout)) {
+      throw new Error('You need to do: gem install jekyll');
+    }
+  });
+}
 
 function buildCSS() {
-  var css =
-    execSync(__dirname + '/../node_modules/less/bin/lessc ' + POUCHDB_LESS);
-  fs.writeFileSync(POUCHDB_CSS, css);
-  console.log('Updated: ', POUCHDB_CSS);
+  return mkdirp(__dirname + '/../docs/static/css').then(function () {
+    var cmd = __dirname + '/../node_modules/less/bin/lessc ' + POUCHDB_LESS;
+    return exec(cmd);
+  }).then(function (child) {
+    return fs.writeFileAsync(POUCHDB_CSS, child.stdout);
+  }).then(function () {
+    console.log('Updated: ', POUCHDB_CSS);
+  });
 }
-
-if (!process.env.BUILD) {
-  watchGlob('docs/static/less/*/*.less', buildCSS);
-}
-buildCSS();
-
-process.chdir('docs');
 
 function buildJekyll(path) {
   // Dont rebuild on website artifacts being written
   if (path && /^_site/.test(path.relative)) {
     return;
   }
-  execSync('jekyll build');
-  console.log('=> Rebuilt jekyll');
-  highlightEs6();
-  console.log('=> Highlighted ES6');
+  return exec('jekyll build').then(function () {
+    console.log('=> Rebuilt jekyll');
+    return highlightEs6();
+  }).then(function () {
+    console.log('=> Highlighted ES6');
+  });
 }
 
 function highlightEs6() {
-
   var path = require('path').resolve(__dirname, '../docs/_site');
 
   // TODO: this is a fragile and hacky way to get
@@ -60,12 +61,24 @@ function highlightEs6() {
   });
 }
 
+function onError(err) {
+  console.error(err);
+  process.exit(1);
+}
+
+function buildEverything() {
+  return bluebird.resolve()
+    .then(checkJekyll)
+    .then(buildCSS)
+    .then(buildJekyll)
+    .catch(onError);
+}
+
 if (!process.env.BUILD) {
   watchGlob('**', buildJekyll);
-  buildJekyll();
+  watchGlob('docs/static/less/*/*.less', buildCSS);
   http_server.createServer({root: '_site', cache: '-1'}).listen(4000);
   console.log('Server address: http://0.0.0.0:4000');
-} else {
-  execSync('jekyll build');
-  highlightEs6();
 }
+
+buildEverything();

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "leveldown": "~0.10.2"
   },
   "devDependencies": {
+    "child-process-promise": "^1.1.0",
     "pouchdb-express-router": "^0.0.2",
     "bundle-collapser": "^1.1.1",
     "rimraf": "2.2.8",
@@ -64,7 +65,6 @@
     "glob": "~3.2.9",
     "watch-glob": "~0.1.1",
     "mkdirp": "~0.4.2",
-    "exec-sync": "~0.1.6",
     "ua-parser-js": "^0.6.2",
     "chai": "^1.9.1",
     "mocha": "^1.18.2",


### PR DESCRIPTION
We don't have Travis tests to ensure that `npm run build-site` works, but I tested informally and it's fine for me (live reload, can do `BUILD=1`).