### PR TITLE
(#3871) - support "rev" option in getAttachment()

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -20,7 +20,9 @@
   "globals": {
     "PouchDB": true,
     "should": true,
-    "Promise": true
+    "Promise": true,
+    "atob": true,
+    "btoa": true
   },
   "predef": [
     "describe",

--- a/docs/_includes/api/get_attachment.html
+++ b/docs/_includes/api/get_attachment.html
@@ -6,11 +6,17 @@ db.getAttachment(docId, attachmentId, [options], [callback])
 
 Get attachment data.
 
+### Options
+
+* `options.rev`: as with [get()](#fetch_document), you can pass a `rev` in and get back an attachment for the document at that particular revision.
+
 #### Example Usage:
+
+Get an attachment with filename `'att.txt'` from document with ID `'doc'`:
 
 {% include code/start.html id="get_att1" type="callback" %}
 {% highlight js %}
-db.getAttachment('doc', 'att.txt', function(err, res) {
+db.getAttachment('doc', 'att.txt', function(err, blobOrBuffer) {
   if (err) { return console.log(err); }
   // handle result
 });
@@ -18,7 +24,7 @@ db.getAttachment('doc', 'att.txt', function(err, res) {
 {% include code/end.html %}
 {% include code/start.html id="get_att1" type="promise" %}
 {% highlight js %}
-db.getAttachment('doc', 'att.txt').then(function (result) {
+db.getAttachment('doc', 'att.txt').then(function (blobOrBuffer) {
   // handle result
 }).catch(function (err) {
   console.log(err);
@@ -26,9 +32,30 @@ db.getAttachment('doc', 'att.txt').then(function (result) {
 {% endhighlight %}
 {% include code/end.html %}
 
-#### Example Response:
+Get an attachment with filename `'att.txt'` from document with ID `'doc'`, at
+the revision `'1-abcd'`:
 
-The response will be a `Blob` object in the browser, and a `Buffer` object in Node.js.
+{% include code/start.html id="get_att2" type="callback" %}
+{% highlight js %}
+db.getAttachment('doc', 'att.txt', {rev: '1-abcd'}, function(err, blobOrBuffer) {
+  if (err) { return console.log(err); }
+  // handle result
+});
+{% endhighlight %}
+{% include code/end.html %}
+{% include code/start.html id="get_att2" type="promise" %}
+{% highlight js %}
+db.getAttachment('doc', 'att.txt', {rev: '1-abcd'}).then(function (blobOrBuffer) {
+  // handle result
+}).catch(function (err) {
+  console.log(err);
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+#### Response type:
+
+The response will be a `Blob` object in the browser, and a `Buffer` object in Node.js. See [blob-util](https://github.com/nolanlawson/blob-util) for utilities to transform `Blob`s to other formats, such as base64-encoded strings, data URLs, array buffers, etc.
 
 #### Inline base64 attachments
 

--- a/lib/adapters/http/http.js
+++ b/lib/adapters/http/http.js
@@ -12,10 +12,25 @@ var MAX_URL_LENGTH = 1800;
 var readAsBinaryString = require('../../deps/binary/readAsBinaryString');
 var binaryStringToBlob = require('../../deps/binary/binaryStringToBlob');
 var utils = require('../../utils');
+var Promise = utils.Promise;
+var base64 = require('../../deps/binary/base64');
+var btoa = base64.btoa;
+var atob = base64.atob;
 var errors = require('../../deps/errors');
 var log = require('debug')('pouchdb:http');
 var isBrowser = typeof process === 'undefined' || process.browser;
 var buffer = require('../../deps/buffer');
+
+function blobToBase64(blobOrBuffer) {
+  if (!isBrowser) {
+    return Promise.resolve(blobOrBuffer.toString('base64'));
+  }
+  return new Promise(function (resolve) {
+    readAsBinaryString(blobOrBuffer, function (bin) {
+      resolve(btoa(bin));
+    });
+  });
+}
 
 function encodeDocId(id) {
   if (/^_design/.test(id)) {
@@ -29,22 +44,15 @@ function encodeDocId(id) {
 
 function preprocessAttachments(doc) {
   if (!doc._attachments || !Object.keys(doc._attachments)) {
-    return utils.Promise.resolve();
+    return Promise.resolve();
   }
 
-  return utils.Promise.all(Object.keys(doc._attachments).map(function (key) {
+  return Promise.all(Object.keys(doc._attachments).map(function (key) {
     var attachment = doc._attachments[key];
     if (attachment.data && typeof attachment.data !== 'string') {
-      if (isBrowser) {
-        return new utils.Promise(function (resolve) {
-          readAsBinaryString(attachment.data, function (binary) {
-            attachment.data = utils.btoa(binary);
-            resolve();
-          });
-        });
-      } else {
-        attachment.data = attachment.data.toString('base64');
-      }
+      return blobToBase64(attachment.data).then(function (b64) {
+        attachment.data = b64;
+      });
     }
   }));
 }
@@ -82,7 +90,7 @@ function getHost(name, opts) {
 
     if (opts.auth || uri.auth) {
       var nAuth = opts.auth || uri.auth;
-      var token = utils.btoa(nAuth.username + ':' + nAuth.password);
+      var token = btoa(nAuth.username + ':' + nAuth.password);
       uri.headers.Authorization = 'Basic ' + token;
     }
 
@@ -141,6 +149,17 @@ function HttpPouch(opts, callback) {
     var reqOpts = utils.extend(true, utils.clone(ajaxOpts), options);
     log(reqOpts.method + ' ' + reqOpts.url);
     return utils.ajax(reqOpts, callback);
+  }
+
+  function ajaxPromise(opts) {
+    return new Promise(function (resolve, reject) {
+      ajax(opts, function (err, res) {
+        if (err) {
+          return reject(err);
+        }
+        resolve(res);
+      });
+    });
   }
 
   // Create a new CouchDB database based on the given opts
@@ -273,9 +292,6 @@ function HttpPouch(opts, callback) {
       opts = {};
     }
     opts = utils.clone(opts);
-    if (opts.auto_encode === undefined) {
-      opts.auto_encode = true;
-    }
 
     // List of parameters to add to the GET request
     var params = [];
@@ -309,13 +325,6 @@ function HttpPouch(opts, callback) {
       params.push('open_revs=' + opts.open_revs);
     }
 
-    // If it exists, add the opts.attachments value to the list of parameters.
-    // If attachments=true the resulting JSON will include the base64-encoded
-    // contents in the "data" property of each attachment.
-    if (opts.attachments) {
-      params.push('attachments=true');
-    }
-
     // If it exists, add the opts.rev value to the list of parameters.
     // If rev is given a revision number then get the specified revision.
     if (opts.rev) {
@@ -333,9 +342,7 @@ function HttpPouch(opts, callback) {
     params = params.join('&');
     params = params === '' ? '' : '?' + params;
 
-    if (opts.auto_encode) {
-      id = encodeDocId(id);
-    }
+    id = encodeDocId(id);
 
     // Set the options for the ajax call
     var options = {
@@ -346,30 +353,53 @@ function HttpPouch(opts, callback) {
     var getRequestAjaxOpts = opts.ajax || {};
     utils.extend(true, options, getRequestAjaxOpts);
 
-    // If the given id contains at least one '/' and the part before the '/'
-    // is NOT "_design" and is NOT "_local"
-    // OR
-    // If the given id contains at least two '/' and the part before the first
-    // '/' is "_design".
-    // TODO This second condition seems strange since if parts[0] === '_design'
-    // then we already know that parts[0] !== '_local'.
-    var parts = id.split('/');
-    if ((parts.length > 1 && parts[0] !== '_design' && parts[0] !== '_local') ||
-        (parts.length > 2 && parts[0] === '_design' && parts[0] !== '_local')) {
-      // Binary is expected back from the server
-      options.binary = true;
+    function fetchAttachments(doc) {
+      var atts = doc._attachments;
+      var filenames = atts && Object.keys(atts);
+      if (!atts || !filenames.length) {
+        return;
+      }
+      // we fetch these manually in separate XHRs, because
+      // Sync Gateway would normally send it back as multipart/mixed,
+      // which we cannot parse. Also, this is more efficient than
+      // receiving attachments as base64-encoded strings.
+      return Promise.all(filenames.map(function (filename) {
+        var att = atts[filename];
+        var path = encodeDocId(doc._id) + '/' + encodeAttachmentId(filename) +
+          '?rev=' + doc._rev;
+        return ajaxPromise({
+          headers: host.headers,
+          method: 'GET',
+          url: genDBUrl(host, path),
+          binary: true
+        }).then(blobToBase64).then(function (b64) {
+          delete att.stub;
+          delete att.length;
+          att.data = b64;
+        });
+      }));
     }
 
-    // Get the document
-    ajax(options, function (err, doc, xhr) {
-      // If the document does not exist, send an error to the callback
-      if (err) {
-        return callback(err);
+    function fetchAllAttachments(docOrDocs) {
+      if (Array.isArray(docOrDocs)) {
+        return Promise.all(docOrDocs.map(function (doc) {
+          if (doc.ok) {
+            return fetchAttachments(doc.ok);
+          }
+        }));
       }
+      return fetchAttachments(docOrDocs);
+    }
 
-      // Send the document to the callback
-      callback(null, doc, xhr);
-    });
+    ajaxPromise(options).then(function (res) {
+      return Promise.resolve().then(function () {
+        if (opts.attachments) {
+          return fetchAllAttachments(res);
+        }
+      }).then(function () {
+        callback(null, res);
+      });
+    }).catch(callback);
   });
 
   // Delete the document given by doc from the database given by host.
@@ -420,15 +450,14 @@ function HttpPouch(opts, callback) {
       callback = opts;
       opts = {};
     }
-    opts = utils.clone(opts);
-    if (opts.auto_encode === undefined) {
-      opts.auto_encode = true;
-    }
-    if (opts.auto_encode) {
-      docId = encodeDocId(docId);
-    }
-    opts.auto_encode = false;
-    api.get(docId + '/' + encodeAttachmentId(attachmentId), opts, callback);
+    var url = genDBUrl(host, encodeDocId(docId)) + '/' +
+      encodeAttachmentId(attachmentId);
+    ajax({
+      headers: host.headers,
+      method: 'GET',
+      url: url,
+      binary: true
+    }, callback);
   });
 
   // Remove the attachment given by the id and rev
@@ -472,7 +501,7 @@ function HttpPouch(opts, callback) {
     if (typeof blob === 'string') {
       var binary;
       try {
-        binary = utils.atob(blob);
+        binary = atob(blob);
       } catch (err) {
         // it's not base64-encoded, so throw error
         return callback(errors.error(errors.BAD_ARG,
@@ -603,7 +632,7 @@ function HttpPouch(opts, callback) {
       req.new_edits = opts.new_edits;
     }
 
-    utils.Promise.all(req.docs.map(preprocessAttachments)).then(function () {
+    Promise.all(req.docs.map(preprocessAttachments)).then(function () {
       // Update/create the documents
       ajax({
         headers: host.headers,

--- a/lib/adapters/http/http.js
+++ b/lib/adapters/http/http.js
@@ -450,8 +450,9 @@ function HttpPouch(opts, callback) {
       callback = opts;
       opts = {};
     }
+    var params = opts.rev ? ('?rev=' + opts.rev) : '';
     var url = genDBUrl(host, encodeDocId(docId)) + '/' +
-      encodeAttachmentId(attachmentId);
+      encodeAttachmentId(attachmentId) + params;
     ajax({
       headers: host.headers,
       method: 'GET',

--- a/lib/adapters/idb/idb-utils.js
+++ b/lib/adapters/idb/idb-utils.js
@@ -2,6 +2,9 @@
 
 var errors = require('../../deps/errors');
 var utils = require('../../utils');
+var base64 = require('../../deps/binary/base64');
+var atob = base64.atob;
+var btoa = base64.btoa;
 var constants = require('./idb-constants');
 var readAsBinaryString = require('../../deps/binary/readAsBinaryString');
 var binaryStringToArrayBuffer =
@@ -93,7 +96,7 @@ exports.readBlobData = function (body, type, encode, callback) {
       callback('');
     } else if (typeof body !== 'string') { // we have blob support
       readAsBinaryString(body, function (binary) {
-        callback(utils.btoa(binary));
+        callback(btoa(binary));
       });
     } else { // no blob support
       callback(body);

--- a/lib/deps/binary/base64.js
+++ b/lib/deps/binary/base64.js
@@ -4,6 +4,7 @@ var buffer = require('./../buffer');
 
 if (typeof atob === 'function') {
   exports.atob = function (str) {
+    /* global atob */
     return atob(str);
   };
 } else {
@@ -20,6 +21,7 @@ if (typeof atob === 'function') {
 
 if (typeof btoa === 'function') {
   exports.btoa = function (str) {
+    /* global btoa */
     return btoa(str);
   };
 } else {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "throw-max-listeners-error": "^1.0.0",
     "child-process-promise": "^1.1.0",
-    "pouchdb-express-router": "^0.0.2",
+    "pouchdb-express-router": "^0.0.5",
     "bundle-collapser": "^1.1.1",
     "rimraf": "2.2.8",
     "pouchdb-server": "^0.6.1",

--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -815,6 +815,7 @@ adapters.forEach(function (adapter) {
           should.exist(doc._attachments['foo.txt'], 'doc has attachment');
           doc._attachments['foo.txt'].content_type.should.equal('text/plain');
           db.getAttachment('bin_doc', 'foo.txt', function (err, res) {
+            should.not.exist(err, 'fetched attachment');
             testUtils.readBlob(res, function (data) {
               data.should.equal('This is a base64 encoded text');
               db.put(binAttDoc2, function (err, rev) {
@@ -1515,6 +1516,106 @@ adapters.forEach(function (adapter) {
             att.content_type.should.equal('text/plain');
           });
         });
+    });
+
+    it('Test getAttachment with specific rev', function () {
+      var db = new PouchDB(dbs.name, {auto_compaction: false});
+
+      var doc = {
+        _id: 'a'
+      };
+      var rev1;
+      var rev2;
+      var rev3;
+      return db.put(doc).then(function (res) {
+        doc._rev = rev1 = res.rev;
+        doc._attachments = {
+          'foo.txt': {
+            content_type: 'text/plain',
+            data: 'Zm9v'
+          }
+        };
+        return db.put(doc);
+      }).then(function (res) {
+        doc._rev = rev2 = res.rev;
+
+        delete doc._attachments;
+        return db.put(doc);
+      }).then(function (res) {
+        doc._rev = rev3 = res.rev;
+
+        return db.getAttachment('a', 'foo.txt', {rev: rev2});
+      }).then(function (blob) {
+        should.exist(blob);
+
+        return PouchDB.utils.Promise.all([
+          db.getAttachment('a', 'foo.txt', {rev: rev1}),
+          db.getAttachment('a', 'foo.txt', {rev: '3-fake'}),
+          db.getAttachment('a', 'foo.txt'),
+          db.getAttachment('a', 'foo.txt', {}),
+          db.getAttachment('a', 'foo.txt', {rev: rev3})
+        ].map(function (promise) {
+          return promise.then(function () {
+            throw new Error('expected an error');
+          }, function (err) {
+            should.exist(err);
+            err.status.should.equal(404);
+          });
+        }));
+      });
+    });
+
+    it('Test getAttachment with diff revs and content', function () {
+      var db = new PouchDB(dbs.name, {auto_compaction: false});
+
+      var doc = {
+        _id: 'a',
+        _attachments: {
+          'foo.txt': {
+            content_type: 'text/plain',
+            data: 'Zm9v'
+          }
+        }
+      };
+      var rev1;
+      var rev2;
+      var rev3;
+      return db.put(doc).then(function (res) {
+        doc._rev = rev1 = res.rev;
+        doc._attachments = {
+          'foo.txt': {
+            content_type: 'text/plain',
+            data: 'YmFy'
+          }
+        };
+        return db.put(doc);
+      }).then(function (res) {
+        doc._rev = rev2 = res.rev;
+        doc._attachments = {
+          'foo.txt': {
+            content_type: 'text/plain',
+            data: 'YmF6'
+          }
+        };
+        return db.put(doc);
+      }).then(function (res) {
+        doc._rev = rev3 = res.rev;
+
+        var testCases = [
+          [db.getAttachment('a', 'foo.txt'), 'baz'],
+          [db.getAttachment('a', 'foo.txt', {rev: rev3}), 'baz'],
+          [db.getAttachment('a', 'foo.txt', {rev: rev2}), 'bar'],
+          [db.getAttachment('a', 'foo.txt', {rev: rev1}), 'foo']
+        ];
+
+        return PouchDB.utils.Promise.all(testCases.map(function (testCase) {
+          var promise = testCase[0];
+          var expected = testCase[1];
+          return promise.then(testUtils.readBlobPromise).then(function (bin) {
+            bin.should.equal(expected, 'didn\'t get blob we expected for rev');
+          });
+        }));
+      });
     });
 
     it('Test stubs', function (done) {

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -95,6 +95,12 @@ testUtils.readBlob = function (blob, callback) {
   }
 };
 
+testUtils.readBlobPromise = function (blob) {
+  return new PouchDB.utils.Promise(function (resolve) {
+    testUtils.readBlob(blob, resolve);
+  });
+};
+
 testUtils.base64Blob = function (blob, callback) {
   if (typeof module !== 'undefined' && module.exports) {
     callback(blob.toString('base64'));


### PR DESCRIPTION
Originally this commit was part of #3870, but I broke
it into a separate PR to make it easier to digest.

I did rebase this on top of #3871, however, to avoid
bitrotting myself.