### PR TITLE
(#3963) - fix attachment length for stubs

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -48,7 +48,7 @@ function cleanDocs(docs) {
       for (var j = 0; j < atts.length; j++) {
         var att = atts[j];
         doc._attachments[att] = utils.pick(doc._attachments[att],
-          ['data', 'digest', 'content_type', 'revpos', 'stub']);
+          ['data', 'digest', 'content_type', 'length', 'revpos', 'stub']);
       }
     }
   }


### PR DESCRIPTION
Test fails before the fix, succeeds after.

In short, we weren't being careful enough to
test the `.length` property after a `put()` with
stubs. The new test should handle that.