### PR TITLE
(#3921) - avoid extend() in merge.js

### DIFF
--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,6 +1,4 @@
 'use strict';
-var extend = require('pouchdb-extend');
-
 
 // for a better overview of what this is doing, read:
 // https://github.com/apache/couchdb/blob/master/src/couchdb/couch_key_tree.erl
@@ -211,9 +209,6 @@ function stem(tree, depth) {
 var PouchMerge = {};
 
 PouchMerge.merge = function (tree, path, depth) {
-  // Ugh, nicer way to not modify arguments in place?
-  tree = extend(true, [], tree);
-  path = extend(true, {}, path);
   var newTree = doMerge(tree, path);
   return {
     tree: stem(newTree.tree, depth),

--- a/tests/performance/perf.basics.js
+++ b/tests/performance/perf.basics.js
@@ -36,6 +36,26 @@ module.exports = function (PouchDB, opts) {
         db.bulkDocs(docs, done);
       }
     }, {
+      name: 'basic-updates',
+      assertions: 1,
+      iterations: 100,
+      setup: function (db, callback) {
+        var docs = [];
+        for (var i = 0; i < 100; i++) {
+          docs.push({});
+        }
+        db.bulkDocs(docs, callback);
+      },
+      test: function (db, itr, _, done) {
+        db.allDocs({include_docs: true}, function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          var docs = res.rows.map(function (x) { return x.doc; });
+          db.bulkDocs(docs, done);
+        });
+      }
+    }, {
       name: 'basic-gets',
       assertions: 1,
       iterations: 10000,

--- a/tests/unit/test.merge.js
+++ b/tests/unit/test.merge.js
@@ -10,45 +10,68 @@ var winningRev = mergeJs.winningRev;
 
 describe('test.merge.js', function () {
 
-  var simple = {pos: 1, ids: ['1', {}, []]};
-  var two0 = {pos: 1, ids: ['1', {}, [['2_0', {}, []]]]};
-  var two1 = {pos: 1, ids: ['1', {}, [['2_1', {}, []]]]};
-  var newleaf = {pos: 2, ids: ['2_0', {}, [['3', {}, []]]]};
-  var withnewleaf = {pos: 1, ids: ['1', {}, [['2_0', {}, [['3', {}, []]]]]]};
-  var newbranch = {pos: 1, ids: ['1', {}, [['2_0', {}, []], ['2_1', {}, []]]]};
-  var newdeepbranch = {pos: 2, ids: ['2_0', {}, [['3_1', {}, []]]]};
+  var simple;
+  var two0;
+  var two1;
+  var newleaf;
+  var withnewleaf;
+  var newbranch;
+  var newdeepbranch;
+  var stemmededit;
+  var stemmedconflicts;
+  var newbranchleaf;
+  var newbranchleafbranch;
+  var stemmed2;
+  var stemmed3;
+  var partialrecover;
 
-  var stemmededit = {pos: 3, ids: ['3', {}, []]};
-  var stemmedconflicts = [simple, stemmededit];
+  /*
+   * Our merge() function actually mutates the input object, because it's
+   * more performant than deep cloning the object every time it's passed
+   * into merge(). So in order for these tests to pass, we need to redefine
+   * these objects every time.
+   */
+  beforeEach(function () {
+    simple = {pos: 1, ids: ['1', {}, []]};
+    two0 = {pos: 1, ids: ['1', {}, [['2_0', {}, []]]]};
+    two1 = {pos: 1, ids: ['1', {}, [['2_1', {}, []]]]};
+    newleaf = {pos: 2, ids: ['2_0', {}, [['3', {}, []]]]};
+    withnewleaf = {pos: 1, ids: ['1', {}, [['2_0', {}, [['3', {}, []]]]]]};
+    newbranch = {pos: 1, ids: ['1', {}, [['2_0', {}, []], ['2_1', {}, []]]]};
+    newdeepbranch = {pos: 2, ids: ['2_0', {}, [['3_1', {}, []]]]};
 
-  var newbranchleaf = {
-    pos: 1,
-    ids: ['1', {}, [['2_0', {}, [['3', {}, []]]], ['2_1', {}, []]]]
-  };
+    stemmededit = {pos: 3, ids: ['3', {}, []]};
+    stemmedconflicts = [simple, stemmededit];
 
-  var newbranchleafbranch = {
-    pos: 1,
-    ids: ['1', {}, [
-      ['2_0', {}, [['3', {}, []], ['3_1', {}, []]]], ['2_1', {}, []]
-    ]]
-  };
+    newbranchleaf = {
+      pos: 1,
+      ids: ['1', {}, [['2_0', {}, [['3', {}, []]]], ['2_1', {}, []]]]
+    };
 
-  var stemmed2 = [
-    {pos: 1, ids: ['1', {}, [['2_1', {}, []]]]},
-    {pos: 2, ids: ['2_0', {}, [['3', {}, []], ['3_1', {}, []]]]}
-  ];
+    newbranchleafbranch = {
+      pos: 1,
+      ids: ['1', {}, [
+        ['2_0', {}, [['3', {}, []], ['3_1', {}, []]]], ['2_1', {}, []]
+      ]]
+    };
 
-  var stemmed3 = [
-    {pos: 2, ids: ['2_1', {}, []]},
-    {pos: 3, ids: ['3', {}, []]},
-    {pos: 3, ids: ['3_1', {}, []]}
-  ];
+    stemmed2 = [
+      {pos: 1, ids: ['1', {}, [['2_1', {}, []]]]},
+      {pos: 2, ids: ['2_0', {}, [['3', {}, []], ['3_1', {}, []]]]}
+    ];
 
-  var partialrecover = [
-    {pos: 1, ids: ['1', {}, [['2_0', {}, [['3', {}, []]]]]]},
-    {pos: 2, ids: ['2_1', {}, []]},
-    {pos: 3, ids: ['3_1', {}, []]}
-  ];
+    stemmed3 = [
+      {pos: 2, ids: ['2_1', {}, []]},
+      {pos: 3, ids: ['3', {}, []]},
+      {pos: 3, ids: ['3_1', {}, []]}
+    ];
+
+    partialrecover = [
+      {pos: 1, ids: ['1', {}, [['2_0', {}, [['3', {}, []]]]]]},
+      {pos: 2, ids: ['2_1', {}, []]},
+      {pos: 3, ids: ['3_1', {}, []]}
+    ];
+  });
 
   it('Merging a path into an empty tree is the path', function () {
     merge([], simple, 10).should.deep.equal({


### PR DESCRIPTION
Same as #4140, but containing just the (risky) in-place mangling of trees/paths.

This is a harmless commit per our unit tests, but since it introduces slightly surprising behavior (`merge()` modifies the input objects), it needs a lot of justification from profiling. When I get a chance (or if someone else wants to hop on this!) I think I can demonstrate that this offers a big boost to our speed (especially in `bulkDocs()`), so it's well worth it.