### PR TITLE
(#3846) - don't merge - test in fakeIndexedDB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,9 @@ env:
   - CLIENT=selenium:firefox COMMAND=test
   - CLIENT=selenium:phantomjs ES5_SHIM=true COMMAND=test
 
+  # Test fakeIndexedDB
+  - CLIENT=selenium:phantomjs FAKE_IDB=true COMMAND=test
+
   # Test auto-compaction in Node, Phantom, and Firefox
   - AUTO_COMPACTION=true CLIENT=node COMMAND=test
   - AUTO_COMPACTION=true CLIENT=selenium:firefox COMMAND=test

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -28,6 +28,9 @@ var queryParams = {};
 if (process.env.ES5_SHIM || process.env.ES5_SHIMS) {
   queryParams.es5shim = true;
 }
+if (process.env.FAKE_IDB) {
+  queryParams.fakeIDB = true;
+}
 if (process.env.ADAPTERS) {
   queryParams.adapters = process.env.ADAPTERS;
 }

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -57,6 +57,9 @@ if (process.env.ADAPTERS) {
 if (process.env.ES5_SHIM || process.env.ES5_SHIMS) {
   qs.es5shim = true;
 }
+if (process.env.FAKE_IDB) {
+  qs.fakeIDB = true;
+}
 if (process.env.AUTO_COMPACTION) {
   qs.autoCompaction = true;
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "bundle-collapser": "^1.1.1",
     "rimraf": "2.2.8",
     "pouchdb-server": "^0.6.1",
+    "fake-indexeddb": "^1.0.0",
     "express-pouchdb": "^0.13.0",
     "commander": "~2.1.0",
     "uglify-js": "~2.4.6",

--- a/tests/integration/fake-idb-setup.js
+++ b/tests/integration/fake-idb-setup.js
@@ -1,0 +1,12 @@
+window.indexedDB = window.fakeIndexedDB;
+window.IDBCursor = window.FDBCursor;
+window.IDBCursorWithValue = window.FDBCursorWithValue;
+window.IDBDatabase = window.FDBDatabase;
+window.IDBFactory = window.FDBFactory;
+window.IDBIndex = window.FDBIndex;
+window.IDBKeyRange = window.FDBKeyRange;
+window.IDBObjectStore = window.FDBObjectStore;
+window.IDBOpenDBRequest = window.FDBOpenDBRequest;
+window.IDBRequest = window.FDBRequest;
+window.IDBTransaction = window.FDBTransaction;
+window.IDBVersionChangeEvent = window.FDBVersionChangeEvent;

--- a/tests/integration/index.html
+++ b/tests/integration/index.html
@@ -13,6 +13,13 @@
         document.write('<script src="../../node_modules/es5-shim/es5-shim.js"></' + 'script>');
       }
     </script>
+    <script>
+      var val = window.location.search.match(/[&\?]fakeIDB?=([^&\?]+)/);
+      if (val && val[1] === 'true') {
+        document.write('<script src="../../node_modules/fake-indexeddb/dist/fakeIndexedDB.js"></' + 'script>');
+        document.write('<script src="fake-idb-setup.js"></' + 'script>');
+      }
+    </script>
     <script src="../../node_modules/mocha/mocha.js"></script>
     <script src="../../node_modules/chai/chai.js"></script>
     <script>


### PR DESCRIPTION
I don't actually want to merge this; I just want to
confirm that it's testing on Travis.

This thing is interesting, but I don't think it actually
buys us much. It's not much faster than regular IndexedDB,
it would be tricky for us to run it in Node, and out of all
the browsers we test, it only works in PhantomJS, because it
turns out you can't override window.indexedDB in either Firefox
or Chrome. But it is kinda neat, and it does seem to pass the tests!