### PR TITLE
(#4098) remove deprecated onChange and complete

### DIFF
--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -950,7 +950,7 @@ function HttpPouch(opts, callback) {
             if (returnDocs) {
               results.results.push(c);
             }
-            utils.call(opts.onChange, c);
+            opts.onChange(c);
           }
           return ret;
         });

--- a/lib/changes.js
+++ b/lib/changes.js
@@ -14,7 +14,6 @@ function Changes(db, opts, callback) {
   var self = this;
   this.db = db;
   opts = opts ? utils.clone(opts) : {};
-  var oldComplete = callback || opts.complete || function () {};
   var complete = opts.complete = utils.once(function (err, resp) {
     if (err) {
       self.emit('error', err);
@@ -24,17 +23,13 @@ function Changes(db, opts, callback) {
     self.removeAllListeners();
     db.removeListener('destroyed', onDestroy);
   });
-  if (oldComplete) {
+  if (callback) {
     self.on('complete', function (resp) {
-      oldComplete(null, resp);
+      callback(null, resp);
     });
     self.on('error', function (err) {
-      oldComplete(err);
+      callback(err);
     });
-  }
-  var oldOnChange = opts.onChange;
-  if (oldOnChange) {
-    self.on('change', oldOnChange);
   }
   function onDestroy() {
     self.cancel();
@@ -70,9 +65,6 @@ function Changes(db, opts, callback) {
     };
   });
   self.once('cancel', function () {
-    if (oldOnChange) {
-      self.removeListener('change', oldOnChange);
-    }
     db.removeListener('destroyed', onDestroy);
     opts.complete(null, {status: 'cancelled'});
   });

--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -90,11 +90,6 @@ function PouchDB(name, opts, callback) {
         }
       } catch (err) {
         self.taskqueue.fail(err);
-        self.changes = utils.toPromise(function (opts) {
-          if (opts.complete) {
-            opts.complete(err);
-          }
-        });
       }
     }());
     if (error) {

--- a/lib/replicate/index.js
+++ b/lib/replicate/index.js
@@ -21,9 +21,7 @@ function replicateWrapper(src, target, opts, callback) {
   if (typeof opts === 'undefined') {
     opts = {};
   }
-  if (!opts.complete) {
-    opts.complete = callback || function () {};
-  }
+  opts.complete = callback;
   opts = utils.clone(opts);
   opts.continuous = opts.continuous || opts.live;
   opts.retry = ('retry' in opts) ? opts.retry : false;

--- a/lib/replicate/replicate.js
+++ b/lib/replicate/replicate.js
@@ -391,10 +391,6 @@ function replicate(src, target, opts, returnValue, result) {
   if (!returnValue._addedListeners) {
     returnValue.once('cancel', completeReplication);
 
-    if (typeof opts.onChange === 'function') {
-      returnValue.on('change', opts.onChange);
-    }
-
     if (typeof opts.complete === 'function') {
       returnValue.once('error', opts.complete);
       returnValue.once('complete', function (result) {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -27,18 +27,6 @@ function Sync(src, target, opts, callback) {
   var self = this;
   this.canceled = false;
 
-  var onChange, complete;
-  if ('onChange' in opts) {
-    onChange = opts.onChange;
-    delete opts.onChange;
-  }
-  if (typeof callback === 'function' && !opts.complete) {
-    complete = callback;
-  } else if ('complete' in opts) {
-    complete = opts.complete;
-    delete opts.complete;
-  }
-
   this.push = replicate(src, target, opts);
   this.pull = replicate(target, src, opts);
 
@@ -151,16 +139,16 @@ function Sync(src, target, opts, callback) {
       pull: resp[1]
     };
     self.emit('complete', out);
-    if (complete) {
-      complete(null, out);
+    if (callback) {
+      callback(null, out);
     }
     self.removeAllListeners();
     return out;
   }, function (err) {
     self.cancel();
     self.emit('error', err);
-    if (complete) {
-      complete(err);
+    if (callback) {
+      callback(err);
     }
     self.removeAllListeners();
     throw err;

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -294,17 +294,15 @@ adapters.forEach(function (adapter) {
       var db = new PouchDB(dbs.name);
       var changes = db.changes({
         live: true,
-        include_docs: true,
-        onChange: function (change) {
-          if (change.doc._deleted) {
-            changes.cancel();
-          }
-        },
-        complete: function (err, result) {
-          result.status.should.equal('cancelled');
-          done();
+        include_docs: true
+      }).on('change', function (change) {
+        if (change.doc._deleted) {
+          changes.cancel();
         }
-      });
+      }).on('complete', function (result) {
+        result.status.should.equal('cancelled');
+        done();
+      }).on('error', done);
       db.post({ _id: 'somestuff' }, function (err, res) {
         db.remove({
           _id: res.id,

--- a/tests/integration/test.bulk_docs.js
+++ b/tests/integration/test.bulk_docs.js
@@ -531,7 +531,7 @@ adapters.forEach(function (adapter) {
 
       db.bulkDocs({docs: docsA, new_edits: false}, function (err, result) {
         should.not.exist(err);
-        db.changes({complete: function (err, result) {
+        db.changes().on('complete', function (result) {
           var ids = result.results.map(function (row) {
             return row.id;
           });
@@ -543,27 +543,26 @@ adapters.forEach(function (adapter) {
           db.bulkDocs({docs: docsB, new_edits: false}, function (err, result) {
             should.not.exist(err);
             db.changes({
-              since : update_seq,
-              complete: function (err, result) {
-                var ids = result.results.map(function (row) {
-                  return row.id;
-                });
-                ids.should.not.include("foo321");
-                ids.should.not.include("fee321");
-                ids.should.include("faa321");
+              since: update_seq
+            }).on('complete', function (result) {
+              var ids = result.results.map(function (row) {
+                return row.id;
+              });
+              ids.should.not.include("foo321");
+              ids.should.not.include("fee321");
+              ids.should.include("faa321");
 
-                db.get('foo321', function (err, res) {
-                  res._rev.should.equal('1-x');
-                  res.bar.should.equal("baz");
-                  db.info(function (err, info) {
-                    info.doc_count.should.equal(3);
-                    done();
-                  });
+              db.get('foo321', function (err, res) {
+                res._rev.should.equal('1-x');
+                res.bar.should.equal("baz");
+                db.info(function (err, info) {
+                  info.doc_count.should.equal(3);
+                  done();
                 });
-              }
-            });
+              });
+            }).on('error', done);
           });
-        }});
+        }).on('error', done);
       });
     });
 

--- a/tests/integration/test.conflicts.js
+++ b/tests/integration/test.conflicts.js
@@ -33,16 +33,14 @@ adapters.forEach(function (adapter) {
             should.exist(res.ok, 'Put second doc');
             db.put(doc2, function (err) {
               err.name.should.equal('conflict', 'Put got a conflicts');
-              db.changes({
-                complete: function (err, results) {
-                  results.results.should.have.length(1);
-                  doc2._rev = undefined;
-                  db.put(doc2, function (err) {
-                    err.name.should.equal('conflict', 'Another conflict');
-                    done();
-                  });
-                }
-              });
+              db.changes().on('complete', function (results) {
+                results.results.should.have.length(1);
+                doc2._rev = undefined;
+                db.put(doc2, function (err) {
+                  err.name.should.equal('conflict', 'Another conflict');
+                  done();
+                });
+              }).on('error', done);
             });
           });
         });

--- a/tests/integration/test.constructor.js
+++ b/tests/integration/test.constructor.js
@@ -60,13 +60,5 @@ describe('constructor errors', function () {
         done();
       });
     });
-    it('changes', function (done) {
-      new PouchDB().changes({
-        complete: function (err, resp) {
-            should.exist(err);
-            done(resp);
-          }
-      });
-    });
   });
 });

--- a/tests/integration/test.design_docs.js
+++ b/tests/integration/test.design_docs.js
@@ -58,19 +58,16 @@ adapters.forEach(function (adapter) {
       db.bulkDocs({ docs: docs1 }, function (err, info) {
         var changes = db.changes({
           live: true,
-          filter: 'foo/even',
-          onChange: function (change) {
-            count += 1;
-            if (count === 4) {
-              changes.cancel();
-            }
-          },
-          complete: function (err, result) {
-            result.status.should.equal('cancelled');
-            done();
-          },
-
-        });
+          filter: 'foo/even'
+        }).on('change', function (change) {
+          count += 1;
+          if (count === 4) {
+            changes.cancel();
+          }
+        }).on('complete', function (result) {
+          result.status.should.equal('cancelled');
+          done();
+        }).on('error', done);
         db.bulkDocs({ docs: docs2 }, {});
       });
     });

--- a/tests/integration/test.http.js
+++ b/tests/integration/test.http.js
@@ -53,14 +53,13 @@ describe('test.http.js', function () {
         ajax.apply(this, arguments);
       };
       db.changes({
-        since: 100,
-        onChange: function (change) { },
-        complete: function (err, result) {
-          callCount.should.equal(1, 'One _changes call to complete changes');
-          PouchDB.utils.ajax = ajax;
-          done();
-        }
-      });
+        since: 100
+      }).on('change', function (change) {
+      }).on('complete', function (result) {
+        callCount.should.equal(1, 'One _changes call to complete changes');
+        PouchDB.utils.ajax = ajax;
+        done();
+      }).on('error', done);
     });
   });
 

--- a/tests/integration/test.slash_id.js
+++ b/tests/integration/test.slash_id.js
@@ -78,18 +78,16 @@ adapters.forEach(function (adapter) {
           }
           res.rows[1].doc._attachments.should.include
             .keys('attachment/with/slash');
-          db.changes({
-            complete: function (err, res) {
-              res.results.sort(function (a, b) {
-                return a.id.localeCompare(b.id);
-              });
-              for (var i = 0; i < 3; i++) {
-                res.results[i].id.should
-                  .equal(docs[i]._id, 'correctly inserted');
-              }
-              done();
+          db.changes().on('complete', function (res) {
+            res.results.sort(function (a, b) {
+              return a.id.localeCompare(b.id);
+            });
+            for (var i = 0; i < 3; i++) {
+              res.results[i].id.should
+                .equal(docs[i]._id, 'correctly inserted');
             }
-          });
+            done();
+          }).on('error', done);
         });
       });
     });

--- a/tests/integration/test.sync.js
+++ b/tests/integration/test.sync.js
@@ -173,10 +173,8 @@ adapters.forEach(function (adapters) {
     it('Test sync cancel', function (done) {
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
-      var replications = db.sync(remote, {
-        complete: function (err, result) {
-          done();
-        }
+      var replications = db.sync(remote).on('complete', function () {
+        done();
       });
       should.exist(replications);
       replications.cancel();
@@ -225,14 +223,9 @@ adapters.forEach(function (adapters) {
           return new PouchDB.utils.Promise(function (resolve, reject) {
             db = new PouchDB(dbs.name);
             remote = new PouchDB(dbs.remote);
-            var sync = db.sync(remote, {
-              complete: function (err) {
-                if (err) {
-                  return reject(err);
-                }
-                resolve();
-              }
-            });
+            var sync = db.sync(remote)
+              .on('error', reject)
+              .on('complete', resolve);
             sync.cancel();
           }).then(function () {
             return PouchDB.utils.Promise.all([


### PR DESCRIPTION
Removes these options both from `changes()` and from `replicate()`.
Only the new style is supported.