### PR TITLE
(#2858) - add "binary" option, use it in replication

### DIFF
--- a/docs/_guides/attachments.md
+++ b/docs/_guides/attachments.md
@@ -234,8 +234,9 @@ db.put({
 
 The `bulkDocs()` and `post()` APIs also accept attachments in either format.
 
-When you fetch attachments, however, `getAttachment()` will always return Blobs/Buffers, whereas
-`get()`/`allDocs()`/`query()` with `{attachments: true}` will always return base64-encoded strings. 
+When you fetch attachments, however, `getAttachment()` will always return Blobs/Buffers.
+
+The other "read" APIs, such as `get()`, `allDocs()`, `changes()`, and `query()` have an `{attachments: true}` option that returns the attachments base64-encoded strings. If you add `{binary: true}`, though, they will return Blobs/Buffers.
 
 Related API documentation
 --------

--- a/docs/_includes/api/batch_fetch.html
+++ b/docs/_includes/api/batch_fetch.html
@@ -13,6 +13,7 @@ All options default to `false` unless otherwise specified.
 * `options.include_docs`: Include the document itself in each row in the `doc` field. Otherwise by default you only get the `_id` and `_rev` properties.
     - `options.conflicts`: Include conflict information in the `_conflicts` field of a doc.
   - `options.attachments`: Include attachment data as base64-encoded string.
+    - `options.binary`: Return attachment data as Blobs/Buffers, instead of as base64-encoded strings.
 * `options.startkey` &amp; `options.endkey`: Get documents with IDs in a certain range (inclusive/inclusive).
 * `options.inclusive_end`: Include documents having an ID equal to the given `options.endkey`. Default: `true`.
 * `options.limit`: Maximum number of documents to return.

--- a/docs/_includes/api/changes.html
+++ b/docs/_includes/api/changes.html
@@ -17,6 +17,7 @@ All options default to `false` unless otherwise specified.
 * `options.include_docs`: Include the associated document with each change.
   * `options.conflicts`: Include conflicts.
   * `options.attachments`: Include attachments.
+    - `options.binary`: Return attachment data as Blobs/Buffers, instead of as base64-encoded strings.
 * `options.descending`: Reverse the order of the output documents.
 * `options.since`: Start the results from the change immediately after the given sequence number. You can also pass `'now'` if you want only new changes (when `live` is `true`).
 * `options.limit`: Limit the number of results to this number.

--- a/docs/_includes/api/fetch_document.html
+++ b/docs/_includes/api/fetch_document.html
@@ -17,6 +17,7 @@ All options default to `false` unless otherwise specified.
 * `options.open_revs`: Fetch all leaf revisions if `open_revs="all"` or fetch all leaf revisions specified in `open_revs` array. Leaves will be returned in the same order as specified in input array.
 * `options.conflicts`: If specified, conflicting leaf revisions will be attached in `_conflicts` array.
 * `options.attachments`: Include attachment data.
+  * `options.binary`: Return attachment data as Blobs/Buffers, instead of as base64-encoded strings.
 * `options.local_seq` (*DEPRECATED*): Include sequence number of the revision in the database, this will be removed in the next major version.
 * `options.ajax`: An object of options to be sent to the ajax requester. In Node they are sent verbatim to [request][] with the exception of:
 * `options.ajax.cache`: Appends a random string to the end of all HTTP GET requests to avoid them being cached on IE. Set this to `true` to prevent this happening.

--- a/docs/_includes/api/query_database.html
+++ b/docs/_includes/api/query_database.html
@@ -32,6 +32,7 @@ All options default to `false` unless otherwise specified.
 * `options.include_docs`: Include the document in each row in the `doc` field.
     - `options.conflicts`: Include conflicts in the `_conflicts` field of a doc.
   - `options.attachments`: Include attachment data.
+    - `options.binary`: Return attachment data as Blobs/Buffers, instead of as base64-encoded strings.
 * `options.startkey` &amp; `options.endkey`: Get rows with keys in a certain range (inclusive/inclusive).
 * `options.inclusive_end`: Include rows having a key equal to the given `options.endkey`. Default: `true`.
 * `options.limit`: Maximum number of rows to return.

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -595,8 +595,10 @@ AbstractPouchDB.prototype.get =
         return callback(null, doc);
       }
       Object.keys(attachments).forEach(function (key) {
-        this._getAttachment(attachments[key],
-                            {encode: true, ctx: ctx}, function (err, data) {
+        this._getAttachment(attachments[key], {
+          binary: opts.binary,
+          ctx: ctx
+        }, function (err, data) {
           var att = doc._attachments[key];
           att.data = data;
           delete att.stub;
@@ -634,6 +636,7 @@ AbstractPouchDB.prototype.getAttachment =
     }
     if (res.doc._attachments && res.doc._attachments[attachmentId]) {
       opts.ctx = res.ctx;
+      opts.binary = true;
       self._getAttachment(res.doc._attachments[attachmentId], opts, callback);
     } else {
       return callback(errors.error(errors.MISSING_DOC));

--- a/lib/adapters/http/http.js
+++ b/lib/adapters/http/http.js
@@ -10,7 +10,10 @@ var CHANGES_BATCH_SIZE = 25;
 var MAX_URL_LENGTH = 1800;
 
 var readAsBinaryString = require('../../deps/binary/readAsBinaryString');
-var binaryStringToBlob = require('../../deps/binary/binaryStringToBlob');
+var binStringToBluffer =
+  require('../../deps/binary/binaryStringToBlobOrBuffer');
+var b64StringToBluffer =
+  require('../../deps/binary/base64StringToBlobOrBuffer');
 var utils = require('../../utils');
 var Promise = utils.Promise;
 var clone = utils.clone;
@@ -20,7 +23,6 @@ var atob = base64.atob;
 var errors = require('../../deps/errors');
 var log = require('debug')('pouchdb:http');
 var isBrowser = typeof process === 'undefined' || process.browser;
-var buffer = require('../../deps/buffer');
 var createMultipart = require('../../deps/multipart');
 
 function blobToBase64(blobOrBuffer) {
@@ -31,6 +33,17 @@ function blobToBase64(blobOrBuffer) {
     readAsBinaryString(blobOrBuffer, function (bin) {
       resolve(btoa(bin));
     });
+  });
+}
+
+function readAttachmentsAsBlobOrBuffer(row) {
+  var atts = row.doc && row.doc._attachments;
+  if (!atts) {
+    return;
+  }
+  Object.keys(atts).forEach(function (filename) {
+    var att = atts[filename];
+    att.data = b64StringToBluffer(att.data, att.content_type);
   });
 }
 
@@ -382,10 +395,15 @@ function HttpPouch(opts, callback) {
           method: 'GET',
           url: genDBUrl(host, path),
           binary: true
-        }).then(blobToBase64).then(function (b64) {
+        }).then(function (blob) {
+          if (opts.binary) {
+            return blob;
+          }
+          return blobToBase64(blob);
+        }).then(function (data) {
           delete att.stub;
           delete att.length;
-          att.data = b64;
+          att.data = data;
         });
       }));
     }
@@ -518,11 +536,7 @@ function HttpPouch(opts, callback) {
         return callback(errors.error(errors.BAD_ARG,
                         'Attachments need to be base64 encoded'));
       }
-      if (isBrowser) {
-        blob = binaryStringToBlob(binary, type);
-      } else {
-        blob = binary ? new buffer(binary, 'binary') : '';
-      }
+      blob = binary ? binStringToBluffer(binary, type) : '';
     }
 
     var opts = {
@@ -768,12 +782,17 @@ function HttpPouch(opts, callback) {
     }
 
     // Get the document listing
-    ajax({
+    ajaxPromise({
       headers: clone(host.headers),
       method: method,
       url: genDBUrl(host, '_all_docs' + params),
       body: body
-    }, callback);
+    }).then(function (res) {
+      if (opts.include_docs && opts.attachments && opts.binary) {
+        res.rows.forEach(readAttachmentsAsBlobOrBuffer);
+      }
+      callback(null, res);
+    }).catch(callback);
   });
 
   // Get a list of changes made to documents in the database given by host.
