### PR TITLE
(#3921) - optimize rootToLeaf()

### DIFF
--- a/lib/merge.js
+++ b/lib/merge.js
@@ -304,17 +304,28 @@ PouchMerge.collectConflicts = function (metadata) {
   return conflicts;
 };
 
-PouchMerge.rootToLeaf = function (tree) {
+// build up a list of all the paths to the leafs in this revision tree
+PouchMerge.rootToLeaf = function (revs) {
   var paths = [];
-  PouchMerge.traverseRevTree(tree, function (isLeaf, pos, id, history, opts) {
-    history = history ? history.slice(0) : [];
+  var toVisit = revs.slice();
+  var node;
+  while ((node = toVisit.pop())) {
+    var pos = node.pos;
+    var tree = node.ids;
+    var id = tree[0];
+    var opts = tree[1];
+    var branches = tree[2];
+    var isLeaf = branches.length === 0;
+
+    var history = node.history ? node.history.slice() : [];
     history.push({id: id, opts: opts});
     if (isLeaf) {
-      var rootPos = pos + 1 - history.length;
-      paths.push({pos: rootPos, ids: history});
+      paths.push({pos: (pos + 1 - history.length), ids: history});
     }
-    return history;
-  });
+    for (var i = 0, len = branches.length; i < len; i++) {
+      toVisit.push({pos: pos + 1, ids: branches[i], history: history});
+    }
+  }
   return paths.reverse();
 };
 


### PR DESCRIPTION
Perf tests showed this was taking up a significant amount of
time as well. Basically everything in `merge.js` needs to be
optimized to the extreme, as far as I can tell.

The big detriment of these kinds of changes is that the code
becomes less readable, but I think `merge.js` is pretty opaque
and CS-y as it is, so I don't mind so much. Also this removes
all external dependencies from that particular function.