### PR TITLE
DON'T MERGE - test removing vuvuzela

### DIFF
--- a/lib/deps/json.js
+++ b/lib/deps/json.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.safeJsonParse = function safeJsonParse(str) {
+  return JSON.parse(str);
+};
+
+exports.safeJsonStringify = function safeJsonStringify(json) {
+  return JSON.stringify(json);
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -142,20 +142,6 @@ exports.compactTree = function compactTree(metadata) {
   return revs;
 };
 
-var vuvuzela = require('vuvuzela');
-
-exports.safeJsonParse = function safeJsonParse(str) {
-  try {
-    return JSON.parse(str);
-  } catch (e) {
-    return vuvuzela.parse(str);
-  }
-};
-
-exports.safeJsonStringify = function safeJsonStringify(json) {
-  try {
-    return JSON.stringify(json);
-  } catch (e) {
-    return vuvuzela.stringify(json);
-  }
-};
+var json = require('./deps/json');
+exports.safeJsonParse = json.safeJsonParse;
+exports.safeJsonStringify = json.safeJsonStringify;

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "pouchdb-upsert": "^1.0.2",
     "request": "~2.28.0",
     "spark-md5": "0.0.5",
-    "through2": "^0.4.1",
-    "vuvuzela": "^1.0.0"
+    "through2": "^0.4.1"
   },
   "optionalDependencies": {
     "leveldown": "~0.10.2"


### PR DESCRIPTION
We have a test that supposedly should demonstrate why
vuvuzela is actually necessary (it's this one:
https://github.com/pouchdb/pouchdb/blob/466f5ea516c629136f81ca5201f98166ed274cde/tests/test.replication.js#L112-L182), but I want to make
sure that Travis is actually running browsers that can
catch it, because oddly my local Chrome/Firefox cannot.