### PR TITLE
(#3921) - small optimizations to merge.js

### DIFF
--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,6 +1,4 @@
 'use strict';
-var extend = require('pouchdb-extend');
-
 
 // for a better overview of what this is doing, read:
 // https://github.com/apache/couchdb/blob/master/src/couchdb/couch_key_tree.erl
@@ -27,6 +25,20 @@ function binarySearch(arr, item, comparator) {
     }
   }
   return low;
+}
+
+function sortByPos(a, b) {
+  return a.pos - b.pos;
+}
+
+function sortByDeletedThenPosThenId(a, b) {
+  if (a.deleted !== b.deleted) {
+    return a.deleted > b.deleted ? 1 : -1;
+  }
+  if (a.pos !== b.pos) {
+    return b.pos - a.pos;
+  }
+  return a.id < b.id ? 1 : -1;
 }
 
 // assuming the arr is sorted, insert the item in the proper place
@@ -105,7 +117,8 @@ function doMerge(tree, path, dontExpand) {
     return {tree: [path], conflicts: 'new_leaf'};
   }
 
-  tree.forEach(function (branch) {
+  for (var i = 0, len = tree.length; i < len; i++) {
+    var branch = tree[i];
     if (branch.pos === path.pos && branch.ids[0] === path.ids[0]) {
       // Paths start at the same position and have the same root, so they need
       // merged
@@ -135,11 +148,15 @@ function doMerge(tree, path, dontExpand) {
           }
           continue;
         }
-        /*jshint loopfunc:true */
-        item.ids[2].forEach(function (el, idx) {
-          trees.push(
-            {ids: el, diff: item.diff - 1, parent: item.ids, parentIdx: idx});
-        });
+        var elements = item.ids[2];
+        for (var j = 0, elementsLen = elements.length; j < elementsLen; j++) {
+          trees.push({
+            ids: elements[j],
+            diff: item.diff - 1,
+            parent: item.ids,
+            parentIdx: j
+          });
+        }
       }
 
       var el = candidateParents[0];
@@ -156,16 +173,14 @@ function doMerge(tree, path, dontExpand) {
     } else {
       restree.push(branch);
     }
-  });
+  }
 
   // We didnt find
   if (!merged) {
     restree.push(path);
   }
 
-  restree.sort(function (a, b) {
-    return a.pos - b.pos;
-  });
+  restree.sort(sortByPos);
 
   return {
     tree: restree,
@@ -194,9 +209,6 @@ function stem(tree, depth) {
 var PouchMerge = {};
 
 PouchMerge.merge = function (tree, path, depth) {
-  // Ugh, nicer way to not modify arguments in place?
-  tree = extend(true, [], tree);
-  path = extend(true, {}, path);
   var newTree = doMerge(tree, path);
   return {
     tree: stem(newTree.tree, depth),
@@ -217,15 +229,7 @@ PouchMerge.winningRev = function (metadata) {
       leafs.push({pos: pos, id: id, deleted: !!opts.deleted});
     }
   });
-  leafs.sort(function (a, b) {
-    if (a.deleted !== b.deleted) {
-      return a.deleted > b.deleted ? 1 : -1;
-    }
-    if (a.pos !== b.pos) {
-      return b.pos - a.pos;
-    }
-    return a.id < b.id ? 1 : -1;
-  });
+  leafs.sort(sortByDeletedThenPosThenId);
 
   return leafs[0].pos + '-' + leafs[0].id;
 };
@@ -257,10 +261,10 @@ PouchMerge.collectLeaves = function (revs) {
       leaves.push({rev: pos + "-" + id, pos: pos, opts: opts});
     }
   });
-  leaves.sort(function (a, b) {
-    return b.pos - a.pos;
-  });
-  leaves.forEach(function (leaf) { delete leaf.pos; });
+  leaves.sort(sortByPos).reverse();
+  for (var i = 0, len = leaves.length; i < len; i++) {
+    delete leaves[i].pos;
+  }
   return leaves;
 };
 
@@ -271,11 +275,12 @@ PouchMerge.collectConflicts = function (metadata) {
   var win = PouchMerge.winningRev(metadata);
   var leaves = PouchMerge.collectLeaves(metadata.rev_tree);
   var conflicts = [];
-  leaves.forEach(function (leaf) {
+  for (var i = 0, len = leaves.length; i < len; i++) {
+    var leaf = leaves[i];
     if (leaf.rev !== win && !leaf.opts.deleted) {
       conflicts.push(leaf.rev);
     }
-  });
+  }
   return conflicts;
 };
 
@@ -286,11 +291,11 @@ PouchMerge.rootToLeaf = function (tree) {
     history.push({id: id, opts: opts});
     if (isLeaf) {
       var rootPos = pos + 1 - history.length;
-      paths.unshift({pos: rootPos, ids: history});
+      paths.push({pos: rootPos, ids: history});
     }
     return history;
   });
-  return paths;
+  return paths.reverse();
 };
 
 

