### PR TITLE
(#4701) - extract out browser-only code

### DIFF
--- a/lib/adapters-browser.js
+++ b/lib/adapters-browser.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  idb: require('./adapters/idb'),
+  websql: require('./adapters/websql')
+};

--- a/lib/adapters.js
+++ b/lib/adapters.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  leveldb: require('./adapters/leveldb')
+};

--- a/lib/deps/binary/base64StringToBlobOrBuffer-browser.js
+++ b/lib/deps/binary/base64StringToBlobOrBuffer-browser.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var atob = require('./base64').atob;
+var binaryStringToBlobOrBuffer = require('./binaryStringToBlobOrBuffer');
+
+module.exports = function (b64, type) {
+  return binaryStringToBlobOrBuffer(atob(b64), type);
+};

--- a/lib/deps/binary/base64StringToBlobOrBuffer.js
+++ b/lib/deps/binary/base64StringToBlobOrBuffer.js
@@ -1,16 +1,7 @@
 'use strict';
 
-var isBrowser = typeof process === 'undefined' || process.browser;
-var atob = require('./base64').atob;
-var binaryStringToBlobOrBuffer = require('./binaryStringToBlobOrBuffer');
 var typedBuffer = require('./typedBuffer');
 
-if (isBrowser) {
-  module.exports = function (b64, type) {
-    return binaryStringToBlobOrBuffer(atob(b64), type);
-  };
-} else {
-  module.exports = function (b64, type) {
-    return typedBuffer(b64, 'base64', type);
-  };
-}
+module.exports = function (b64, type) {
+  return typedBuffer(b64, 'base64', type);
+};

--- a/lib/deps/binary/binaryStringToBlobOrBuffer-browser.js
+++ b/lib/deps/binary/binaryStringToBlobOrBuffer-browser.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var createBlob = require('./blob');
+var binaryStringToArrayBuffer = require('./binaryStringToArrayBuffer');
+
+module.exports = function (binString, type) {
+  return createBlob([binaryStringToArrayBuffer(binString)], {type: type});
+};

--- a/lib/deps/binary/binaryStringToBlobOrBuffer.js
+++ b/lib/deps/binary/binaryStringToBlobOrBuffer.js
@@ -1,17 +1,7 @@
 'use strict';
 
-var isBrowser = typeof process === 'undefined' || process.browser;
 var typedBuffer = require('./typedBuffer');
 
-var createBlob = require('./blob');
-var binaryStringToArrayBuffer = require('./binaryStringToArrayBuffer');
-
-if (isBrowser) {
-  module.exports = function (binString, type) {
-    return createBlob([binaryStringToArrayBuffer(binString)], {type: type});
-  };
-} else {
-  module.exports = function (binString, type) {
-    return typedBuffer(binString, 'binary', type);
-  };
-}
+module.exports = function (binString, type) {
+  return typedBuffer(binString, 'binary', type);
+};

--- a/lib/deps/binary/buffer.js
+++ b/lib/deps/binary/buffer.js
@@ -1,2 +1,2 @@
-//this soley exists so we can exclude it in browserify
+//this solely exists so we can exclude it in browserify
 module.exports = Buffer;

