### PR TITLE
(#3921) - optimize merge.stem()

### DIFF
--- a/lib/merge.js
+++ b/lib/merge.js
@@ -47,18 +47,21 @@ function insertSorted(arr, item, comparator) {
   arr.splice(idx, 0, item);
 }
 
-// Turn a path as a flat array into a tree with a single branch
-function pathToTree(path) {
-  var doc = path.shift();
-  var root = [doc.id, doc.opts, []];
-  var leaf = root;
-  var nleaf;
-
-  while (path.length) {
-    doc = path.shift();
-    nleaf = [doc.id, doc.opts, []];
-    leaf[2].push(nleaf);
-    leaf = nleaf;
+// Turn a path as a flat array into a tree with a single branch.
+// If any should be stemmed from the beginning of the array, that's passed
+// in as the second argument
+function pathToTree(path, numStemmed) {
+  var root;
+  var leaf;
+  for (var i = numStemmed, len = path.length; i < len; i++) {
+    var node = path[i];
+    var currentLeaf = [node.id, node.opts, []];
+    if (leaf) {
+      leaf[2].push(currentLeaf);
+      leaf = currentLeaf;
+    } else {
+      root = leaf = currentLeaf;
+    }
   }
   return root;
 }
@@ -190,20 +193,28 @@ function doMerge(tree, path, dontExpand) {
 
 // To ensure we dont grow the revision tree infinitely, we stem old revisions
 function stem(tree, depth) {
-  // First we break out the tree into a complete list of root to leaf paths,
-  // we cut off the start of the path and generate a new set of flat trees
-  var stemmedPaths = PouchMerge.rootToLeaf(tree).map(function (path) {
-    var stemmed = path.ids.slice(-depth);
-    return {
-      pos: path.pos + (path.ids.length - stemmed.length),
-      ids: pathToTree(stemmed)
+  // First we break out the tree into a complete list of root to leaf paths
+  var paths = PouchMerge.rootToLeaf(tree);
+  var result;
+  for (var i = 0, len = paths.length; i < len; i++) {
+    // Then for each path, we cut off the start of the path based on the
+    // `depth` to stem to, and generate a new set of flat trees
+    var path = paths[i];
+    var stemmed = path.ids;
+    var numStemmed = Math.max(0, stemmed.length - depth);
+    var stemmedNode = {
+      pos: path.pos + numStemmed,
+      ids: pathToTree(stemmed, numStemmed)
     };
-  });
-  // Then we remerge all those flat trees together, ensuring that we dont
-  // connect trees that would go beyond the depth limit
-  return stemmedPaths.reduce(function (prev, current) {
-    return doMerge(prev, current, true).tree;
-  }, [stemmedPaths.shift()]);
+    // Then we remerge all those flat trees together, ensuring that we dont
+    // connect trees that would go beyond the depth limit
+    if (result) {
+      result = doMerge(result, stemmedNode, true).tree;
+    } else {
+      result = [stemmedNode];
+    }
+  }
+  return result;
 }
 
 var PouchMerge = {};


### PR DESCRIPTION
Another offender per the performance tests, 
optimized as much as possible.

Using the `basic-updates` test in Node with 
leveldown and iterations increased to 200, the score is:
47173ms before, 45004ms after.