### PR TITLE
(#4154) - Adds aliases for start and end keys.

### DIFF
--- a/lib/mapreduce/index.js
+++ b/lib/mapreduce/index.js
@@ -9,7 +9,7 @@ var normalizeKey = pouchCollate.normalizeKey;
 var parseIndexableString = pouchCollate.parseIndexableString;
 var createView = require('./create-view');
 var evalFunc = require('./evalfunc');
-var log; 
+var log;
 /* istanbul ignore else */
 if ((typeof console !== 'undefined') && (typeof console.log === 'function')) {
   log = Function.prototype.bind.call(console.log, console);
@@ -235,7 +235,9 @@ function httpQuery(db, fun, opts) {
   addHttpParam('stale', opts, params);
   addHttpParam('conflicts', opts, params);
   addHttpParam('startkey', opts, params, true);
+  addHttpParam('start_key', opts, params, true);
   addHttpParam('endkey', opts, params, true);
+  addHttpParam('end_key', opts, params, true);
   addHttpParam('inclusive_end', opts, params);
   addHttpParam('key', opts, params, true);
 
@@ -680,6 +682,12 @@ function queryViewInQueue(view, opts) {
     var viewOpts = {
       descending : opts.descending
     };
+    if (opts.start_key) {
+        opts.startkey = opts.start_key;
+    }
+    if (opts.end_key) {
+        opts.endkey = opts.end_key;
+    }
     if (typeof opts.startkey !== 'undefined') {
       viewOpts.startkey = opts.descending ?
         toIndexableString([opts.startkey, {}]) :


### PR DESCRIPTION
Fixes this issue by adding aliases in `mapreduce`:
- `start_key` is treated as `startkey`
- `end_key` is treated as `endkey`