### PR TITLE
(#4144) - Removes pouchdb-upsert dependency.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -459,7 +459,7 @@ AbstractPouchDB.prototype._compact = function (opts, callback) {
     .on('complete', onComplete)
     .on('error', callback);
 };
-/* Begin api wrappers. Specific functionality to storage belongs in the 
+/* Begin api wrappers. Specific functionality to storage belongs in the
    _[method] */
 AbstractPouchDB.prototype.get =
   utils.adapterFun('get', function (id, opts, callback) {
@@ -784,12 +784,9 @@ AbstractPouchDB.prototype.registerDependentDatabase =
     doc.dependentDbs[dependentDb] = true;
     return doc;
   }
-  upsert(this, '_local/_pouch_dependentDbs', diffFun, function (err) {
-    if (err) {
-      return callback(err);
-    }
-    return callback(null, {db: depDB});
-  });
+  upsert(this, '_local/_pouch_dependentDbs', diffFun)
+    .then(callback.bind(this, null, {db: depDB}))
+    .catch(callback);
 });
 
 AbstractPouchDB.prototype.destroy =

--- a/lib/deps/upsert.js
+++ b/lib/deps/upsert.js
@@ -1,7 +1,55 @@
 'use strict';
 
-var upsert = require('pouchdb-upsert').upsert;
+var Promise = require('lie');
 
-module.exports = function (db, doc, diffFun, cb) {
-  return upsert.call(db, doc, diffFun, cb);
+// this is essentially the "update sugar" function from daleharvey/pouchdb#1388
+// the diffFun tells us what delta to apply to the doc.  it either returns
+// the doc, or false if it doesn't need to do an update after all
+var upsert = module.exports = function upsert(db, docId, diffFun) {
+  return new Promise(function (fulfill, reject) {
+    if (typeof docId !== 'string') {
+      return reject(new Error('doc id is required'));
+    }
+
+    db.get(docId, function (err, doc) {
+      if (err) {
+        /* istanbul ignore next */
+        if (err.status !== 404) {
+          return reject(err);
+        }
+        doc = {};
+      }
+
+      // the user might change the _rev, so save it for posterity
+      var docRev = doc._rev;
+      var newDoc = diffFun(doc);
+
+      if (!newDoc) {
+        // if the diffFun returns falsy, we short-circuit as
+        // an optimization
+        return fulfill({updated: false, rev: docRev});
+      }
+
+      // users aren't allowed to modify these values,
+      // so reset them here
+      newDoc._id = docId;
+      newDoc._rev = docRev;
+      fulfill(tryAndPut(db, newDoc, diffFun));
+    });
+  });
 };
+
+function tryAndPut(db, doc, diffFun) {
+  return db.put(doc).then(function (res) {
+    return {
+      updated: true,
+      rev: res.rev
+    };
+  }, function (err) {
+    /* istanbul ignore next */
+    if (err.status !== 409) {
+      throw err;
+    }
+    return upsert(db, doc._id, diffFun);
+  });
+}

--- a/lib/mapreduce/create-view.js
+++ b/lib/mapreduce/create-view.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var upsert = require('./upsert');
+var upsert = require('../deps/upsert');
 var Promise = require('../deps/promise');
 var md5 = require('./md5');
 
@@ -49,7 +49,7 @@ module.exports = function (opts) {
         db.auto_compaction = true;
         var view = {
           name: depDbName,
-          db: db, 
+          db: db,
           sourceDB: sourceDB,
           adapter: sourceDB.adapter,
           mapFun: mapFun,

--- a/lib/mapreduce/upsert.js
+++ b/lib/mapreduce/upsert.js
@@ -1,7 +1,0 @@
-'use strict';
-
-var upsert = require('pouchdb-upsert').upsert;
-
-module.exports = function (db, doc, diffFun) {
-  return upsert.apply(db, [doc, diffFun]);
-};

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "memdown": "^1.0.0",
     "pouchdb-collate": "^1.2.0",
     "pouchdb-collections": "^1.0.0",
-    "pouchdb-upsert": "^1.0.2",
     "request": "~2.28.0",
     "spark-md5": "0.0.5",
     "through2": "^0.4.1",

--- a/tests/unit/test.mapreduce.js
+++ b/tests/unit/test.mapreduce.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
-var upsert = require('../../lib/mapreduce/upsert');
+var upsert = require('../../lib/deps/upsert');
 var utils = require('../../lib/mapreduce/utils');
 var Promise = require('../../lib/deps/promise');
 


### PR DESCRIPTION
Basically copies the file from the npm package. Removes support for
callback style (can still be used with callbackify).