### PR TITLE
(#4107) - add coveralls coverage reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "glob": "~3.2.9",
     "http-server": "~0.5.5",
     "istanbul": "^0.2.7",
+    "istanbul-coveralls": "^1.0.3",
     "jshint": "^2.7.0",
     "less": "~1.7.0",
     "mkdirp": "~0.4.2",
@@ -69,6 +70,7 @@
     "replace": "^0.2.9",
     "rimraf": "2.2.8",
     "sauce-connect-launcher": "0.11.1",
+    "seedrandom": "^2.4.0",
     "selenium-standalone": "3.0.2",
     "tape": "~2.12.2",
     "throw-max-listeners-error": "^1.0.0",
@@ -77,8 +79,7 @@
     "uglify-js": "~2.4.6",
     "watch-glob": "~0.1.1",
     "watchify": "^2.4.0",
-    "wd": "~0.2.8",
-    "seedrandom": "^2.4.0"
+    "wd": "~0.2.8"
   },
   "scripts": {
     "build-js": "npm run build-main-js && npm run min && npm run build-plugins",
@@ -102,7 +103,7 @@
     "publish-site": "sh bin/publish-site.sh",
     "build-site": "node ./bin/build-site.js",
     "shell": "node ./bin/repl.js",
-    "report-coverage": "node ./bin/run-coverage.js",
+    "report-coverage": "node ./bin/run-coverage.js && istanbul-coveralls --no-rm",
     "build-perf": "browserify tests/performance/*.js > tests/performance-bundle.js",
     "verify-bundle-size": "sh bin/verify-bundle-size.sh"
   },


### PR DESCRIPTION
Seems this should be all we need to add to get Coveralls support.
I already signed us up for the pouchdb/pouchdb org.

Here's an example of what a PR will look like:
* https://github.com/noopkat/avrgirl-stk500v2/pull/2