### PR TITLE
(#4240) - switch to phantom for pouchdb-server test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ env:
 
   # Test against pouchdb-server
   - CLIENT=node SERVER=pouchdb-server COMMAND=test
-  - CLIENT=selenium:firefox SERVER=pouchdb-server COMMAND=test
+  - CLIENT=selenium:phantomjs ES5_SHIM=true SERVER=pouchdb-server COMMAND=test
   - SERVER_ADAPTER=memdown LEVEL_ADAPTER=memdown SERVER=pouchdb-server COMMAND=test
 
   # Test against pouchdb-express-router
@@ -123,7 +123,7 @@ matrix:
   - node_js: "iojs"
     env: CLIENT=node COMMAND=test
   - env: CLIENT=node SERVER=pouchdb-server COMMAND=test
-  - env: CLIENT=selenium:firefox SERVER=pouchdb-server COMMAND=test
+  - env: CLIENT=selenium:phantomjs ES5_SHIM=true SERVER=pouchdb-server COMMAND=test
 
 
   fast_finish: true


### PR DESCRIPTION
So I suspect this issue is related to the proxy using
too many connections (or something), and that it's
an issue the average user will never run into and so we
might as well just do the easy fix and switch to PhantomJS
instead of Firefox. PhantomJS is faster anyway.

Obviously eventually I want to track this down, but it's
more important to catch real bugs in PouchDB Server.