### PR TITLE
(#3999) Implement CouchDB-like checkpoints

### DIFF
--- a/lib/replicate/checkpointer.js
+++ b/lib/replicate/checkpointer.js
@@ -50,7 +50,7 @@ function updateCheckpoint(db, id, checkpoint, session, returnValue) {
     return db.put(doc).catch(function (err) {
       if (err.status === 409) {
         // retry; someone is trying to write a checkpoint simultaneously
-        return updateCheckpoint(db, id, checkpoint, returnValue);
+        return updateCheckpoint(db, id, checkpoint, session, returnValue);
       }
       throw err;
     });

--- a/lib/replicate/checkpointer.js
+++ b/lib/replicate/checkpointer.js
@@ -6,6 +6,15 @@ var pouchCollate = require('pouchdb-collate');
 var collate = pouchCollate.collate;
 
 var REPLICATION_ID_VERSION = 2;
+// This is an arbitrary number to limit the
+// amount of replication history we save in the checkpoint.
+// If we save too much, the checkpoing docs will become very big,
+// if we save fewer, we'll run a greater risk of having to
+// read all the changes from 0 when checkpoint PUTs fail
+// CouchDB 2.0 has a more involved history pruning,
+// but let's go for the simple version for now.
+var CHECKPOINT_HISTORY_SIZE = 5;
+var LOWEST_SEQ = 0;
 
 function updateCheckpoint(db, id, checkpoint, session, returnValue) {
   return db.get(id).catch(function (err) {
@@ -38,9 +47,8 @@ function updateCheckpoint(db, id, checkpoint, session, returnValue) {
 
     // Just take the last pieces in history, to
     // avoid really big checkpoint docs.
-    // CouchDB 2.0 has a more involved history pruning,
-    // but let's go for the simple version for now.
-    doc.history = doc.history.slice(0, 5);
+    // see comment on history size above
+    doc.history = doc.history.slice(0, CHECKPOINT_HISTORY_SIZE);
 
     doc.replication_id_version = REPLICATION_ID_VERSION;
 
@@ -113,11 +121,11 @@ Checkpointer.prototype.getCheckpoint = function () {
   var self = this;
   return self.target.get(self.id).then(function (targetDoc) {
     return self.src.get(self.id).then(function (sourceDoc) {
-      // TODO: Discuss the 'return 0's here
-      // can we do something better?
+      // Since we can't migrate an old version doc to a new one
+      // (no session id), we just go with the lowest seq in this case
       if(targetDoc.replication_id_version !==
          sourceDoc.replication_id_version) {
-        return 0;
+        return LOWEST_SEQ;
       }
 
       var version;
@@ -127,24 +135,24 @@ Checkpointer.prototype.getCheckpoint = function () {
         version = "undefined";
       }
 
-      if(comparisons[version]) {
+      if(version in comparisons) {
         return comparisons[version](targetDoc, sourceDoc);
       }
 
-      return 0;
+      return LOWEST_SEQ;
     }, function (err) {
       if (err.status === 404 && targetDoc.last_seq) {
         return self.src.put({
           _id: self.id,
-          last_seq: 0
+          last_seq: LOWEST_SEQ
         }).then(function () {
-          return 0;
+          return LOWEST_SEQ;
         }, function (err) {
           if (err.status === 401) {
             self.readOnlySource = true;
             return targetDoc.last_seq;
           }
-          return 0;
+          return LOWEST_SEQ;
         });
       }
       throw err;
@@ -153,14 +161,12 @@ Checkpointer.prototype.getCheckpoint = function () {
     if (err.status !== 404) {
       throw err;
     }
-    return 0;
+    return LOWEST_SEQ;
   });
 };
 // This checkpoint comparison is ported from CouchDBs source
 // they come from here:
 // https://github.com/apache/couchdb-couch-replicator/blob/master/src/couch_replicator.erl#L863-L906
-
-var LOWEST_SEQ = 0;
 
 function compareReplicationLogs(srcDoc, tgtDoc) {
   if(srcDoc.session_id === tgtDoc.session_id) {

--- a/lib/replicate/checkpointer.js
+++ b/lib/replicate/checkpointer.js
@@ -35,7 +35,7 @@ function updateCheckpoint(db, id, checkpoint, session, returnValue) {
       return;
     }
     // Filter out current entry for this replication
-    doc.history = (doc.history || []).filter(function(item) {
+    doc.history = (doc.history || []).filter(function (item) {
       return item.session_id !== session;
     });
 
@@ -123,19 +123,19 @@ Checkpointer.prototype.getCheckpoint = function () {
     return self.src.get(self.id).then(function (sourceDoc) {
       // Since we can't migrate an old version doc to a new one
       // (no session id), we just go with the lowest seq in this case
-      if(targetDoc.replication_id_version !==
+      if (targetDoc.replication_id_version !==
          sourceDoc.replication_id_version) {
         return LOWEST_SEQ;
       }
 
       var version;
-      if(targetDoc.replication_id_version) {
+      if (targetDoc.replication_id_version) {
         version = targetDoc.replication_id_version.toString();
       } else {
         version = "undefined";
       }
 
-      if(version in comparisons) {
+      if (version in comparisons) {
         return comparisons[version](targetDoc, sourceDoc);
       }
 
@@ -168,8 +168,8 @@ Checkpointer.prototype.getCheckpoint = function () {
 // they come from here:
 // https://github.com/apache/couchdb-couch-replicator/blob/master/src/couch_replicator.erl#L863-L906
 
-function compareReplicationLogs(srcDoc, tgtDoc) {
-  if(srcDoc.session_id === tgtDoc.session_id) {
+function compareReplicationLogs (srcDoc, tgtDoc) {
+  if (srcDoc.session_id === tgtDoc.session_id) {
     return {
       last_seq: srcDoc.last_seq,
       history: srcDoc.history || []
@@ -181,7 +181,7 @@ function compareReplicationLogs(srcDoc, tgtDoc) {
   return compareReplicationHistory(sourceHistory, targetHistory);
 }
 
-function compareReplicationHistory(sourceHistory, targetHistory) {
+function compareReplicationHistory (sourceHistory, targetHistory) {
   // the erlang loop via function arguments is not so easy to repeat in JS
   // therefore, doing this as recursion
   var S = sourceHistory[0];
@@ -189,7 +189,7 @@ function compareReplicationHistory(sourceHistory, targetHistory) {
   var T = targetHistory[0];
   var targetRest = targetHistory.slice(1);
 
-  if(!S || targetHistory.length === 0) {
+  if (!S || targetHistory.length === 0) {
     return {
       last_seq: LOWEST_SEQ,
       history: []
@@ -197,7 +197,7 @@ function compareReplicationHistory(sourceHistory, targetHistory) {
   }
 
   var sourceId = S.session_id;
-  if(hasSessionId(sourceId, targetHistory)) {
+  if (hasSessionId(sourceId, targetHistory)) {
     return {
       last_seq: S.last_seq,
       history: sourceHistory
@@ -205,7 +205,7 @@ function compareReplicationHistory(sourceHistory, targetHistory) {
   }
 
   var targetId = T.session_id;
-  if(hasSessionId(targetId, sourceRest)) {
+  if (hasSessionId(targetId, sourceRest)) {
     return {
       last_seq: T.last_seq,
       history: targetRest
@@ -215,15 +215,15 @@ function compareReplicationHistory(sourceHistory, targetHistory) {
   return compareReplicationHistory(sourceRest, targetRest);
 }
 
-function hasSessionId(sessionId, history) {
+function hasSessionId (sessionId, history) {
   var props = history[0];
   var rest = history.slice(1);
 
-  if(!sessionId || history.length === 0) {
+  if (!sessionId || history.length === 0) {
     return false;
   }
 
-  if(sessionId === props.session_id) {
+  if (sessionId === props.session_id) {
     return true;
   }
 

--- a/lib/replicate/checkpointer.js
+++ b/lib/replicate/checkpointer.js
@@ -107,21 +107,23 @@ Checkpointer.prototype.getCheckpoint = function () {
   var self = this;
   return self.target.get(self.id).then(function (targetDoc) {
     return self.src.get(self.id).then(function (sourceDoc) {
-      debugger;
-      console.log('Got CheckPoints', targetDoc, sourceDoc);
       // TODO: Discuss the 'return 0's here
       // can we do something better?
       if(targetDoc.replication_id_version !== sourceDoc.replication_id_version) {
-        console.log('diff versions');
         return 0;
       }
 
-      if(comparisons[targetDoc.replication_id_version.toString()]) {
-        console.log('chosing comparinson function', targetDoc.replication_id_version.toString());
-        return comparisons[targetDoc.replication_id_version.toString()](targetDoc, sourceDoc);
+      var version;
+      if(targetDoc.replication_id_version) {
+        version = targetDoc.replication_id_version.toString();
+      } else {
+        version = "undefined";
       }
 
-      console.log('same version, no comparison');
+      if(comparisons[version]) {
+        return comparisons[version](targetDoc, sourceDoc);
+      }
+
       return 0;
     }, function (err) {
       console.log('caught err in sourceDoc', err);

--- a/lib/replicate/checkpointer.js
+++ b/lib/replicate/checkpointer.js
@@ -5,7 +5,8 @@ var explain404 = require('./../deps/explain404');
 var pouchCollate = require('pouchdb-collate');
 var collate = pouchCollate.collate;
 
-var REPLICATION_ID_VERSION = 2;
+var CHECKPOINT_VERSION = 1;
+var REPLICATOR = "pouchdb";
 // This is an arbitrary number to limit the
 // amount of replication history we save in the checkpoint.
 // If we save too much, the checkpoing docs will become very big,
@@ -26,7 +27,8 @@ function updateCheckpoint(db, id, checkpoint, session, returnValue) {
         session_id: session,
         _id: id,
         history: [],
-        replication_id_version: REPLICATION_ID_VERSION
+        replicator: REPLICATOR,
+        version: CHECKPOINT_VERSION
       };
     }
     throw err;
@@ -50,7 +52,8 @@ function updateCheckpoint(db, id, checkpoint, session, returnValue) {
     // see comment on history size above
     doc.history = doc.history.slice(0, CHECKPOINT_HISTORY_SIZE);
 
-    doc.replication_id_version = REPLICATION_ID_VERSION;
+    doc.version = CHECKPOINT_VERSION;
+    doc.replicator = REPLICATOR;
 
     doc.session_id = session;
     doc.last_seq = checkpoint;
@@ -111,7 +114,7 @@ var comparisons = {
 
     return 0;
   },
-  "2": function(targetDoc, sourceDoc) {
+  "1": function(targetDoc, sourceDoc) {
     // This is the comparison function ported from CouchDB
     return compareReplicationLogs(sourceDoc, targetDoc).last_seq;
   }
@@ -123,14 +126,14 @@ Checkpointer.prototype.getCheckpoint = function () {
     return self.src.get(self.id).then(function (sourceDoc) {
       // Since we can't migrate an old version doc to a new one
       // (no session id), we just go with the lowest seq in this case
-      if (targetDoc.replication_id_version !==
-         sourceDoc.replication_id_version) {
+      if (targetDoc.version !==
+         sourceDoc.version) {
         return LOWEST_SEQ;
       }
 
       var version;
-      if (targetDoc.replication_id_version) {
-        version = targetDoc.replication_id_version.toString();
+      if (targetDoc.version) {
+        version = targetDoc.version.toString();
       } else {
         version = "undefined";
       }

--- a/lib/replicate/checkpointer.js
+++ b/lib/replicate/checkpointer.js
@@ -5,20 +5,44 @@ var explain404 = require('./../deps/explain404');
 var pouchCollate = require('pouchdb-collate');
 var collate = pouchCollate.collate;
 
-function updateCheckpoint(db, id, checkpoint, returnValue) {
+function updateCheckpoint(db, id, checkpoint, session, returnValue) {
   return db.get(id).catch(function (err) {
     if (err.status === 404) {
       if (db.type() === 'http') {
         explain404('PouchDB is just checking if a remote checkpoint exists.');
       }
-      return {_id: id};
+      return {
+        session_id: session,
+        _id: id,
+        history: [],
+        replication_id_version: 2
+      };
     }
     throw err;
   }).then(function (doc) {
     if (returnValue.cancelled) {
       return;
     }
+    // Filter out current entry for this replication
+    doc.history = (doc.history || []).filter(function(item) {
+      return item.session_id !== session;
+    });
+
+    // Add the latest checkpoint to history
+    doc.history.unshift({
+      last_seq: checkpoint,
+      session_id: session
+    });
+
+    // Just take the last pieces in history, to
+    // avoid really big checkpoint docs.
+    // CouchDB 2.0 has a more involved history pruning,
+    // but let's go for the simple version for now.
+    doc.history = doc.history.slice(0, 5);
+
+    doc.session_id = session;
     doc.last_seq = checkpoint;
+
     return db.put(doc).catch(function (err) {
       if (err.status === 409) {
         // retry; someone is trying to write a checkpoint simultaneously
@@ -36,23 +60,23 @@ function Checkpointer(src, target, id, returnValue) {
   this.returnValue = returnValue;
 }
 
-Checkpointer.prototype.writeCheckpoint = function (checkpoint) {
+Checkpointer.prototype.writeCheckpoint = function (checkpoint, session) {
   var self = this;
-  return this.updateTarget(checkpoint).then(function () {
-    return self.updateSource(checkpoint);
+  return this.updateTarget(checkpoint, session).then(function () {
+    return self.updateSource(checkpoint, session);
   });
 };
 
-Checkpointer.prototype.updateTarget = function (checkpoint) {
-  return updateCheckpoint(this.target, this.id, checkpoint, this.returnValue);
+Checkpointer.prototype.updateTarget = function (checkpoint, session) {
+  return updateCheckpoint(this.target, this.id, checkpoint, session, this.returnValue);
 };
 
-Checkpointer.prototype.updateSource = function (checkpoint) {
+Checkpointer.prototype.updateSource = function (checkpoint, session) {
   var self = this;
   if (this.readOnlySource) {
     return Promise.resolve(true);
   }
-  return updateCheckpoint(this.src, this.id, checkpoint, this.returnValue)
+  return updateCheckpoint(this.src, this.id, checkpoint, session, this.returnValue)
     .catch(function (err) {
       var isForbidden = typeof err.status === 'number' &&
         Math.floor(err.status / 100) === 4;
@@ -64,15 +88,43 @@ Checkpointer.prototype.updateSource = function (checkpoint) {
     });
 };
 
+var comparisons = {
+  "undefined": function(targetDoc, sourceDoc) {
+    // This is the previous comparison function
+    if (collate(targetDoc.last_seq, sourceDoc.last_seq) === 0) {
+      return sourceDoc.last_seq;
+    }
+
+    return 0;
+  },
+  "2": function(targetDoc, sourceDoc) {
+    // This is the comparison function ported from CouchDB
+    return compareReplicationLogs(sourceDoc, targetDoc).last_seq;
+  }
+};
+
 Checkpointer.prototype.getCheckpoint = function () {
   var self = this;
   return self.target.get(self.id).then(function (targetDoc) {
     return self.src.get(self.id).then(function (sourceDoc) {
-      if (collate(targetDoc.last_seq, sourceDoc.last_seq) === 0) {
-        return sourceDoc.last_seq;
+      debugger;
+      console.log('Got CheckPoints', targetDoc, sourceDoc);
+      // TODO: Discuss the 'return 0's here
+      // can we do something better?
+      if(targetDoc.replication_id_version !== sourceDoc.replication_id_version) {
+        console.log('diff versions');
+        return 0;
       }
+
+      if(comparisons[targetDoc.replication_id_version.toString()]) {
+        console.log('chosing comparinson function', targetDoc.replication_id_version.toString());
+        return comparisons[targetDoc.replication_id_version.toString()](targetDoc, sourceDoc);
+      }
+
+      console.log('same version, no comparison');
       return 0;
     }, function (err) {
+      console.log('caught err in sourceDoc', err);
       if (err.status === 404 && targetDoc.last_seq) {
         return self.src.put({
           _id: self.id,
@@ -90,11 +142,79 @@ Checkpointer.prototype.getCheckpoint = function () {
       throw err;
     });
   }).catch(function (err) {
+    console.log('caught err in targetDoc', err);
     if (err.status !== 404) {
       throw err;
     }
     return 0;
   });
 };
+// This checkpoint comparison is ported from CouchDBs source
+// they come from here: https://github.com/apache/couchdb-couch-replicator/blob/master/src/couch_replicator.erl#L863-L906
+
+var LOWEST_SEQ = 0;
+
+function compareReplicationLogs(srcDoc, tgtDoc) {
+  if(srcDoc.session_id === tgtDoc.session_id) {
+    return {
+      last_seq: srcDoc.last_seq,
+      history: srcDoc.history || []
+    };
+  }
+
+  var sourceHistory = srcDoc.history || [];
+  var targetHistory = tgtDoc.history || [];
+  return compareReplicationHistory(sourceHistory, targetHistory);
+}
+
+function compareReplicationHistory(sourceHistory, targetHistory) {
+  // the erlang loop via function arguments is not so easy to repeat in JS
+  // therefore, doing this as recursion
+  var S = sourceHistory[0];
+  var sourceRest = sourceHistory.slice(1);
+  var T = targetHistory[0];
+  var targetRest = targetHistory.slice(1);
+
+  if(!S || targetHistory.length === 0) {
+    return {
+      last_seq: LOWEST_SEQ,
+      history: []
+    };
+  }
+
+  var sourceId = S.session_id;
+  if(hasSessionId(sourceId, targetHistory)) {
+    return {
+      last_seq: S.recorded_seq,
+      history: sourceHistory
+    };
+  }
+
+  var targetId = T.session_id;
+  if(hasSessionId(targetId, sourceRest)) {
+    return {
+      last_seq: T.recorded_seq,
+      history: targetRest
+    };
+  }
+
+  return compareReplicationHistory(sourceRest, targetRest);
+}
+
+function hasSessionId(sessionId, history) {
+  var props = history[0];
+  var rest = history.slice(1);
+
+  if(!sessionId || history.length === 0) {
+    return false;
+  }
+
+  if(sessionId === props.session_id) {
+    return true;
+  }
+
+  return hasSessionId(sessionId, rest);
+}
+
 
 module.exports = Checkpointer;

--- a/lib/replicate/checkpointer.js
+++ b/lib/replicate/checkpointer.js
@@ -72,7 +72,8 @@ Checkpointer.prototype.writeCheckpoint = function (checkpoint, session) {
 };
 
 Checkpointer.prototype.updateTarget = function (checkpoint, session) {
-  return updateCheckpoint(this.target, this.id, checkpoint, session, this.returnValue);
+  return updateCheckpoint(this.target, this.id, checkpoint,
+      session, this.returnValue);
 };
 
 Checkpointer.prototype.updateSource = function (checkpoint, session) {
@@ -80,7 +81,8 @@ Checkpointer.prototype.updateSource = function (checkpoint, session) {
   if (this.readOnlySource) {
     return Promise.resolve(true);
   }
-  return updateCheckpoint(this.src, this.id, checkpoint, session, this.returnValue)
+  return updateCheckpoint(this.src, this.id, checkpoint,
+      session, this.returnValue)
     .catch(function (err) {
       var isForbidden = typeof err.status === 'number' &&
         Math.floor(err.status / 100) === 4;
@@ -113,7 +115,8 @@ Checkpointer.prototype.getCheckpoint = function () {
     return self.src.get(self.id).then(function (sourceDoc) {
       // TODO: Discuss the 'return 0's here
       // can we do something better?
-      if(targetDoc.replication_id_version !== sourceDoc.replication_id_version) {
+      if(targetDoc.replication_id_version !==
+         sourceDoc.replication_id_version) {
         return 0;
       }
 
@@ -154,7 +157,8 @@ Checkpointer.prototype.getCheckpoint = function () {
   });
 };
 // This checkpoint comparison is ported from CouchDBs source
-// they come from here: https://github.com/apache/couchdb-couch-replicator/blob/master/src/couch_replicator.erl#L863-L906
+// they come from here:
+// https://github.com/apache/couchdb-couch-replicator/blob/master/src/couch_replicator.erl#L863-L906
 
 var LOWEST_SEQ = 0;
 

--- a/lib/replicate/checkpointer.js
+++ b/lib/replicate/checkpointer.js
@@ -5,6 +5,8 @@ var explain404 = require('./../deps/explain404');
 var pouchCollate = require('pouchdb-collate');
 var collate = pouchCollate.collate;
 
+var REPLICATION_ID_VERSION = 2;
+
 function updateCheckpoint(db, id, checkpoint, session, returnValue) {
   return db.get(id).catch(function (err) {
     if (err.status === 404) {
@@ -15,7 +17,7 @@ function updateCheckpoint(db, id, checkpoint, session, returnValue) {
         session_id: session,
         _id: id,
         history: [],
-        replication_id_version: 2
+        replication_id_version: REPLICATION_ID_VERSION
       };
     }
     throw err;
@@ -39,6 +41,8 @@ function updateCheckpoint(db, id, checkpoint, session, returnValue) {
     // CouchDB 2.0 has a more involved history pruning,
     // but let's go for the simple version for now.
     doc.history = doc.history.slice(0, 5);
+
+    doc.replication_id_version = REPLICATION_ID_VERSION;
 
     doc.session_id = session;
     doc.last_seq = checkpoint;

--- a/lib/replicate/checkpointer.js
+++ b/lib/replicate/checkpointer.js
@@ -130,7 +130,6 @@ Checkpointer.prototype.getCheckpoint = function () {
 
       return 0;
     }, function (err) {
-      console.log('caught err in sourceDoc', err);
       if (err.status === 404 && targetDoc.last_seq) {
         return self.src.put({
           _id: self.id,
@@ -148,7 +147,6 @@ Checkpointer.prototype.getCheckpoint = function () {
       throw err;
     });
   }).catch(function (err) {
-    console.log('caught err in targetDoc', err);
     if (err.status !== 404) {
       throw err;
     }
@@ -191,7 +189,7 @@ function compareReplicationHistory(sourceHistory, targetHistory) {
   var sourceId = S.session_id;
   if(hasSessionId(sourceId, targetHistory)) {
     return {
-      last_seq: S.recorded_seq,
+      last_seq: S.last_seq,
       history: sourceHistory
     };
   }
@@ -199,7 +197,7 @@ function compareReplicationHistory(sourceHistory, targetHistory) {
   var targetId = T.session_id;
   if(hasSessionId(targetId, sourceRest)) {
     return {
-      last_seq: T.recorded_seq,
+      last_seq: T.last_seq,
       history: targetRest
     };
   }

--- a/lib/replicate/replicate.js
+++ b/lib/replicate/replicate.js
@@ -30,6 +30,8 @@ function replicate(src, target, opts, returnValue, result) {
   var checkpointer;
   var allErrors = [];
   var changedDocs = [];
+  // Like couchdb, every replication gets a unique session id
+  var session = utils.uuid();
 
   result = result || {
     ok: true,
@@ -102,7 +104,7 @@ function replicate(src, target, opts, returnValue, result) {
 
   function finishBatch() {
     writingCheckpoint = true;
-    return checkpointer.writeCheckpoint(currentBatch.seq).then(function () {
+    return checkpointer.writeCheckpoint(currentBatch.seq, session).then(function () {
       writingCheckpoint = false;
       if (state.cancelled) {
         completeReplication();
@@ -406,7 +408,7 @@ function replicate(src, target, opts, returnValue, result) {
   } else {
     initCheckpointer().then(function () {
       writingCheckpoint = true;
-      return checkpointer.writeCheckpoint(opts.since);
+      return checkpointer.writeCheckpoint(opts.since, session);
     }).then(function () {
       writingCheckpoint = false;
       if (state.cancelled) {

--- a/lib/replicate/replicate.js
+++ b/lib/replicate/replicate.js
@@ -104,7 +104,8 @@ function replicate(src, target, opts, returnValue, result) {
 
   function finishBatch() {
     writingCheckpoint = true;
-    return checkpointer.writeCheckpoint(currentBatch.seq, session).then(function () {
+    return checkpointer.writeCheckpoint(currentBatch.seq,
+        session).then(function () {
       writingCheckpoint = false;
       if (state.cancelled) {
         completeReplication();

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -2745,6 +2745,7 @@ adapters.forEach(function (adapters) {
           }
 
           if(!called) {
+            mismatch = false;
             done();
             called = true;
           }

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -2553,7 +2553,7 @@ adapters.forEach(function (adapters) {
       source.changes = function (opts) {
 
         if (mismatch) {
-          opts.since.should.be.at.least(1);
+          opts.since.should.not.equal(0);
         }
         return changes.apply(source, arguments);
       };
@@ -2612,7 +2612,7 @@ adapters.forEach(function (adapters) {
           checkpoint = doc._id;
         }
 
-        if (!writeStrange || doc.last_seq !== 1) {
+        if (!writeStrange || (doc.last_seq !== 1 && doc.last_seq[0] !== 1)) {
           return putte.apply(this, arguments);
         }
 
@@ -2686,7 +2686,7 @@ adapters.forEach(function (adapters) {
           checkpoint = doc._id;
         }
 
-        if (!writeStrange || doc.last_seq !== 1) {
+        if (!writeStrange || (doc.last_seq !== 1 && doc.last_seq[0] !== 1)) {
           return putte.apply(this, arguments);
         }
 
@@ -2711,7 +2711,7 @@ adapters.forEach(function (adapters) {
         if(mismatch) {
           // If we resolve to 0, the checkpoint resolver has not
           // been going through the sessions
-          opts.since.should.be.at.least(1);
+          opts.since.should.not.equal(0);
 
           mismatch = false;
         }
@@ -2770,7 +2770,7 @@ adapters.forEach(function (adapters) {
         var args = [].slice.call(arguments, 0);
 
         // Write an old-style checkpoint on the first replication:
-        if (writeStrange && doc.last_seq === 1) {
+        if (writeStrange && (doc.last_seq === 1 || doc.last_seq[0] === 1)) {
           var newDoc = {
             _id: doc._id,
             last_seq: doc.last_seq
@@ -2797,7 +2797,7 @@ adapters.forEach(function (adapters) {
         if (secondRound) {
           // Test 1: Check that we read the old style local doc
           // and didn't start from 0
-          opts.since.should.be.at.least(1);
+          opts.since.should.not.equal(0);
         }
         return changes.apply(source, arguments);
       };
@@ -2818,7 +2818,6 @@ adapters.forEach(function (adapters) {
          ]);
        }).then(function (res) {
         // [0] = target checkpoint, [1] = source checkpoint
-        res[0].last_seq.should.equal(res[1].last_seq);
         should.not.exist(res[0].session_id);
         should.not.exist(res[1].session_id);
 

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -2611,7 +2611,8 @@ adapters.forEach(function (adapters) {
             _id: res._id,
             _rev: res._rev,
             last_seq: 1,
-            replication_id_version: 2,
+            version: 1,
+            replicator: "pouchdb",
             session_id: "aaaa11111aaaaaaaa",
             history: [{
               session_id:  "aaaa11111aaaaaaaa",
@@ -2695,7 +2696,8 @@ adapters.forEach(function (adapters) {
             _id: res._id,
             _rev: res._rev,
             last_seq: 2222,
-            replication_id_version: 2,
+            version: 1,
+            replicator: "pouchdb",
             session_id: "weirdo_checkpoint",
             history: [{
               session_id: "weirdo_checkpoint",
@@ -2809,9 +2811,10 @@ adapters.forEach(function (adapters) {
          should.exist(checkpointId);
          return remote.get(checkpointId);
        }).then(function (res) {
-         should.exist(res.replication_id_version);
+         should.exist(res.version);
+         should.exist(res.replicator);
          should.exist(res.session_id);
-         res.replication_id_version.should.equal(2);
+         res.version.should.equal(1);
          res.session_id.should.be.a('string');
        });
     });

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -2758,7 +2758,7 @@ adapters.forEach(function (adapters) {
            if(callback) {
              callback.call(this, null, checkPoint);
            }
-           return Promise.resolve(checkPoint);
+           return PouchDB.utils.Promise.resolve(checkPoint);
          }
 
          if(this === remote) {

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -2532,7 +2532,7 @@ adapters.forEach(function (adapters) {
       remote.get = function(id, callback) {
         if(mismatch && /_local/.test(id)) {
           var cb;
-          var pr = new Promise(function(resolve, reject) {
+          var pr = new PouchDB.utils.Promise(function(resolve, reject) {
             cb = function(err, res) {
               if(err) {
                 return reject(err);
@@ -2596,7 +2596,7 @@ adapters.forEach(function (adapters) {
       remote.get = function(id, callback) {
         if(mismatch && /_local/.test(id)) {
           var cb;
-          var pr = new Promise(function(resolve, reject) {
+          var pr = new PouchDB.utils.Promise(function(resolve, reject) {
             cb = function(err, res) {
               if(err) {
                 return reject(err);
@@ -2670,7 +2670,7 @@ adapters.forEach(function (adapters) {
       remote.get = function(id, callback) {
         if(mismatch && /_local/.test(id)) {
           var cb;
-          var pr = new Promise(function(resolve, reject) {
+          var pr = new PouchDB.utils.Promise(function(resolve, reject) {
             cb = function(err, res) {
               if(err) {
                 return reject(err);
@@ -2746,7 +2746,7 @@ adapters.forEach(function (adapters) {
        var oldstyle = true;
        var checkpointId;
 
-       function getChecker (id, callback) {
+       var getChecker = function(id, callback) {
          if(oldstyle && /^_local/.test(id)) {
            checkpointId = id;
 
@@ -2765,7 +2765,7 @@ adapters.forEach(function (adapters) {
            return remoteGet.apply(this, arguments);
          }
          return dbGet.apply(this, arguments);
-       }
+       };
 
        var db = new PouchDB(dbs.name);
        var remote = new PouchDB(dbs.remote);


### PR DESCRIPTION
Sending the PR for review, I'll be happy to squash commits but i expect some comments on this first :)

This PR implements CouchDB-like checkpoints, to avoid losing the entire replication history when 2 checkpoints mismatch. Every replication writes a `session_id` that is compared, and if they match, the last_seq from the source db checkpoint is used. If the session_id does not match, the checkpoint docs has a `history` array, where session_id from previous replications are compared to find an older common point. Fir doc size reasons, I did not include all the keys that CouchDB has, and the history is limited to 5 items. 

Comparison:
```
// Checkpoint format used in this PR:
{
     "_id": "_local/edd1d4be175dd4c88b6ec1f07731d98e",
     "_rev": "0-6",
     "session_id": "6030857ab3a97de2a59238c2943da145",
     "last_seq": 8308,
     "replication_id_version": 2,
     "history": [{
         "session_id": "6030857ab3a97de2a59238c2943da145",
         "last_seq": 8308
     }]
}

// CouchDB checkpoint style:
{
     "_id": "_local/edd1d4be175dd4c88b6ec1f07731d98e",
     "_rev": "0-6",
     "session_id": "6030857ab3a97de2a59238c2943da145",
     "source_last_seq": 8308,
     "replication_id_version": 3,
     "history": [{
         "session_id": "6030857ab3a97de2a59238c2943da145",
         "start_time": "Tue, 30 Jun 2015 14:27:08 GMT",
         "end_time": "Tue, 30 Jun 2015 14:27:28 GMT",
         "start_last_seq": 2304,
         "end_last_seq": 8308,
         "recorded_seq": 8308,
         "missing_checked": 6004,
         "missing_found": 6004,
         "docs_read": 6004,
         "docs_written": 0,
         "doc_write_failures": 6004
     }],
     "_revisions": {
         "start": 0,
         "ids": ["6"]
     }
 } 
// old PouchDB checkpoints look like this:
{
     "_id": "_local/edd1d4be175dd4c88b6ec1f07731d98e",
     "_rev": "0-6",
     "last_seq": 8308
}
```

This means that new PouchDB checkpoints are backwards compatible, which they wouldn't be if we used the CouchDB format. 

I've been testing this in the app where i found the original issue, and it has been solving the problem well there. 

Looking forward to any feedback on this!

Issue #3999 