### PR TITLE
(#3922) - move more stuff out of utils

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -7,6 +7,8 @@ var EventEmitter = require('events').EventEmitter;
 var upsert = require('./deps/upsert');
 var Changes = require('./changes');
 var Promise = utils.Promise;
+var isDeleted = require('./deps/docs/is-deleted');
+var isLocalId = require('./deps/docs/is-local-id');
 
 /*
  * A generic pouch adapter
@@ -202,7 +204,7 @@ AbstractPouchDB.prototype.put =
   if (error) {
     return callback(error);
   }
-  if (utils.isLocalId(doc._id) && typeof this._putLocal === 'function') {
+  if (isLocalId(doc._id) && typeof this._putLocal === 'function') {
     if (doc._deleted) {
       return this._removeLocal(doc, callback);
     } else {
@@ -305,7 +307,7 @@ AbstractPouchDB.prototype.remove =
   opts.was_delete = true;
   var newDoc = {_id: doc._id, _rev: (doc._rev || opts.rev)};
   newDoc._deleted = true;
-  if (utils.isLocalId(newDoc._id) && typeof this._removeLocal === 'function') {
+  if (isLocalId(newDoc._id) && typeof this._removeLocal === 'function') {
     return this._removeLocal(doc, callback);
   }
   this.bulkDocs({docs: [newDoc]}, opts, yankError(callback));
@@ -468,7 +470,7 @@ AbstractPouchDB.prototype.get =
   if (typeof id !== 'string') {
     return callback(errors.error(errors.INVALID_ID));
   }
-  if (utils.isLocalId(id) && typeof this._getLocal === 'function') {
+  if (isLocalId(id) && typeof this._getLocal === 'function') {
     return this._getLocal(id, callback);
   }
   var leaves = [], self = this;
@@ -546,7 +548,7 @@ AbstractPouchDB.prototype.get =
       }
     }
 
-    if (utils.isDeleted(metadata, doc._rev)) {
+    if (isDeleted(metadata, doc._rev)) {
       doc._deleted = true;
     }
 

--- a/lib/adapters/idb/idb-bulk-docs.js
+++ b/lib/adapters/idb/idb-bulk-docs.js
@@ -2,6 +2,10 @@
 
 var utils = require('../../utils');
 var errors = require('../../deps/errors');
+var preprocessAttachments =
+  require('../../deps/docs/preprocess-attachments');
+var processDocs = require('../../deps/docs/process-docs');
+var isLocalId = require('../../deps/docs/is-local-id');
 var idbUtils = require('./idb-utils');
 var idbConstants = require('./idb-constants');
 
@@ -30,7 +34,7 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
 
   for (var i = 0, len = docInfos.length; i < len; i++) {
     var doc = docInfos[i];
-    if (doc._id && utils.isLocalId(doc._id)) {
+    if (doc._id && isLocalId(doc._id)) {
       continue;
     }
     doc = docInfos[i] = utils.parseDoc(doc, opts.new_edits);
@@ -48,7 +52,7 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
   var preconditionErrored = false;
   var blobType = api._meta.blobSupport ? 'blob' : 'base64';
 
-  utils.preprocessAttachments(docInfos, blobType, function (err) {
+  preprocessAttachments(docInfos, blobType, function (err) {
     if (err) {
       return callback(err);
     }
@@ -84,10 +88,9 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
     });
   }
 
-  function processDocs() {
+  function idbProcessDocs() {
 
-    utils.processDocs(docInfos, api, fetchedDocs, txn, results,
-      writeDoc, opts);
+    processDocs(docInfos, api, fetchedDocs, txn, results, writeDoc, opts);
   }
 
   function fetchExistingDocs() {
@@ -100,7 +103,7 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
 
     function checkDone() {
       if (++numFetched === docInfos.length) {
-        processDocs();
+        idbProcessDocs();
       }
     }
 
@@ -115,7 +118,7 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
 
     for (var i = 0, len = docInfos.length; i < len; i++) {
       var docInfo = docInfos[i];
-      if (docInfo._id && utils.isLocalId(docInfo._id)) {
+      if (docInfo._id && isLocalId(docInfo._id)) {
         checkDone(); // skip local docs
         continue;
       }

--- a/lib/adapters/idb/idb.js
+++ b/lib/adapters/idb/idb.js
@@ -2,6 +2,8 @@
 
 var utils = require('../../utils');
 var merge = require('../../merge');
+var isDeleted = require('../../deps/docs/is-deleted');
+var isLocalId = require('../../deps/docs/is-local-id');
 var errors = require('../../deps/errors');
 var idbUtils = require('./idb-utils');
 var idbConstants = require('./idb-constants');
@@ -85,7 +87,7 @@ function init(api, opts, callback) {
       var cursor = event.target.result;
       if (cursor) {
         var metadata = cursor.value;
-        var deleted = utils.isDeleted(metadata);
+        var deleted = isDeleted(metadata);
         metadata.deletedOrLocal = deleted ? "1" : "0";
         docStore.put(metadata);
         cursor.continue();
@@ -113,7 +115,7 @@ function init(api, opts, callback) {
       if (cursor) {
         var metadata = cursor.value;
         var docId = metadata.id;
-        var local = utils.isLocalId(docId);
+        var local = isLocalId(docId);
         var rev = merge.winningRev(metadata);
         if (local) {
           var docIdRev = docId + "::" + rev;
@@ -317,7 +319,7 @@ function init(api, opts, callback) {
         err = errors.error(errors.MISSING_DOC, 'missing');
         return finish();
       }
-      if (utils.isDeleted(metadata) && !opts.rev) {
+      if (isDeleted(metadata) && !opts.rev) {
         err = errors.error(errors.MISSING_DOC, "deleted");
         return finish();
       }

--- a/lib/adapters/leveldb/leveldb.js
+++ b/lib/adapters/leveldb/leveldb.js
@@ -18,6 +18,10 @@ requireLeveldown();
 var errors = require('../../deps/errors');
 var merge = require('../../merge');
 var utils = require('../../utils');
+var isDeleted = require('../../deps/docs/is-deleted');
+var isLocalId = require('../../deps/docs/is-local-id');
+var processDocs = require('../../deps/docs/process-docs');
+var md5 = require('../../deps/md5');
 var migrate = require('../../deps/migrate');
 var Deque = require("double-ended-queue");
 
@@ -326,7 +330,7 @@ function LevelPouch(opts, callback) {
         return callback(errors.error(errors.MISSING_DOC, 'missing'));
       }
 
-      if (utils.isDeleted(metadata) && !opts.rev) {
+      if (isDeleted(metadata) && !opts.rev) {
         return callback(errors.error(errors.MISSING_DOC, "deleted"));
       }
 
@@ -402,7 +406,7 @@ function LevelPouch(opts, callback) {
     // parse the docs and give each a sequence number
     var userDocs = req.docs;
     var docInfos = userDocs.map(function (doc, i) {
-      if (doc._id && utils.isLocalId(doc._id)) {
+      if (doc._id && isLocalId(doc._id)) {
         return doc;
       }
       var newDoc = utils.parseDoc(doc, newEdits);
@@ -477,7 +481,7 @@ function LevelPouch(opts, callback) {
       }
 
       userDocs.forEach(function (doc) {
-        if (doc._id && utils.isLocalId(doc._id)) {
+        if (doc._id && isLocalId(doc._id)) {
           // skip local docs
           return checkDone();
         }
@@ -564,7 +568,7 @@ function LevelPouch(opts, callback) {
 
       function onLoadEnd(doc, key, attachmentSaved) {
         return function (data) {
-          utils.MD5(data).then(
+          md5(data).then(
             onMD5Load(doc, key, data, attachmentSaved)
           );
         };
@@ -597,7 +601,7 @@ function LevelPouch(opts, callback) {
             onLoadEnd(docInfo, key, attachmentSaved));
           continue;
         }
-        utils.MD5(data).then(
+        md5(data).then(
           onMD5Load(docInfo, key, data, attachmentSaved)
         );
       }
@@ -775,8 +779,8 @@ function LevelPouch(opts, callback) {
         if (err) {
           return callback(err);
         }
-        utils.processDocs(docInfos, api, fetchedDocs,
-          txn, results, writeDoc, opts, finish);
+        processDocs(docInfos, api, fetchedDocs, txn, results, writeDoc,
+          opts, finish);
       });
     });
   });
@@ -824,7 +828,7 @@ function LevelPouch(opts, callback) {
       var docstream = stores.docStore.readStream(readstreamOpts);
 
       var throughStream = through(function (entry, _, next) {
-        if (!utils.isDeleted(entry.value)) {
+        if (!isDeleted(entry.value)) {
           if (skip-- > 0) {
             next();
             return;
@@ -860,7 +864,7 @@ function LevelPouch(opts, callback) {
           }
           if (opts.inclusive_end === false && metadata.id === opts.endkey) {
             return next();
-          } else if (utils.isDeleted(metadata)) {
+          } else if (isDeleted(metadata)) {
             if (opts.deleted === 'ok') {
               doc.value.deleted = true;
               doc.doc = null;
@@ -1042,7 +1046,7 @@ function LevelPouch(opts, callback) {
       // metadata not cached, have to go fetch it
       stores.docStore.get(doc._id, function (err, metadata) {
         if (opts.cancelled || opts.done || db.isClosed() ||
-          utils.isLocalId(metadata.id)) {
+          isLocalId(metadata.id)) {
           return next();
         }
         docIdsToMetadata.set(doc._id, metadata);

--- a/lib/adapters/websql/websql-bulk-docs.js
+++ b/lib/adapters/websql/websql-bulk-docs.js
@@ -2,6 +2,10 @@
 
 var utils = require('../../utils');
 var errors = require('../../deps/errors');
+var preprocessAttachments =
+  require('../../deps/docs/preprocess-attachments');
+var isLocalId = require('../../deps/docs/is-local-id');
+var processDocs = require('../../deps/docs/process-docs');
 
 var websqlUtils = require('./websql-utils');
 var websqlConstants = require('./websql-constants');
@@ -22,7 +26,7 @@ function websqlBulkDocs(req, opts, api, db, Changes, callback) {
 
   // Parse the docs, give them a sequence number for the result
   var docInfos = userDocs.map(function (doc) {
-    if (doc._id && utils.isLocalId(doc._id)) {
+    if (doc._id && isLocalId(doc._id)) {
       return doc;
     }
     var newDoc = utils.parseDoc(doc, newEdits);
@@ -248,9 +252,8 @@ function websqlBulkDocs(req, opts, api, db, Changes, callback) {
     }
   }
 
-  function processDocs() {
-    utils.processDocs(docInfos, api, fetchedDocs,
-      tx, results, writeDoc, opts);
+  function websqlProcessDocs() {
+    processDocs(docInfos, api, fetchedDocs, tx, results, writeDoc, opts);
   }
 
   function fetchExistingDocs(callback) {
@@ -267,7 +270,7 @@ function websqlBulkDocs(req, opts, api, db, Changes, callback) {
     }
 
     docInfos.forEach(function (docInfo) {
-      if (docInfo._id && utils.isLocalId(docInfo._id)) {
+      if (docInfo._id && isLocalId(docInfo._id)) {
         return checkDone(); // skip local docs
       }
       var id = docInfo.metadata.id;
@@ -303,7 +306,7 @@ function websqlBulkDocs(req, opts, api, db, Changes, callback) {
     });
   }
 
-  utils.preprocessAttachments(docInfos, 'binary', function (err) {
+  preprocessAttachments(docInfos, 'binary', function (err) {
     if (err) {
       return callback(err);
     }
@@ -313,7 +316,7 @@ function websqlBulkDocs(req, opts, api, db, Changes, callback) {
         if (err) {
           preconditionErrored = err;
         } else {
-          fetchExistingDocs(processDocs);
+          fetchExistingDocs(websqlProcessDocs);
         }
       });
     }, unknownError(callback), complete);

--- a/lib/adapters/websql/websql.js
+++ b/lib/adapters/websql/websql.js
@@ -2,6 +2,8 @@
 
 var utils = require('../../utils');
 var merge = require('../../merge');
+var isDeleted = require('../../deps/docs/is-deleted');
+var isLocalId = require('../../deps/docs/is-local-id');
 var errors = require('../../deps/errors');
 var parseHexString = require('../../deps/parse-hex');
 var binStringToBlob = require('../../deps/binary/binaryStringToBlobOrBuffer');
@@ -154,10 +156,10 @@ function WebSqlPouch(opts, callback) {
             var item = result.rows.item(i);
             var seq = item.seq;
             var metadata = JSON.parse(item.metadata);
-            if (utils.isDeleted(metadata)) {
+            if (isDeleted(metadata)) {
               deleted.push(seq);
             }
-            if (utils.isLocalId(metadata.id)) {
+            if (isLocalId(metadata.id)) {
               local.push(metadata.id);
             }
           }

--- a/lib/changes.js
+++ b/lib/changes.js
@@ -1,5 +1,6 @@
 'use strict';
 var utils = require('./utils');
+var isDeleted = require('./deps/docs/is-deleted');
 var merge = require('./merge');
 var errors = require('./deps/errors');
 var EE = require('events').EventEmitter;
@@ -113,7 +114,7 @@ function processChange(doc, metadata, opts) {
     doc: doc
   };
 
-  if (utils.isDeleted(metadata, doc._rev)) {
+  if (isDeleted(metadata, doc._rev)) {
     change.deleted = true;
   }
   if (opts.conflicts) {

--- a/lib/deps/docs/is-deleted.js
+++ b/lib/deps/docs/is-deleted.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var merge = require('../../merge');
+
+// check if a specific revision of a doc has been deleted
+//  - metadata: the metadata object from the doc store
+//  - rev: (optional) the revision to check. defaults to winning revision
+function isDeleted(metadata, rev) {
+  if (!rev) {
+    rev = merge.winningRev(metadata);
+  }
+  var dashIndex = rev.indexOf('-');
+  if (dashIndex !== -1) {
+    rev = rev.substring(dashIndex + 1);
+  }
+  var deleted = false;
+  merge.traverseRevTree(metadata.rev_tree,
+    function (isLeaf, pos, id, acc, opts) {
+      if (id === rev) {
+        deleted = !!opts.deleted;
+      }
+    });
+
+  return deleted;
+}
+
+module.exports = isDeleted;

--- a/lib/deps/docs/is-local-id.js
+++ b/lib/deps/docs/is-local-id.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function isLocalId(id) {
+  return (/^_local/).test(id);
+}
+
+module.exports = isLocalId;

--- a/lib/deps/docs/parse-doc.js
+++ b/lib/deps/docs/parse-doc.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var errors = require('./errors');
-var uuid = require('./uuid');
+var errors = require('./../errors');
+var uuid = require('./../uuid');
 
 function toObject(array) {
   return array.reduce(function (obj, item) {

--- a/lib/deps/docs/preprocess-attachments.js
+++ b/lib/deps/docs/preprocess-attachments.js
@@ -1,0 +1,107 @@
+'use strict';
+
+var base64 = require('../binary/base64');
+var arrayBuffToBinString = require('../binary/arrayBufferToBinaryString');
+var readAsArrayBuffer = require('../binary/readAsArrayBuffer');
+var binStringToBlobOrBuffer = require('../binary/binaryStringToBlobOrBuffer');
+var errors = require('../errors');
+var md5 = require('../md5');
+
+function preprocessAttachments(docInfos, blobType, callback) {
+
+  if (!docInfos.length) {
+    return callback();
+  }
+
+  var docv = 0;
+
+  function parseBase64(data) {
+    try {
+      return base64.atob(data);
+    } catch (e) {
+      var err = errors.error(errors.BAD_ARG,
+        'Attachments need to be base64 encoded');
+      return {error: err};
+    }
+  }
+
+  function preprocessAttachment(att, callback) {
+    if (att.stub) {
+      return callback();
+    }
+    if (typeof att.data === 'string') {
+      // input is a base64 string
+
+      var asBinary = parseBase64(att.data);
+      if (asBinary.error) {
+        return callback(asBinary.error);
+      }
+
+      att.length = asBinary.length;
+      if (blobType === 'blob') {
+        att.data = binStringToBlobOrBuffer(asBinary, att.content_type);
+      } else if (blobType === 'base64') {
+        att.data = base64.btoa(asBinary);
+      } else { // binary
+        att.data = asBinary;
+      }
+      md5(asBinary).then(function (result) {
+        att.digest = 'md5-' + result;
+        callback();
+      });
+    } else { // input is a blob
+      readAsArrayBuffer(att.data, function (buff) {
+        if (blobType === 'binary') {
+          att.data = arrayBuffToBinString(buff);
+        } else if (blobType === 'base64') {
+          att.data = base64.btoa(arrayBuffToBinString(buff));
+        }
+        md5(buff).then(function (result) {
+          att.digest = 'md5-' + result;
+          att.length = buff.byteLength;
+          callback();
+        });
+      });
+    }
+  }
+
+  var overallErr;
+
+  docInfos.forEach(function (docInfo) {
+    var attachments = docInfo.data && docInfo.data._attachments ?
+      Object.keys(docInfo.data._attachments) : [];
+    var recv = 0;
+
+    if (!attachments.length) {
+      return done();
+    }
+
+    function processedAttachment(err) {
+      overallErr = err;
+      recv++;
+      if (recv === attachments.length) {
+        done();
+      }
+    }
+
+    for (var key in docInfo.data._attachments) {
+      if (docInfo.data._attachments.hasOwnProperty(key)) {
+        preprocessAttachment(docInfo.data._attachments[key],
+          processedAttachment);
+      }
+    }
+  });
+
+  function done() {
+    docv++;
+    if (docInfos.length === docv) {
+      if (overallErr) {
+        callback(overallErr);
+      } else {
+        callback();
+      }
+    }
+  }
+}
+
+module.exports = preprocessAttachments;

--- a/lib/deps/docs/process-docs.js
+++ b/lib/deps/docs/process-docs.js
@@ -1,0 +1,98 @@
+'use strict';
+
+var merge = require('../../merge');
+var errors = require('../errors');
+var updateDoc = require('./update-doc');
+var isDeleted = require('./is-deleted');
+var isLocalId = require('./is-local-id');
+
+var collections = require('pouchdb-collections');
+var Map = collections.Map;
+
+function processDocs(docInfos, api, fetchedDocs, tx, results, writeDoc, opts,
+                     overallCallback) {
+
+  if (!docInfos.length) {
+    return;
+  }
+
+  function insertDoc(docInfo, resultsIdx, callback) {
+    // Cant insert new deleted documents
+    var winningRev = merge.winningRev(docInfo.metadata);
+    var deleted = isDeleted(docInfo.metadata, winningRev);
+    if ('was_delete' in opts && deleted) {
+      results[resultsIdx] = errors.error(errors.MISSING_DOC, 'deleted');
+      return callback();
+    }
+
+    var delta = deleted ? 0 : 1;
+
+    writeDoc(docInfo, winningRev, deleted, deleted, false,
+      delta, resultsIdx, callback);
+  }
+
+  var newEdits = opts.new_edits;
+  var idsToDocs = new Map();
+
+  var docsDone = 0;
+  var docsToDo = docInfos.length;
+
+  function checkAllDocsDone() {
+    if (++docsDone === docsToDo && overallCallback) {
+      overallCallback();
+    }
+  }
+
+  docInfos.forEach(function (currentDoc, resultsIdx) {
+
+    if (currentDoc._id && isLocalId(currentDoc._id)) {
+      api[currentDoc._deleted ? '_removeLocal' : '_putLocal'](
+        currentDoc, {ctx: tx}, function (err) {
+          if (err) {
+            results[resultsIdx] = err;
+          } else {
+            results[resultsIdx] = {ok: true};
+          }
+          checkAllDocsDone();
+        });
+      return;
+    }
+
+    var id = currentDoc.metadata.id;
+    if (idsToDocs.has(id)) {
+      docsToDo--; // duplicate
+      idsToDocs.get(id).push([currentDoc, resultsIdx]);
+    } else {
+      idsToDocs.set(id, [[currentDoc, resultsIdx]]);
+    }
+  });
+
+  // in the case of new_edits, the user can provide multiple docs
+  // with the same id. these need to be processed sequentially
+  idsToDocs.forEach(function (docs, id) {
+    var numDone = 0;
+
+    function docWritten() {
+      if (++numDone < docs.length) {
+        nextDoc();
+      } else {
+        checkAllDocsDone();
+      }
+    }
+    function nextDoc() {
+      var value = docs[numDone];
+      var currentDoc = value[0];
+      var resultsIdx = value[1];
+
+      if (fetchedDocs.has(id)) {
+        updateDoc(fetchedDocs.get(id), currentDoc, results,
+          resultsIdx, docWritten, writeDoc, newEdits);
+      } else {
+        insertDoc(currentDoc, resultsIdx, docWritten);
+      }
+    }
+    nextDoc();
+  });
+}
+
+module.exports = processDocs;

--- a/lib/deps/docs/update-doc.js
+++ b/lib/deps/docs/update-doc.js
@@ -1,0 +1,72 @@
+'use strict';
+
+var merge = require('../../merge');
+var errors = require('../errors');
+var isDeleted = require('./is-deleted');
+var parseDoc = require('./parse-doc').parseDoc;
+
+function revExists(metadata, rev) {
+  var found = false;
+  merge.traverseRevTree(metadata.rev_tree, function (leaf, pos, id) {
+    if ((pos + '-' + id) === rev) {
+      found = true;
+    }
+  });
+  return found;
+}
+
+function updateDoc(prev, docInfo, results, i, cb, writeDoc, newEdits) {
+
+  if (revExists(prev, docInfo.metadata.rev)) {
+    results[i] = docInfo;
+    return cb();
+  }
+
+  // TODO: some of these can be pre-calculated, but it's safer to just
+  // call merge.winningRev() and isDeleted() all over again
+  var previousWinningRev = merge.winningRev(prev);
+  var previouslyDeleted = isDeleted(prev, previousWinningRev);
+  var deleted = isDeleted(docInfo.metadata);
+  var isRoot = /^1-/.test(docInfo.metadata.rev);
+
+  if (previouslyDeleted && !deleted && newEdits && isRoot) {
+    var newDoc = docInfo.data;
+    newDoc._rev = previousWinningRev;
+    newDoc._id = docInfo.metadata.id;
+    docInfo = parseDoc(newDoc, newEdits);
+  }
+
+  var merged = merge.merge(prev.rev_tree, docInfo.metadata.rev_tree[0], 1000);
+
+  var inConflict = newEdits && (((previouslyDeleted && deleted) ||
+    (!previouslyDeleted && merged.conflicts !== 'new_leaf') ||
+    (previouslyDeleted && !deleted && merged.conflicts === 'new_branch')));
+
+  if (inConflict) {
+    var err = errors.error(errors.REV_CONFLICT);
+    results[i] = err;
+    return cb();
+  }
+
+  var newRev = docInfo.metadata.rev;
+  docInfo.metadata.rev_tree = merged.tree;
+  if (prev.rev_map) {
+    docInfo.metadata.rev_map = prev.rev_map; // used by leveldb
+  }
+
+  // recalculate
+  var winningRev = merge.winningRev(docInfo.metadata);
+  var winningRevIsDeleted = isDeleted(docInfo.metadata, winningRev);
+
+  // calculate the total number of documents that were added/removed,
+  // from the perspective of total_rows/doc_count
+  var delta = (previouslyDeleted === winningRevIsDeleted) ? 0 :
+    previouslyDeleted < winningRevIsDeleted ? -1 : 1;
+
+  var newRevIsDeleted = isDeleted(docInfo.metadata, newRev);
+
+  writeDoc(docInfo, winningRev, winningRevIsDeleted, newRevIsDeleted,
+    true, delta, i, cb);
+}
+
+module.exports = updateDoc;

--- a/lib/deps/md5.js
+++ b/lib/deps/md5.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var toPromise = require('./to-promise');
 var base64 = require('./binary/base64');
 var crypto = require('crypto');
 var Md5 = require('spark-md5');
@@ -41,7 +42,7 @@ function appendString(buffer, data, start, end) {
   buffer.appendBinary(data);
 }
 
-module.exports = function (data, callback) {
+module.exports = toPromise(function (data, callback) {
   if (!process.browser) {
     var base64 = crypto.createHash('md5').update(data).digest('base64');
     callback(null, base64);
@@ -72,4 +73,4 @@ module.exports = function (data, callback) {
     }
   }
   loadNextChunk();
-};
+});

--- a/lib/deps/migrate.js
+++ b/lib/deps/migrate.js
@@ -2,7 +2,7 @@
 
 var fs = require('fs');
 var path = require('path');
-var utils = require('../utils');
+var isLocalId = require('./docs/is-local-id');
 var merge = require('../merge');
 var levelup = require('levelup');
 var through = require('through2').obj;
@@ -133,7 +133,7 @@ exports.localAndMetaStores = function (db, stores, callback) {
           startKey: '_',
           endKey: '_\xFF'
         }).pipe(through(function (ch, _, next) {
-          if (!utils.isLocalId(ch.key)) {
+          if (!isLocalId(ch.key)) {
             return next();
           }
           batches.push({
@@ -167,7 +167,7 @@ exports.localAndMetaStores = function (db, stores, callback) {
           }
           deletedSeqs[seq] = true;
           stores.bySeqStore.get(seq, function (err, resp) {
-            if (err || !utils.isLocalId(resp._id)) {
+            if (err || !isLocalId(resp._id)) {
               return next();
             }
             batches.push({

--- a/lib/deps/once.js
+++ b/lib/deps/once.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var getArguments = require('argsarray');
+
+function once(fun) {
+  var called = false;
+  return getArguments(function (args) {
+    if (called) {
+      throw new Error('once called more than once');
+    } else {
+      called = true;
+      fun.apply(this, args);
+    }
+  });
+}
+
+module.exports = once;

--- a/lib/deps/to-promise.js
+++ b/lib/deps/to-promise.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var Promise = require('./promise');
+var getArguments = require('argsarray');
+var once = require('./once');
+
+function toPromise(func) {
+  //create the function we will be returning
+  return getArguments(function (args) {
+    var self = this;
+    var tempCB =
+      (typeof args[args.length - 1] === 'function') ? args.pop() : false;
+    // if the last argument is a function, assume its a callback
+    var usedCB;
+    if (tempCB) {
+      // if it was a callback, create a new callback which calls it,
+      // but do so async so we don't trap any errors
+      usedCB = function (err, resp) {
+        process.nextTick(function () {
+          tempCB(err, resp);
+        });
+      };
+    }
+    var promise = new Promise(function (fulfill, reject) {
+      var resp;
+      try {
+        var callback = once(function (err, mesg) {
+          if (err) {
+            reject(err);
+          } else {
+            fulfill(mesg);
+          }
+        });
+        // create a callback for this invocation
+        // apply the function in the orig context
+        args.push(callback);
+        resp = func.apply(self, args);
+        if (resp && typeof resp.then === 'function') {
+          fulfill(resp);
+        }
+      } catch (e) {
+        reject(e);
+      }
+    });
+    // if there is a callback, call it back
+    if (usedCB) {
+      promise.then(function (result) {
+        usedCB(null, result);
+      }, usedCB);
+    }
+    promise.cancel = function () {
+      return this;
+    };
+    return promise;
+  });
+}
+
+module.exports = toPromise;

--- a/lib/replicate/gen-replication-id.js
+++ b/lib/replicate/gen-replication-id.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var utils = require('../utils');
+var md5 = require('../deps/md5');
 
 // TODO: check CouchDB's replication id generation
 // Generate a unique id particular to this replication
@@ -10,12 +10,12 @@ function genReplicationId(src, target, opts) {
     return target.id().then(function (target_id) {
       var queryData = src_id + target_id + filterFun +
         JSON.stringify(opts.query_params) + opts.doc_ids;
-      return utils.MD5(queryData).then(function (md5) {
+      return md5(queryData).then(function (md5sum) {
         // can't use straight-up md5 alphabet, because
         // the char '/' is interpreted as being for attachments,
         // and + is also not url-safe
-        md5 = md5.replace(/\//g, '.').replace(/\+/g, '_');
-        return '_local/' + md5;
+        md5sum = md5sum.replace(/\//g, '.').replace(/\+/g, '_');
+        return '_local/' + md5sum;
       });
     });
   });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,12 +6,11 @@ exports.ajax = require('./deps/ajax');
 exports.createBlob = require('./deps/binary/blob');
 exports.uuid = require('./deps/uuid');
 exports.getArguments = require('argsarray');
-var errors = require('./deps/errors');
 var EventEmitter = require('events').EventEmitter;
 var collections = require('pouchdb-collections');
 exports.Map = collections.Map;
 exports.Set = collections.Set;
-var parseDoc = require('./deps/parse-doc');
+var parseDoc = require('./deps/docs/parse-doc');
 
 var Promise = require('./deps/promise');
 exports.Promise = Promise;
@@ -26,9 +25,6 @@ var binStringToBlobOrBuffer =
   require('./deps/binary/binaryStringToBlobOrBuffer');
 var b64StringToBlobOrBuffer =
   require('./deps/binary/base64StringToBlobOrBuffer');
-var arrayBufferToBinaryString =
-  require('./deps/binary/arrayBufferToBinaryString');
-var readAsArrayBuffer = require('./deps/binary/readAsArrayBuffer');
 
 // TODO: only used by the integration tests
 exports.binaryStringToBlobOrBuffer = binStringToBlobOrBuffer;
@@ -80,42 +76,6 @@ exports.call = exports.getArguments(function (args) {
     fun.apply(this, args);
   }
 });
-
-exports.isLocalId = function (id) {
-  return (/^_local/).test(id);
-};
-
-// check if a specific revision of a doc has been deleted
-//  - metadata: the metadata object from the doc store
-//  - rev: (optional) the revision to check. defaults to winning revision
-exports.isDeleted = function (metadata, rev) {
-  if (!rev) {
-    rev = merge.winningRev(metadata);
-  }
-  var dashIndex = rev.indexOf('-');
-  if (dashIndex !== -1) {
-    rev = rev.substring(dashIndex + 1);
-  }
-  var deleted = false;
-  merge.traverseRevTree(metadata.rev_tree,
-  function (isLeaf, pos, id, acc, opts) {
-    if (id === rev) {
-      deleted = !!opts.deleted;
-    }
-  });
-
-  return deleted;
-};
-
-exports.revExists = function (metadata, rev) {
-  var found = false;
-  merge.traverseRevTree(metadata.rev_tree, function (leaf, pos, id) {
-    if ((pos + '-' + id) === rev) {
-      found = true;
-    }
-  });
-  return found;
-};
 
 exports.filterChange = function filterChange(opts) {
   var req = {};
@@ -262,68 +222,9 @@ Changes.prototype.notify = function (dbName) {
   this.notifyLocalWindows(dbName);
 };
 
-exports.once = function (fun) {
-  var called = false;
-  return exports.getArguments(function (args) {
-    if (called) {
-      throw new Error('once called  more than once');
-    } else {
-      called = true;
-      fun.apply(this, args);
-    }
-  });
-};
+exports.once = require('./deps/once');
 
-exports.toPromise = function (func) {
-  //create the function we will be returning
-  return exports.getArguments(function (args) {
-    var self = this;
-    var tempCB =
-      (typeof args[args.length - 1] === 'function') ? args.pop() : false;
-    // if the last argument is a function, assume its a callback
-    var usedCB;
-    if (tempCB) {
-      // if it was a callback, create a new callback which calls it,
-      // but do so async so we don't trap any errors
-      usedCB = function (err, resp) {
-        process.nextTick(function () {
-          tempCB(err, resp);
-        });
-      };
-    }
-    var promise = new Promise(function (fulfill, reject) {
-      var resp;
-      try {
-        var callback = exports.once(function (err, mesg) {
-          if (err) {
-            reject(err);
-          } else {
-            fulfill(mesg);
-          }
-        });
-        // create a callback for this invocation
-        // apply the function in the orig context
-        args.push(callback);
-        resp = func.apply(self, args);
-        if (resp && typeof resp.then === 'function') {
-          fulfill(resp);
-        }
-      } catch (e) {
-        reject(e);
-      }
-    });
-    // if there is a callback, call it back
-    if (usedCB) {
-      promise.then(function (result) {
-        usedCB(null, result);
-      }, usedCB);
-    }
-    promise.cancel = function () {
-      return this;
-    };
-    return promise;
-  });
-};
+exports.toPromise = require('./deps/to-promise');
 
 exports.adapterFun = function (name, callback) {
   var log = require('debug')('pouchdb:api');
@@ -453,8 +354,6 @@ exports.cancellableFun = function (fun, self, opts) {
   return promise;
 };
 
-exports.MD5 = exports.toPromise(require('./deps/md5'));
-
 exports.explain404 = require('./deps/explain404');
 
 exports.info = function (str) {
@@ -469,245 +368,6 @@ exports.compare = function (left, right) {
   return left < right ? -1 : left > right ? 1 : 0;
 };
 
-exports.updateDoc = function updateDoc(prev, docInfo, results,
-                                       i, cb, writeDoc, newEdits) {
-
-  if (exports.revExists(prev, docInfo.metadata.rev)) {
-    results[i] = docInfo;
-    return cb();
-  }
-
-  // TODO: some of these can be pre-calculated, but it's safer to just
-  // call merge.winningRev() and exports.isDeleted() all over again
-  var previousWinningRev = merge.winningRev(prev);
-  var previouslyDeleted = exports.isDeleted(prev, previousWinningRev);
-  var deleted = exports.isDeleted(docInfo.metadata);
-  var isRoot = /^1-/.test(docInfo.metadata.rev);
-
-  if (previouslyDeleted && !deleted && newEdits && isRoot) {
-    var newDoc = docInfo.data;
-    newDoc._rev = previousWinningRev;
-    newDoc._id = docInfo.metadata.id;
-    docInfo = exports.parseDoc(newDoc, newEdits);
-  }
-
-  var merged = merge.merge(prev.rev_tree, docInfo.metadata.rev_tree[0], 1000);
-
-  var inConflict = newEdits && (((previouslyDeleted && deleted) ||
-    (!previouslyDeleted && merged.conflicts !== 'new_leaf') ||
-    (previouslyDeleted && !deleted && merged.conflicts === 'new_branch')));
-
-  if (inConflict) {
-    var err = errors.error(errors.REV_CONFLICT);
-    results[i] = err;
-    return cb();
-  }
-
-  var newRev = docInfo.metadata.rev;
-  docInfo.metadata.rev_tree = merged.tree;
-  if (prev.rev_map) {
-    docInfo.metadata.rev_map = prev.rev_map; // used by leveldb
-  }
-
-  // recalculate
-  var winningRev = merge.winningRev(docInfo.metadata);
-  var winningRevIsDeleted = exports.isDeleted(docInfo.metadata, winningRev);
-
-  // calculate the total number of documents that were added/removed,
-  // from the perspective of total_rows/doc_count
-  var delta = (previouslyDeleted === winningRevIsDeleted) ? 0 :
-      previouslyDeleted < winningRevIsDeleted ? -1 : 1;
-
-  var newRevIsDeleted = exports.isDeleted(docInfo.metadata, newRev);
-
-  writeDoc(docInfo, winningRev, winningRevIsDeleted, newRevIsDeleted,
-    true, delta, i, cb);
-};
-
-exports.processDocs = function processDocs(docInfos, api, fetchedDocs,
-                                           tx, results, writeDoc, opts,
-                                           overallCallback) {
-
-  if (!docInfos.length) {
-    return;
-  }
-
-  function insertDoc(docInfo, resultsIdx, callback) {
-    // Cant insert new deleted documents
-    var winningRev = merge.winningRev(docInfo.metadata);
-    var deleted = exports.isDeleted(docInfo.metadata, winningRev);
-    if ('was_delete' in opts && deleted) {
-      results[resultsIdx] = errors.error(errors.MISSING_DOC, 'deleted');
-      return callback();
-    }
-
-    var delta = deleted ? 0 : 1;
-
-    writeDoc(docInfo, winningRev, deleted, deleted, false,
-      delta, resultsIdx, callback);
-  }
-
-  var newEdits = opts.new_edits;
-  var idsToDocs = new exports.Map();
-
-  var docsDone = 0;
-  var docsToDo = docInfos.length;
-
-  function checkAllDocsDone() {
-    if (++docsDone === docsToDo && overallCallback) {
-      overallCallback();
-    }
-  }
-
-  docInfos.forEach(function (currentDoc, resultsIdx) {
-
-    if (currentDoc._id && exports.isLocalId(currentDoc._id)) {
-      api[currentDoc._deleted ? '_removeLocal' : '_putLocal'](
-        currentDoc, {ctx: tx}, function (err) {
-          if (err) {
-            results[resultsIdx] = err;
-          } else {
-            results[resultsIdx] = {ok: true};
-          }
-          checkAllDocsDone();
-        });
-      return;
-    }
-
-    var id = currentDoc.metadata.id;
-    if (idsToDocs.has(id)) {
-      docsToDo--; // duplicate
-      idsToDocs.get(id).push([currentDoc, resultsIdx]);
-    } else {
-      idsToDocs.set(id, [[currentDoc, resultsIdx]]);
-    }
-  });
-
-  // in the case of new_edits, the user can provide multiple docs
-  // with the same id. these need to be processed sequentially
-  idsToDocs.forEach(function (docs, id) {
-    var numDone = 0;
-
-    function docWritten() {
-      if (++numDone < docs.length) {
-        nextDoc();
-      } else {
-        checkAllDocsDone();
-      }
-    }
-    function nextDoc() {
-      var value = docs[numDone];
-      var currentDoc = value[0];
-      var resultsIdx = value[1];
-
-      if (fetchedDocs.has(id)) {
-        exports.updateDoc(fetchedDocs.get(id), currentDoc, results,
-          resultsIdx, docWritten, writeDoc, newEdits);
-      } else {
-        insertDoc(currentDoc, resultsIdx, docWritten);
-      }
-    }
-    nextDoc();
-  });
-};
-
-exports.preprocessAttachments = function preprocessAttachments(
-    docInfos, blobType, callback) {
-
-  if (!docInfos.length) {
-    return callback();
-  }
-
-  var docv = 0;
-
-  function parseBase64(data) {
-    try {
-      return base64.atob(data);
-    } catch (e) {
-      var err = errors.error(errors.BAD_ARG,
-                             'Attachments need to be base64 encoded');
-      return {error: err};
-    }
-  }
-
-  function preprocessAttachment(att, callback) {
-    if (att.stub) {
-      return callback();
-    }
-    if (typeof att.data === 'string') {
-      // input is a base64 string
-
-      var asBinary = parseBase64(att.data);
-      if (asBinary.error) {
-        return callback(asBinary.error);
-      }
-
-      att.length = asBinary.length;
-      if (blobType === 'blob') {
-        att.data = binStringToBlobOrBuffer(asBinary, att.content_type);
-      } else if (blobType === 'base64') {
-        att.data = base64.btoa(asBinary);
-      } else { // binary
-        att.data = asBinary;
-      }
-      exports.MD5(asBinary).then(function (result) {
-        att.digest = 'md5-' + result;
-        callback();
-      });
-    } else { // input is a blob
-      readAsArrayBuffer(att.data, function (buff) {
-        if (blobType === 'binary') {
-          att.data = arrayBufferToBinaryString(buff);
-        } else if (blobType === 'base64') {
-          att.data = base64.btoa(arrayBufferToBinaryString(buff));
-        }
-        exports.MD5(buff).then(function (result) {
-          att.digest = 'md5-' + result;
-          att.length = buff.byteLength;
-          callback();
-        });
-      });
-    }
-  }
-
-  var overallErr;
-
-  docInfos.forEach(function (docInfo) {
-    var attachments = docInfo.data && docInfo.data._attachments ?
-      Object.keys(docInfo.data._attachments) : [];
-    var recv = 0;
-
-    if (!attachments.length) {
-      return done();
-    }
-
-    function processedAttachment(err) {
-      overallErr = err;
-      recv++;
-      if (recv === attachments.length) {
-        done();
-      }
-    }
-
-    for (var key in docInfo.data._attachments) {
-      if (docInfo.data._attachments.hasOwnProperty(key)) {
-        preprocessAttachment(docInfo.data._attachments[key],
-          processedAttachment);
-      }
-    }
-  });
-
-  function done() {
-    docv++;
-    if (docInfos.length === docv) {
-      if (overallErr) {
-        callback(overallErr);
-      } else {
-        callback();
-      }
-    }
-  }
-};
 
 // compact a tree by marking its non-leafs as missing,
 // and return a list of revs to delete


### PR DESCRIPTION
Feels cleaner when everything is separate files,
rather than having them all inside one big `utils.js`.