### PR TITLE
(#3900) - add db.once('destroyed') tests

### DIFF
--- a/tests/integration/test.events.js
+++ b/tests/integration/test.events.js
@@ -58,6 +58,27 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('3900 db emits destroyed event', function () {
+      return new PouchDB('testdb').then(function (db) {
+        return new PouchDB.utils.Promise(function (resolve) {
+          db.once('destroyed', function () {
+            resolve();
+          });
+          db.destroy();
+        });
+      });
+    });
+
+    it('3900 db emits destroyed event 2', function () {
+      var db = new PouchDB('testdb');
+      return new PouchDB.utils.Promise(function (resolve) {
+        db.once('destroyed', function () {
+          resolve();
+        });
+        db.destroy();
+      });
+    });
+
     it('emit creation event', function (done) {
       var db = new PouchDB(dbs.name).on('created', function (newDB) {
         db.should.equal(newDB, 'should be same thing');


### PR DESCRIPTION
Well, I was surprised to see we weren't testing
this (except for PouchDB.defaults), so I added
some tests. They are passing, so maybe it's just
that the `'destroyed'` events aren't emitted
in certain tests (e.g. the changes/replicate tests).