### PR TITLE
(#3990) - Create new global ajax wrapper

### DIFF
--- a/lib/adapters/idb/blobSupport.js
+++ b/lib/adapters/idb/blobSupport.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('../../utils');
+
 var idbConstants = require('./constants');
 var DETECT_BLOB_SUPPORT_STORE = idbConstants.DETECT_BLOB_SUPPORT_STORE;
 

--- a/lib/deps/request-browser.js
+++ b/lib/deps/request-browser.js
@@ -120,15 +120,6 @@ function xhRequest(options, callback) {
     xhr = new XMLHttpRequest();
   }
 
-  // cache-buster, specifically designed to work around IE's aggressive caching
-  // see http://www.dashbay.com/2011/05/internet-explorer-caches-ajax/
-  // Also Safari caches POSTs, so we need to cache-bust those too.
-  if ((options.method === 'POST' || options.method === 'GET') &&
-      !options.cache) {
-    var hasArgs = options.url.indexOf('?') !== -1;
-    options.url += (hasArgs ? '&' : '?') + '_nonce=' + Date.now();
-  }
-
   xhr.open(options.method, options.url);
   xhr.withCredentials = true;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ var PouchDB = require('./setup');
 
 module.exports = PouchDB;
 
-PouchDB.ajax = require('./deps/ajax');
+PouchDB.ajax = require('./prequest');
 PouchDB.utils = require('./utils');
 PouchDB.Errors = require('./deps/errors');
 PouchDB.replicate = require('./replicate').replicate;

--- a/lib/prequest.js
+++ b/lib/prequest.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var ajax = require('./deps/ajax');
+
+module.exports = function(opts, callback) {
+
+  // cache-buster, specifically designed to work around IE's aggressive caching
+  // see http://www.dashbay.com/2011/05/internet-explorer-caches-ajax/
+  // Also Safari caches POSTs, so we need to cache-bust those too.
+  if (process.browser &&
+      (opts.method === 'POST' || opts.method === 'GET') && !opts.cache) {
+    var hasArgs = opts.url.indexOf('?') !== -1;
+    opts.url += (hasArgs ? '&' : '?') + '_nonce=' + Date.now();
+  }
+
+  return ajax(opts, callback);
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,7 @@
 /*global chrome */
 var merge = require('./merge');
 exports.extend = require('pouchdb-extend');
-exports.ajax = require('./deps/ajax');
+exports.ajax = require('./prequest');
 exports.createBlob = require('./deps/binary/blob'); // TODO: don't export this
 exports.uuid = require('./deps/uuid');
 exports.getArguments = require('argsarray');


### PR DESCRIPTION
So we may not want to switch to fetch() api, but this is still worth doing I think, we should try to have clean reusable polyfills in `/deps/` and the PouchDB logic like nonce should be kept outside of it, if we want to limit the number of requests pouchdb makes in the browser than it can be done here or in a similiar way