### PR TITLE
(#3921) - more optimizations to merge.js

### DIFF
--- a/lib/adapters/leveldb/index.js
+++ b/lib/adapters/leveldb/index.js
@@ -61,6 +61,18 @@ var safeJsonEncoding = {
   type: 'cheap-json'
 };
 
+// winningRev and deleted are performance-killers, but
+// in newer versions of PouchDB, they are cached on the metadata
+function getWinningRev(metadata) {
+  return 'winningRev' in metadata ?
+    metadata.winningRev : merge.winningRev(metadata);
+}
+
+function getIsDeleted(metadata, winningRev) {
+  return 'deleted' in metadata ?
+    metadata.deleted : isDeleted(metadata, winningRev);
+}
+
 function fetchAttachment(att, stores, opts) {
   var type = att.content_type;
   return new utils.Promise(function (resolve, reject) {
@@ -333,11 +345,12 @@ function LevelPouch(opts, callback) {
         return callback(errors.error(errors.MISSING_DOC, 'missing'));
       }
 
-      if (isDeleted(metadata) && !opts.rev) {
+      var rev = getWinningRev(metadata);
+      var deleted = getIsDeleted(metadata, rev);
+      if (deleted && !opts.rev) {
         return callback(errors.error(errors.MISSING_DOC, "deleted"));
       }
 
-      var rev = merge.winningRev(metadata);
       rev = opts.rev ? opts.rev : rev;
 
       var seq = metadata.rev_map[rev];
@@ -819,7 +832,12 @@ function LevelPouch(opts, callback) {
       var docstream = stores.docStore.readStream(readstreamOpts);
 
       var throughStream = through(function (entry, _, next) {
-        if (!isDeleted(entry.value)) {
+        var metadata = entry.value;
+        // winningRev and deleted are performance-killers, but
+        // in newer versions of PouchDB, they are cached on the metadata
+        var winningRev = getWinningRev(metadata);
+        var deleted = getIsDeleted(metadata, winningRev);
+        if (!deleted) {
           if (skip-- > 0) {
             next();
             return;
@@ -833,12 +851,12 @@ function LevelPouch(opts, callback) {
           next();
           return;
         }
-        function allDocsInner(metadata, data) {
+        function allDocsInner(data) {
           var doc = {
             id: metadata.id,
             key: metadata.id,
             value: {
-              rev: merge.winningRev(metadata)
+              rev: winningRev
             }
           };
           if (opts.include_docs) {
@@ -855,7 +873,7 @@ function LevelPouch(opts, callback) {
           }
           if (opts.inclusive_end === false && metadata.id === opts.endkey) {
             return next();
-          } else if (isDeleted(metadata)) {
+          } else if (deleted) {
             if (opts.deleted === 'ok') {
               doc.value.deleted = true;
               doc.doc = null;
@@ -866,15 +884,14 @@ function LevelPouch(opts, callback) {
           results.push(doc);
           next();
         }
-        var metadata = entry.value;
         if (opts.include_docs) {
-          var seq = metadata.rev_map[merge.winningRev(metadata)];
+          var seq = metadata.rev_map[winningRev];
           stores.bySeqStore.get(formatSeq(seq), function (err, data) {
-            allDocsInner(metadata, data);
+            allDocsInner(data);
           });
         }
         else {
-          allDocsInner(metadata);
+          allDocsInner();
         }
       }, function (next) {
         utils.Promise.resolve().then(function () {
@@ -983,7 +1000,7 @@ function LevelPouch(opts, callback) {
       var metadata;
 
       function onGetMetadata(metadata) {
-        var winningRev = merge.winningRev(metadata);
+        var winningRev = getWinningRev(metadata);
 
         function onGetWinningDoc(winningDoc) {
 

--- a/lib/deps/docs/isDeleted.js
+++ b/lib/deps/docs/isDeleted.js
@@ -2,6 +2,10 @@
 
 var merge = require('../../merge');
 
+function getTrees(node) {
+  return node.ids;
+}
+
 // check if a specific revision of a doc has been deleted
 //  - metadata: the metadata object from the doc store
 //  - rev: (optional) the revision to check. defaults to winning revision
@@ -9,17 +13,16 @@ function isDeleted(metadata, rev) {
   if (!rev) {
     rev = merge.winningRev(metadata);
   }
-  var dashIndex = rev.indexOf('-');
-  rev = rev.substring(dashIndex + 1);
-  var deleted = false;
-  merge.traverseRevTree(metadata.rev_tree,
-    function (isLeaf, pos, id, acc, opts) {
-      if (id === rev) {
-        deleted = !!opts.deleted;
-      }
-    });
+  var id = rev.substring(rev.indexOf('-') + 1);
+  var toVisit = metadata.rev_tree.map(getTrees);
 
-  return deleted;
+  var tree;
+  while ((tree = toVisit.pop())) {
+    if (tree[0] === id) {
+      return !!tree[1].deleted;
+    }
+    toVisit = toVisit.concat(tree[2]);
+  }
 }
 
 module.exports = isDeleted;

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -31,16 +31,6 @@ function sortByPos(a, b) {
   return a.pos - b.pos;
 }
 
-function sortByDeletedThenPosThenId(a, b) {
-  if (a.deleted !== b.deleted) {
-    return a.deleted > b.deleted ? 1 : -1;
-  }
-  if (a.pos !== b.pos) {
-    return b.pos - a.pos;
-  }
-  return a.id < b.id ? 1 : -1;
-}
-
 // assuming the arr is sorted, insert the item in the proper place
 function insertSorted(arr, item, comparator) {
   var idx = binarySearch(arr, item, comparator);
@@ -222,16 +212,33 @@ PouchMerge.merge = function (tree, path, depth) {
 // The final sort algorithm is slightly documented in a sidebar here:
 // http://guide.couchdb.org/draft/conflicts.html
 PouchMerge.winningRev = function (metadata) {
-  var leafs = [];
-  PouchMerge.traverseRevTree(metadata.rev_tree,
-                              function (isLeaf, pos, id, something, opts) {
-    if (isLeaf) {
-      leafs.push({pos: pos, id: id, deleted: !!opts.deleted});
+  var winningId;
+  var winningPos;
+  var winningDeleted;
+  var toVisit = metadata.rev_tree.slice();
+  var node;
+  while ((node = toVisit.pop())) {
+    var tree = node.ids;
+    var branches = tree[2];
+    var pos = node.pos;
+    if (branches.length) { // non-leaf
+      for (var i = 0, len = branches.length; i < len; i++) {
+        toVisit.push({pos: pos + 1, ids: branches[i]});
+      }
+      continue;
     }
-  });
-  leafs.sort(sortByDeletedThenPosThenId);
+    var deleted = !!tree[1].deleted;
+    var id = tree[0];
+    // sort by deleted, then pos, then id
+    if (!winningId || (winningDeleted !== deleted ? winningDeleted :
+        winningPos !== pos ? winningPos < pos : winningId < id)) {
+      winningId = id;
+      winningPos = pos;
+      winningDeleted = deleted;
+    }
+  }
 
-  return leafs[0].pos + '-' + leafs[0].id;
+  return winningPos + '-' + winningId;
 };
 
 // Pretty much all below can be combined into a higher order function to


### PR DESCRIPTION
I've been motivated to work on this recently, because I noticed that `pouchdb-server --in-memory` is actually *slower than CouchDB*. When I run the `basic-updates` perf test, I get ~17.5s for CouchDB and ~22s for PouchDB Server. This to me is pretty unreasonable, since one is in-memory and the other one writes to disk.

After profiling, I saw that `isDeleted` and `winningRev` were still the biggest performance-killers. After this fix, not so much. Now the time is down to about 21s.

Before:

![screenshot from 2015-08-22 17 59 31](https://cloud.githubusercontent.com/assets/283842/9426073/c53c03ce-48f7-11e5-9743-0434c8c3e1cc.png)


After:

![screenshot from 2015-08-22 18 00 41](https://cloud.githubusercontent.com/assets/283842/9426074/c9558052-48f7-11e5-9c92-2f3f770de8de.png)

So TLDR we are still slower than CouchDB even when we run in-memory, but this is an improvement. I think next I am going to have to upgrade my tools and use some better profilers than the node-inspector profiler, so that I can find V8 deoptimizations and poor memory usage (garbage collection seems to be taking up a lot of time).