### PR TITLE
(#3908) - prefer non-inlined attachments for allDocs()

### DIFF
--- a/lib/replicate/get-docs.js
+++ b/lib/replicate/get-docs.js
@@ -59,16 +59,8 @@ function getDocs(src, diffs, state) {
     return Promise.all(diffKeys.map(processDiffDoc));
   }
 
-  function hasValidAttachments(doc) {
-    var atts = doc._attachments;
-    var attNames = atts && Object.keys(atts);
-
-    var hasAttachments = atts && attNames.length > 0;
-    // These will be stubs in CouchDB < 1.6 because attachments
-    // weren't supported in _all_docs
-    var hasAttachmentData = hasAttachments && !atts[attNames[0]].stub;
-
-    return !hasAttachments || hasAttachmentData;
+  function hasAttachments(doc) {
+    return doc._attachments && Object.keys(doc._attachments).length > 0;
   }
 
   function fetchRevisionOneDocs(ids) {
@@ -76,15 +68,14 @@ function getDocs(src, diffs, state) {
     // a single request using _all_docs
     return src.allDocs({
       keys: ids,
-      include_docs: true,
-      attachments: true
+      include_docs: true
     }).then(function (res) {
       if (state.cancelled) {
         throw new Error('cancelled');
       }
       res.rows.forEach(function (row) {
         if (row.deleted || !row.doc || !isGenOne(row.value.rev) ||
-            !hasValidAttachments(row.doc)) {
+            hasAttachments(row.doc)) {
           // if any of these conditions apply, we need to fetch using get()
           return;
         }


### PR DESCRIPTION
This should probably be configurable, because the strategy you want will depend on the size and number of your attachments.

But for the time being, we should at least be consistent about which one we're doing. Plus, this version supports CSG.