### PR TITLE
(#3833) - Support start_key and end_key alias for allDocs

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -650,6 +650,12 @@ AbstractPouchDB.prototype.allDocs =
   }
   opts = utils.clone(opts);
   opts.skip = typeof opts.skip !== 'undefined' ? opts.skip : 0;
+  if (opts.start_key) {
+    opts.startkey = opts.start_key;
+  }
+  if (opts.end_key) {
+    opts.endkey = opts.end_key;
+  }
   if ('keys' in opts) {
     if (!Array.isArray(opts.keys)) {
       return callback(new TypeError('options.keys must be an array'));

--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -695,6 +695,10 @@ function HttpPouch(opts, callback) {
     if (opts.key) {
       params.push('key=' + encodeURIComponent(JSON.stringify(opts.key)));
     }
+    
+    if (opts.start_key) {
+      opts.startkey = opts.start_key;
+    }
 
     // If opts.startkey exists, add the startkey value to the list of
     // parameters.
@@ -703,6 +707,10 @@ function HttpPouch(opts, callback) {
     if (opts.startkey) {
       params.push('startkey=' +
         encodeURIComponent(JSON.stringify(opts.startkey)));
+    }
+
+    if (opts.end_key) {
+      opts.endkey = opts.end_key;
     }
 
     // If opts.endkey exists, add the endkey value to the list of parameters.

--- a/tests/integration/test.all_docs.js
+++ b/tests/integration/test.all_docs.js
@@ -280,6 +280,16 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('3883 start_key end_key aliases', function () {
+      var db = new PouchDB(dbs.name);
+      var docs = [{_id: 'a', foo: 'a'}, {_id: 'z', foo: 'z'}];
+      return db.bulkDocs(docs).then(function() {
+        return db.allDocs({start_key: 'z', end_key: 'z'});
+      }).then(function (result) {
+        result.rows.should.have.length(1, 'Exclude a result');
+      });
+    });
+
     it('test total_rows with a variety of criteria', function (done) {
       this.timeout(20000);
       var db = new PouchDB(dbs.name);


### PR DESCRIPTION
**Issue:** #3883 

This PR implements the `start_key` alias for `allDocs`.

I've written things quite verbose in some places. I'm new to pouchdb (this is the first time I've interacted with it!) but I wrote the solution in a way that I think would be easier to read than some alternatives.

I hope I've done a good job and welcome feedback if I haven't!
Thanks @daleharvey for the great breakdown in what to do.

:panda_face: 

