### PR TITLE
(#4243) - add report-coverage to allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,7 @@ matrix:
     env: CLIENT=node COMMAND=test
   - env: CLIENT=node SERVER=pouchdb-server COMMAND=test
   - env: CLIENT=selenium:firefox SERVER=pouchdb-server COMMAND=test
+  - env: COMMAND=report-coverage
 
 
   fast_finish: true


### PR DESCRIPTION
It's been permafail for the past couple of days. Not
sure if the problem is coveralls, the script, etc...