### PR TITLE
(#4071) - more coverage fixes

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -37,6 +37,7 @@
     "indexedDB",
     "IDBKeyRange",
     "openDatabase",
-    "sqlitePlugin"
+    "sqlitePlugin",
+    "chrome"
   ]
 }

--- a/bin/test-node.sh
+++ b/bin/test-node.sh
@@ -20,6 +20,10 @@ fi
 if [ $TYPE = "mapreduce" ]; then
     TESTS_PATH="tests/mapreduce/test.*.js"
 fi
+if [ $COVERAGE ]; then
+    # run all tests when testing for coverage
+    TESTS_PATH="tests/{unit,integration,mapreduce}/test*.js"
+fi
 
 
 if [ $PERF ]; then

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -608,6 +608,7 @@ AbstractPouchDB.prototype.get =
     } else {
       if (doc._attachments) {
         for (var key in doc._attachments) {
+          /* istanbul ignore else */
           if (doc._attachments.hasOwnProperty(key)) {
             doc._attachments[key].stub = true;
           }

--- a/lib/adapters/idb/blobSupport.js
+++ b/lib/adapters/idb/blobSupport.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('../../utils');
+var createBlob = require('../../deps/binary/blob');
 
 var idbConstants = require('./constants');
 var DETECT_BLOB_SUPPORT_STORE = idbConstants.DETECT_BLOB_SUPPORT_STORE;
@@ -22,7 +23,7 @@ var DETECT_BLOB_SUPPORT_STORE = idbConstants.DETECT_BLOB_SUPPORT_STORE;
 //
 function checkBlobSupport(txn, idb) {
   return new utils.Promise(function (resolve, reject) {
-    var blob = utils.createBlob([''], {type: 'image/png'});
+    var blob = createBlob([''], {type: 'image/png'});
     txn.objectStore(DETECT_BLOB_SUPPORT_STORE).put(blob, 'key');
     txn.oncomplete = function () {
       // have to do it in a separate transaction, else the correct

--- a/lib/adapters/idb/index.js
+++ b/lib/adapters/idb/index.js
@@ -10,6 +10,7 @@ var idbConstants = require('./constants');
 var idbBulkDocs = require('./bulkDocs');
 var idbAllDocs = require('./allDocs');
 var checkBlobSupport = require('./blobSupport');
+var hasLocalStorage = require('../../deps/env/hasLocalStorage');
 
 var ADAPTER_VERSION = idbConstants.ADAPTER_VERSION;
 var ATTACH_AND_SEQ_STORE = idbConstants.ATTACH_AND_SEQ_STORE;
@@ -774,7 +775,7 @@ function init(api, opts, callback) {
       if (IdbPouch.openReqList[dbName]) {
         IdbPouch.openReqList[dbName] = null;
       }
-      if (utils.hasLocalStorage() && (dbName in localStorage)) {
+      if (hasLocalStorage() && (dbName in localStorage)) {
         delete localStorage[dbName];
       }
       callback(null, { 'ok': true });

--- a/lib/adapters/idb/utils.js
+++ b/lib/adapters/idb/utils.js
@@ -7,6 +7,7 @@ var btoa = base64.btoa;
 var constants = require('./constants');
 var readAsBinaryString = require('../../deps/binary/readAsBinaryString');
 var b64StringToBlob = require('../../deps/binary/base64StringToBlobOrBuffer');
+var createBlob = require('../../deps/binary/blob');
 
 function tryCode(fun, that, args) {
   try {
@@ -78,7 +79,7 @@ exports.decodeDoc = function (doc) {
   if (!doc) {
     return doc;
   }
-  var idx = utils.lastIndexOf(doc._doc_id_rev, ':');
+  var idx = doc._doc_id_rev.lastIndexOf(':');
   doc._id = doc._doc_id_rev.substring(0, idx - 1);
   doc._rev = doc._doc_id_rev.substring(idx + 1);
   delete doc._doc_id_rev;
@@ -91,7 +92,7 @@ exports.decodeDoc = function (doc) {
 exports.readBlobData = function (body, type, asBlob, callback) {
   if (asBlob) {
     if (!body) {
-      callback(utils.createBlob([''], {type: type}));
+      callback(createBlob([''], {type: type}));
     } else if (typeof body !== 'string') { // we have blob support
       callback(body);
     } else { // no blob support

--- a/lib/adapters/leveldb/transaction.js
+++ b/lib/adapters/leveldb/transaction.js
@@ -37,6 +37,7 @@ LevelTransaction.prototype.get = function (store, key, callback) {
   }
   store.get(key, function (err, res) {
     if (err) {
+      /* istanbul ignore else */
       if (err.name === 'NotFoundError') {
         cache.set(key, null);
       }

--- a/lib/adapters/websql/index.js
+++ b/lib/adapters/websql/index.js
@@ -7,6 +7,7 @@ var isLocalId = require('../../deps/docs/isLocalId');
 var errors = require('../../deps/errors');
 var parseHexString = require('../../deps/parseHex');
 var binStringToBlob = require('../../deps/binary/binaryStringToBlobOrBuffer');
+var hasLocalStorage = require('../../deps/env/hasLocalStorage');
 
 var websqlConstants = require('./constants');
 var websqlUtils = require('./utils');
@@ -120,7 +121,7 @@ function WebSqlPouch(opts, callback) {
 
   function dbCreated() {
     // note the db name in case the browser upgrades to idb
-    if (utils.hasLocalStorage()) {
+    if (hasLocalStorage()) {
       window.localStorage['_pouch__websqldb_' + api._name] = true;
     }
     callback(null, api);
@@ -994,7 +995,7 @@ function WebSqlPouch(opts, callback) {
         tx.executeSql('DROP TABLE IF EXISTS ' + store, []);
       });
     }, unknownError(callback), function () {
-      if (utils.hasLocalStorage()) {
+      if (hasLocalStorage()) {
         delete window.localStorage['_pouch__websqldb_' + api._name];
         delete window.localStorage[api._name];
       }

--- a/lib/changesHandler.js
+++ b/lib/changesHandler.js
@@ -1,0 +1,106 @@
+'use strict';
+
+var EventEmitter = require('events').EventEmitter;
+var inherits = require('inherits');
+var isChromeApp = require('./deps/env/isChromeApp');
+var hasLocalStorage = require('./deps/env/hasLocalStorage');
+var pick = require('./deps/pick');
+var call = require('./deps/call');
+
+inherits(Changes, EventEmitter);
+
+/* istanbul ignore next */
+function attachBrowserEvents(self) {
+  if (isChromeApp()) {
+    chrome.storage.onChanged.addListener(function (e) {
+      // make sure it's event addressed to us
+      if (e.db_name != null) {
+        //object only has oldValue, newValue members
+        self.emit(e.dbName.newValue);
+      }
+    });
+  } else if (hasLocalStorage()) {
+    if (typeof addEventListener !== 'undefined') {
+      addEventListener("storage", function (e) {
+        self.emit(e.key);
+      });
+    } else { // old IE
+      window.attachEvent("storage", function (e) {
+        self.emit(e.key);
+      });
+    }
+  }
+}
+
+function Changes() {
+  EventEmitter.call(this);
+  this._listeners = {};
+
+  attachBrowserEvents(this);
+}
+Changes.prototype.addListener = function (dbName, id, db, opts) {
+  if (this._listeners[id]) {
+    return;
+  }
+  var self = this;
+  var inprogress = false;
+  function eventFunction() {
+    if (!self._listeners[id]) {
+      return;
+    }
+    if (inprogress) {
+      inprogress = 'waiting';
+      return;
+    }
+    inprogress = true;
+    var changesOpts = pick(opts, [
+      'style', 'include_docs', 'attachments', 'conflicts', 'filter',
+      'doc_ids', 'view', 'since', 'query_params', 'binary'
+    ]);
+
+    db.changes(changesOpts).on('change', function (c) {
+      if (c.seq > opts.since && !opts.cancelled) {
+        opts.since = c.seq;
+        call(opts.onChange, c);
+      }
+    }).on('complete', function () {
+      if (inprogress === 'waiting') {
+        setTimeout(function(){
+          eventFunction();
+        },0);
+      }
+      inprogress = false;
+    }).on('error', function () {
+      inprogress = false;
+    });
+  }
+  this._listeners[id] = eventFunction;
+  this.on(dbName, eventFunction);
+};
+
+Changes.prototype.removeListener = function (dbName, id) {
+  if (!(id in this._listeners)) {
+    return;
+  }
+  EventEmitter.prototype.removeListener.call(this, dbName,
+    this._listeners[id]);
+};
+
+
+/* istanbul ignore next */
+Changes.prototype.notifyLocalWindows = function (dbName) {
+  //do a useless change on a storage thing
+  //in order to get other windows's listeners to activate
+  if (isChromeApp()) {
+    chrome.storage.local.set({dbName: dbName});
+  } else if (hasLocalStorage()) {
+    localStorage[dbName] = (localStorage[dbName] === "a") ? "b" : "a";
+  }
+};
+
+Changes.prototype.notify = function (dbName) {
+  this.emit(dbName);
+  this.notifyLocalWindows(dbName);
+};
+
+module.exports = Changes;

--- a/lib/deps/binary/base64.js
+++ b/lib/deps/binary/base64.js
@@ -2,6 +2,7 @@
 
 var buffer = require('./buffer');
 
+/* istanbul ignore if */
 if (typeof atob === 'function') {
   exports.atob = function (str) {
     /* global atob */
@@ -19,6 +20,7 @@ if (typeof atob === 'function') {
   };
 }
 
+/* istanbul ignore if */
 if (typeof btoa === 'function') {
   exports.btoa = function (str) {
     /* global btoa */

--- a/lib/deps/binary/blob.js
+++ b/lib/deps/binary/blob.js
@@ -4,6 +4,7 @@
 // browsers that don't support the native Blob constructor (e.g.
 // old QtWebKit versions, Android < 4.4).
 function createBlob(parts, properties) {
+  /* global BlobBuilder,MSBlobBuilder,MozBlobBuilder,WebKitBlobBuilder */
   parts = parts || [];
   properties = properties || {};
   try {
@@ -12,11 +13,11 @@ function createBlob(parts, properties) {
     if (e.name !== "TypeError") {
       throw e;
     }
-    var BlobBuilder = global.BlobBuilder ||
-                      global.MSBlobBuilder ||
-                      global.MozBlobBuilder ||
-                      global.WebKitBlobBuilder;
-    var builder = new BlobBuilder();
+    var Builder = typeof BlobBuilder !== 'undefined' ? BlobBuilder :
+                  typeof MSBlobBuilder !== 'undefined' ? MSBlobBuilder :
+                  typeof MozBlobBuilder !== 'undefined' ? MozBlobBuilder :
+                  WebKitBlobBuilder;
+    var builder = new Builder();
     for (var i = 0; i < parts.length; i += 1) {
       builder.append(parts[i]);
     }

--- a/lib/deps/call.js
+++ b/lib/deps/call.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var getArguments = require('argsarray');
+
+// Pretty dumb name for a function, just wraps callback calls so we dont
+// to if (callback) callback() everywhere
+module.exports = getArguments(function (args) {
+  var fun = args.shift();
+  fun.apply(this, args);
+});

--- a/lib/deps/docs/isDeleted.js
+++ b/lib/deps/docs/isDeleted.js
@@ -10,9 +10,7 @@ function isDeleted(metadata, rev) {
     rev = merge.winningRev(metadata);
   }
   var dashIndex = rev.indexOf('-');
-  if (dashIndex !== -1) {
-    rev = rev.substring(dashIndex + 1);
-  }
+  rev = rev.substring(dashIndex + 1);
   var deleted = false;
   merge.traverseRevTree(metadata.rev_tree,
     function (isLeaf, pos, id, acc, opts) {

--- a/lib/deps/docs/parseDoc.js
+++ b/lib/deps/docs/parseDoc.js
@@ -150,6 +150,7 @@ exports.parseDoc = function (doc, newEdits) {
 
   var result = {metadata : {}, data : {}};
   for (var key in doc) {
+    /* istanbul ignore else */
     if (doc.hasOwnProperty(key)) {
       var specialKey = key[0] === '_';
       if (specialKey && !reservedWords[key]) {

--- a/lib/deps/docs/processDocs.js
+++ b/lib/deps/docs/processDocs.js
@@ -12,10 +12,6 @@ var Map = collections.Map;
 function processDocs(docInfos, api, fetchedDocs, tx, results, writeDoc, opts,
                      overallCallback) {
 
-  if (!docInfos.length) {
-    return;
-  }
-
   function insertDoc(docInfo, resultsIdx, callback) {
     // Cant insert new deleted documents
     var winningRev = merge.winningRev(docInfo.metadata);

--- a/lib/deps/env/hasLocalStorage-browser.js
+++ b/lib/deps/env/hasLocalStorage-browser.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var isChromeApp = require('./isChromeApp');
+
+var hasLocal;
+
+if (isChromeApp()) {
+  hasLocal = false;
+} else {
+  try {
+    localStorage.setItem('_pouch_check_localstorage', 1);
+    hasLocal = !!localStorage.getItem('_pouch_check_localstorage');
+  } catch (e) {
+    hasLocal = false;
+  }
+}
+
+module.exports = function hasLocalStorage() {
+  return hasLocal;
+};

--- a/lib/deps/env/hasLocalStorage.js
+++ b/lib/deps/env/hasLocalStorage.js
@@ -1,0 +1,6 @@
+'use strict';
+
+// in Node of course this is false
+module.exports = function hasLocalStorage() {
+  return false;
+};

--- a/lib/deps/env/isChromeApp-browser.js
+++ b/lib/deps/env/isChromeApp-browser.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = function isChromeApp() {
+  return (typeof chrome !== "undefined" &&
+    typeof chrome.storage !== "undefined" &&
+    typeof chrome.storage.local !== "undefined");
+};

--- a/lib/deps/env/isChromeApp.js
+++ b/lib/deps/env/isChromeApp.js
@@ -1,0 +1,6 @@
+'use strict';
+
+// in Node of course this is false
+module.exports = function isChromeApp() {
+  return false;
+};

--- a/lib/deps/errors.js
+++ b/lib/deps/errors.js
@@ -219,14 +219,7 @@ exports.generateErrorFromResponse = function (res) {
     errMsg = errReason;
   } else if (errName === 'bad_request' && errType.message !== errReason) {
     // if bad_request error already found based on reason don't override.
-
-    // attachment errors.
-    if (errReason.indexOf('unknown stub attachment') === 0) {
-      errType = errors.MISSING_STUB;
-      errMsg = errReason;
-    } else {
-      errType = errors.BAD_REQUEST;
-    }
+    errType = errors.BAD_REQUEST;
   }
 
   // fallback to error by statys or unknown error.
@@ -248,9 +241,6 @@ exports.generateErrorFromResponse = function (res) {
   }
   if (res.status) {
     error.status = res.status;
-  }
-  if (res.statusText) {
-    error.name = res.statusText;
   }
   if (res.missing) {
     error.missing = res.missing;

--- a/lib/deps/migrate.js
+++ b/lib/deps/migrate.js
@@ -56,6 +56,7 @@ exports.toSublevel = function (name, db, callback) {
     var done = [];
     stores.forEach(function (store, i) {
       move(store, i, function (err, storePath) {
+        /* istanbul ignore if */
         if (err) {
           return callback(err);
         }

--- a/lib/deps/once.js
+++ b/lib/deps/once.js
@@ -5,7 +5,9 @@ var getArguments = require('argsarray');
 function once(fun) {
   var called = false;
   return getArguments(function (args) {
+    /* istanbul ignore if */
     if (called) {
+      // this is a smoke test and should never actually happen
       throw new Error('once called more than once');
     } else {
       called = true;

--- a/lib/deps/parseUri.js
+++ b/lib/deps/parseUri.js
@@ -3,43 +3,35 @@
 // originally parseUri 1.2.2, now patched by us
 // (c) Steven Levithan <stevenlevithan.com>
 // MIT License
-var options = {
-  strictMode: false,
-  key: ["source", "protocol", "authority", "userInfo", "user", "password",
-    "host", "port", "relative", "path", "directory", "file", "query",
-    "anchor"],
-  q:   {
-    name:   "queryKey",
-    parser: /(?:^|&)([^&=]*)=?([^&]*)/g
-  },
-  parser: {
-    /* jshint maxlen: false */
-    strict: /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/,
-    loose:  /^(?:(?![^:@]+:[^:@\/]*@)([^:\/?#.]+):)?(?:\/\/)?((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?)(((\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?([^?#\/]*))(?:\?([^#]*))?(?:#(.*))?)/
-  }
-};
+var keys = ["source", "protocol", "authority", "userInfo", "user", "password",
+    "host", "port", "relative", "path", "directory", "file", "query", "anchor"];
+var qName ="queryKey";
+var qParser = /(?:^|&)([^&=]*)=?([^&]*)/g;
+
+// use the "loose" parser
+/* jshint maxlen: false */
+var parser = /^(?:(?![^:@]+:[^:@\/]*@)([^:\/?#.]+):)?(?:\/\/)?((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?)(((\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?([^?#\/]*))(?:\?([^#]*))?(?:#(.*))?)/;
+
 function parseUri(str) {
-  var o = options;
-  var m = o.parser[o.strictMode ? "strict" : "loose"].exec(str);
+  var m = parser.exec(str);
   var uri = {};
   var i = 14;
 
   while (i--) {
-    var key = o.key[i];
+    var key = keys[i];
     var value = m[i] || "";
     var encoded = ['user', 'password'].indexOf(key) !== -1;
     uri[key] = encoded ? decodeURIComponent(value) : value;
   }
 
-  uri[o.q.name] = {};
-  uri[o.key[12]].replace(o.q.parser, function ($0, $1, $2) {
+  uri[qName] = {};
+  uri[keys[12]].replace(qParser, function ($0, $1, $2) {
     if ($1) {
-      uri[o.q.name][$1] = $2;
+      uri[qName][$1] = $2;
     }
   });
 
   return uri;
 }
-
 
 module.exports = parseUri;

--- a/lib/deps/pick.js
+++ b/lib/deps/pick.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// like underscore/lodash _.pick()
+module.exports = function pick(obj, arr) {
+  var res = {};
+  for (var i = 0, len = arr.length; i < len; i++) {
+    var prop = arr[i];
+    if (prop in obj) {
+      res[prop] = obj[prop];
+    }
+  }
+  return res;
+};

--- a/lib/deps/promise.js
+++ b/lib/deps/promise.js
@@ -1,7 +1,3 @@
 'use strict';
-
-if (typeof Promise === 'function') {
-  module.exports = Promise;
-} else {
-  module.exports = require('lie');
-}
+/* istanbul ignore next */
+module.exports = typeof Promise === 'function' ? Promise : require('lie');

--- a/lib/deps/toPromise.js
+++ b/lib/deps/toPromise.js
@@ -48,9 +48,6 @@ function toPromise(func) {
         usedCB(null, result);
       }, usedCB);
     }
-    promise.cancel = function () {
-      return this;
-    };
     return promise;
   });
 }

--- a/lib/mapreduce/utils.js
+++ b/lib/mapreduce/utils.js
@@ -1,11 +1,6 @@
 'use strict';
-/* istanbul ignore if */
-if (typeof global.Promise === 'function') {
-  exports.Promise = global.Promise;
-} else {
-  exports.Promise = require('lie');
-}
 
+exports.Promise = require('../deps/promise');
 exports.inherits = require('inherits');
 exports.extend = require('pouchdb-extend');
 var argsarray = require('argsarray');
@@ -37,23 +32,15 @@ exports.callbackify = function (fun) {
 };
 
 // Promise finally util similar to Q.finally
-exports.fin = function (promise, cb) {
+exports.fin = function (promise, finalPromiseFactory) {
   return promise.then(function (res) {
-    var promise2 = cb();
-    if (typeof promise2.then === 'function') {
-      return promise2.then(function () {
-        return res;
-      });
-    }
-    return res;
+    return finalPromiseFactory().then(function () {
+      return res;
+    });
   }, function (reason) {
-    var promise2 = cb();
-    if (typeof promise2.then === 'function') {
-      return promise2.then(function () {
-        throw reason;
-      });
-    }
-    throw reason;
+    return finalPromiseFactory().then(function () {
+      throw reason;
+    });
   });
 };
 

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -3,6 +3,8 @@
 var PouchDB = require("./constructor");
 var utils = require('./utils');
 var EventEmitter = require('events').EventEmitter;
+var hasLocalStorage = require('./deps/env/hasLocalStorage');
+
 PouchDB.adapters = {};
 PouchDB.preferredAdapters = [];
 
@@ -40,7 +42,7 @@ PouchDB.parseAdapter = function (name, opts) {
 
   // check for browsers that have been upgraded from websql-only to websql+idb
   var skipIdb = 'idb' in PouchDB.adapters && 'websql' in PouchDB.adapters &&
-    utils.hasLocalStorage() &&
+    hasLocalStorage() &&
     localStorage['_pouch__websqldb_' + PouchDB.prefix + name];
 
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,12 +1,9 @@
 /*jshint strict: false */
-/*global chrome */
 var merge = require('./merge');
 exports.extend = require('pouchdb-extend');
 exports.ajax = require('./deps/ajax/prequest');
-exports.createBlob = require('./deps/binary/blob'); // TODO: don't export this
 exports.uuid = require('./deps/uuid');
 exports.getArguments = require('argsarray');
-var EventEmitter = require('events').EventEmitter;
 var collections = require('pouchdb-collections');
 exports.Map = collections.Map;
 exports.Set = collections.Set;
@@ -27,51 +24,13 @@ var binStringToBlobOrBuffer =
 // TODO: only used by the integration tests
 exports.binaryStringToBlobOrBuffer = binStringToBlobOrBuffer;
 
-exports.lastIndexOf = function (str, char) {
-  for (var i = str.length - 1; i >= 0; i--) {
-    if (str.charAt(i) === char) {
-      return i;
-    }
-  }
-  return -1;
-};
-
 exports.clone = function (obj) {
   return exports.extend(true, {}, obj);
 };
 
-// like underscore/lodash _.pick()
-function pick(obj, arr) {
-  var res = {};
-  for (var i = 0, len = arr.length; i < len; i++) {
-    var prop = arr[i];
-    if (prop in obj) {
-      res[prop] = obj[prop];
-    }
-  }
-  return res;
-}
-exports.pick = pick;
-
+exports.pick = require('./deps/pick');
 exports.inherits = require('inherits');
-
-function isChromeApp() {
-  return (typeof chrome !== "undefined" &&
-          typeof chrome.storage !== "undefined" &&
-          typeof chrome.storage.local !== "undefined");
-}
-
-// Pretty dumb name for a function, just wraps callback calls so we dont
-// to if (callback) callback() everywhere
-exports.call = exports.getArguments(function (args) {
-  if (!args.length) {
-    return;
-  }
-  var fun = args.shift();
-  if (typeof fun === 'function') {
-    fun.apply(this, args);
-  }
-});
+exports.call = require('./deps/call');
 
 exports.filterChange = function filterChange(opts) {
   var req = {};
@@ -91,6 +50,7 @@ exports.filterChange = function filterChange(opts) {
       delete change.doc;
     } else if (!opts.attachments) {
       for (var att in change.doc._attachments) {
+        /* istanbul ignore else */
         if (change.doc._attachments.hasOwnProperty(att)) {
           change.doc._attachments[att].stub = true;
         }
@@ -109,115 +69,7 @@ exports.isCordova = function () {
           typeof phonegap !== "undefined");
 };
 
-exports.hasLocalStorage = function () {
-  if (isChromeApp()) {
-    return false;
-  }
-  try {
-    localStorage.setItem('_pouch_check_localstorage', 1);
-    return !!localStorage.getItem('_pouch_check_localstorage');
-  } catch (e) {
-    return false;
-  }
-};
-exports.Changes = Changes;
-exports.inherits(Changes, EventEmitter);
-function Changes() {
-  if (!(this instanceof Changes)) {
-    return new Changes();
-  }
-  var self = this;
-  EventEmitter.call(this);
-  this.isChrome = isChromeApp();
-  this._listeners = {};
-  this.hasLocal = false;
-  if (!this.isChrome) {
-    this.hasLocal = exports.hasLocalStorage();
-  }
-  if (this.isChrome) {
-    chrome.storage.onChanged.addListener(function (e) {
-      // make sure it's event addressed to us
-      if (e.db_name != null) {
-        //object only has oldValue, newValue members
-        self.emit(e.dbName.newValue);
-      }
-    });
-  } else if (this.hasLocal) {
-    if (typeof addEventListener !== 'undefined') {
-      addEventListener("storage", function (e) {
-        self.emit(e.key);
-      });
-    } else { // old IE
-      window.attachEvent("storage", function (e) {
-        self.emit(e.key);
-      });
-    }
-  }
-
-}
-Changes.prototype.addListener = function (dbName, id, db, opts) {
-  if (this._listeners[id]) {
-    return;
-  }
-  var self = this;
-  var inprogress = false;
-  function eventFunction() {
-    if (!self._listeners[id]) {
-      return;
-    }
-    if (inprogress) {
-      inprogress = 'waiting';
-      return;
-    }
-    inprogress = true;
-    var changesOpts = pick(opts, [
-      'style', 'include_docs', 'attachments', 'conflicts', 'filter',
-      'doc_ids', 'view', 'since', 'query_params', 'binary'
-    ]);
-
-    db.changes(changesOpts).on('change', function (c) {
-      if (c.seq > opts.since && !opts.cancelled) {
-        opts.since = c.seq;
-        exports.call(opts.onChange, c);
-      }
-    }).on('complete', function () {
-      if (inprogress === 'waiting') {
-        setTimeout(function(){
-          eventFunction();
-        },0);
-      }
-      inprogress = false;
-    }).on('error', function () {
-      inprogress = false;
-    });
-  }
-  this._listeners[id] = eventFunction;
-  this.on(dbName, eventFunction);
-};
-
-Changes.prototype.removeListener = function (dbName, id) {
-  if (!(id in this._listeners)) {
-    return;
-  }
-  EventEmitter.prototype.removeListener.call(this, dbName,
-    this._listeners[id]);
-};
-
-
-Changes.prototype.notifyLocalWindows = function (dbName) {
-  //do a useless change on a storage thing
-  //in order to get other windows's listeners to activate
-  if (this.isChrome) {
-    chrome.storage.local.set({dbName: dbName});
-  } else if (this.hasLocal) {
-    localStorage[dbName] = (localStorage[dbName] === "a") ? "b" : "a";
-  }
-};
-
-Changes.prototype.notify = function (dbName) {
-  this.emit(dbName);
-  this.notifyLocalWindows(dbName);
-};
+exports.Changes = require('./changesHandler');
 
 exports.once = require('./deps/once');
 
@@ -227,25 +79,25 @@ exports.adapterFun = function (name, callback) {
   var log = require('debug')('pouchdb:api');
 
   function logApiCall(self, name, args) {
-    if (!log.enabled) {
-      return;
-    }
-    var logArgs = [self._db_name, name];
-    for (var i = 0; i < args.length - 1; i++) {
-      logArgs.push(args[i]);
-    }
-    log.apply(null, logArgs);
+    /* istanbul ignore if */
+    if (log.enabled) {
+      var logArgs = [self._db_name, name];
+      for (var i = 0; i < args.length - 1; i++) {
+        logArgs.push(args[i]);
+      }
+      log.apply(null, logArgs);
 
-    // override the callback itself to log the response
-    var origCallback = args[args.length - 1];
-    args[args.length - 1] = function (err, res) {
-      var responseArgs = [self._db_name, name];
-      responseArgs = responseArgs.concat(
-        err ? ['error', err] : ['success', res]
-      );
-      log.apply(null, responseArgs);
-      origCallback(err, res);
-    };
+      // override the callback itself to log the response
+      var origCallback = args[args.length - 1];
+      args[args.length - 1] = function (err, res) {
+        var responseArgs = [self._db_name, name];
+        responseArgs = responseArgs.concat(
+          err ? ['error', err] : ['success', res]
+        );
+        log.apply(null, responseArgs);
+        origCallback(err, res);
+      };
+    }
   }
 
 
@@ -268,87 +120,6 @@ exports.adapterFun = function (name, callback) {
     }
     return callback.apply(this, args);
   }));
-};
-
-exports.cancellableFun = function (fun, self, opts) {
-
-  opts = opts ? exports.clone(true, {}, opts) : {};
-
-  var emitter = new EventEmitter();
-  var oldComplete = opts.complete || function () { };
-  var complete = opts.complete = exports.once(function (err, resp) {
-    if (err) {
-      oldComplete(err);
-    } else {
-      emitter.emit('end', resp);
-      oldComplete(null, resp);
-    }
-    emitter.removeAllListeners();
-  });
-  var oldOnChange = opts.onChange || function () {};
-  var lastChange = 0;
-  self.on('destroyed', function () {
-    emitter.removeAllListeners();
-  });
-  opts.onChange = function (change) {
-    oldOnChange(change);
-    if (change.seq <= lastChange) {
-      return;
-    }
-    lastChange = change.seq;
-    emitter.emit('change', change);
-    if (change.deleted) {
-      emitter.emit('delete', change);
-    } else if (change.changes.length === 1 &&
-      change.changes[0].rev.slice(0, 1) === '1-') {
-      emitter.emit('create', change);
-    } else {
-      emitter.emit('update', change);
-    }
-  };
-  var promise = new Promise(function (fulfill, reject) {
-    opts.complete = function (err, res) {
-      if (err) {
-        reject(err);
-      } else {
-        fulfill(res);
-      }
-    };
-  });
-
-  promise.then(function (result) {
-    complete(null, result);
-  }, complete);
-
-  // this needs to be overwridden by caller, dont fire complete until
-  // the task is ready
-  promise.cancel = function () {
-    promise.isCancelled = true;
-    if (self.taskqueue.isReady) {
-      opts.complete(null, {status: 'cancelled'});
-    }
-  };
-
-  if (!self.taskqueue.isReady) {
-    self.taskqueue.addTask(function () {
-      if (promise.isCancelled) {
-        opts.complete(null, {status: 'cancelled'});
-      } else {
-        fun(self, opts, promise);
-      }
-    });
-  } else {
-    fun(self, opts, promise);
-  }
-  promise.on = emitter.on.bind(emitter);
-  promise.once = emitter.once.bind(emitter);
-  promise.addListener = emitter.addListener.bind(emitter);
-  promise.removeListener = emitter.removeListener.bind(emitter);
-  promise.removeAllListeners = emitter.removeAllListeners.bind(emitter);
-  promise.setMaxListeners = emitter.setMaxListeners.bind(emitter);
-  promise.listeners = emitter.listeners.bind(emitter);
-  promise.emit = emitter.emit.bind(emitter);
-  return promise;
 };
 
 exports.explain404 = require('./deps/ajax/explain404');

--- a/package.json
+++ b/package.json
@@ -120,6 +120,8 @@
     "./lib/deps/ajax/createMultipartPart.js": "./lib/deps/ajax/createMultipartPart-browser.js",
     "./lib/deps/ajax/defaultBody.js": "./lib/deps/ajax/defaultBody-browser.js",
     "./lib/deps/ajax/explain404.js": "./lib/deps/ajax/explain404-browser.js",
+    "./lib/deps/env/hasLocalStorage.js": "./lib/deps/env/hasLocalStorage-browser.js",
+    "./lib/deps/env/isChromeApp.js": "./lib/deps/env/isChromeApp-browser.js",
     "./lib/deps/binary/base64StringToBlobOrBuffer.js": "./lib/deps/binary/base64StringToBlobOrBuffer-browser.js",
     "./lib/deps/binary/binaryStringToBlobOrBuffer.js": "./lib/deps/binary/binaryStringToBlobOrBuffer-browser.js",
     "./lib/deps/binary/blobOrBufferToBase64.js": "./lib/deps/binary/blobOrBufferToBase64-browser.js",

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -51,11 +51,38 @@ testUtils.couchHost = function () {
   return 'http://localhost:2020';
 };
 
+// Abstracts constructing a Blob object, so it also works in older
+// browsers that don't support the native Blob constructor (e.g.
+// old QtWebKit versions, Android < 4.4).
+// Copied over from createBlob.js in PouchDB because we don't
+// want to have to export this function in utils
+function createBlob(parts, properties) {
+  /* global BlobBuilder,MSBlobBuilder,MozBlobBuilder,WebKitBlobBuilder */
+  parts = parts || [];
+  properties = properties || {};
+  try {
+    return new Blob(parts, properties);
+  } catch (e) {
+    if (e.name !== "TypeError") {
+      throw e;
+    }
+    var Builder = typeof BlobBuilder !== 'undefined' ? BlobBuilder :
+                  typeof MSBlobBuilder !== 'undefined' ? MSBlobBuilder :
+                  typeof MozBlobBuilder !== 'undefined' ? MozBlobBuilder :
+                  WebKitBlobBuilder;
+    var builder = new Builder();
+    for (var i = 0; i < parts.length; i += 1) {
+      builder.append(parts[i]);
+    }
+    return builder.getBlob(properties.type);
+  }
+}
+
 testUtils.makeBlob = function (data, type) {
   if (typeof module !== 'undefined' && module.exports) {
     return new Buffer(data, 'binary');
   } else {
-    return PouchDB.utils.createBlob([data], {
+    return createBlob([data], {
       type: (type || 'text/plain')
     });
   }

--- a/tests/mapreduce/test.mapreduce.js
+++ b/tests/mapreduce/test.mapreduce.js
@@ -1169,6 +1169,21 @@ function tests(suiteName, dbName, dbType, viewType) {
         });
       });
 
+      it('Returns ok for viewCleanup on empty db, callback style', function () {
+        return new PouchDB(dbName).then(function (db) {
+          return new Promise(function (resolve, reject) {
+            db.viewCleanup(function (err, res) {
+              if (err) {
+                return reject(err);
+              }
+              resolve(res);
+            });
+          }).then(function (res) {
+            res.ok.should.equal(true);
+          });
+        });
+      });
+
       it('Returns ok for viewCleanup after modifying view', function () {
         return new PouchDB(dbName).then(function (db) {
           var ddoc = {

--- a/tests/unit/test.parse-uri.js
+++ b/tests/unit/test.parse-uri.js
@@ -1,0 +1,35 @@
+'use strict';
+
+require('chai').should();
+var parseUri = require('../../lib/deps/parseUri');
+
+describe('test.parse-uri.js', function () {
+
+  it('parses a basic uri', function () {
+    var parsed = parseUri('http://foobar.com');
+    parsed.host.should.equal('foobar.com');
+    parsed.protocol.should.equal('http');
+  });
+
+  it('parses a complex uri', function () {
+    var parsed = parseUri('http://user:pass@foo.com/baz/bar/index.html?hey=yo');
+    parsed.should.deep.equal({
+        anchor: '',
+      query: 'hey=yo',
+      file: 'index.html',
+      directory: '/baz/bar/',
+      path: '/baz/bar/index.html',
+      relative: '/baz/bar/index.html?hey=yo',
+      port: '',
+      host: 'foo.com',
+      password: 'pass',
+      user: 'user',
+      userInfo: 'user:pass',
+      authority: 'user:pass@foo.com',
+      protocol: 'http',
+      source: 'http://user:pass@foo.com/baz/bar/index.html?hey=yo',
+      queryKey: { hey: 'yo' } }
+    );
+  });
+
+});


### PR DESCRIPTION
Yet more code coverage fixes, on top of #4077.
Coverage is now up to 93.73%.

Major changes:

1. `COVERAGE=1 npm t` now runs integration, unit, and mapreduce tests
2. `Changes` moved from `utils.js` to its own file, `changesHandler.js`
3. Dead code removed
4. `/* istanbul ignore */` added where it makes sense to ignore code (e.g. `isChromeApp()`)
5. `parseUri.js` simplified
6. General refactoring to move stuff out of `utils.js`.