### PR TITLE
(#3857) - refactor replicate.js a bit

### DIFF
--- a/lib/replicate/get-docs.js
+++ b/lib/replicate/get-docs.js
@@ -1,0 +1,121 @@
+'use strict';
+
+var utils = require('./../utils');
+var clone = utils.clone;
+var Promise = utils.Promise;
+
+var MAX_SIMULTANEOUS_REVS = 50;
+
+function isGenOne(rev) {
+  return /^1-/.test(rev);
+}
+
+//
+// Fetch all the documents from the src as described in the "diffs",
+// which is a mapping of docs IDs to revisions. If the state ever
+// changes to "cancelled", then the returned promise will be rejected.
+// Else it will be resolved with a list of fetched documents.
+//
+function getDocs(src, diffs, state) {
+  diffs = clone(diffs); // we do not need to modify this
+
+  var resultDocs = [];
+
+  function fetchMissingRevs(id, missingRevs) {
+    var opts = {
+      revs: true,
+      open_revs: missingRevs,
+      attachments: true
+    };
+    return src.get(id, opts).then(function (docs) {
+      if (state.cancelled) {
+        throw new Error('cancelled');
+      }
+      docs.forEach(function (doc) {
+        if (doc.ok) {
+          resultDocs.push(doc.ok);
+        }
+      });
+    });
+  }
+
+  function processDiffDoc(id) {
+    var missing = diffs[id].missing;
+    // avoid url too long error by batching
+    var missingBatches = [];
+    for (var i = 0; i < missing.length; i += MAX_SIMULTANEOUS_REVS) {
+      var missingBatch = missing.slice(i,
+        Math.min(missing.length, i + MAX_SIMULTANEOUS_REVS));
+      missingBatches.push(missingBatch);
+    }
+
+    return Promise.all(missingBatches.map(function (missingRevs) {
+      return fetchMissingRevs(id, missingRevs);
+    }));
+  }
+
+  function getAllDocs() {
+    var diffKeys = Object.keys(diffs);
+    return Promise.all(diffKeys.map(processDiffDoc));
+  }
+
+  function hasValidAttachments(doc) {
+    var atts = doc._attachments;
+    var attNames = atts && Object.keys(atts);
+
+    var hasAttachments = atts && attNames.length > 0;
+    // These will be stubs in CouchDB < 1.6 because attachments
+    // weren't supported in _all_docs
+    var hasAttachmentData = hasAttachments && !atts[attNames[0]].stub;
+
+    return !hasAttachments || hasAttachmentData;
+  }
+
+  function fetchRevisionOneDocs(ids) {
+    // Optimization: fetch gen-1 docs and attachments in
+    // a single request using _all_docs
+    return src.allDocs({
+      keys: ids,
+      include_docs: true,
+      attachments: true
+    }).then(function (res) {
+      if (state.cancelled) {
+        throw new Error('cancelled');
+      }
+      res.rows.forEach(function (row) {
+        if (row.deleted || !row.doc || !isGenOne(row.value.rev) ||
+            !hasValidAttachments(row.doc)) {
+          // if any of these conditions apply, we need to fetch using get()
+          return;
+        }
+
+        // the doc we got back from allDocs() is sufficient
+        resultDocs.push(row.doc);
+        delete diffs[row.id];
+      });
+    });
+  }
+
+  function getRevisionOneDocs() {
+    // filter out the generation 1 docs and get them
+    // leaving the non-generation one docs to be got otherwise
+    var ids = Object.keys(diffs).filter(function (id) {
+      var missing = diffs[id].missing;
+      return missing.length === 1 && isGenOne(missing[0]);
+    });
+    if (ids.length > 0) {
+      return fetchRevisionOneDocs(ids);
+    }
+  }
+
+  function returnDocs() {
+    return resultDocs;
+  }
+
+  return Promise.resolve()
+    .then(getRevisionOneDocs)
+    .then(getAllDocs)
+    .then(returnDocs);
+}
+
+module.exports = getDocs;

--- a/lib/replicate/replicate.js
+++ b/lib/replicate/replicate.js
@@ -1,16 +1,10 @@
 'use strict';
 
 var utils = require('./../utils');
-var Promise = utils.Promise;
 var Checkpointer = require('./checkpointer');
 var backOff = require('./backoff');
 var genReplicationId = require('./gen-replication-id');
-
-var MAX_SIMULTANEOUS_REVS = 50;
-
-function isGenOne(rev) {
-  return /^1-/.test(rev);
-}
+var getDocs = require('./get-docs');
 
 function replicate(src, target, opts, returnValue, result) {
   var batches = [];               // list of batches to be processed
@@ -106,89 +100,6 @@ function replicate(src, target, opts, returnValue, result) {
     });
   }
 
