### PR TITLE
(#3969) - trim npm size, fix bower build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@ tests/cordova/www
 .idea
 phantomjsdriver.log
 bower_components
+docs

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -18,7 +18,7 @@ npm publish
 # Create git tag, which is also the Bower/Github release
 git add dist -f
 git add bower.json component.json package.json lib/version-browser.js
-git rm -r bin docs scripts tests vendor
+git rm -r bin docs scripts tests
 
 git commit -m "build $VERSION"
 


### PR DESCRIPTION
The `docs/` folder was taking up 7MB of unnecessary
space in the npm package, and the `vendor` folder
does not exist anymore.