### PR TITLE
(#XXXX) - Test chrome stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ env:
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome:36 COMMAND=test
   - CLIENT=saucelabs:chrome:37 COMMAND=test
-  - CLIENT=saucelabs:chrome:39 COMMAND=test
+  - CLIENT=saucelabs:chrome COMMAND=test
   - CLIENT=saucelabs:safari:6 COMMAND=test
   - SKIP_MIGRATION=true CLIENT="saucelabs:iphone:8.1:OS X 10.10" COMMAND=test
   - CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test


### PR DESCRIPTION
I would like to reduce the amount of chrome tests we have running, we only need to support the latest stable of chrome (testing the beta version may be a sensible option too). I know we currently have older chromes as a proxy for older androids so not removing them yet, but hopefully we can get the rest of android tests working and explicity test the things we support and not test the things we dont