### PR TITLE
(#3444 #3921) - use custom clone, fix Dates

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -106,7 +106,7 @@ function allDocsKeysQuery(api, opts, callback) {
     offset: opts.skip
   };
   return Promise.all(keys.map(function (key) {
-    var subOpts = utils.extend(true, {key: key, deleted: 'ok'}, opts);
+    var subOpts = utils.extend({key: key, deleted: 'ok'}, opts);
     ['limit', 'skip', 'keys'].forEach(function (optKey) {
       delete subOpts[optKey];
     });
@@ -722,7 +722,7 @@ AbstractPouchDB.prototype.bulkDocs =
     opts = {};
   }
 
-  opts = utils.clone(opts);
+  opts = utils.clone(opts || {});
 
   if (Array.isArray(req)) {
     req = {

--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -142,7 +142,7 @@ function HttpPouch(opts, callback) {
   var ajaxOpts = opts.ajax || {};
   opts = clone(opts);
   function ajax(options, callback) {
-    var reqOpts = utils.extend(true, clone(ajaxOpts), options);
+    var reqOpts = utils.extend(clone(ajaxOpts), options);
     log(reqOpts.method + ' ' + reqOpts.url);
     return utils.ajax(reqOpts, callback);
   }
@@ -351,7 +351,7 @@ function HttpPouch(opts, callback) {
       url: genDBUrl(host, id + params)
     };
     var getRequestAjaxOpts = opts.ajax || {};
-    utils.extend(true, options, getRequestAjaxOpts);
+    utils.extend(options, getRequestAjaxOpts);
 
     function fetchAttachments(doc) {
       var atts = doc._attachments;

--- a/lib/adapters/idb/index.js
+++ b/lib/adapters/idb/index.js
@@ -292,11 +292,8 @@ function init(api, opts, callback) {
     var doc;
     var metadata;
     var err;
-    var txn;
-    opts = utils.clone(opts);
-    if (opts.ctx) {
-      txn = opts.ctx;
-    } else {
+    var txn = opts.ctx;
+    if (!txn) {
       var txnResult = openTransactionSafely(idb,
         [DOC_STORE, BY_SEQ_STORE, ATTACH_STORE], 'readonly');
       if (txnResult.error) {
@@ -345,7 +342,6 @@ function init(api, opts, callback) {
 
   api._getAttachment = function (attachment, opts, callback) {
     var txn;
-    opts = utils.clone(opts);
     if (opts.ctx) {
       txn = opts.ctx;
     } else {

--- a/lib/adapters/websql/index.js
+++ b/lib/adapters/websql/index.js
@@ -540,18 +540,15 @@ function WebSqlPouch(opts, callback) {
   };
 
   api._get = function (id, opts, callback) {
-    opts = utils.clone(opts);
     var doc;
     var metadata;
     var err;
-    if (!opts.ctx) {
-      db.readTransaction(function (txn) {
-        opts.ctx = txn;
-        api._get(id, opts, callback);
-      });
-      return;
-    }
     var tx = opts.ctx;
+    if (!tx) {
+      return db.readTransaction(function (txn) {
+        api._get(id, utils.extend({ctx: txn}, opts), callback);
+      });
+    }
 
     function finish() {
       callback(err, {doc: doc, metadata: metadata, ctx: tx});

--- a/lib/deps/ajax/ajax-core.js
+++ b/lib/deps/ajax/ajax-core.js
@@ -20,7 +20,7 @@ function ajax(options, callback) {
     cache: false
   };
 
-  options = utils.extend(true, defaultOptions, options);
+  options = utils.extend(defaultOptions, options);
 
 
   function onSuccess(obj, resp, cb) {

--- a/lib/deps/clone.js
+++ b/lib/deps/clone.js
@@ -1,0 +1,55 @@
+'use strict';
+
+function isPlainObject(object) {
+  // dead-simple "is this a straight-up object" test, taken
+  // from pouchdb-extend ala jQuery 1.9.0
+  // Own properties are enumerated firstly, so to speed up,
+  // if last one is own, then all properties are own.
+
+  if (typeof object.hasOwnProperty !== 'function') {
+    return false;
+  }
+
+  var key;
+  for (key in object) {}
+  return key === undefined || object.hasOwnProperty(key);
+}
+
+module.exports = function clone(object) {
+  var newObject;
+  var i;
+  var len;
+
+  if (!object || typeof object !== 'object') {
+    return object;
+  }
+
+  if (Array.isArray(object)) {
+    newObject = [];
+    for (i = 0, len = object.length; i < len; i++) {
+      newObject[i] = clone(object[i]);
+    }
+    return newObject;
+  }
+
+  // special case: to avoid inconsistencies between IndexedDB
+  // and other backends, we automatically stringify Dates
+  if (object instanceof Date) {
+    return object.toISOString();
+  }
+
+  if (!isPlainObject(object)) {
+    return object;
+  }
+
+  newObject = {};
+  for (i in object) {
+    if (object.hasOwnProperty(i)) {
+      var value = clone(object[i]);
+      if (typeof value !== 'undefined') {
+        newObject[i] = value;
+      }
+    }
+  }
+  return newObject;
+};

--- a/lib/deps/extend.js
+++ b/lib/deps/extend.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var clone = require('./clone');
+
+function extendInner(obj, otherObj) {
+  for (var key in otherObj) {
+    if (otherObj.hasOwnProperty(key)) {
+      var value = clone(otherObj[key]);
+      if (typeof value !== 'undefined') {
+        obj[key] = value;
+      }
+    }
+  }
+}
+
+module.exports = function extend(obj, obj2, obj3) {
+  extendInner(obj, obj2);
+  if (obj3) {
+    extendInner(obj, obj3);
+  }
+  return obj;
+};

--- a/lib/mapreduce/create-view.js
+++ b/lib/mapreduce/create-view.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var upsert = require('./upsert');
-var utils = require('./utils');
-var Promise = utils.Promise;
+var Promise = require('../deps/promise');
+var md5 = require('./md5');
 
 module.exports = function (opts) {
   var sourceDB = opts.db;
@@ -25,7 +25,7 @@ module.exports = function (opts) {
   return sourceDB.info().then(function (info) {
 
     var depDbName = info.db_name + '-mrview-' +
-      (temporary ? 'temp' : utils.MD5(viewSignature));
+      (temporary ? 'temp' : md5(viewSignature));
 
     // save the view name in the source db so it can be cleaned up if necessary
     // (e.g. when the _design doc is deleted, remove all associated view data)

--- a/lib/mapreduce/index.js
+++ b/lib/mapreduce/index.js
@@ -17,7 +17,8 @@ if ((typeof console !== 'undefined') && (typeof console.log === 'function')) {
   log = function () {};
 }
 var utils = require('./utils');
-var Promise = utils.Promise;
+var Promise = require('../deps/promise');
+var inherits = require('inherits');
 var persistentQueues = {};
 var tempViewQueue = new TaskQueue();
 var CHANGES_BATCH_SIZE = 50;
@@ -850,7 +851,7 @@ exports.query = function (fun, opts, callback) {
     callback = opts;
     opts = {};
   }
-  opts = utils.extend(true, {}, opts);
+  opts = opts || {};
 
   if (typeof fun === 'function') {
     fun = {map : fun};
@@ -874,7 +875,7 @@ function QueryParseError(message) {
   } catch (e) {}
 }
 
-utils.inherits(QueryParseError, Error);
+inherits(QueryParseError, Error);
 
 function NotFoundError(message) {
   this.status = 404;
@@ -886,7 +887,7 @@ function NotFoundError(message) {
   } catch (e) {}
 }
 
-utils.inherits(NotFoundError, Error);
+inherits(NotFoundError, Error);
 
 function BuiltInError(message) {
   this.status = 500;
@@ -898,4 +899,4 @@ function BuiltInError(message) {
   } catch (e) {}
 }
 
-utils.inherits(BuiltInError, Error);
+inherits(BuiltInError, Error);

--- a/lib/mapreduce/taskqueue.js
+++ b/lib/mapreduce/taskqueue.js
@@ -4,7 +4,7 @@
  * callbacks will eventually fire (once).
  */
 
-var Promise = require('./utils').Promise;
+var Promise = require('../deps/promise');
 
 function TaskQueue() {
   this.promise = new Promise(function (fulfill) {fulfill(); });

--- a/lib/mapreduce/utils.js
+++ b/lib/mapreduce/utils.js
@@ -1,8 +1,5 @@
 'use strict';
 
-exports.Promise = require('../deps/promise');
-exports.inherits = require('inherits');
-exports.extend = require('pouchdb-extend');
 var argsarray = require('argsarray');
 
 exports.promisedCallback = function (promise, callback) {
@@ -79,5 +76,3 @@ exports.uniq = function (arr) {
   }
   return output;
 };
-
-exports.MD5 = require('./md5');

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -125,7 +125,7 @@ PouchDB.defaults = function (defaultOpts) {
       name = undefined;
     }
 
-    opts = utils.extend(true, {}, defaultOpts, opts);
+    opts = utils.extend({}, defaultOpts, opts);
     PouchDB.call(this, name, opts, callback);
   }
 
@@ -141,7 +141,7 @@ PouchDB.defaults = function (defaultOpts) {
       opts = name;
       name = undefined;
     }
-    opts = utils.extend(true, {}, defaultOpts, opts);
+    opts = utils.extend({}, defaultOpts, opts);
     return PouchDB.destroy(name, opts, callback);
   });
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,5 @@
 /*jshint strict: false */
 var merge = require('./merge');
-exports.extend = require('pouchdb-extend');
 exports.ajax = require('./deps/ajax/prequest');
 exports.uuid = require('./deps/uuid');
 exports.getArguments = require('argsarray');
@@ -24,9 +23,8 @@ var binStringToBlobOrBuffer =
 // TODO: only used by the integration tests
 exports.binaryStringToBlobOrBuffer = binStringToBlobOrBuffer;
 
-exports.clone = function (obj) {
-  return exports.extend(true, {}, obj);
-};
+exports.clone = require('./deps/clone');
+exports.extend = require('./deps/extend');
 
 exports.pick = require('./deps/pick');
 exports.inherits = require('inherits');

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "miller-rabin": "1.1.1",
     "pouchdb-collate": "^1.2.0",
     "pouchdb-collections": "^1.0.0",
-    "pouchdb-extend": "^0.1.2",
     "pouchdb-upsert": "^1.0.2",
     "request": "~2.28.0",
     "spark-md5": "0.0.5",


### PR DESCRIPTION
I have a few goals with this:

* improve speed of `extend()` and `clone()`, which is still a perf drain per the profiler
* remove `pouchdb-extend`, which is a weird jquery `extend()` fork and we can do better
* fix the consistency of Date parsing, because I realized we can kill two birds with one stone, and since we're always cloning `docs` when we do `bulkDocs()`, we might as well stringify the `Date`s while we're doing it, so people can stop being confused by the inconsistency between IndexedDB and other backends (with no effect on performance).

BTW to justify my `clone()` implementation compared to `JSON.parse(JSON.stringify(obj))`, check out http://jsperf.com/deep-copy-vs-json-stringify-json-parse/15

When this is green, I will provide performance numbers.