### PR TITLE
(#3923) Use opts.prefix if it exists

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -70,7 +70,7 @@ PouchDB.parseAdapter = function (name, opts) {
       adapter.use_prefix : true;
 
   return {
-    name: usePrefix ? (PouchDB.prefix + name) : name,
+    name: usePrefix ? ((opts.prefix || PouchDB.prefix) + name) : name,
     adapter: adapterName
   };
 };


### PR DESCRIPTION
This is a quick workaround for prefix defaults not being respected when using the http adapter.