### PR TITLE
(#4168) - fix constructor memory leak

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -77,26 +77,22 @@ There is a limit of one database per app in some versions of the Android WebView
 
 If you see this warning:
 
-    (node) warning: possible EventEmitter memory leak detected. 21 listeners added.
+    (node) warning: possible EventEmitter memory leak detected. 11 listeners added.
     Use emitter.setMaxListeners() to increase limit.
 
 This is because PouchDB uses Node-style [EventEmitters](https://nodejs.org/api/events.html) for its events. An EventEmitter is any object that has an `.on()` or `once()` method, such as `db.changes().on('change', ...`.
 
-By default, all EventEmitters have 10 listeners, although the `PouchDB` object defaults to 20. If you exceed that limit, e.g. by attaching many `changes()` listeners, creating many `PouchDB` objects, or running many simultaneous `replicate()` or `sync()` events, then you may exceed this limit.
+By default, all EventEmitters have 10 listeners, and if you exceed that limit, e.g. by attaching many `changes()` listeners or running many simultaneous `replicate()` or `sync()` events, then you may exceed this limit.
 
 **This could indicate a memory leak in your code**. Check to make sure that you are calling `cancel()` on any `changes()`, `replicate()`, or `sync()` handlers, if you are constantly starting and stopping those events.
 
 If you're sure it's not a memory leak, though, you can increase the limit by doing:
 
 {% highlight javascript %}
-PouchDB.setMaxListeners(20); // or 30 or 40 or however many you need
-{% endhighlight %}
-
-Sometimes the EventEmitter is the `PouchDB` object itself, though, and in that case you need to do:
-
-{% highlight javascript %}
 db.setMaxListeners(20);  // or 30 or 40 or however many you need
 {% endhighlight %}
+
+In the above example, `db` refers to a database object you created using `new PouchDB('dbname')`.
 
 {% include anchor.html class="h3" title="Database size limitation of ~5MB on iOS with Cordova/Phone Gap" hash="size_limitation_5mb" %}
 

--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -26,24 +26,28 @@ function defaultCallback(err) {
 // by the constructor, which then broadcasts it to any other dbs
 // that may have been created with the same name.
 function prepareForDestruction(self, opts) {
+  var name = opts.originalName;
+  var ctor = self.constructor;
+  var destructionListeners = ctor._destructionListeners;
 
-  function constructorDestructionListener(name) {
-    if (name === opts.originalName) {
-      self.removeListener('destroyed', destructionListener);
-      self.emit('destroyed', self);
-    }
-  }
-
-  function destructionListener() {
-    // we destroyed ourselves, so no need to listen on the constructor
-    PouchDB.removeListener('destroyed', constructorDestructionListener);
-    PouchDB.emit('destroyed', opts.originalName);
+  function onDestroyed() {
+    ctor.emit('destroyed', name);
     //so we don't have to sift through all dbnames
-    PouchDB.emit(opts.originalName, 'destroyed');
+    ctor.emit(name, 'destroyed');
   }
 
-  PouchDB.once('destroyed', constructorDestructionListener);
-  self.once('destroyed', destructionListener);
+  function onConstructorDestroyed() {
+    self.removeListener('destroyed', onDestroyed);
+    self.emit('destroyed', self);
+  }
+
+  self.once('destroyed', onDestroyed);
+
+  // in setup.js, the constructor is primed to listen for destroy events
+  if (!destructionListeners.has(name)) {
+    destructionListeners.set(name, []);
+  }
+  destructionListeners.get(name).push(onConstructorDestroyed);
 }
 
 utils.inherits(PouchDB, Adapter);

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -18,7 +18,19 @@ function setUpEventEmitter(Pouch) {
       Pouch[key] = eventEmitter[key].bind(eventEmitter);
     }
   });
-  Pouch.setMaxListeners(20); // increase from default of 10
+
+  // these are created in constructor.js, and allow us to notify each DB with
+  // the same name that it was destroyed, via the constructor object
+  var destructionListeners = Pouch._destructionListeners = new utils.Map();
+  Pouch.on('destroyed', function onConstructorDestroyed(name) {
+    if (!destructionListeners.has(name)) {
+      return;
+    }
+    destructionListeners.get(name).forEach(function (callback) {
+      callback();
+    });
+    destructionListeners.delete(name);
+  });
 }
 
 setUpEventEmitter(PouchDB);

--- a/tests/integration/test.events.js
+++ b/tests/integration/test.events.js
@@ -103,5 +103,11 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('#4168 multiple constructor calls don\'t leak listeners', function () {
+      for (var i = 0; i < 50; i++) {
+        new PouchDB(dbs.name);
+      }
+    });
+
   });
 });

--- a/tests/mapreduce/test.persisted.js
+++ b/tests/mapreduce/test.persisted.js
@@ -45,16 +45,6 @@ function tests(suiteName, dbName, dbType) {
       });
     }
 
-    before(function () {
-      // briefly increase the limit from 20 because we momentarily
-      // go over during these tests
-      PouchDB.setMaxListeners(30);
-    });
-
-    after(function () {
-      PouchDB.setMaxListeners(20);
-    });
-
     beforeEach(function () {
       Promise = PouchDB.utils.Promise;
       return new PouchDB(dbName).destroy();
@@ -586,7 +576,6 @@ function tests(suiteName, dbName, dbType) {
     if (dbType === 'local' && isNode) {
       it('#239 test memdown db', function () {
         var destroyedDBs = [];
-        PouchDB.setMaxListeners(100);
         PouchDB.on('destroyed', function (db) {
           destroyedDBs.push(db);
         });


### PR DESCRIPTION
I apologize for my previous "fix" (https://github.com/pouchdb/pouchdb/pull/4168),
which just papered over the problem. I found a test that
fails (calling `new PouchDB()` multiple times), and I've implemented
a fix. As a bonus, we no longer have to increase the max listeners
from 10, either in PouchDB itself or in our tests.