### PR TITLE
(#3962) - stop fetching attachments in separate requests

### DIFF
--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -36,8 +36,8 @@ function blobToBase64(blobOrBuffer) {
   });
 }
 
-function readAttachmentsAsBlobOrBuffer(row) {
-  var atts = row.doc && row.doc._attachments;
+function readDocAttachmentsAsBlobOrBuffer(doc) {
+  var atts = doc._attachments;
   if (!atts) {
     return;
   }
@@ -45,6 +45,13 @@ function readAttachmentsAsBlobOrBuffer(row) {
     var att = atts[filename];
     att.data = b64StringToBluffer(att.data, att.content_type);
   });
+}
+
+function readRowAttachmentsAsBlobOrBuffer(row) {
+  if (!row.doc) {
+    return;
+  }
+  return readDocAttachmentsAsBlobOrBuffer(row.doc);
 }
 
 function encodeDocId(id) {
@@ -361,6 +368,11 @@ function HttpPouch(opts, callback) {
       params.push('conflicts=' + opts.conflicts);
     }
 
+    // yay attachments
+    if (opts.attachments) {
+      params.push('attachments=true');
+    }
+
     // Format the list of parameters into a valid URI query string
     params = params.join('&');
     params = params === '' ? '' : '?' + params;
@@ -376,57 +388,15 @@ function HttpPouch(opts, callback) {
     var getRequestAjaxOpts = opts.ajax || {};
     utils.extend(true, options, getRequestAjaxOpts);
 
-    function fetchAttachments(doc) {
-      var atts = doc._attachments;
-      var filenames = atts && Object.keys(atts);
-      if (!atts || !filenames.length) {
-        return;
-      }
-      // we fetch these manually in separate XHRs, because
-      // Sync Gateway would normally send it back as multipart/mixed,
-      // which we cannot parse. Also, this is more efficient than
-      // receiving attachments as base64-encoded strings.
-      return Promise.all(filenames.map(function (filename) {
-        var att = atts[filename];
-        var path = encodeDocId(doc._id) + '/' + encodeAttachmentId(filename) +
-          '?rev=' + doc._rev;
-        return ajaxPromise({
-          headers: clone(host.headers),
-          method: 'GET',
-          url: genDBUrl(host, path),
-          binary: true
-        }).then(function (blob) {
-          if (opts.binary) {
-            return blob;
-          }
-          return blobToBase64(blob);
-        }).then(function (data) {
-          delete att.stub;
-          delete att.length;
-          att.data = data;
-        });
-      }));
-    }
-
-    function fetchAllAttachments(docOrDocs) {
-      if (Array.isArray(docOrDocs)) {
-        return Promise.all(docOrDocs.map(function (doc) {
-          if (doc.ok) {
-            return fetchAttachments(doc.ok);
-          }
-        }));
-      }
-      return fetchAttachments(docOrDocs);
-    }
-
     ajaxPromise(options).then(function (res) {
-      return Promise.resolve().then(function () {
-        if (opts.attachments) {
-          return fetchAllAttachments(res);
+      if (opts.attachments && opts.binary) {
+        if (Array.isArray(res)) {
+          res.forEach(readDocAttachmentsAsBlobOrBuffer);
+        } else {
+          readDocAttachmentsAsBlobOrBuffer(res);
         }
-      }).then(function () {
-        callback(null, res);
-      });
+      }
+      callback(null, res);
     }).catch(callback);
   });
 
@@ -789,7 +759,7 @@ function HttpPouch(opts, callback) {
       body: body
     }).then(function (res) {
       if (opts.include_docs && opts.attachments && opts.binary) {
-        res.rows.forEach(readAttachmentsAsBlobOrBuffer);
+        res.rows.forEach(readRowAttachmentsAsBlobOrBuffer);
       }
       callback(null, res);
     }).catch(callback);
@@ -961,7 +931,7 @@ function HttpPouch(opts, callback) {
           var ret = utils.filterChange(opts)(c);
           if (ret) {
             if (opts.include_docs && opts.attachments && opts.binary) {
-              readAttachmentsAsBlobOrBuffer(c);
+              readRowAttachmentsAsBlobOrBuffer(c);
             }
             if (returnDocs) {
               results.results.push(c);

--- a/lib/replicate/getDocs.js
+++ b/lib/replicate/getDocs.js
@@ -60,8 +60,16 @@ function getDocs(src, diffs, state) {
     return Promise.all(diffKeys.map(processDiffDoc));
   }
 
-  function hasAttachments(doc) {
-    return doc._attachments && Object.keys(doc._attachments).length > 0;
+  function hasValidAttachments(doc) {
+    var atts = doc._attachments;
+    var attNames = atts && Object.keys(atts);
+
+    var hasAttachments = atts && attNames.length > 0;
+    // These will be stubs in CouchDB < 1.6 because attachments
+    // weren't supported in _all_docs
+    var hasAttachmentData = hasAttachments && !atts[attNames[0]].stub;
+
+    return !hasAttachments || hasAttachmentData;
   }
 
   function fetchRevisionOneDocs(ids) {
@@ -69,14 +77,15 @@ function getDocs(src, diffs, state) {
     // a single request using _all_docs
     return src.allDocs({
       keys: ids,
-      include_docs: true
+      include_docs: true,
+      attachments: true
     }).then(function (res) {
       if (state.cancelled) {
         throw new Error('cancelled');
       }
       res.rows.forEach(function (row) {
         if (row.deleted || !row.doc || !isGenOne(row.value.rev) ||
-            hasAttachments(row.doc)) {
+            !hasValidAttachments(row.doc)) {
           // if any of these conditions apply, we need to fetch using get()
           return;
         }


### PR DESCRIPTION
This essentially reverts 6e4aca8802c377aa93ccb95a13874338f43a8cb8 and 8207da70de80dad930cec6ae2e541f06c8391fac.

This was a dumb mistake on my part, to try to eke out additional performance improvements and improve CSG support by removing base64 inlining of attachments and fetching the attachments in a separate request instead.

CSG needs to add `application/json` support if they want to be able to replicate attachments to Pouch. I'm tired of implementing crazy workarounds.

As for Couch, it seems like `multipart/mixed` is never going to be a viable solution for Pouch, because 1) since they send the attachments gzipped, we would have to manually gunzip using some slow JS library, and 2) even if they made gzipping optional, then we're sending attachments unzipped, which might mean a larger payload than gzipped json (citation needed).

If we want to bring this feature back, then as @ermouth says, we would probably need tests that better simulate the browser dropping many concurrent connections.