--- a/lib/deps/md5-browser.js
+++ b/lib/deps/md5-browser.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var toPromise = require('./toPromise');
+var base64 = require('./binary/base64');
+var Md5 = require('spark-md5');
+var setImmediateShim = global.setImmediate || global.setTimeout;
+var MD5_CHUNK_SIZE = 32768;
+
+// convert a 64-bit int to a binary string
+function intToString(int) {
+  return String.fromCharCode(int & 0xff) +
+    String.fromCharCode((int >>> 8) & 0xff) +
+    String.fromCharCode((int >>> 16) & 0xff) +
+    String.fromCharCode((int >>> 24) & 0xff);
+}
+
+// convert an array of 64-bit ints into
+// a base64-encoded string
+function rawToBase64(raw) {
+  var res = '';
+  for (var i = 0, len = raw.length; i < len; i++) {
+    res += intToString(raw[i]);
+  }
+  return base64.btoa(res);
+}
+
+function appendBuffer(buffer, data, start, end) {
+  if (start > 0 || end < data.byteLength) {
+    // only create a subarray if we really need to
+    data = new Uint8Array(data, start,
+      Math.min(end, data.byteLength) - start);
+  }
+  buffer.append(data);
+}
+
+function appendString(buffer, data, start, end) {
+  if (start > 0 || end < data.length) {
+    // only create a substring if we really need to
+    data = data.substring(start, end);
+  }
+  buffer.appendBinary(data);
+}
+
+module.exports = toPromise(function (data, callback) {
+  var inputIsString = typeof data === 'string';
+  var len = inputIsString ? data.length : data.byteLength;
+  var chunkSize = Math.min(MD5_CHUNK_SIZE, len);
+  var chunks = Math.ceil(len / chunkSize);
+  var currentChunk = 0;
+  var buffer = inputIsString ? new Md5() : new Md5.ArrayBuffer();
+
+  var append = inputIsString ? appendString : appendBuffer;
+
+  function loadNextChunk() {
+    var start = currentChunk * chunkSize;
+    var end = start + chunkSize;
+    currentChunk++;
+    if (currentChunk < chunks) {
+      append(buffer, data, start, end);
+      setImmediateShim(loadNextChunk);
+    } else {
+      append(buffer, data, start, end);
+      var raw = buffer.end(true);
+      var base64 = rawToBase64(raw);
+      callback(null, base64);
+      buffer.destroy();
+    }
+  }
+  loadNextChunk();
+});

--- a/lib/deps/md5.js
+++ b/lib/deps/md5.js
@@ -1,76 +1,9 @@
 'use strict';
 
 var toPromise = require('./toPromise');
-var base64 = require('./binary/base64');
 var crypto = require('crypto');
