### PR TITLE
(#3847) - cancel sync in an onunload event

### DIFF
--- a/lib/replicate/replicate.js
+++ b/lib/replicate/replicate.js
@@ -473,6 +473,13 @@ function replicate(src, target, opts, returnValue, result) {
         opts.complete(null, result);
       });
     }
+    if (typeof window !== 'undefined') {
+      // cancel when the page is refreshed
+      window.addEventListener('beforeunload', function unloadListener() {
+        returnValue.cancel();
+        window.removeEventListener('beforeunload', unloadListener);
+      });
+    }
     returnValue._addedListeners = true;
   }
 


### PR DESCRIPTION
This may or may not fix #3847. I can't tell, because
I can't actually reproduce it.

This commit should probably not be merged without
further discussion and an actual reproducible test.