### PR TITLE
Feature: Allow user to raise changes/attachments timeout

### DIFF
--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -545,7 +545,7 @@ function HttpPouch(opts, callback) {
       url: url,
       processData: false,
       body: blob,
-      timeout: 60000
+      timeout: ajaxOpts.timeout || 60000
     };
     opts.headers['Content-Type'] = type;
     // Add the attachment
@@ -806,7 +806,7 @@ function HttpPouch(opts, callback) {
     var batchSize = 'batch_size' in opts ? opts.batch_size : CHANGES_BATCH_SIZE;
 
     opts = clone(opts);
-    opts.timeout = opts.timeout || 30 * 1000;
+    opts.timeout = opts.timeout || ajaxOpts.timeout || 30 * 1000;
 
     // We give a 5 second buffer for CouchDB changes to respond with
     // an ok timeout

--- a/tests/integration/test.http.js
+++ b/tests/integration/test.http.js
@@ -86,4 +86,31 @@ describe('test.http.js', function () {
     uri.host.should.equal('foo.com');
   });
 
+
+  it('Allows the "ajax timeout" to extend "changes timeout"', function() {
+    var timeout = 120000;
+    var db = new PouchDB(dbs.name, {
+      skipSetup: true,
+      ajax: {
+        timeout: timeout
+      }
+    });
+
+    var ajax = PouchDB.utils.ajax;
+    var ajaxOpts;
+    PouchDB.utils.ajax = function(opts) {
+      if(/changes/.test(opts.url)) {
+        ajaxOpts = opts;
+      }
+    };
+
+    db.changes({
+      onChange: function(change) {}
+    });
+
+    should.exist(ajaxOpts);
+    ajaxOpts.timeout.should.equal(timeout);
+
+    PouchDB.utils.ajax = ajax;
+  });
 });


### PR DESCRIPTION
This is a feature-request, since we're seeing the changes call taking longer than 30 seconds sometimes. 
Would be nice to be able to up it a notch!

Cheers!