### PR TITLE
(#4189) - better CORS error message

### DIFF
--- a/lib/deps/ajax/ajax-core.js
+++ b/lib/deps/ajax/ajax-core.js
@@ -6,6 +6,7 @@ var errors = require('./../errors');
 var utils = require('../../utils');
 var applyTypeToBuffer = require('./applyTypeToBuffer');
 var defaultBody = require('./defaultBody');
+var explainCors = require('./explainCors');
 
 function ajax(options, callback) {
 
@@ -87,7 +88,14 @@ function ajax(options, callback) {
 
   return request(options, function (err, response, body) {
     if (err) {
-      err.status = response ? response.statusCode : 400;
+      if (response) {
+        if (response.statusCode === 0) {
+          explainCors(); // statusCode 0 indicates a CORS error (405)
+        }
+        err.status = response.statusCode;
+      } else {
+        err.status = 400;
+      }
       return onError(err, callback);
     }
 

--- a/lib/deps/ajax/explainCors-browser.js
+++ b/lib/deps/ajax/explainCors-browser.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = function () {
+  if ('console' in global && 'error' in console) {
+    console.error('PouchDB error: the remote database does not seem to have ' +
+      'CORS enabled. To fix this, please enable CORS: ' +
+      'http://pouchdb.com/errors.html#no_access_control_allow_origin_header');
+  }
+};

--- a/lib/deps/ajax/explainCors.js
+++ b/lib/deps/ajax/explainCors.js
@@ -1,0 +1,4 @@
+'use strict';
+
+//Node users don't need to see this warning
+module.exports = function () {};

--- a/lib/deps/errors.js
+++ b/lib/deps/errors.js
@@ -222,7 +222,7 @@ exports.generateErrorFromResponse = function (res) {
     errType = errors.BAD_REQUEST;
   }
 
-  // fallback to error by statys or unknown error.
+  // fallback to error by status or unknown error.
   if (!errType) {
     errType = errors.getErrorTypeByProp('status', res.status, errReason) ||
                 errors.UNKNOWN_ERROR;

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "./lib/deps/ajax/createMultipartPart.js": "./lib/deps/ajax/createMultipartPart-browser.js",
     "./lib/deps/ajax/defaultBody.js": "./lib/deps/ajax/defaultBody-browser.js",
     "./lib/deps/ajax/explain404.js": "./lib/deps/ajax/explain404-browser.js",
+    "./lib/deps/ajax/explainCors.js": "./lib/deps/ajax/explainCors-browser.js",
     "./lib/deps/env/hasLocalStorage.js": "./lib/deps/env/hasLocalStorage-browser.js",
     "./lib/deps/env/isChromeApp.js": "./lib/deps/env/isChromeApp-browser.js",
     "./lib/deps/binary/base64StringToBlobOrBuffer.js": "./lib/deps/binary/base64StringToBlobOrBuffer-browser.js",


### PR DESCRIPTION
This adds a console error for browser users when we detect CORS is unavailable, and it also uses a custom 405 error instead of "UnknownError".

Here's what it looks like in Chrome:

![screenshot from 2015-08-23 15 15 03](https://cloud.githubusercontent.com/assets/283842/9429772/783cb01a-49aa-11e5-82fb-5dbd73934a86.png)

And in Firefox:

![screenshot from 2015-08-23 15 19 22](https://cloud.githubusercontent.com/assets/283842/9429774/7d6a5fa6-49aa-11e5-8146-5b67d9ab9947.png)

