### PR TITLE
(#4164) - reenable idb-alt/localstorage tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,8 +100,6 @@ matrix:
   - env: CLIENT=node SERVER=pouchdb-express-router COMMAND=test
   - node_js: "iojs"
     env: CLIENT=node COMMAND=test
-  - env: CLIENT=selenium:firefox ADAPTERS=idb-alt COMMAND=test
-  - env: CLIENT=selenium:firefox ADAPTERS=localstorage COMMAND=test
 
   fast_finish: true
 


### PR DESCRIPTION
These tests should be fixed in buffer v3.4.3.