### PR TITLE
(#2832) - avoid application/json for doc GETs

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -20,7 +20,9 @@
   "globals": {
     "PouchDB": true,
     "should": true,
-    "Promise": true
+    "Promise": true,
+    "atob": true,
+    "btoa": true
   },
   "predef": [
     "describe",

--- a/lib/adapters/http/http.js
+++ b/lib/adapters/http/http.js
@@ -12,10 +12,25 @@ var MAX_URL_LENGTH = 1800;
 var readAsBinaryString = require('../../deps/binary/readAsBinaryString');
 var binaryStringToBlob = require('../../deps/binary/binaryStringToBlob');
 var utils = require('../../utils');
+var Promise = utils.Promise;
+var base64 = require('../../deps/binary/base64');
+var btoa = base64.btoa;
+var atob = base64.atob;
 var errors = require('../../deps/errors');
 var log = require('debug')('pouchdb:http');
 var isBrowser = typeof process === 'undefined' || process.browser;
 var buffer = require('../../deps/buffer');
+
+function blobToBase64(blobOrBuffer) {
+  if (!isBrowser) {
+    return Promise.resolve(blobOrBuffer.toString('base64'));
+  }
+  return new Promise(function (resolve) {
+    readAsBinaryString(blobOrBuffer, function (bin) {
+      resolve(btoa(bin));
+    });
+  });
+}
 
 function encodeDocId(id) {
   if (/^_design/.test(id)) {
@@ -29,22 +44,15 @@ function encodeDocId(id) {
 
 function preprocessAttachments(doc) {
   if (!doc._attachments || !Object.keys(doc._attachments)) {
-    return utils.Promise.resolve();
+    return Promise.resolve();
   }
 
-  return utils.Promise.all(Object.keys(doc._attachments).map(function (key) {
+  return Promise.all(Object.keys(doc._attachments).map(function (key) {
     var attachment = doc._attachments[key];
     if (attachment.data && typeof attachment.data !== 'string') {
-      if (isBrowser) {
-        return new utils.Promise(function (resolve) {
-          readAsBinaryString(attachment.data, function (binary) {
-            attachment.data = utils.btoa(binary);
-            resolve();
-          });
-        });
-      } else {
-        attachment.data = attachment.data.toString('base64');
-      }
+      return blobToBase64(attachment.data).then(function (b64) {
+        attachment.data = b64;
+      });
     }
   }));
 }
@@ -82,7 +90,7 @@ function getHost(name, opts) {
 
     if (opts.auth || uri.auth) {
       var nAuth = opts.auth || uri.auth;
-      var token = utils.btoa(nAuth.username + ':' + nAuth.password);
+      var token = btoa(nAuth.username + ':' + nAuth.password);
       uri.headers.Authorization = 'Basic ' + token;
     }
 
@@ -141,6 +149,17 @@ function HttpPouch(opts, callback) {
     var reqOpts = utils.extend(true, utils.clone(ajaxOpts), options);
     log(reqOpts.method + ' ' + reqOpts.url);
     return utils.ajax(reqOpts, callback);
+  }
+
+  function ajaxPromise(opts) {
+    return new Promise(function (resolve, reject) {
+      ajax(opts, function (err, res) {
+        if (err) {
+          return reject(err);
+        }
+        resolve(res);
+      });
+    });
   }
 
   // Create a new CouchDB database based on the given opts
@@ -273,9 +292,6 @@ function HttpPouch(opts, callback) {
       opts = {};
     }
     opts = utils.clone(opts);
-    if (opts.auto_encode === undefined) {
-      opts.auto_encode = true;
-    }
 
     // List of parameters to add to the GET request
     var params = [];
@@ -309,13 +325,6 @@ function HttpPouch(opts, callback) {
       params.push('open_revs=' + opts.open_revs);
     }
 
-    // If it exists, add the opts.attachments value to the list of parameters.
-    // If attachments=true the resulting JSON will include the base64-encoded
-    // contents in the "data" property of each attachment.
-    if (opts.attachments) {
-      params.push('attachments=true');
-    }
-
     // If it exists, add the opts.rev value to the list of parameters.
     // If rev is given a revision number then get the specified revision.
     if (opts.rev) {
@@ -333,9 +342,7 @@ function HttpPouch(opts, callback) {
     params = params.join('&');
     params = params === '' ? '' : '?' + params;
 
-    if (opts.auto_encode) {
-      id = encodeDocId(id);
-    }
+    id = encodeDocId(id);
 
     // Set the options for the ajax call
     var options = {
@@ -346,30 +353,53 @@ function HttpPouch(opts, callback) {
     var getRequestAjaxOpts = opts.ajax || {};
     utils.extend(true, options, getRequestAjaxOpts);
 
-    // If the given id contains at least one '/' and the part before the '/'
-    // is NOT "_design" and is NOT "_local"
-    // OR
-    // If the given id contains at least two '/' and the part before the first
-    // '/' is "_design".
-    // TODO This second condition seems strange since if parts[0] === '_design'
-    // then we already know that parts[0] !== '_local'.
-    var parts = id.split('/');
-    if ((parts.length > 1 && parts[0] !== '_design' && parts[0] !== '_local') ||
-        (parts.length > 2 && parts[0] === '_design' && parts[0] !== '_local')) {
-      // Binary is expected back from the server
-      options.binary = true;
+    function fetchAttachments(doc) {
+      var atts = doc._attachments;
+      var filenames = atts && Object.keys(atts);
+      if (!atts || !filenames.length) {
+        return;
+      }
+      // we fetch these manually in separate XHRs, because
+      // Sync Gateway would normally send it back as multipart/mixed,
+      // which we cannot parse. Also, this is more efficient than
+      // receiving attachments as base64-encoded strings.
+      return Promise.all(filenames.map(function (filename) {
+        var att = atts[filename];
+        var path = encodeDocId(doc._id) + '/' + encodeAttachmentId(filename) +
+          '?rev=' + doc._rev;
+        return ajaxPromise({
+          headers: host.headers,
+          method: 'GET',
+          url: genDBUrl(host, path),
+          binary: true
+        }).then(blobToBase64).then(function (b64) {
+          delete att.stub;
+          delete att.length;
+          att.data = b64;
+        });
+      }));
     }
 
-    // Get the document
-    ajax(options, function (err, doc, xhr) {
-      // If the document does not exist, send an error to the callback
-      if (err) {
-        return callback(err);
+    function fetchAllAttachments(docOrDocs) {
+      if (Array.isArray(docOrDocs)) {
+        return Promise.all(docOrDocs.map(function (doc) {
+          if (doc.ok) {
+            return fetchAttachments(doc.ok);
+          }
+        }));
       }
+      return fetchAttachments(docOrDocs);
+    }
 
-      // Send the document to the callback
-      callback(null, doc, xhr);
-    });
+    ajaxPromise(options).then(function (res) {
+      return Promise.resolve().then(function () {
+        if (opts.attachments) {
+          return fetchAllAttachments(res);
+        }
+      }).then(function () {
+        callback(null, res);
+      });
+    }).catch(callback);
   });
 
   // Delete the document given by doc from the database given by host.
@@ -420,15 +450,14 @@ function HttpPouch(opts, callback) {
       callback = opts;
       opts = {};
     }
-    opts = utils.clone(opts);
-    if (opts.auto_encode === undefined) {
-      opts.auto_encode = true;
-    }
-    if (opts.auto_encode) {
-      docId = encodeDocId(docId);
-    }
-    opts.auto_encode = false;
-    api.get(docId + '/' + encodeAttachmentId(attachmentId), opts, callback);
+    var url = genDBUrl(host, encodeDocId(docId)) + '/' +
+      encodeAttachmentId(attachmentId);
+    ajax({
+      headers: host.headers,
+      method: 'GET',
+      url: url,
+      binary: true
+    }, callback);
   });
 
   // Remove the attachment given by the id and rev
@@ -472,7 +501,7 @@ function HttpPouch(opts, callback) {
     if (typeof blob === 'string') {
       var binary;
       try {
-        binary = utils.atob(blob);
+        binary = atob(blob);
       } catch (err) {
         // it's not base64-encoded, so throw error
         return callback(errors.error(errors.BAD_ARG,
@@ -603,7 +632,7 @@ function HttpPouch(opts, callback) {
       req.new_edits = opts.new_edits;
     }
 
-    utils.Promise.all(req.docs.map(preprocessAttachments)).then(function () {
+    Promise.all(req.docs.map(preprocessAttachments)).then(function () {
       // Update/create the documents
       ajax({
         headers: host.headers,

--- a/lib/adapters/idb/idb-utils.js
+++ b/lib/adapters/idb/idb-utils.js
@@ -2,6 +2,9 @@
 
 var errors = require('../../deps/errors');
 var utils = require('../../utils');
+var base64 = require('../../deps/binary/base64');
+var atob = base64.atob;
+var btoa = base64.btoa;
 var constants = require('./idb-constants');
 var readAsBinaryString = require('../../deps/binary/readAsBinaryString');
 var binaryStringToArrayBuffer =
@@ -93,7 +96,7 @@ exports.readBlobData = function (body, type, encode, callback) {
       callback('');
     } else if (typeof body !== 'string') { // we have blob support
       readAsBinaryString(body, function (binary) {
-        callback(utils.btoa(binary));
+        callback(btoa(binary));
       });
     } else { // no blob support
       callback(body);

--- a/lib/deps/binary/base64.js
+++ b/lib/deps/binary/base64.js
@@ -4,6 +4,7 @@ var buffer = require('./../buffer');
 
 if (typeof atob === 'function') {
   exports.atob = function (str) {
+    /* global atob */
     return atob(str);
   };
 } else {
@@ -20,6 +21,7 @@ if (typeof atob === 'function') {
 
 if (typeof btoa === 'function') {
   exports.btoa = function (str) {
+    /* global btoa */
     return btoa(str);
   };
 } else {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "throw-max-listeners-error": "^1.0.0",
     "child-process-promise": "^1.1.0",
-    "pouchdb-express-router": "^0.0.2",
+    "pouchdb-express-router": "^0.0.5",
     "bundle-collapser": "^1.1.1",
     "rimraf": "2.2.8",
     "pouchdb-server": "^0.6.1",


### PR DESCRIPTION
This is step 1 to get Sync Gateway support, as well as to have
more efficient attachment parsing.

My solution involves the insight that multipart/mixed is actually
really stupidly difficult to parse in the browser (gzipped
binary strings? wtf), so it makes more sense to just avoid using
`attachments: true` with `get()`s entirely, and do separate
HTTP GET requests instead.

Now, usually I'm opposed to additional HTTP requests, but in this case
I think it makes sense. By fetching attachments independently,
the browser can do the hard work of gzip-decoding, and we can still
send attachments over the wire in the most efficient binary format.
People who don't like this, and who prefer to have everything in a single
JSON object, can just avoid using attachments (as they should anyway,
for small bits of text data).

I decided to put this logic in `http.js` itself rather than the replicator,
because 1) I see no case where anybody would prefer actually passing
`attachments:true` to CouchDB and get the attachments back in base64 format,
and 2) this helps us get ALL the tests passing against CSG, even those
where we directly `get()` with `attachments:true`.

Step 2 for CSG support will be to support PUTing documents with multipart/related
type. This PR does not do that.

This PR also has some unrelated fixes that I noticed as I was writing it:

1) accidental usage of raw `btoa` in idb.js
2) ~~we weren't actually supporting `getAttachment` with the `rev` option. Whoops!~~ moved to #3871