### PR TITLE
(nolanlawson/pouchdb-load#29) - export generateReplicationId

### DIFF
--- a/extras/generateReplicationId.js
+++ b/extras/generateReplicationId.js
@@ -1,0 +1,4 @@
+'use strict';
+
+// allow external plugins to require('pouchdb/extras/genReplicationId')
+module.exports = require('../lib/replicate/generateReplicationId');

--- a/lib/replicate/generateReplicationId.js
+++ b/lib/replicate/generateReplicationId.js
@@ -10,9 +10,9 @@ function sortObjectPropertiesByKey(queryParams) {
   }, {});
 }
 
-// TODO: check CouchDB's replication id generation
-// Generate a unique id particular to this replication
-function genReplicationId(src, target, opts) {
+// Generate a unique id particular to this replication.
+// Not guaranteed to align perfectly with CouchDB's rep ids.
+function generateReplicationId(src, target, opts) {
   var docIds = opts.doc_ids ? opts.doc_ids.sort(collate) : '';
   var filterFun = opts.filter ? opts.filter.toString() : '';
   var queryParams = '';
@@ -41,4 +41,4 @@ function genReplicationId(src, target, opts) {
   });
 }
 
-module.exports = genReplicationId;
+module.exports = generateReplicationId;

--- a/lib/replicate/replicate.js
+++ b/lib/replicate/replicate.js
@@ -3,7 +3,7 @@
 var utils = require('./../utils');
 var Checkpointer = require('./checkpointer');
 var backOff = require('./backoff');
-var genReplicationId = require('./genReplicationId');
+var generateReplicationId = require('./generateReplicationId');
 var getDocs = require('./getDocs');
 
 function replicate(src, target, opts, returnValue, result) {
@@ -49,7 +49,7 @@ function replicate(src, target, opts, returnValue, result) {
     if (checkpointer) {
       return utils.Promise.resolve();
     }
-    return genReplicationId(src, target, opts).then(function (res) {
+    return generateReplicationId(src, target, opts).then(function (res) {
       repId = res;
       checkpointer = new Checkpointer(src, target, repId, state);
     });

--- a/tests/unit/test.extras.js
+++ b/tests/unit/test.extras.js
@@ -25,4 +25,11 @@ describe('test.extras.js', function () {
     promise.name.should.equal('Promise');
   });
 
+  it('extras/generateReplicationId should exist', function () {
+    var genReplicationId = require('../../extras/generateReplicationId');
+    should.exist(genReplicationId);
+    genReplicationId.should.be.a('function');
+    genReplicationId.name.should.equal('generateReplicationId');
+  });
+
 });

--- a/tests/unit/test.gen-replication-id.js
+++ b/tests/unit/test.gen-replication-id.js
@@ -4,7 +4,7 @@ var memdown = require('memdown');
 var PouchDB = require('../../lib/index');
 var sourceDb = new PouchDB({name: 'local_db', db: memdown});
 var targetDb = new PouchDB({name: 'target_db', db: memdown});
-var genReplicationId = require('../../lib/replicate/genReplicationId');
+var genReplicationId = require('../../lib/replicate/generateReplicationId');
 
 require('chai').should();
 


### PR DESCRIPTION
Renamed from `genReplicationId` because if we're going to
export it, we should use the full name.