### PR TITLE
(#3877) - refactor binary

### DIFF
--- a/lib/adapters/http/http.js
+++ b/lib/adapters/http/http.js
@@ -9,6 +9,8 @@ var CHANGES_BATCH_SIZE = 25;
 // TODO: we could measure the full URL to enforce exactly 2000 chars
 var MAX_URL_LENGTH = 1800;
 
+var readAsBinaryString = require('../../deps/binary/readAsBinaryString');
+var binaryStringToBlob = require('../../deps/binary/binaryStringToBlob');
 var utils = require('../../utils');
 var errors = require('../../deps/errors');
 var log = require('debug')('pouchdb:http');
@@ -35,7 +37,7 @@ function preprocessAttachments(doc) {
     if (attachment.data && typeof attachment.data !== 'string') {
       if (isBrowser) {
         return new utils.Promise(function (resolve) {
-          utils.readAsBinaryString(attachment.data, function (binary) {
+          readAsBinaryString(attachment.data, function (binary) {
             attachment.data = utils.btoa(binary);
             resolve();
           });
@@ -477,7 +479,7 @@ function HttpPouch(opts, callback) {
                         'Attachments need to be base64 encoded'));
       }
       if (isBrowser) {
-        blob = utils.createBlob([utils.fixBinary(binary)], {type: type});
+        blob = binaryStringToBlob(binary, type);
       } else {
         blob = binary ? new buffer(binary, 'binary') : '';
       }

--- a/lib/adapters/idb/idb-utils.js
+++ b/lib/adapters/idb/idb-utils.js
@@ -3,6 +3,9 @@
 var errors = require('../../deps/errors');
 var utils = require('../../utils');
 var constants = require('./idb-constants');
+var readAsBinaryString = require('../../deps/binary/readAsBinaryString');
+var binaryStringToArrayBuffer =
+  require('../../deps/binary/binaryStringToArrayBuffer');
 
 function tryCode(fun, that, args) {
   try {
@@ -89,7 +92,7 @@ exports.readBlobData = function (body, type, encode, callback) {
     if (!body) {
       callback('');
     } else if (typeof body !== 'string') { // we have blob support
-      utils.readAsBinaryString(body, function (binary) {
+      readAsBinaryString(body, function (binary) {
         callback(utils.btoa(binary));
       });
     } else { // no blob support
@@ -101,7 +104,7 @@ exports.readBlobData = function (body, type, encode, callback) {
     } else if (typeof body !== 'string') { // we have blob support
       callback(body);
     } else { // no blob support
-      body = utils.fixBinary(atob(body));
+      body = binaryStringToArrayBuffer(atob(body));
       callback(utils.createBlob([body], {type: type}));
     }
   }

--- a/lib/adapters/leveldb/leveldb.js
+++ b/lib/adapters/leveldb/leveldb.js
@@ -20,6 +20,9 @@ var utils = require('../../utils');
 var migrate = require('../../deps/migrate');
 var Deque = require("double-ended-queue");
 
+var readAsBinaryString = require('../../deps/binary/readAsBinaryString');
+var binaryStringToBlob = require('../../deps/binary/binaryStringToBlob');
+
 var LevelTransaction = require('./leveldb-transaction');
 
 var DOC_STORE = 'document-store';
@@ -353,8 +356,7 @@ function LevelPouch(opts, callback) {
         if (opts.encode) {
           data = utils.btoa(attach);
         } else {
-          data = utils.createBlob([utils.fixBinary(attach)],
-            {type: attachment.content_type});
+          data = binaryStringToBlob(attach, attachment.content_type);
         }
       } else {
         data = opts.encode ? utils.btoa(attach) : attach;
@@ -565,7 +567,7 @@ function LevelPouch(opts, callback) {
         } else if (!process.browser) {
           data = att.data;
         } else { // browser
-          utils.readAsBinaryString(att.data,
+          readAsBinaryString(att.data,
             onLoadEnd(docInfo, key, attachmentSaved));
           continue;
         }

--- a/lib/adapters/websql/websql.js
+++ b/lib/adapters/websql/websql.js
@@ -4,6 +4,7 @@ var utils = require('../../utils');
 var merge = require('../../merge');
 var errors = require('../../deps/errors');
 var parseHexString = require('../../deps/parse-hex');
+var binaryStringToBlob = require('../../deps/binary/binaryStringToBlob');
 
 var websqlConstants = require('./websql-constants');
 var websqlUtils = require('./websql-utils');
@@ -845,8 +846,7 @@ function WebSqlPouch(opts, callback) {
       if (opts.encode) {
         res = utils.btoa(data);
       } else {
-        data = utils.fixBinary(data);
-        res = utils.createBlob([data], {type: type});
+        res = binaryStringToBlob(data, type);
       }
       callback(null, res);
     });

--- a/lib/deps/binary/arrayBufferToBinaryString.js
+++ b/lib/deps/binary/arrayBufferToBinaryString.js
@@ -1,0 +1,14 @@
+'use strict';
+
+//Can't find original post, but this is close
+//http://stackoverflow.com/questions/6965107/ (continues on next line)
+//converting-between-strings-and-arraybuffers
+module.exports = function (buffer) {
+  var binary = '';
+  var bytes = new Uint8Array(buffer);
+  var length = bytes.byteLength;
+  for (var i = 0; i < length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return binary;
+};

--- a/lib/deps/binary/base64.js
+++ b/lib/deps/binary/base64.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var buffer = require('./buffer');
+var buffer = require('./../buffer');
 
 if (typeof atob === 'function') {
   exports.atob = function (str) {

--- a/lib/deps/binary/binaryStringToArrayBuffer.js
+++ b/lib/deps/binary/binaryStringToArrayBuffer.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// From http://stackoverflow.com/questions/14967647/ (continues on next line)
+// encode-decode-image-with-base64-breaks-image (2013-04-21)
+module.exports = function (bin) {
+  var length = bin.length;
+  var buf = new ArrayBuffer(length);
+  var arr = new Uint8Array(buf);
+  for (var i = 0; i < length; i++) {
+    arr[i] = bin.charCodeAt(i);
+  }
+  return buf;
+};

--- a/lib/deps/binary/binaryStringToBlob.js
+++ b/lib/deps/binary/binaryStringToBlob.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var createBlob = require('./blob');
+var binaryStringToArrayBuffer = require('./binaryStringToArrayBuffer');
+
+module.exports = function binaryStringToBlob(binString, type) {
+  return createBlob([binaryStringToArrayBuffer(binString)], {type: type});
+};

--- a/lib/deps/binary/blob.js
+++ b/lib/deps/binary/blob.js
@@ -1,8 +1,8 @@
 "use strict";
 
-//Abstracts constructing a Blob object, so it also works in older
-//browsers that don't support the native Blob constructor. (i.e.
-//old QtWebKit versions, at least).
+// Abstracts constructing a Blob object, so it also works in older
+// browsers that don't support the native Blob constructor (e.g.
+// old QtWebKit versions, Android < 4.4).
 function createBlob(parts, properties) {
   parts = parts || [];
   properties = properties || {};

--- a/lib/deps/binary/readAsArrayBuffer.js
+++ b/lib/deps/binary/readAsArrayBuffer.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// simplified API. universal browser support is assumed
+module.exports = function (blob, callback) {
+  var reader = new FileReader();
+  reader.onloadend = function (e) {
+    var result = e.target.result || new ArrayBuffer(0);
+    callback(result);
+  };
+  reader.readAsArrayBuffer(blob);
+};

--- a/lib/deps/binary/readAsBinaryString.js
+++ b/lib/deps/binary/readAsBinaryString.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var arrayBufferToBinaryString = require('./arrayBufferToBinaryString');
+
+// shim for browsers that don't support it
+module.exports = function (blob, callback) {
+  var reader = new FileReader();
+  var hasBinaryString = typeof reader.readAsBinaryString === 'function';
+  reader.onloadend = function (e) {
+    var result = e.target.result || '';
+    if (hasBinaryString) {
+      return callback(result);
+    }
+    callback(arrayBufferToBinaryString(result));
+  };
+  if (hasBinaryString) {
+    reader.readAsBinaryString(blob);
+  } else {
+    reader.readAsArrayBuffer(blob);
+  }
+};

--- a/lib/deps/md5.js
+++ b/lib/deps/md5.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var base64 = require('./base64');
+var base64 = require('./binary/base64');
 var crypto = require('crypto');
 var Md5 = require('spark-md5');
 var setImmediateShim = global.setImmediate || global.setTimeout;

--- a/lib/deps/request-browser.js
+++ b/lib/deps/request-browser.js
@@ -2,8 +2,9 @@
 /* global Headers */
 'use strict';
 
-var createBlob = require('./blob.js');
+var createBlob = require('./binary/blob.js');
 var utils = require('../utils');
+var readAsArrayBuffer = require('./binary/readAsArrayBuffer');
 
 function wrappedFetch() {
   var wrappedPromise = {};
@@ -52,8 +53,8 @@ function fetchRequest(options, callback) {
   }
 
   if (options.body && (options.body instanceof Blob)) {
-    utils.readAsBinaryString(options.body, function(binary) {
-      fetchOptions.body = utils.fixBinary(binary);
+    readAsArrayBuffer(options.body, function (arrayBuffer) {
+      fetchOptions.body = arrayBuffer;
     });
   } else if (options.body &&
              options.processData &&
@@ -203,8 +204,8 @@ function xhRequest(options, callback) {
   };
 
   if (options.body && (options.body instanceof Blob)) {
-    utils.readAsBinaryString(options.body, function (binary) {
-      xhr.send(utils.fixBinary(binary));
+    readAsArrayBuffer(options.body, function (arrayBuffer) {
+      xhr.send(arrayBuffer);
     });
   } else {
     xhr.send(options.body);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@
 var merge = require('./merge');
 exports.extend = require('pouchdb-extend');
 exports.ajax = require('./deps/ajax');
-exports.createBlob = require('./deps/blob');
+exports.createBlob = require('./deps/binary/blob');
 exports.uuid = require('./deps/uuid');
 exports.getArguments = require('argsarray');
 var errors = require('./deps/errors');
@@ -15,6 +15,20 @@ var parseDoc = require('./deps/parse-doc');
 
 var Promise = require('./deps/promise');
 exports.Promise = Promise;
+
+var base64 = require('./deps/binary/base64');
+
+// TODO: don't export these
+exports.atob = base64.atob;
+exports.btoa = base64.btoa;
+
+var binaryStringToBlob = require('./deps/binary/binaryStringToBlob');
+var arrayBufferToBinaryString =
+  require('./deps/binary/arrayBufferToBinaryString');
+var readAsArrayBuffer = require('./deps/binary/readAsArrayBuffer');
+
+// TODO: only used by the integration tests
+exports.binaryStringToBlob = binaryStringToBlob;
 
 exports.lastIndexOf = function (str, char) {
   for (var i = str.length - 1; i >= 0; i--) {
@@ -247,55 +261,6 @@ Changes.prototype.notify = function (dbName) {
   this.notifyLocalWindows(dbName);
 };
 
-var base64 = require('./deps/base64');
-exports.atob = base64.atob;
-exports.btoa = base64.btoa;
-
-// From http://stackoverflow.com/questions/14967647/ (continues on next line)
-// encode-decode-image-with-base64-breaks-image (2013-04-21)
-exports.fixBinary = function (bin) {
-  if (!process.browser) {
-    // don't need to do this in Node
-    return bin;
-  }
-
-  var length = bin.length;
-  var buf = new ArrayBuffer(length);
-  var arr = new Uint8Array(buf);
-  for (var i = 0; i < length; i++) {
-    arr[i] = bin.charCodeAt(i);
-  }
-  return buf;
-};
-
-// shim for browsers that don't support it
-exports.readAsBinaryString = function (blob, callback) {
-  var reader = new FileReader();
-  var hasBinaryString = typeof reader.readAsBinaryString === 'function';
-  reader.onloadend = function (e) {
-    var result = e.target.result || '';
-    if (hasBinaryString) {
-      return callback(result);
-    }
-    callback(exports.arrayBufferToBinaryString(result));
-  };
-  if (hasBinaryString) {
-    reader.readAsBinaryString(blob);
-  } else {
-    reader.readAsArrayBuffer(blob);
-  }
-};
-
-// simplified API. universal browser support is assumed
-exports.readAsArrayBuffer = function (blob, callback) {
-  var reader = new FileReader();
-  reader.onloadend = function (e) {
-    var result = e.target.result || new ArrayBuffer(0);
-    callback(result);
-  };
-  reader.readAsArrayBuffer(blob);
-};
-
 exports.once = function (fun) {
   var called = false;
   return exports.getArguments(function (args) {
@@ -404,19 +369,6 @@ exports.adapterFun = function (name, callback) {
     }
     return callback.apply(this, args);
   }));
-};
-
-//Can't find original post, but this is close
-//http://stackoverflow.com/questions/6965107/ (continues on next line)
-//converting-between-strings-and-arraybuffers
-exports.arrayBufferToBinaryString = function (buffer) {
-  var binary = "";
-  var bytes = new Uint8Array(buffer);
-  var length = bytes.byteLength;
-  for (var i = 0; i < length; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return binary;
 };
 
 exports.cancellableFun = function (fun, self, opts) {
@@ -669,7 +621,7 @@ exports.preprocessAttachments = function preprocessAttachments(
 
   function parseBase64(data) {
     try {
-      return exports.atob(data);
+      return base64.atob(data);
     } catch (e) {
       var err = errors.error(errors.BAD_ARG,
                              'Attachments need to be base64 encoded');
@@ -691,10 +643,9 @@ exports.preprocessAttachments = function preprocessAttachments(
 
       att.length = asBinary.length;
       if (blobType === 'blob') {
-        att.data = exports.createBlob([exports.fixBinary(asBinary)],
-          {type: att.content_type});
+        att.data = binaryStringToBlob(asBinary, att.content_type);
       } else if (blobType === 'base64') {
-        att.data = exports.btoa(asBinary);
+        att.data = base64.btoa(asBinary);
       } else { // binary
         att.data = asBinary;
       }
@@ -703,11 +654,11 @@ exports.preprocessAttachments = function preprocessAttachments(
         callback();
       });
     } else { // input is a blob
-      exports.readAsArrayBuffer(att.data, function (buff) {
+      readAsArrayBuffer(att.data, function (buff) {
         if (blobType === 'binary') {
-          att.data = exports.arrayBufferToBinaryString(buff);
+          att.data = arrayBufferToBinaryString(buff);
         } else if (blobType === 'base64') {
-          att.data = exports.btoa(exports.arrayBufferToBinaryString(buff));
+          att.data = base64.btoa(arrayBufferToBinaryString(buff));
         }
         exports.MD5(buff).then(function (result) {
           att.digest = 'md5-' + result;

--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -1084,9 +1084,8 @@ adapters.forEach(function (adapter) {
       db.put({ _id: 'foo' }, function (err, res) {
         db.get('foo', function (err, doc) {
           var data = pngAttDoc._attachments['foo.png'].data;
-          var blob = testUtils
-            .makeBlob(PouchDB.utils.fixBinary(PouchDB.utils.atob(data)),
-              'image/png');
+          var blob = testUtils.binaryStringToBlob(testUtils.atob(data),
+            'image/png');
           db.putAttachment('foo', 'foo.png', doc._rev, blob, 'image/png',
               function (err, info) {
             should.not.exist(err, 'attachment inserted');
@@ -1544,16 +1543,15 @@ adapters.forEach(function (adapter) {
       db.put({ _id: 'foo' }, function (err, res) {
         db.get('foo', function (err, doc) {
           var data = binAttDoc._attachments['foo.txt'].data;
-          var blob = testUtils
-            .makeBlob(PouchDB.utils.fixBinary(PouchDB.utils.atob(data)),
-              'text/plain');
+          var blob = testUtils.binaryStringToBlob(testUtils.atob(data),
+            'text/plain');
           db.putAttachment('foo', 'foo.txt', doc._rev, blob, 'text/plain',
                            function (err, info) {
             should.not.exist(err, 'attachment inserted');
             db.getAttachment('foo', 'foo.txt', function (err, blob) {
               should.not.exist(err, 'attachment gotten');
               testUtils.readBlob(blob, function (returnedData) {
-                PouchDB.utils.btoa(returnedData).should.equal(data);
+                testUtils.btoa(returnedData).should.equal(data);
                 db.get('foo', function (err, doc) {
                   should.not.exist(err, 'err on get');
                   delete doc._attachments["foo.txt"].revpos;
@@ -1591,16 +1589,15 @@ adapters.forEach(function (adapter) {
       db.put({ _id: 'foo' }, function (err, res) {
         db.get('foo', function (err, doc) {
           var data = pngAttDoc._attachments['foo.png'].data;
-          var blob = testUtils
-            .makeBlob(PouchDB.utils.fixBinary(PouchDB.utils.atob(data)),
-                                              'image/png');
+          var blob = testUtils.binaryStringToBlob(testUtils.atob(data),
+            'image/png');
           db.putAttachment('foo', 'foo.png', doc._rev, blob, 'image/png',
                            function (err, info) {
             should.not.exist(err, 'attachment inserted');
             db.getAttachment('foo', 'foo.png', function (err, blob) {
               should.not.exist(err, 'attachment gotten');
               testUtils.readBlob(blob, function (returnedData) {
-                PouchDB.utils.btoa(returnedData).should.equal(data);
+                testUtils.btoa(returnedData).should.equal(data);
                 db.get('foo', function (err, doc) {
                   should.not.exist(err, 'err on get');
                   delete doc._attachments["foo.png"].revpos;
@@ -1730,9 +1727,8 @@ adapters.forEach(function (adapter) {
         db.put({ _id: 'foo' }, function (err, res) {
           db.get('foo', function (err, doc) {
             var data = pngAttDoc._attachments['foo.png'].data;
-            var blob = testUtils
-              .makeBlob(PouchDB.utils.fixBinary(PouchDB.utils.atob(data)),
-                'image/png');
+            var blob = testUtils.binaryStringToBlob(
+              testUtils.atob(data), 'image/png');
             if (typeof URL === 'undefined') {
               // phantomjs doesn't have this, give up on this test
               return done();
@@ -1795,7 +1791,7 @@ adapters.forEach(function (adapter) {
           testUtils.readBlob(blob, resolve);
         });
       }).then(function (bin) {
-        PouchDB.utils.btoa(bin).should.equal(base64);
+        testUtils.btoa(bin).should.equal(base64);
       });
     });
 
@@ -1829,16 +1825,15 @@ adapters.forEach(function (adapter) {
           db.get('foo', function (err, doc) {
 
             getData(function (err, data) {
-              var blob = testUtils
-                .makeBlob(PouchDB.utils.fixBinary(PouchDB.utils.atob(data)),
-                  'image/png');
+              var blob = testUtils.binaryStringToBlob(
+                  testUtils.atob(data), 'image/png');
               db.putAttachment('foo', 'foo.png', doc._rev, blob, 'image/png',
                   function (err, info) {
                 should.not.exist(err, 'attachment inserted');
                 db.getAttachment('foo', 'foo.png', function (err, blob) {
                   should.not.exist(err, 'attachment gotten');
                   testUtils.readBlob(blob, function (returnedData) {
-                    PouchDB.utils.btoa(returnedData).should.equal(data);
+                    testUtils.btoa(returnedData).should.equal(data);
                     db.get('foo', function (err, doc) {
                       should.not.exist(err, 'err on get');
                       delete doc._attachments["foo.png"].revpos;
@@ -1918,10 +1913,9 @@ repl_adapters.forEach(function (adapters) {
       var remote = new PouchDB(dbs.remote);
       var rev;
 
-      var data = PouchDB.utils.btoa('foobar');
-      var blob = testUtils
-        .makeBlob(PouchDB.utils.fixBinary(PouchDB.utils.atob(data)),
-          'text/plain');
+      var data = testUtils.btoa('foobar');
+      var blob = testUtils.binaryStringToBlob(
+        testUtils.atob(data), 'text/plain');
 
       doc._attachments = {};
       var expectedKeys = [];
@@ -1958,8 +1952,7 @@ repl_adapters.forEach(function (adapters) {
         'OWIz8gAIXFH9zmC63XRyTsOsCWk2A9Ga7wCXlA9m2S6G4JlVwQkpw/Ymxr' +
         'UgNoMoyxBwSMH/WnAzy5cnfLFu+dK2l5gMvuPGLGJd1/9AOiBQiEgkzOpg' +
         'AAAABJRU5ErkJggg==';
-      var blob = testUtils
-        .makeBlob(PouchDB.utils.fixBinary(PouchDB.utils.atob(data)),
+      var blob = testUtils.binaryStringToBlob(testUtils.atob(data),
           'image/png');
 
       doc._attachments = {};

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -59,6 +59,21 @@ testUtils.makeBlob = function (data, type) {
   }
 };
 
+testUtils.binaryStringToBlob = function (bin, type) {
+  if (typeof module !== 'undefined' && module.exports) {
+    return new Buffer(bin, 'binary');
+  }
+  return PouchDB.utils.binaryStringToBlob(bin, type);
+};
+
+testUtils.btoa = function (arg) {
+  return PouchDB.utils.btoa(arg);
+};
+
+testUtils.atob = function (arg) {
+  return PouchDB.utils.atob(arg);
+};
+
 testUtils.readBlob = function (blob, callback) {
   if (typeof module !== 'undefined' && module.exports) {
     callback(blob.toString('binary'));


### PR DESCRIPTION
Move them out of `utils.js` and into their own separate files.
None of this is a functional change, except for a small optimization
I noticed in `request-browser.js`, where we can directly use
`readAsArrayBuffer` instead of first converting to a binary string.