### PR TITLE
(#3881) - filter extraneous keys from _attachments

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -34,6 +34,35 @@ function yankError(callback) {
   };
 }
 
+// clean docs given to us by the user
+function cleanDocs(docs) {
+  for (var i = 0; i < docs.length; i++) {
+    var doc = docs[i];
+    if (doc._deleted) {
+      delete doc._attachments; // ignore atts for deleted docs
+    } else if (doc._attachments) {
+      // filter out extraneous keys from _attachments
+      var atts = Object.keys(doc._attachments);
+      for (var j = 0; j < atts.length; j++) {
+        var att = atts[j];
+        doc._attachments[att] = utils.pick(doc._attachments[att],
+          ['data', 'digest', 'content_type', 'revpos', 'stub']);
+      }
+    }
+  }
+}
+
+// compare two docs, first by _id then by _rev
+function compareByIdThenRev(a, b) {
+  var idCompare = utils.compare(a._id, b._id);
+  if (idCompare !== 0) {
+    return idCompare;
+  }
+  var aStart = a._revisions ? a._revisions.start : 0;
+  var bStart = b._revisions ? b._revisions.start : 0;
+  return utils.compare(aStart, bStart);
+}
+
 // for every node in a revision tree computes its distance from the closest
 // leaf
 function computeHeight(revs) {
@@ -715,22 +744,10 @@ AbstractPouchDB.prototype.bulkDocs =
   if (!opts.new_edits && this.type() !== 'http') {
     // ensure revisions of the same doc are sorted, so that
     // the local adapter processes them correctly (#2935)
-    req.docs.sort(function (a, b) {
-      var idCompare = utils.compare(a._id, b._id);
-      if (idCompare !== 0) {
-        return idCompare;
-      }
-      var aStart = a._revisions ? a._revisions.start : 0;
-      var bStart = b._revisions ? b._revisions.start : 0;
-      return utils.compare(aStart, bStart);
-    });
+    req.docs.sort(compareByIdThenRev);
   }
 
-  req.docs.forEach(function (doc) {
-    if (doc._deleted) {
-      delete doc._attachments; // ignore atts for deleted docs
-    }
-  });
+  cleanDocs(req.docs);
 
   return this._bulkDocs(req, opts, function (err, res) {
     if (err) {

--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -468,6 +468,30 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('#3881 filter extraneous keys from _attachments', function () {
+      var db = new PouchDB(dbs.name);
+      return db.put({
+        _id: 'foo',
+        _attachments: {
+          'foo.txt': {
+            data: '',
+            content_type: 'text/plain',
+            follows: false,
+            foo: 'bar',
+            baz: true,
+            quux: 1
+          }
+        }
+      }).then(function () {
+        return db.get('foo', {attachments: true});
+      }).then(function (doc) {
+        var keys = Object.keys(doc._attachments['foo.txt']).filter(function (x) {
+          return x !== 'revpos'; // not supported by PouchDB right now
+        }).sort();
+        keys.should.deep.equal(['content_type', 'data', 'digest']);
+      });
+    });
+
     it('#2771 allDocs() 1, single attachment', function () {
       var db = new PouchDB(dbs.name);
       return db.put(binAttDoc).then(function () {


### PR DESCRIPTION
@daleharvey this is the fix that will make it so we don't
need to explicitly filter "follows" in express-pouchdb
and pouchdb-express-router. As it turns out, CouchDB
does this same thing if you include odd keys in the
_attachments object.