### PR TITLE
(#3858) - fix all EventEmitter leaks in tests

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -94,6 +94,34 @@ function allDocsKeysQuery(api, opts, callback) {
   });
 }
 
+// all compaction is done in a queue, to avoid attaching
+// too many listeners at once
+function doNextCompaction(self) {
+  var task = self._compactionQueue[0];
+  var opts = task.opts;
+  var callback = task.callback;
+  self.get('_local/compaction').catch(function () {
+    return false;
+  }).then(function (doc) {
+    if (doc && doc.last_seq) {
+      opts.last_seq = doc.last_seq;
+    }
+    self._compact(opts, function (err, res) {
+      if (err) {
+        callback(err);
+      } else {
+        callback(null, res);
+      }
+      process.nextTick(function () {
+        self._compactionQueue.shift();
+        if (self._compactionQueue.length) {
+          doNextCompaction(self);
+        }
+      });
+    });
+  });
+}
+
 utils.inherits(AbstractPouchDB, EventEmitter);
 module.exports = AbstractPouchDB;
 
@@ -364,17 +392,11 @@ AbstractPouchDB.prototype.compact =
 
   opts = utils.clone(opts || {});
 
-  self.get('_local/compaction').catch(function () {
-    return false;
-  }).then(function (doc) {
-    if (typeof self._compact === 'function') {
-      if (doc && doc.last_seq) {
-        opts.last_seq = doc.last_seq;
-      }
-      return self._compact(opts, callback);
-    }
-
-  });
+  self._compactionQueue = self._compactionQueue || [];
+  self._compactionQueue.push({opts: opts, callback: callback});
+  if (self._compactionQueue.length === 1) {
+    doNextCompaction(self);
+  }
 });
 AbstractPouchDB.prototype._compact = function (opts, callback) {
   var self = this;

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -145,7 +145,7 @@ PouchDB.defaults = function (defaultOpts) {
   eventEmitterMethods.forEach(function (method) {
     PouchAlt[method] = eventEmitter[method].bind(eventEmitter);
   });
-  PouchAlt.setMaxListeners(0);
+  PouchAlt.setMaxListeners(10);
 
   PouchAlt.preferredAdapters = PouchDB.preferredAdapters.slice();
   Object.keys(PouchDB).forEach(function (key) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -150,7 +150,7 @@ function Changes() {
   var self = this;
   EventEmitter.call(this);
   this.isChrome = isChromeApp();
-  this.listeners = {};
+  this._listeners = {};
   this.hasLocal = false;
   if (!this.isChrome) {
     this.hasLocal = exports.hasLocalStorage();
@@ -177,13 +177,13 @@ function Changes() {
 
 }
 Changes.prototype.addListener = function (dbName, id, db, opts) {
-  if (this.listeners[id]) {
+  if (this._listeners[id]) {
     return;
   }
   var self = this;
   var inprogress = false;
   function eventFunction() {
-    if (!self.listeners[id]) {
+    if (!self._listeners[id]) {
       return;
     }
     if (inprogress) {
@@ -219,16 +219,16 @@ Changes.prototype.addListener = function (dbName, id, db, opts) {
       inprogress = false;
     });
   }
-  this.listeners[id] = eventFunction;
+  this._listeners[id] = eventFunction;
   this.on(dbName, eventFunction);
 };
 
 Changes.prototype.removeListener = function (dbName, id) {
-  if (!(id in this.listeners)) {
+  if (!(id in this._listeners)) {
     return;
   }
   EventEmitter.prototype.removeListener.call(this, dbName,
-    this.listeners[id]);
+    this._listeners[id]);
 };
 
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "leveldown": "~0.10.2"
   },
   "devDependencies": {
+    "throw-max-listeners-error": "^1.0.0",
     "child-process-promise": "^1.1.0",
     "pouchdb-express-router": "^0.0.2",
     "bundle-collapser": "^1.1.1",

--- a/tests/integration/node.setup.js
+++ b/tests/integration/node.setup.js
@@ -1,5 +1,8 @@
 "use strict";
 
+// throw an error if any EventEmitter adds too many listeners
+require('throw-max-listeners-error');
+
 var testsDir = process.env.TESTS_DIR || './tmp';
 var exec = require('child_process').exec;
 function cleanup() {

--- a/tests/integration/test.compaction.js
+++ b/tests/integration/test.compaction.js
@@ -1518,6 +1518,10 @@ adapters.forEach(function (adapter) {
 
       var doc = {_id: 'foo'};
 
+      // we know we're going to reach this because of all the changes()
+      // we're doing at once
+      db.setMaxListeners(1000);
+
       return db.put(doc).then(function (res) {
         doc._rev = res.rev;
       }).then(function () {

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -3649,6 +3649,10 @@ adapters.forEach(function (adapters) {
       var remote = new PouchDB(dbs.remote);
       var Promise = PouchDB.utils.Promise;
 
+      // we know we're easily going to go over that limit
+      // because of all the parallel replications we're doing
+      db.setMaxListeners(100);
+
       function timeoutPromise(delay, fun) {
         return new Promise(function (resolve) {
           setTimeout(resolve, delay);


### PR DESCRIPTION
This also adds [a new module I wrote](https://github.com/nolanlawson/throw-max-listeners-error) which throws an error
if the maximum number of listeners is ever exceeded. It
only runs in the Node tests, but this should be a great
way to prevent future memory leaks.

I can confirm that the module works, and that these fixes were
actually necessary to get the tests passing again.