### PR TITLE
(#3961) - fetch http attachments in batches

### DIFF
--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -8,6 +8,7 @@ var CHANGES_BATCH_SIZE = 25;
 // URL into account, we fudge it a bit.
 // TODO: we could measure the full URL to enforce exactly 2000 chars
 var MAX_URL_LENGTH = 1800;
+var ATTACHMENT_BATCH_SIZE = 6; // browsers cap simultaneous requests at ~6-8
 
 var readAsBinaryString = require('../../deps/binary/readAsBinaryString');
 var binStringToBluffer =
@@ -386,26 +387,40 @@ function HttpPouch(opts, callback) {
       // Sync Gateway would normally send it back as multipart/mixed,
       // which we cannot parse. Also, this is more efficient than
       // receiving attachments as base64-encoded strings.
-      return Promise.all(filenames.map(function (filename) {
-        var att = atts[filename];
-        var path = encodeDocId(doc._id) + '/' + encodeAttachmentId(filename) +
-          '?rev=' + doc._rev;
-        return ajaxPromise({
-          headers: clone(host.headers),
-          method: 'GET',
-          url: genDBUrl(host, path),
-          binary: true
-        }).then(function (blob) {
-          if (opts.binary) {
-            return blob;
-          }
-          return blobToBase64(blob);
-        }).then(function (data) {
-          delete att.stub;
-          delete att.length;
-          att.data = data;
+
+      // do this in batches to avoid too many simultaneous requests
+      var batches = [];
+      for (var i = 0; i < filenames.length; i += ATTACHMENT_BATCH_SIZE) {
+        var end = Math.min(filenames.length, i + ATTACHMENT_BATCH_SIZE);
+        batches.push(filenames.slice(i, end));
+      }
+
+      var promise = Promise.resolve();
+      batches.forEach(function (batch) {
+        promise = promise.then(function () {
+          return Promise.all(batch.map(function (filename) {
+            var att = atts[filename];
+            var path = encodeDocId(doc._id) + '/' +
+              encodeAttachmentId(filename) + '?rev=' + doc._rev;
+            return ajaxPromise({
+              headers: clone(host.headers),
+              method: 'GET',
+              url: genDBUrl(host, path),
+              binary: true
+            }).then(function (blob) {
+              if (opts.binary) {
+                return blob;
+              }
+              return blobToBase64(blob);
+            }).then(function (data) {
+              delete att.stub;
+              delete att.length;
+              att.data = data;
+            });
+          }));
         });
-      }));
+      });
+      return promise;
     }
 
     function fetchAllAttachments(docOrDocs) {


### PR DESCRIPTION
Rebased on https://github.com/pouchdb/pouchdb/pull/3966 to
demonstrate that this passes the tests even if you have
many attachments on the same doc.