### PR TITLE
(#3865) - temporarily add uptodate event back in

### DIFF
--- a/lib/replicate/replicate.js
+++ b/lib/replicate/replicate.js
@@ -178,6 +178,7 @@ function replicate(src, target, opts, returnValue, result) {
         if ((continuous && changesOpts.live) || changesCompleted) {
           returnValue.state = 'pending';
           returnValue.emit('paused');
+          returnValue.emit('uptodate', result);
         }
         if (changesCompleted) {
           completeReplication();


### PR DESCRIPTION
I'd like to do a patch/minor release before the
major release, so let's put the `uptodate` event
back in, before we remove it for 4.0.0.

Unfortunately it appears there aren't (and weren't) any
tests for `uptodate`, but you can compare this
to an older version to see that this is where we were
emitting it:
https://github.com/pouchdb/pouchdb/blob/88336ad236926bffce41b40c7566febade6ef7d0/lib/replicate.js#L359-L360