### PR TITLE
(#4159) - avoid extra http call for destroy()

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -808,6 +808,12 @@ AbstractPouchDB.prototype.destroy =
       callback(null, resp || { 'ok': true });
     });
   }
+
+  if (self.type() === 'http') {
+    // no need to check for dependent DBs if it's a remote DB
+    return destroyDb();
+  }
+
   self.get('_local/_pouch_dependentDbs', function (err, localDoc) {
     if (err) {
       if (err.status !== 404) {


### PR DESCRIPTION
There is no reason to be doing the extra http call
to the `_local/dependentDbs` document for http
databases. This is something that slows down our
tests a lot, because we are constantly destroying
databases, so hopefully this fix should speed up
our test suite.