-var Md5 = require('spark-md5');
-var setImmediateShim = global.setImmediate || global.setTimeout;
-var MD5_CHUNK_SIZE = 32768;
-
-// convert a 64-bit int to a binary string
-function intToString(int) {
-  return String.fromCharCode(int & 0xff) +
-    String.fromCharCode((int >>> 8) & 0xff) +
-    String.fromCharCode((int >>> 16) & 0xff) +
-    String.fromCharCode((int >>> 24) & 0xff);
-}
-
-// convert an array of 64-bit ints into
-// a base64-encoded string
-function rawToBase64(raw) {
-  var res = '';
-  for (var i = 0, len = raw.length; i < len; i++) {
-    res += intToString(raw[i]);
-  }
-  return base64.btoa(res);
-}
-
-function appendBuffer(buffer, data, start, end) {
-  if (start > 0 || end < data.byteLength) {
-    // only create a subarray if we really need to
-    data = new Uint8Array(data, start,
-      Math.min(end, data.byteLength) - start);
-  }
-  buffer.append(data);
-}
-
-function appendString(buffer, data, start, end) {
-  if (start > 0 || end < data.length) {
-    // only create a substring if we really need to
-    data = data.substring(start, end);
-  }
-  buffer.appendBinary(data);
-}
 
 module.exports = toPromise(function (data, callback) {
-  if (!process.browser) {
-    var base64 = crypto.createHash('md5').update(data).digest('base64');
-    callback(null, base64);
-    return;
-  }
-  var inputIsString = typeof data === 'string';
-  var len = inputIsString ? data.length : data.byteLength;
-  var chunkSize = Math.min(MD5_CHUNK_SIZE, len);
-  var chunks = Math.ceil(len / chunkSize);
-  var currentChunk = 0;
-  var buffer = inputIsString ? new Md5() : new Md5.ArrayBuffer();
-
-  var append = inputIsString ? appendString : appendBuffer;
-
-  function loadNextChunk() {
-    var start = currentChunk * chunkSize;
-    var end = start + chunkSize;
-    currentChunk++;
-    if (currentChunk < chunks) {
-      append(buffer, data, start, end);
-      setImmediateShim(loadNextChunk);
-    } else {
-      append(buffer, data, start, end);
-      var raw = buffer.end(true);
-      var base64 = rawToBase64(raw);
-      callback(null, base64);
-      buffer.destroy();
-    }
-  }
-  loadNextChunk();
+  var base64 = crypto.createHash('md5').update(data).digest('base64');
+  callback(null, base64);
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,11 +14,10 @@ var httpAdapter = require('./adapters/http');
 PouchDB.adapter('http', httpAdapter);
 PouchDB.adapter('https', httpAdapter);
 
-PouchDB.adapter('idb', require('./adapters/idb'), true);
-PouchDB.adapter('websql', require('./adapters/websql'), true);
 PouchDB.plugin(require('./mapreduce'));
 
-if (!process.browser) {
-  var ldbAdapter = require('./adapters/leveldb');
-  PouchDB.adapter('leveldb', ldbAdapter, true);
-}
+var adapters = require('./adapters');
+
+Object.keys(adapters).forEach(function (adapterName) {
+  PouchDB.adapter(adapterName, adapters[adapterName], true);
+});

--- a/lib/mapreduce/md5-browser.js
+++ b/lib/mapreduce/md5-browser.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var Md5 = require('spark-md5');
+
+module.exports = function (string) {
+  return Md5.hash(string);
+};

--- a/lib/mapreduce/md5.js
+++ b/lib/mapreduce/md5.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var crypto = require('crypto');
+
+module.exports = function (string) {
+  return crypto.createHash('md5').update(string).digest('hex');
+};

--- a/lib/mapreduce/utils.js
+++ b/lib/mapreduce/utils.js
@@ -93,14 +93,4 @@ exports.uniq = function (arr) {
   return output;
 };
 
-var crypto = require('crypto');
-var Md5 = require('spark-md5');
-
-exports.MD5 = function (string) {
-  /* istanbul ignore else */
-  if (!process.browser) {
-    return crypto.createHash('md5').update(string).digest('hex');
-  } else {
-    return Md5.hash(string);
-  }
-};
+exports.MD5 = require('./md5');

--- a/package.json
+++ b/package.json
@@ -114,6 +114,11 @@
     "./lib/adapters/preferredAdapters.js": "./lib/adapters/preferredAdapters-browser.js",
     "./lib/deps/binary/buffer.js": "./lib/deps/binary/buffer-browser.js",
     "./lib/deps/migrate.js": "./lib/deps/migrate-browser.js",
+    "./lib/adapters.js": "./lib/adapters-browser.js",
+    "./lib/deps/binary/base64StringToBlobOrBuffer.js": "./lib/deps/binary/base64StringToBlobOrBuffer-browser.js",
+    "./lib/deps/binary/binaryStringToBlobOrBuffer.js": "./lib/deps/binary/binaryStringToBlobOrBuffer-browser.js",
+    "./lib/mapreduce/md5.js": "./lib/mapreduce/md5-browser.js",
+    "./lib/deps/md5.js": "./lib/deps/md5-browser.js",
     "fs": false,
     "leveldown": false
   }


### PR DESCRIPTION
This improves our code coverage from 65.4% (lines) to 86.91% (lines).

The basic idea is to remove places where we use `if (process.browser)` and instead rely on Browserify switches in package.json. This has a few benefits:

1) Smaller bundle size when browserifying, since we don't ship any code that's supposed to run in Node
2) Conversely, Istanbul auto-ignores browser-only modules like `idb` and `websql`
3) If somebody messes this up, we'll know immediately because browserify will flat-out fail if it can't find a file

Downsides:

1) It's kind of ugly. I can't think of a better convention than `file.js` and `file-browser.js`.
2) It's arguably harder to read than `if (process.browser)`

I think this is the way to go to reach 100% code coverage, but I'm only doing part of the work and then opening a PR so I can get feedback.