### PR TITLE
(#3611) - foo as shorthand for foo/foo in filters

### DIFF
--- a/docs/_includes/api/changes.html
+++ b/docs/_includes/api/changes.html
@@ -28,7 +28,7 @@ All options default to `false` unless otherwise specified.
 * `options.filter`: Reference a filter function from a design document to selectively get updates. To use a view function, pass `_view` here and provide a reference to the view function in `options.view`. See [filtered changes](#filtered-changes) for details.
 * `options.doc_ids`: Only show changes for docs with these ids (array of strings).
 * `options.query_params`: Object containing properties that are passed to the filter function, e.g. `{"foo:"bar"}`, where `"bar"` will be available in the filter function as `params.query.foo`. To access the `params`, define your filter function like `function (doc, params) {/* ... */}`.
-* `options.view`: Specify a view function (e.g. `'design_doc_name/view_name'`) to act as a filter. Documents counted as "passed" for a view filter if a map function emits at least one record for them. **Note**: `options.filter` must be set to `'_view'` for this option to work.
+* `options.view`: Specify a view function (e.g. `'design_doc_name/view_name'` or `'view_name'` as shorthand for `'view_name/view_name'`) to act as a filter. Documents counted as "passed" for a view filter if a map function emits at least one record for them. **Note**: `options.filter` must be set to `'_view'` for this option to work.
 
 **Advanced Options:**
 
@@ -218,6 +218,8 @@ If you are running `changes()` on a remote CouchDB, then the first method will r
 
 If you are running `changes()` on a local PouchDB, then obviously all five methods will run client-side. There are also no performance benefits to using any of the five, so can also just filter yourself, in your own `on('change')` handler. These methods are implemented in PouchDB purely for consistency with CouchDB.
 
+The named functions can either be specified with `'designdoc_id/function_name'` or (if both design doc id and function name are equal) as `'fname'` as shorthand for `'fname/fname'`.
+
 #### Filtering examples
 
 In these examples, we'll work with some mammals. Let's imagine our docs are:
@@ -287,7 +289,7 @@ First `put()` a design document:
 
 {% highlight js %}
 {
-  _id: '_design/mydesign',
+  _id: '_design/myfilter',
   filters: {
     myfilter: function (doc, req) {
       return doc.type === req.query.type;
@@ -300,10 +302,12 @@ Then filter by `type === 'marsupial'`:
 
 {% highlight js %}
 db.changes({
-  filter: 'mydesign/myfilter',
+  filter: 'myfilter',
   query_params: {type: 'marsupial'}
 });
 {% endhighlight %}
+
+Since both the design document and the filter function have the same name, we can shorten the function name to `'myfilter'`.
 
 **Example 5: `view` function inside of a design document**
 

--- a/docs/_includes/api/replication.html
+++ b/docs/_includes/api/replication.html
@@ -20,7 +20,7 @@ All options default to `false` unless otherwise specified.
 * `options.filter`: Reference a filter function from a design document to selectively get updates. To use a view function, pass `_view` here and provide a reference to the view function in `options.view`. See [filtered replication](#filtered-replication) for details.
 * `options.doc_ids`: Only show changes for docs with these ids (array of strings).
 * `options.query_params`: Object containing properties that are passed to the filter function, e.g. `{"foo:"bar"}`, where `"bar"` will be available in the filter function as `params.query.foo`. To access the `params`, define your filter function like `function (doc, params) {/* ... */}`.
-* `options.view`: Specify a view function (e.g. `'design_doc_name/view_name'`) to act as a filter. Documents counted as "passed" for a view filter if a map function emits at least one record for them. **Note**: `options.filter` must be set to `'_view'` for this option to work.
+* `options.view`: Specify a view function (e.g. `'design_doc_name/view_name'` or `'view_name'` as shorthand for `'view_name/view_name'`) to act as a filter. Documents counted as "passed" for a view filter if a map function emits at least one record for them. **Note**: `options.filter` must be set to `'_view'` for this option to work.
 
 **Advanced Options:**
 

--- a/lib/changes.js
+++ b/lib/changes.js
@@ -167,10 +167,16 @@ Changes.prototype.doChanges = function (opts) {
     });
   }
 
-  if (this.db.type() !== 'http' &&
-      opts.filter && typeof opts.filter === 'string' &&
-      !opts.doc_ids) {
-    return this.filterChanges(opts);
+  if (opts.filter && typeof opts.filter === 'string') {
+    if (opts.filter === '_view') {
+      opts.view = utils.normalizeDesignDocFunctionName(opts.view);
+    } else {
+      opts.filter = utils.normalizeDesignDocFunctionName(opts.filter);
+    }
+
+    if (this.db.type() !== 'http' && !opts.doc_ids) {
+      return this.filterChanges(opts);
+    }
   }
 
   if (!('descending' in opts)) {
@@ -201,7 +207,12 @@ Changes.prototype.filterChanges = function (opts) {
       return;
     }
     // fetch a view from a design doc, make it behave like a filter
-    var viewName = opts.view.split('/');
+    var viewName = utils.parseDesignDocFunctionName(opts.view);
+    if (!viewName) {
+      callback(errors.error(errors.BAD_REQUEST,
+                             '`view` filter parameter invalid.'));
+      return;
+    }
     this.db.get('_design/' + viewName[0], function (err, ddoc) {
       if (self.isCancelled) {
         callback(null, {status: 'cancelled'});
@@ -212,7 +223,6 @@ Changes.prototype.filterChanges = function (opts) {
         return;
       }
       if (ddoc && ddoc.views && ddoc.views[viewName[1]]) {
-        
         var filter = evalView(ddoc.views[viewName[1]].map);
         opts.filter = filter;
         self.doChanges(opts);
@@ -228,7 +238,12 @@ Changes.prototype.filterChanges = function (opts) {
     });
   } else {
     // fetch a filter from a design doc
-    var filterName = opts.filter.split('/');
+    var filterName = utils.parseDesignDocFunctionName(opts.filter);
+    if (!filterName) {
+      callback(errors.error(errors.BAD_REQUEST,
+                             '`filter` filter parameter invalid.'));
+      return;
+    }
     this.db.get('_design/' + filterName[0], function (err, ddoc) {
       if (self.isCancelled) {
         callback(null, {status: 'cancelled'});

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -400,3 +400,22 @@ exports.safeJsonStringify = function safeJsonStringify(json) {
     return vuvuzela.stringify(json);
   }
 };
+
+exports.parseDesignDocFunctionName = function (s) {
+  if (!s) {
+    return null;
+  }
+  var parts = s.split('/');
+  if (parts.length === 2) {
+    return parts;
+  } else if (parts.length === 1) {
+    return [s, s];
+  } else {
+    return null;
+  }
+};
+
+exports.normalizeDesignDocFunctionName = function (s) {
+	var normalized = this.parseDesignDocFunctionName(s);
+	return normalized ? normalized.join('/') : null;
+};

--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -507,6 +507,37 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('Changes with shorthand function name', function (done) {
+      var docs = [
+        {_id: '0', integer: 0},
+        {_id: '1', integer: 1},
+        {_id: '2', integer: 2},
+        {
+          _id: '_design/even',
+          integer: 3,
+          filters: { even: 'function (doc) { return doc.integer % 2 === 0; }' }
+        }
+      ];
+      var db = new PouchDB(dbs.name);
+
+      db.bulkDocs({ docs: docs }, function (err, info) {
+        var promise = db.changes({
+          filter: 'even',
+          include_docs: true,
+          complete: function (err, results) {
+            results.results.length.should.equal(2);
+            var zero = findById(results.results, '0');
+            zero.doc.integer.should.equal(0);
+            var two = findById(results.results, '2');
+            two.doc.integer.should.equal(2);
+            done();
+          }
+        });
+        should.exist(promise);
+        promise.cancel.should.be.a('function');
+      });
+    });
+
     it('Changes with filter from nonexistent ddoc', function (done) {
       var docs = [
         {_id: '0', integer: 0},

--- a/tests/unit/test.utils.js
+++ b/tests/unit/test.utils.js
@@ -1,0 +1,31 @@
+
+'use strict';
+
+var should = require('chai').should();
+var utils = require('../../lib/utils.js');
+
+describe('test.utils.js', function () {
+  describe('the design doc function name normalizer', function () {
+    it('normalizes foo to foo/foo', function () {
+      utils.normalizeDesignDocFunctionName('foo').should.be.eql('foo/foo');
+    });
+    it('normalizes foo/bar to foo/bar', function () {
+      utils.normalizeDesignDocFunctionName('foo/bar').should.be.eql('foo/bar');
+    });
+    it('normalizes null to a non existing value', function () {
+      should.not.exist(utils.normalizeDesignDocFunctionName(null));
+    });
+  });
+  describe('ddoc function name parser', function () {
+    it('parses foo/bar as [foo,bar]', function () {
+      utils.parseDesignDocFunctionName('foo/bar').should.be.eql(['foo', 'bar']);
+    });
+    it('parses foo as [foo,foo]', function () {
+      utils.parseDesignDocFunctionName('foo').should.be.eql(['foo', 'foo']);
+    });
+    it('throws if it can\'t parse the function name', function () {
+      should.not.exist(utils.parseDesignDocFunctionName(null));
+      should.not.exist(utils.parseDesignDocFunctionName('foo/bar/baz'));
+    });
+  });
+});


### PR DESCRIPTION
These were the only instances I found where a name like `foo/foo` is needed.

fixes #3611 
