### PR TITLE
localstorage availability in safari private

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -114,8 +114,8 @@ exports.hasLocalStorage = function () {
     return false;
   }
   try {
-    localStorage.setItem('pouchdblstest', 1);
-    return !!localStorage.getItem('pouchdblstest');
+    localStorage.setItem('_pouch_check_localstorage', 1);
+    return !!localStorage.getItem('_pouch_check_localstorage');
   } catch (e) {
     return false;
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -114,7 +114,8 @@ exports.hasLocalStorage = function () {
     return false;
   }
   try {
-    return localStorage;
+    localStorage.setItem('pouchdblstest', 1)
+    return localStorage.getItem('pouchdblstest') ? true : false;
   } catch (e) {
     return false;
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -114,8 +114,8 @@ exports.hasLocalStorage = function () {
     return false;
   }
   try {
-    localStorage.setItem('pouchdblstest', 1)
-    return localStorage.getItem('pouchdblstest') ? true : false;
+    localStorage.setItem('pouchdblstest', 1);
+    return !!localStorage.getItem('pouchdblstest');
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
Safari private mode still exposes the localStorage object but sets the DOM quota to 0, making it non-functional.

I'd like to still be able to use the pouchdb memory adapter in safari private mode, but this test seems to make it fail, since it attempts to use localStorage thinking it will be functional.