@@ -941,6 +960,9 @@ function HttpPouch(opts, callback) {
           leftToFetch--;
           var ret = utils.filterChange(opts)(c);
           if (ret) {
+            if (opts.include_docs && opts.attachments && opts.binary) {
+              readAttachmentsAsBlobOrBuffer(c);
+            }
             if (returnDocs) {
               results.results.push(c);
             }

--- a/lib/adapters/idb/idb-all-docs.js
+++ b/lib/adapters/idb/idb-all-docs.js
@@ -156,7 +156,7 @@ function idbAllDocs(opts, api, idb, callback) {
 
     function onTxnComplete() {
       if (opts.attachments) {
-        postProcessAttachments(results).then(onResultsReady);
+        postProcessAttachments(results, opts.binary).then(onResultsReady);
       } else {
         onResultsReady();
       }

--- a/lib/adapters/idb/idb-utils.js
+++ b/lib/adapters/idb/idb-utils.js
@@ -3,12 +3,10 @@
 var errors = require('../../deps/errors');
 var utils = require('../../utils');
 var base64 = require('../../deps/binary/base64');
-var atob = base64.atob;
 var btoa = base64.btoa;
 var constants = require('./idb-constants');
 var readAsBinaryString = require('../../deps/binary/readAsBinaryString');
-var binaryStringToArrayBuffer =
-  require('../../deps/binary/binaryStringToArrayBuffer');
+var b64StringToBlob = require('../../deps/binary/base64StringToBlobOrBuffer');
 
 function tryCode(fun, that, args) {
   try {
@@ -90,8 +88,16 @@ exports.decodeDoc = function (doc) {
 // Read a blob from the database, encoding as necessary
 // and translating from base64 if the IDB doesn't support
 // native Blobs
-exports.readBlobData = function (body, type, encode, callback) {
-  if (encode) {
+exports.readBlobData = function (body, type, asBlob, callback) {
+  if (asBlob) {
+    if (!body) {
+      callback(utils.createBlob([''], {type: type}));
+    } else if (typeof body !== 'string') { // we have blob support
+      callback(body);
+    } else { // no blob support
+      callback(b64StringToBlob(body, type));
+    }
+  } else { // as base64 string
     if (!body) {
       callback('');
     } else if (typeof body !== 'string') { // we have blob support
@@ -100,15 +106,6 @@ exports.readBlobData = function (body, type, encode, callback) {
       });
     } else { // no blob support
       callback(body);
-    }
-  } else {
-    if (!body) {
-      callback(utils.createBlob([''], {type: type}));
-    } else if (typeof body !== 'string') { // we have blob support
-      callback(body);
-    } else { // no blob support
-      body = binaryStringToArrayBuffer(atob(body));
-      callback(utils.createBlob([body], {type: type}));
     }
   }
 };
@@ -150,7 +147,7 @@ exports.fetchAttachmentsIfNecessary = function (doc, opts, txn, cb) {
 // we don't know whether we stored a true Blob or
 // a base64-encoded string, and if it's a Blob it
 // needs to be read outside of the transaction context
-exports.postProcessAttachments = function (results) {
+exports.postProcessAttachments = function (results, asBlob) {
   return utils.Promise.all(results.map(function (row) {
     if (row.doc && row.doc._attachments) {
       var attNames = Object.keys(row.doc._attachments);
@@ -162,10 +159,10 @@ exports.postProcessAttachments = function (results) {
         var body = attObj.body;
         var type = attObj.content_type;
         return new utils.Promise(function (resolve) {
-          exports.readBlobData(body, type, true, function (base64) {
+          exports.readBlobData(body, type, asBlob, function (data) {
             row.doc._attachments[att] = utils.extend(
               utils.pick(attObj, ['digest', 'content_type']),
-              {data: base64}
+              {data: data}
             );
             resolve();
           });

--- a/lib/adapters/idb/idb.js
+++ b/lib/adapters/idb/idb.js
@@ -358,7 +358,7 @@ function init(api, opts, callback) {
 
     txn.objectStore(ATTACH_STORE).get(digest).onsuccess = function (e) {
       var body = e.target.result.body;
-      readBlobData(body, type, opts.encode, function (blobData) {
+      readBlobData(body, type, opts.binary, function (blobData) {
         callback(null, blobData);
       });
     };
@@ -489,7 +489,7 @@ function init(api, opts, callback) {
           // for the benefit of live listeners
           if (opts.attachments && opts.include_docs) {
             fetchAttachmentsIfNecessary(winningDoc, opts, txn, function () {
-              postProcessAttachments([change]).then(function () {
+              postProcessAttachments([change], opts.binary).then(function () {
                 opts.onChange(change);
               });
             });

--- a/lib/adapters/leveldb/leveldb.js
+++ b/lib/adapters/leveldb/leveldb.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var isBrowser = typeof process === 'undefined' || process.browser;
 var levelup = require('levelup');
 var sublevel = require('level-sublevel');
 var through = require('through2').obj;
@@ -21,7 +22,8 @@ var migrate = require('../../deps/migrate');
 var Deque = require("double-ended-queue");
 
 var readAsBinaryString = require('../../deps/binary/readAsBinaryString');
-var binaryStringToBlob = require('../../deps/binary/binaryStringToBlob');
+var binStringToBluffer =
+  require('../../deps/binary/binaryStringToBlobOrBuffer');
 
 var LevelTransaction = require('./leveldb-transaction');
 
@@ -51,32 +53,56 @@ var safeJsonEncoding = {
   type: 'cheap-json'
 };
 
-function fetchAttachments(results, stores) {
-  return utils.Promise.all(results.map(function (row) {
-    if (row.doc && row.doc._attachments) {
-      var attNames = Object.keys(row.doc._attachments);
-      return utils.Promise.all(attNames.map(function (att) {
-        var attObj = row.doc._attachments[att];
-        if ('data' in attObj) { // already fetched
-          return;
+function fetchAttachment(att, stores, opts) {
+  var type = att.content_type;
+  return new utils.Promise(function (resolve, reject) {
+    stores.binaryStore.get(att.digest, function (err, buffer) {
+      var data;
+      if (err) {
+        if (err.name !== 'NotFoundError') {
+          return reject(err);
+        } else {
+          // empty
+          if (!opts.binary) {
+            data = '';
+          } else {
+            data = binStringToBluffer('', type);
+          }
         }
-        return new utils.Promise(function (resolve, reject) {
-          stores.binaryStore.get(attObj.digest, function (err, buffer) {
-            var base64 = '';
-            if (err && err.name !== 'NotFoundError') {
-              return reject(err);
-            } else if (!err) {
-              base64 = utils.btoa(buffer);
-            }
-            row.doc._attachments[att] = utils.extend(
-              utils.pick(attObj, ['digest', 'content_type']),
-              {data: base64}
-            );
-            resolve();
-          });
-        });
-      }));
+      } else { // non-empty
+        if (!opts.binary) {
+          data = utils.btoa(buffer);
+        } else if (isBrowser) { // browser, it's a binary string
+          data = binStringToBluffer(buffer, type);
+        } else { // node, it's already a buffer
+          data = buffer;
+        }
+      }
+      delete att.stub;
+      delete att.length;
+      att.data = data;
+      resolve();
+    });
+  });
+}
+
+function fetchAttachments(results, stores, opts) {
+  var atts = [];
+  results.forEach(function (row) {
+    if (!(row.doc && row.doc._attachments)) {
+      return;
     }
+    var attNames = Object.keys(row.doc._attachments);
+    attNames.forEach(function (attName) {
+      var att = row.doc._attachments[attName];
+      if (!('data' in att)) {
+        atts.push(att);
+      }
+    });
+  });
+
+  return utils.Promise.all(atts.map(function (att) {
+    return fetchAttachment(att, stores, opts);
   }));
 }
 
@@ -342,7 +368,7 @@ function LevelPouch(opts, callback) {
 
       if (err && err.name === 'NotFoundError') {
         // Empty attachment
-        data = opts.encode ? '' : process.browser ?
+        data = !opts.binary ? '' : isBrowser ?
           utils.createBlob([''], {type: attachment.content_type}) :
           new Buffer('');
         return callback(null, data);
@@ -352,14 +378,14 @@ function LevelPouch(opts, callback) {
         return callback(err);
       }
 
-      if (process.browser) {
-        if (opts.encode) {
-          data = utils.btoa(attach);
+      if (isBrowser) {
+        if (opts.binary) {
+          data = binStringToBluffer(attach, attachment.content_type);
         } else {
-          data = binaryStringToBlob(attach, attachment.content_type);
+          data = utils.btoa(attach);
         }
       } else {
-        data = opts.encode ? utils.btoa(attach) : attach;
+        data = opts.binary ? attach : utils.btoa(attach);
       }
       callback(null, data);
     });
@@ -564,7 +590,7 @@ function LevelPouch(opts, callback) {
                      'Attachments need to be base64 encoded'));
             return;
           }
-        } else if (!process.browser) {
+        } else if (!isBrowser) {
           data = att.data;
         } else { // browser
           readAsBinaryString(att.data,
@@ -857,7 +883,9 @@ function LevelPouch(opts, callback) {
         }
       }, function (next) {
         utils.Promise.resolve().then(function () {
-          return opts.attachments && fetchAttachments(results, stores);
+          if (opts.include_docs && opts.attachments){
+            return fetchAttachments(results, stores, opts);
+          }
         }).then(function () {
           callback(null, {
             total_rows: docCount,
@@ -926,13 +954,13 @@ function LevelPouch(opts, callback) {
       changeStream.unpipe(throughStream);
       changeStream.destroy();
       if (!opts.continuous && !opts.cancelled) {
-        utils.Promise.resolve().then(function () {
-          if (opts.include_docs && opts.attachments) {
-            return fetchAttachments(results, stores);
-          }
-        }).then(function () {
+        if (opts.include_docs && opts.attachments) {
+          fetchAttachments(results, stores, opts).then(function () {
+            opts.complete(null, {results: results, last_seq: lastSeq});
+          });
+        } else {
           opts.complete(null, {results: results, last_seq: lastSeq});
-        });
+        }
       }
     }
     var changeStream = stores.bySeqStore.readStream(streamOpts);
@@ -973,7 +1001,7 @@ function LevelPouch(opts, callback) {
             if (opts.attachments && opts.include_docs) {
               // fetch attachment immediately for the benefit
               // of live listeners
-              fetchAttachments([change], stores).then(function () {
+              fetchAttachments([change], stores, opts).then(function () {
                 opts.onChange(change);
               });
             } else {

--- a/lib/adapters/websql/websql.js
+++ b/lib/adapters/websql/websql.js
@@ -4,7 +4,7 @@ var utils = require('../../utils');
 var merge = require('../../merge');
 var errors = require('../../deps/errors');
 var parseHexString = require('../../deps/parse-hex');
-var binaryStringToBlob = require('../../deps/binary/binaryStringToBlob');
+var binStringToBlob = require('../../deps/binary/binaryStringToBlobOrBuffer');
 
 var websqlConstants = require('./websql-constants');
 var websqlUtils = require('./websql-utils');
@@ -42,11 +42,11 @@ function fetchAttachmentsIfNecessary(doc, opts, api, txn, cb) {
 
   function fetchAttachment(doc, att) {
     var attObj = doc._attachments[att];
-    var attOpts = {encode: true, ctx: txn};
-    api._getAttachment(attObj, attOpts, function (_, base64) {
+    var attOpts = {binary: opts.binary, ctx: txn};
+    api._getAttachment(attObj, attOpts, function (_, data) {
       doc._attachments[att] = utils.extend(
         utils.pick(attObj, ['digest', 'content_type']),
-        { data: base64 }
+        { data: data }
       );
       checkDone();
     });
@@ -843,10 +843,10 @@ function WebSqlPouch(opts, callback) {
       var item = result.rows.item(0);
       var data = item.escaped ? websqlUtils.unescapeBlob(item.body) :
         parseHexString(item.body, encoding);
-      if (opts.encode) {
-        res = utils.btoa(data);
+      if (opts.binary) {
+        res = binStringToBlob(data, type);
       } else {
-        res = binaryStringToBlob(data, type);
+        res = utils.btoa(data);
       }
       callback(null, res);
     });

--- a/lib/deps/binary/base64StringToBlobOrBuffer.js
+++ b/lib/deps/binary/base64StringToBlobOrBuffer.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var isBrowser = typeof process === 'undefined' || process.browser;
+var atob = require('./base64').atob;
+var binaryStringToBlobOrBuffer = require('./binaryStringToBlobOrBuffer');
+var buffer = require('../buffer');
+
+if (isBrowser) {
+  module.exports = function (b64, type) {
+    return binaryStringToBlobOrBuffer(atob(b64), type);
+  };
+} else {
+  module.exports = function (b64) {
+    return new buffer(b64, 'base64');
+  };
+}

--- a/lib/deps/binary/binaryStringToBlob.js
+++ b/lib/deps/binary/binaryStringToBlob.js
@@ -1,8 +1,0 @@
-'use strict';
-
-var createBlob = require('./blob');
-var binaryStringToArrayBuffer = require('./binaryStringToArrayBuffer');
-
-module.exports = function binaryStringToBlob(binString, type) {
-  return createBlob([binaryStringToArrayBuffer(binString)], {type: type});
-};

--- a/lib/deps/binary/binaryStringToBlobOrBuffer.js
+++ b/lib/deps/binary/binaryStringToBlobOrBuffer.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var isBrowser = typeof process === 'undefined' || process.browser;
+var buffer = require('../buffer');
+
+var createBlob = require('./blob');
+var binaryStringToArrayBuffer = require('./binaryStringToArrayBuffer');
+
+if (isBrowser) {
+  module.exports = function (binString, type) {
+    return createBlob([binaryStringToArrayBuffer(binString)], {type: type});
+  };
+} else {
+  module.exports = function (binString) {
+    return new buffer(binString, 'binary');
+  };
+}

--- a/lib/replicate/get-docs.js
+++ b/lib/replicate/get-docs.js
@@ -25,7 +25,8 @@ function getDocs(src, diffs, state) {
     var opts = {
       revs: true,
       open_revs: missingRevs,
-      attachments: true
+      attachments: true,
+      binary: true
     };
     return src.get(id, opts).then(function (docs) {
       if (state.cancelled) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,13 +22,18 @@ var base64 = require('./deps/binary/base64');
 exports.atob = base64.atob;
 exports.btoa = base64.btoa;
 
-var binaryStringToBlob = require('./deps/binary/binaryStringToBlob');
+var binStringToBlobOrBuffer =
+  require('./deps/binary/binaryStringToBlobOrBuffer');
+var b64StringToBlobOrBuffer =
+  require('./deps/binary/base64StringToBlobOrBuffer');
 var arrayBufferToBinaryString =
   require('./deps/binary/arrayBufferToBinaryString');
 var readAsArrayBuffer = require('./deps/binary/readAsArrayBuffer');
 
 // TODO: only used by the integration tests
-exports.binaryStringToBlob = binaryStringToBlob;
+exports.binaryStringToBlobOrBuffer = binStringToBlobOrBuffer;
+// TODO: only used by mapreduce
+exports.base64StringToBlobOrBuffer = b64StringToBlobOrBuffer;
 
 exports.lastIndexOf = function (str, char) {
   for (var i = str.length - 1; i >= 0; i--) {
@@ -44,14 +49,17 @@ exports.clone = function (obj) {
 };
 
 // like underscore/lodash _.pick()
-exports.pick = function (obj, arr) {
+function pick(obj, arr) {
   var res = {};
   for (var i = 0, len = arr.length; i < len; i++) {
     var prop = arr[i];
-    res[prop] = obj[prop];
+    if (prop in obj) {
+      res[prop] = obj[prop];
+    }
   }
   return res;
-};
+}
+exports.pick = pick;
 
 exports.inherits = require('inherits');
 
@@ -205,19 +213,12 @@ Changes.prototype.addListener = function (dbName, id, db, opts) {
       return;
     }
     inprogress = true;
-    db.changes({
-      style: opts.style,
-      include_docs: opts.include_docs,
-      attachments: opts.attachments,
-      conflicts: opts.conflicts,
-      continuous: false,
-      descending: false,
-      filter: opts.filter,
-      doc_ids: opts.doc_ids,
-      view: opts.view,
-      since: opts.since,
-      query_params: opts.query_params
-    }).on('change', function (c) {
+    var changesOpts = pick(opts, [
+      'style', 'include_docs', 'attachments', 'conflicts', 'filter',
+      'doc_ids', 'view', 'since', 'query_params', 'binary'
+    ]);
+
+    db.changes(changesOpts).on('change', function (c) {
       if (c.seq > opts.since && !opts.cancelled) {
         opts.since = c.seq;
         exports.call(opts.onChange, c);
@@ -643,7 +644,7 @@ exports.preprocessAttachments = function preprocessAttachments(
 
       att.length = asBinary.length;
       if (blobType === 'blob') {
-        att.data = binaryStringToBlob(asBinary, att.content_type);
+        att.data = binStringToBlobOrBuffer(asBinary, att.content_type);
       } else if (blobType === 'base64') {
         att.data = base64.btoa(asBinary);
       } else { // binary

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -60,10 +60,7 @@ testUtils.makeBlob = function (data, type) {
 };
 
 testUtils.binaryStringToBlob = function (bin, type) {
-  if (typeof module !== 'undefined' && module.exports) {
-    return new Buffer(bin, 'binary');
-  }
-  return PouchDB.utils.binaryStringToBlob(bin, type);
+  return PouchDB.utils.binaryStringToBlobOrBuffer(bin, type);
 };
 
 testUtils.btoa = function (arg) {


### PR DESCRIPTION
Proposal: currently it is kinda awkward to get Blobs/Buffers
back from the API, because you can only use `getAttachment()`.
This is a shame, because some of our adapters can directly
return blobs (namely idb and http), meaning that we're doing a useless
base64-encoding and decoding operation during replication
of attachments.

I suggest adding a new option to `get()`: `{binary: true}`.
If included, and if `{attachments: true}`, then attachments
will be returned as Blobs/Buffers instead of base64. Also,
we can start using this option in the replicator.

In the future, I would also like to support `{binary: true}` in
`allDocs()`, `changes()`, and `query()`, but for now just
`get()` is enough for replication between http-idb to be
sped up.

I also put this commit on top of all the other ones to
avoid bitrotting myself.