### PR TITLE
(#4115) - clarify changelog/deprecations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Nightly Build
 
 If you like to live on the bleeding edge, you can find the PouchDB nightly builds at [pouchtest.com/nightly](http://pouchtest.com/nightly).
 
+Changelog
+----
+
+PouchDB follows [semantic versioning](http://semver.org/). To see a changelog with all PouchDB releases, check out the [Github releases page](https://github.com/pouchdb/pouchdb/releases).
+
+For a concise list of breaking changes, there's the [wiki list of breaking changes](https://github.com/pouchdb/pouchdb/wiki/Breaking-changes).
+
+Keep in mind that PouchDB is auto-migrating, so a database created in 1.0.0 will still work if you open it in 4.0.0+. Any release containing a migration is clearly marked in the release notes.
+
 Contributing
 ------------
 


### PR DESCRIPTION
I noticed that it was kind of hard to find our changelog/deprecations if you just google "pouchdb changelog" or "pouchdb breaking changes." Hopefully this will help.