### PR TITLE
(#4168) - increase EventEmitter max to 20

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -77,12 +77,12 @@ There is a limit of one database per app in some versions of the Android WebView
 
 If you see this warning:
 
-    (node) warning: possible EventEmitter memory leak detected. 11 listeners added.
+    (node) warning: possible EventEmitter memory leak detected. 21 listeners added.
     Use emitter.setMaxListeners() to increase limit.
 
 This is because PouchDB uses Node-style [EventEmitters](https://nodejs.org/api/events.html) for its events. An EventEmitter is any object that has an `.on()` or `once()` method, such as `db.changes().on('change', ...`.
 
-By default, all EventEmitters have 10 listeners, and if you exceed that limit, e.g. by attaching many `changes()` listeners, creating many `PouchDB` objects, or running many simultaneous `replicate()` or `sync()` events, then you may exceed this limit.
+By default, all EventEmitters have 10 listeners, although the `PouchDB` object defaults to 20. If you exceed that limit, e.g. by attaching many `changes()` listeners, creating many `PouchDB` objects, or running many simultaneous `replicate()` or `sync()` events, then you may exceed this limit.
 
 **This could indicate a memory leak in your code**. Check to make sure that you are calling `cancel()` on any `changes()`, `replicate()`, or `sync()` handlers, if you are constantly starting and stopping those events.
 

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -12,15 +12,16 @@ PouchDB.prefix = '_pouch_';
 
 var eventEmitter = new EE();
 
-function bindEventEmitterMethods(Pouch) {
+function setUpEventEmitter(Pouch) {
   Object.keys(EE.prototype).forEach(function (key) {
     if (typeof EE.prototype[key] === 'function') {
       Pouch[key] = eventEmitter[key].bind(eventEmitter);
     }
   });
+  Pouch.setMaxListeners(20); // increase from default of 10
 }
 
-bindEventEmitterMethods(PouchDB);
+setUpEventEmitter(PouchDB);
 
 PouchDB.parseAdapter = function (name, opts) {
   var match = name.match(/([a-z\-]*):\/\/(.*)/);
@@ -145,7 +146,7 @@ PouchDB.defaults = function (defaultOpts) {
     return PouchDB.destroy(name, opts, callback);
   });
 
-  bindEventEmitterMethods(PouchAlt);
+  setUpEventEmitter(PouchAlt);
 
   PouchAlt.preferredAdapters = PouchDB.preferredAdapters.slice();
   Object.keys(PouchDB).forEach(function (key) {

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -19,16 +19,6 @@ adapters.forEach(function (adapters) {
 
     var dbs = {};
 
-    before(function () {
-      // briefly increase the limit from 10 because we momentarily
-      // go over during these tests
-      PouchDB.setMaxListeners(20);
-    });
-
-    after(function () {
-      PouchDB.setMaxListeners(10);
-    });
-
     beforeEach(function (done) {
       dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
       dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote');

--- a/tests/mapreduce/test.mapreduce.js
+++ b/tests/mapreduce/test.mapreduce.js
@@ -1177,7 +1177,6 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('multiple view creations and cleanups', function () {
-      PouchDB.setMaxListeners(20); // we briefly go over
       return new PouchDB(dbName).then(function (db) {
         var map = function (doc) {
           emit(doc.num);
@@ -1228,8 +1227,6 @@ function tests(suiteName, dbName, dbType, viewType) {
             res.ok.should.equal(true);
           });
         });
-      }).then(function () {
-        PouchDB.setMaxListeners(10);
       });
     });
 

--- a/tests/mapreduce/test.persisted.js
+++ b/tests/mapreduce/test.persisted.js
@@ -46,13 +46,13 @@ function tests(suiteName, dbName, dbType) {
     }
 
     before(function () {
-      // briefly increase the limit from 10 because we momentarily
+      // briefly increase the limit from 20 because we momentarily
       // go over during these tests
       PouchDB.setMaxListeners(30);
     });
 
     after(function () {
-      PouchDB.setMaxListeners(10);
+      PouchDB.setMaxListeners(20);
     });
 
     beforeEach(function () {


### PR DESCRIPTION
So I started up PouchDB Server and created a single database,
and I saw that I had already hit the EventEmitter warning.

This tells me that we are exceeding the limit of 10 through normal
usage, which explains why so many people have complained about this
starting with 4.0.0.

I don't think it should be the responsibility of users to increase
this limit unless it really, really indicates a memory leak. We have
lots of tests in place to ensure we don't leak memory, and we are the
ones adding all these event listeners to the PouchDB object, so
I would rather we just increase the limit and handle it automatically
for users.