### PR TITLE
(#4164) - increase timeout for slow test

### DIFF
--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -3096,6 +3096,7 @@ adapters.forEach(function (adapter) {
     if (!isSafari) {
       // skip in safari/ios because of size limit popup
       it('putAttachment and getAttachment with big png data', function (done) {
+        this.timeout(90000);
 
         function getData(cb) {
           if (typeof process !== 'undefined' && !process.browser) {


### PR DESCRIPTION
Easy way to fix this problem, at least temporarily. In the meantime
I'll look into `buffer` and see if 3.4.2 fixes the slowness
or if we need to report it as a bug.