### PR TITLE
(#4021) - Aborted fetch on a binary attachment causes the replication to halt.

### DIFF
--- a/lib/deps/ajax.js
+++ b/lib/deps/ajax.js
@@ -129,9 +129,12 @@ function ajax(options, adapterCallback) {
     if (response.statusCode >= 200 && response.statusCode < 300) {
       onSuccess(data, response, callback);
     } else {
-      if (options.binary) {
+      try {
+        // See if we received an error message from the server
+        // If the connection was interrupted, the data might be nothing
+        // that's why we have the try/catch
         data = JSON.parse(data.toString());
-      }
+      } catch(e) {}
       error = errors.generateErrorFromResponse(data);
       error.status = response.statusCode;
       callback(error);

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "less": "~1.7.0",
     "mkdirp": "~0.4.2",
     "mocha": "^1.18.2",
+    "mockery": "^1.4.0",
     "ncp": "~0.5.0",
     "phantomjs": "^1.9.7-5",
     "pouchdb-express-router": "^0.0.6",

--- a/tests/unit/test.ajax.js
+++ b/tests/unit/test.ajax.js
@@ -1,0 +1,75 @@
+'use strict';
+
+var should = require('chai').should();
+var mockery = require('mockery');
+
+describe('test.ajax.js', function () {
+  var opts;
+  var cb;
+  var ajax;
+
+  beforeEach(function() {
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    });
+
+    function requestStub(callOpts, callCB) {
+      opts = callOpts;
+      cb = callCB;
+    }
+
+    mockery.registerMock('request', requestStub);
+    ajax = require('../../lib/deps/ajax');
+  });
+
+  it('should exist', function () {
+    should.exist(ajax);
+    ajax.should.be.a('function');
+  });
+
+  it('detects error on an interrupted binary file', function(done) {
+    ajax({
+      method: 'GET',
+      binary: true,
+      url: 'http://test.db/dbname/docid/filename.jpg'
+    }, function(err, res) {
+      // here's the test, we should get an 'err' response
+      should.exist(err);
+      should.not.exist(res);
+      done();
+    });
+
+    // Simulates an interrupted network request
+    setTimeout(function() {
+      cb(null, {
+        statusCode: 0
+      },
+      "");
+    }, 4);
+  });
+
+  it('should work on a working binary file', function(done) {
+    ajax({
+      method: 'GET',
+      binary: true,
+      url: 'http://test.db/dbname/docid/filename.jpg'
+    }, function(err, res) {
+      should.not.exist(err);
+      should.exist(res);
+      done();
+    });
+
+    setTimeout(function() {
+      cb(null, {
+        statusCode: 200,
+        headers: {
+          'Content-Type': 'image/jpeg'
+        }
+      }, 'sure this is binary data');
+    }, 4);
+  });
+
+});
+


### PR DESCRIPTION
implement other fix for attach error
Added a test for interrupted binary file