### PR TITLE
(#3567) - Reporting db.adapter in db.info

### DIFF
--- a/docs/_includes/api/database_information.html
+++ b/docs/_includes/api/database_information.html
@@ -43,6 +43,8 @@ db.info().then(function (result) {
 
 There are also some details you can use for debugging. These are unofficial and may change at any time:
 
+* `adapter`: The name of the adapter being used (idb, websql, leveldb, ...).
 * `idb_attachment_format`: (IndexedDB) either `'base64'` or `'binary'`, depending on whether the browser [supports binary blobs](/faq.html#data_types).
 * `sqlite_plugin`: (WebSQL) true if the [SQLite Plugin][] is being used.
 * `websql_encoding`: (WebSQL) either `'UTF-8'` or `'UTF-16'`, depending on the [WebSQL implementation](http://pouchdb.com/faq.html#data_types)
+* `backend_adapter`: (Node.JS) the backend *DOWN adapter being used (MemDOWN, RiakDOWN, ...).

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -700,6 +700,7 @@ AbstractPouchDB.prototype.info = utils.adapterFun('info', function (callback) {
     // assume we know better than the adapter, unless it informs us
     info.db_name = info.db_name || self._db_name;
     info.auto_compaction = !!(self.auto_compaction && self.type() !== 'http');
+    info.adapter = info.adapter || self.type();
     callback(null, info);
   });
 });

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -700,7 +700,7 @@ AbstractPouchDB.prototype.info = utils.adapterFun('info', function (callback) {
     // assume we know better than the adapter, unless it informs us
     info.db_name = info.db_name || self._db_name;
     info.auto_compaction = !!(self.auto_compaction && self.type() !== 'http');
-    info.adapter = info.adapter || self.type();
+    info.adapter = self.type();
     callback(null, info);
   });
 });

--- a/lib/adapters/leveldb/index.js
+++ b/lib/adapters/leveldb/index.js
@@ -205,7 +205,8 @@ function LevelPouch(opts, callback) {
   api._info = function (callback) {
     var res = {
       doc_count: db._docCount,
-      update_seq: db._updateSeq
+      update_seq: db._updateSeq,
+      backend_adapter: leveldown.name
     };
     return process.nextTick(function () {
       callback(null, res);

--- a/tests/integration/browser.info.js
+++ b/tests/integration/browser.info.js
@@ -23,9 +23,11 @@ adapters.forEach(function (adapter) {
           case 'websql':
             info.sqlite_plugin.should.be.a('boolean');
             info.websql_encoding.should.be.a('string');
+            info.adapter.should.equal('websql');
             break;
           case 'idb':
             info.idb_attachment_format.should.be.a('string');
+            info.adapter.should.equal('idb');
             break;
           default:
             should.exist(info); // can't make any guarantees

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -773,7 +773,6 @@ adapters.forEach(function (adapter) {
     it('db.info should give adapter name (#3567)', function () {
       var db = new PouchDB(dbs.name);
       return db.info().then(function (info) {
-        // http doesn't support auto compaction
         info.adapter.should.equal(db.type());
       });
     });

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -770,6 +770,14 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('db.info should give adapter name (#3567)', function () {
+      var db = new PouchDB(dbs.name);
+      return db.info().then(function (info) {
+        // http doesn't support auto compaction
+        info.adapter.should.equal(db.adapter);
+      });
+    });
+
     it('db.info should give correct doc_count', function (done) {
       new PouchDB(dbs.name).then(function (db) {
         db.info().then(function (info) {

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -774,7 +774,7 @@ adapters.forEach(function (adapter) {
       var db = new PouchDB(dbs.name);
       return db.info().then(function (info) {
         // http doesn't support auto compaction
-        info.adapter.should.equal(db.adapter);
+        info.adapter.should.equal(db.type());
       });
     });
 

--- a/tests/integration/test.defaults.js
+++ b/tests/integration/test.defaults.js
@@ -118,6 +118,15 @@ if (!process.env.LEVEL_ADAPTER &&
       });
     });
 
+    it('should inform us when using memdown', function () {
+      var opts = { name: 'mydb', db: require('memdown') };
+      return new PouchDB(opts).then(function (db) {
+        return db.info().then(function (info) {
+          info.backend_adapter.should.equal('MemDOWN');
+        });
+      });
+    });
+
     it('constructor emits destroyed when using defaults', function () {
       var CustomPouch = PouchDB.defaults({db: require('memdown')});
 


### PR DESCRIPTION
This is my first pull request, so please let me know if I did anything wrong or something could be improved.

Implementing the reporting of db.adapter in db.info (#3567). Also reporting the backend *DOWN adapter.