### PR TITLE
(#3894) - fix race condition in sync when canceling

### DIFF
--- a/lib/replicate/replicate.js
+++ b/lib/replicate/replicate.js
@@ -345,32 +345,36 @@ function replicate(src, target, opts, returnValue, result) {
 
   function startChanges() {
     initCheckpointer().then(function () {
-      return checkpointer.getCheckpoint();
-    }).then(function (checkpoint) {
-      last_seq = checkpoint;
-      changesOpts = {
-        since: last_seq,
-        limit: batch_size,
-        batch_size: batch_size,
-        style: 'all_docs',
-        doc_ids: doc_ids,
-        returnDocs: true // required so we know when we're done
-      };
-      if (opts.filter) {
-        if (typeof opts.filter !== 'string') {
-          // required for the client-side filter in onChange
-          changesOpts.include_docs = true;
-        } else { // ddoc filter
-          changesOpts.filter = opts.filter;
+      if (state.cancelled) {
+        completeReplication();
+        return;
+      }
+      return checkpointer.getCheckpoint().then(function (checkpoint) {
+        last_seq = checkpoint;
+        changesOpts = {
+          since: last_seq,
+          limit: batch_size,
+          batch_size: batch_size,
+          style: 'all_docs',
+          doc_ids: doc_ids,
+          returnDocs: true // required so we know when we're done
+        };
+        if (opts.filter) {
+          if (typeof opts.filter !== 'string') {
+            // required for the client-side filter in onChange
+            changesOpts.include_docs = true;
+          } else { // ddoc filter
+            changesOpts.filter = opts.filter;
+          }
         }
-      }
-      if (opts.query_params) {
-        changesOpts.query_params = opts.query_params;
-      }
-      if (opts.view) {
-        changesOpts.view = opts.view;
-      }
-      getChanges();
+        if (opts.query_params) {
+          changesOpts.query_params = opts.query_params;
+        }
+        if (opts.view) {
+          changesOpts.view = opts.view;
+        }
+        getChanges();
+      });
     }).catch(function (err) {
       abortReplication('getCheckpoint rejected with ', err);
     });


### PR DESCRIPTION
I managed to actually track this down and write
a test that fails much more consistently. (It's a race
condition, so the test pre-fix doesn't fail 100%
of the time, but it fails about 75% of the time, which
is decent.)

I also rewrote one of the old tests in Promise style,
just for kicks.