-  function processDiffDoc(id) {
-    var diffs = currentBatch.diffs;
-    var allMissing = diffs[id].missing;
-    // avoid url too long error by batching
-    var missingBatches = [];
-    for (var i = 0; i < allMissing.length; i += MAX_SIMULTANEOUS_REVS) {
-      missingBatches.push(allMissing.slice(i, Math.min(allMissing.length,
-        i + MAX_SIMULTANEOUS_REVS)));
-    }
-
-    return Promise.all(missingBatches.map(function (missing) {
-      var opts = {
-        revs: true,
-        open_revs: missing,
-        attachments: true
-      };
-      return src.get(id, opts).then(function (docs) {
-        docs.forEach(function (doc) {
-          if (state.cancelled) {
-            return completeReplication();
-          }
-          if (doc.ok) {
-            result.docs_read++;
-            currentBatch.pendingRevs++;
-            currentBatch.docs.push(doc.ok);
-          }
-        });
-        delete diffs[id];
-      });
-    }));
-  }
-
-  function getAllDocs() {
-    var diffKeys = Object.keys(currentBatch.diffs);
-    return Promise.all(diffKeys.map(processDiffDoc));
-  }
-
-
-  function getRevisionOneDocs() {
-    // filter out the generation 1 docs and get them
-    // leaving the non-generation one docs to be got otherwise
-    var ids = Object.keys(currentBatch.diffs).filter(function (id) {
-      var missing = currentBatch.diffs[id].missing;
-      return missing.length === 1 && isGenOne(missing[0]);
-    });
-    if (!ids.length) { // nothing to fetch
-      return Promise.resolve();
-    }
-    return src.allDocs({
-      keys: ids,
-      include_docs: true,
-      attachments: true
-    }).then(function (res) {
-      if (state.cancelled) {
-        completeReplication();
-        throw (new Error('cancelled'));
-      }
-      res.rows.forEach(function (row) {
-        // Optimization: fetch attachments along with _all_docs.
-        // These will be stubs in CouchDB < 1.6 because attachments
-        // weren't supported in _all_docs.
-        var hasAttachments = row.doc && row.doc._attachments &&
-          Object.keys(row.doc._attachments).length > 0;
-        var hasAttachmentData = hasAttachments &&
-          !row.doc._attachments[Object.keys(row.doc._attachments)[0]].stub;
-
-        if (row.doc && !row.deleted &&
-            isGenOne(row.value.rev) &&
-            (!hasAttachments || hasAttachmentData)
-        ) {
-          result.docs_read++;
-          currentBatch.pendingRevs++;
-          currentBatch.docs.push(row.doc);
-          delete currentBatch.diffs[row.id];
-        }
-      });
-    });
-  }
-
-  function getDocs() {
-    return getRevisionOneDocs().then(getAllDocs);
-  }
-
   function finishBatch() {
     writingCheckpoint = true;
     return checkpointer.writeCheckpoint(currentBatch.seq).then(function () {
@@ -228,7 +139,16 @@ function replicate(src, target, opts, returnValue, result) {
       }
       // currentBatch.diffs elements are deleted as the documents are written
       currentBatch.diffs = diffs;
-      currentBatch.pendingRevs = 0;
+    });
+  }
+
+  function getBatchDocs() {
+    return getDocs(src, currentBatch.diffs, state).then(function (docs) {
+      docs.forEach(function (doc) {
+        delete currentBatch.diffs[doc._id];
+        result.docs_read++;
+        currentBatch.docs.push(doc);
+      });
     });
   }
 
@@ -242,7 +162,7 @@ function replicate(src, target, opts, returnValue, result) {
     }
     currentBatch = batches.shift();
     getDiffs()
-      .then(getDocs)
+      .then(getBatchDocs)
       .then(writeDocs)
       .then(finishBatch)
       .then(startNextBatch)


### PR DESCRIPTION
I am trying to make the replication module a little
easier to understand, so hopefully someone (possibly me)
can go in there and start fixing all our replication issues.

This removes about 100 lines from replicate.js by extracting out
the part that does the generation-1 optimization and fetching docs.