### PR TITLE
BREAKING, merge after 4.0.1 - (#4223) - remove PouchDB.destroy()

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -85,27 +85,6 @@ PouchDB.parseAdapter = function (name, opts) {
   };
 };
 
-PouchDB.destroy = utils.toPromise(function (name, opts, callback) {
-  console.log('PouchDB.destroy() is deprecated and will be removed. ' +
-              'Please use db.destroy() instead.');
-
-  if (typeof opts === 'function' || typeof opts === 'undefined') {
-    callback = opts;
-    opts = {};
-  }
-  if (name && typeof name === 'object') {
-    opts = name;
-    name = undefined;
-  }
-
-  new PouchDB(name, opts, function (err, db) {
-    if (err) {
-      return callback(err);
-    }
-    db.destroy(callback);
-  });
-});
-
 PouchDB.adapter = function (id, obj, addToPreferredAdapters) {
   if (obj.valid()) {
     PouchDB.adapters[id] = obj;
@@ -143,20 +122,6 @@ PouchDB.defaults = function (defaultOpts) {
   }
 
   utils.inherits(PouchAlt, PouchDB);
-
-  PouchAlt.destroy = utils.toPromise(function (name, opts, callback) {
-    if (typeof opts === 'function' || typeof opts === 'undefined') {
-      callback = opts;
-      opts = {};
-    }
-
-    if (name && typeof name === 'object') {
-      opts = name;
-      name = undefined;
-    }
-    opts = utils.extend({}, defaultOpts, opts);
-    return PouchDB.destroy(name, opts, callback);
-  });
 
   setUpEventEmitter(PouchAlt);
 


### PR DESCRIPTION
Another deprecation I would like to get in for 5.0.0.
Let's please wait to merge until after 4.0.1 is published, though.

I went through and audited most of my plugins, express-pouchdb,
PouchDB Server, etc., and I am ready to get rid of `PouchDB.destroy()`.
For every other plugin author, I think we've given fair warning.