### PR TITLE
(#3921) - conditional JSON.parse

### DIFF
--- a/lib/deps/json.js
+++ b/lib/deps/json.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var RECURSIVE_JSON_LIMIT = 10000;
+
+var vuvuzela = require('vuvuzela');
+
+// isolate in its own function because it will be deoptimized
+function tryCatchJsonParse(str) {
+  try {
+    return JSON.parse(str);
+  } catch (e) {
+    return vuvuzela.parse(str);
+  }
+}
+
+exports.safeJsonParse = function safeJsonParse(str) {
+  // if a string is below a certain size, it is unlikely to throw
+  // a "call stack size exceeded" error, so avoid the deoptimized
+  // try-catch function as a perf boost
+  if (str.length < RECURSIVE_JSON_LIMIT) {
+    return JSON.parse(str);
+  }
+  return tryCatchJsonParse(str);
+};
+
+exports.safeJsonStringify = function safeJsonStringify(json) {
+  try {
+    return JSON.stringify(json);
+  } catch (e) {
+    return vuvuzela.stringify(json);
+  }
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -142,20 +142,6 @@ exports.compactTree = function compactTree(metadata) {
   return revs;
 };
 
-var vuvuzela = require('vuvuzela');
-
-exports.safeJsonParse = function safeJsonParse(str) {
-  try {
-    return JSON.parse(str);
-  } catch (e) {
-    return vuvuzela.parse(str);
-  }
-};
-
-exports.safeJsonStringify = function safeJsonStringify(json) {
-  try {
-    return JSON.stringify(json);
-  } catch (e) {
-    return vuvuzela.stringify(json);
-  }
-};
+var json = require('./deps/json');
+exports.safeJsonParse = json.safeJsonParse;
+exports.safeJsonStringify = json.safeJsonStringify;


### PR DESCRIPTION
Only runs `vuvuzela.parse` if the string is very large.
This function seemed to be a big offender in the profiler,
probably due to the deoptimization of try/catch, so it can
only be helpful to remove it where possible.

If this passes, I'll try to get some perf numbers.