--- a/tests/unit/test.merge.js
+++ b/tests/unit/test.merge.js
@@ -10,45 +10,68 @@ var winningRev = mergeJs.winningRev;
 
 describe('test.merge.js', function () {
 
-  var simple = {pos: 1, ids: ['1', {}, []]};
-  var two0 = {pos: 1, ids: ['1', {}, [['2_0', {}, []]]]};
-  var two1 = {pos: 1, ids: ['1', {}, [['2_1', {}, []]]]};
-  var newleaf = {pos: 2, ids: ['2_0', {}, [['3', {}, []]]]};
-  var withnewleaf = {pos: 1, ids: ['1', {}, [['2_0', {}, [['3', {}, []]]]]]};
-  var newbranch = {pos: 1, ids: ['1', {}, [['2_0', {}, []], ['2_1', {}, []]]]};
-  var newdeepbranch = {pos: 2, ids: ['2_0', {}, [['3_1', {}, []]]]};
+  var simple;
+  var two0;
+  var two1;
+  var newleaf;
+  var withnewleaf;
+  var newbranch;
+  var newdeepbranch;
+  var stemmededit;
+  var stemmedconflicts;
+  var newbranchleaf;
+  var newbranchleafbranch;
+  var stemmed2;
+  var stemmed3;
+  var partialrecover;
 
-  var stemmededit = {pos: 3, ids: ['3', {}, []]};
-  var stemmedconflicts = [simple, stemmededit];
+  /*
+   * Our merge() function actually mutates the input object, because it's
+   * more performant than deep cloning the object every time it's passed
+   * into merge(). So in order for these tests to pass, we need to redefine
+   * these objects every time.
+   */
+  beforeEach(function () {
+    simple = {pos: 1, ids: ['1', {}, []]};
+    two0 = {pos: 1, ids: ['1', {}, [['2_0', {}, []]]]};
+    two1 = {pos: 1, ids: ['1', {}, [['2_1', {}, []]]]};
+    newleaf = {pos: 2, ids: ['2_0', {}, [['3', {}, []]]]};
+    withnewleaf = {pos: 1, ids: ['1', {}, [['2_0', {}, [['3', {}, []]]]]]};
+    newbranch = {pos: 1, ids: ['1', {}, [['2_0', {}, []], ['2_1', {}, []]]]};
+    newdeepbranch = {pos: 2, ids: ['2_0', {}, [['3_1', {}, []]]]};
 
-  var newbranchleaf = {
-    pos: 1,
-    ids: ['1', {}, [['2_0', {}, [['3', {}, []]]], ['2_1', {}, []]]]
-  };
+    stemmededit = {pos: 3, ids: ['3', {}, []]};
+    stemmedconflicts = [simple, stemmededit];
 
-  var newbranchleafbranch = {
-    pos: 1,
-    ids: ['1', {}, [
-      ['2_0', {}, [['3', {}, []], ['3_1', {}, []]]], ['2_1', {}, []]
-    ]]
-  };
+    newbranchleaf = {
+      pos: 1,
+      ids: ['1', {}, [['2_0', {}, [['3', {}, []]]], ['2_1', {}, []]]]
+    };
 
-  var stemmed2 = [
-    {pos: 1, ids: ['1', {}, [['2_1', {}, []]]]},
-    {pos: 2, ids: ['2_0', {}, [['3', {}, []], ['3_1', {}, []]]]}
-  ];
+    newbranchleafbranch = {
+      pos: 1,
+      ids: ['1', {}, [
+        ['2_0', {}, [['3', {}, []], ['3_1', {}, []]]], ['2_1', {}, []]
+      ]]
+    };
 
-  var stemmed3 = [
-    {pos: 2, ids: ['2_1', {}, []]},
-    {pos: 3, ids: ['3', {}, []]},
-    {pos: 3, ids: ['3_1', {}, []]}
-  ];
+    stemmed2 = [
+      {pos: 1, ids: ['1', {}, [['2_1', {}, []]]]},
+      {pos: 2, ids: ['2_0', {}, [['3', {}, []], ['3_1', {}, []]]]}
+    ];
 
-  var partialrecover = [
-    {pos: 1, ids: ['1', {}, [['2_0', {}, [['3', {}, []]]]]]},
-    {pos: 2, ids: ['2_1', {}, []]},
-    {pos: 3, ids: ['3_1', {}, []]}
-  ];
+    stemmed3 = [
+      {pos: 2, ids: ['2_1', {}, []]},
+      {pos: 3, ids: ['3', {}, []]},
+      {pos: 3, ids: ['3_1', {}, []]}
+    ];
+
+    partialrecover = [
+      {pos: 1, ids: ['1', {}, [['2_0', {}, [['3', {}, []]]]]]},
+      {pos: 2, ids: ['2_1', {}, []]},
+      {pos: 3, ids: ['3_1', {}, []]}
+    ];
+  });
 
   it('Merging a path into an empty tree is the path', function () {
     merge([], simple, 10).should.deep.equal({


### PR DESCRIPTION
According to performance profiling I've been doing, the big boost here should come from not calling `extend()`, which it turned out was unnecessary anyway. I also went through and removed as many functions-within-functions as I could, and migrated everything from `forEach()` to regular `for` loops.

When this is green, I'll provide some perf numbers to justify it. Looking at the Chrome profiler, though, this should help a lot.