### PR TITLE
(#4216) - remove Function.name checking

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -270,10 +270,15 @@ var pouch = new PouchDB('riak://localhost:8087/somebucket', {db: require('riakdo
 
 There are many other LevelDOWN-based plugins &ndash; far too many to list here. You can find a [mostly-complete list on Github](https://github.com/rvagg/node-levelup/wiki/Modules#storage-back-ends) that includes implementations on top of MySQL, Windows Azure Table Storage, and SQLite.
 
+{% include alert/start.html variant="warning"%}
+We do not currently test against any Node.js-based LevelDOWN adapters other than LevelDOWN and MemDOWN, so the other backends should be considered experimental.
+{% include alert/end.html%}
 
 {% include alert/start.html variant="warning"%}
-We do not currently test against any LevelDOWN adapters other than LevelDB and MemDOWN, so the other backends should be considered experimental.
-{% include alert/end.html%}
+{% markdown %}
+If you open two databases with the same name but different `db`s, then the first one will override the second. Namespace your names if you are using multiple adapters at once! 
+{% endmarkdown %}
+{% include alert/end.html %}
 
 {% include anchor.html title="PouchDB over HTTP" hash="pouchdb_over_http"%}
 

--- a/lib/adapters/leveldb/index.js
+++ b/lib/adapters/leveldb/index.js
@@ -44,7 +44,7 @@ var META_STORE = 'meta-store';
 
 // leveldb barks if we try to open a db multiple times
 // so we cache opened connections here for initstore()
-var dbStores = new utils.Map();
+var dbStore = new utils.Map();
 
 // store the value of update_seq in the by-sequence store the key name will
 // never conflict, since the keys in the by-sequence store are integers
@@ -145,13 +145,6 @@ function LevelPouch(opts, callback) {
 
   if (typeof leveldown.destroy !== 'function') {
     leveldown.destroy = function (name, cb) { cb(); };
-  }
-  var dbStore;
-  if (dbStores.has(leveldown.name)) {
-    dbStore = dbStores.get(leveldown.name);
-  } else {
-    dbStore = new utils.Map();
-    dbStores.set(leveldown.name, dbStore);
   }
   if (dbStore.has(name)) {
     db = dbStore.get(name);
@@ -1377,13 +1370,6 @@ function LevelPouch(opts, callback) {
 
   // close and delete open leveldb stores
   api._destroy = function (callback) {
-    var dbStore;
-    if (dbStores.has(leveldown.name)) {
-      dbStore = dbStores.get(leveldown.name);
-    } else {
-      return callDestroy(name, callback);
-    }
-
     if (dbStore.has(name)) {
       LevelPouch.Changes.removeAllListeners(name);
 

--- a/tests/integration/test.defaults.js
+++ b/tests/integration/test.defaults.js
@@ -63,7 +63,7 @@ if (!process.env.LEVEL_ADAPTER &&
       var opts = { name: 'mydb', db: require('memdown') };
       return new PouchDB(opts).then(function (db) {
         return db.put({_id: 'foo'}).then(function () {
-          return new PouchDB('mydb').then(function (otherDB) {
+          return new PouchDB('mydb_memdown').then(function (otherDB) {
             return db.info().then(function (info1) {
               return otherDB.info().then(function (info2) {
                 info1.doc_count.should.not.equal(info2.doc_count);
@@ -79,15 +79,15 @@ if (!process.env.LEVEL_ADAPTER &&
 
     it('should allow us to destroy memdown', function () {
       var opts = {db: require('memdown') };
-      return new PouchDB('mydb', opts).then(function (db) {
+      return new PouchDB('mydb_memdown', opts).then(function (db) {
         return db.put({_id: 'foo'}).then(function () {
-          return new PouchDB('mydb', opts).then(function (otherDB) {
+          return new PouchDB('mydb_memdown', opts).then(function (otherDB) {
             return db.info().then(function (info1) {
               return otherDB.info().then(function (info2) {
                 info1.doc_count.should.equal(info2.doc_count);
                 return otherDB.destroy();
               }).then(function () {
-                return new PouchDB('mydb', opts).then(function (db3) {
+                return new PouchDB('mydb_memdown', opts).then(function (db3) {
                   return db3.info().then(function (info) {
                     info.doc_count.should.equal(0);
                     return db3.destroy();
@@ -102,7 +102,7 @@ if (!process.env.LEVEL_ADAPTER &&
 
     it('should allow us to use memdown by default', function () {
       var CustomPouch = PouchDB.defaults({db: require('memdown')});
-      return new CustomPouch('mydb').then(function (db) {
+      return new CustomPouch('mydb_memdown').then(function (db) {
         return db.put({_id: 'foo'}).then(function () {
           return new PouchDB('mydb').then(function (otherDB) {
             return db.info().then(function (info1) {
@@ -119,7 +119,7 @@ if (!process.env.LEVEL_ADAPTER &&
     });
 
     it('should inform us when using memdown', function () {
-      var opts = { name: 'mydb', db: require('memdown') };
+      var opts = { name: 'mydb_memdown', db: require('memdown') };
       return new PouchDB(opts).then(function (db) {
         return db.info().then(function (info) {
           info.backend_adapter.should.equal('MemDOWN');
@@ -130,10 +130,10 @@ if (!process.env.LEVEL_ADAPTER &&
     it('constructor emits destroyed when using defaults', function () {
       var CustomPouch = PouchDB.defaults({db: require('memdown')});
 
-      return new CustomPouch('mydb').then(function (db) {
+      return new CustomPouch('mydb_memdown').then(function (db) {
         return new PouchDB.utils.Promise(function (resolve) {
           CustomPouch.once('destroyed', function (name) {
-            name.should.equal('mydb');
+            name.should.equal('mydb_memdown');
             resolve();
           });
           db.destroy();
@@ -144,7 +144,7 @@ if (!process.env.LEVEL_ADAPTER &&
     it('db emits destroyed when using defaults', function () {
       var CustomPouch = PouchDB.defaults({db: require('memdown')});
 
-      return new CustomPouch('mydb').then(function (db) {
+      return new CustomPouch('mydb_memdown').then(function (db) {
         return new PouchDB.utils.Promise(function (resolve) {
           db.once('destroyed', resolve);
           db.destroy();
@@ -156,10 +156,10 @@ if (!process.env.LEVEL_ADAPTER &&
       var CustomPouch = PouchDB.defaults({db: require('memdown')});
 
       CustomPouch.once('created', function (name) {
-        name.should.equal('mydb', 'should be same thing');
+        name.should.equal('mydb_memdown', 'should be same thing');
         done();
       });
-      new PouchDB('mydb');
+      new PouchDB('mydb_memdown');
     });
 
     // somewhat odd behavior (CustomPouch constructor always mirrors PouchDB),
@@ -167,10 +167,10 @@ if (!process.env.LEVEL_ADAPTER &&
     it('PouchDB emits destroyed when using defaults', function () {
       var CustomPouch = PouchDB.defaults({db: require('memdown')});
 
-      return new CustomPouch('mydb').then(function (db) {
+      return new CustomPouch('mydb_memdown').then(function (db) {
         return new PouchDB.utils.Promise(function (resolve) {
           PouchDB.once('destroyed', function (name) {
-            name.should.equal('mydb');
+            name.should.equal('mydb_memdown');
             resolve();
           });
           db.destroy();
@@ -184,10 +184,10 @@ if (!process.env.LEVEL_ADAPTER &&
       var CustomPouch = PouchDB.defaults({db: require('memdown')});
 
       PouchDB.once('created', function (name) {
-        name.should.equal('mydb', 'should be same thing');
+        name.should.equal('mydb_memdown', 'should be same thing');
         done();
       });
-      new CustomPouch('mydb');
+      new CustomPouch('mydb_memdown');
     });
 
   });


### PR DESCRIPTION
This `Function.name` checking only makes sense in Node,
and it only matters when the user creates two databases
with the same name but different `db`s. We can simplify
the code and just document the weird edge case.