### PR TITLE
[WIP] Add csrf protection

### DIFF
--- a/lib/deps/ajax/prequest-browser.js
+++ b/lib/deps/ajax/prequest-browser.js
@@ -2,6 +2,22 @@
 
 var ajax = require('./ajax-core');
 
+function parseCookies (cookieString) {
+
+}
+
+function parseCookies (cookies) {
+  if (!cookies) {
+    return {};
+  }
+
+  return cookies.split(';').reduce(function (list, cookie) {
+    var parts = cookie.split('=');
+    list[parts.shift().trim()] = decodeURI(parts.join('='));
+    return list;
+  }, {});
+}
+
 module.exports = function(opts, callback) {
 
   // cache-buster, specifically designed to work around IE's aggressive caching
@@ -11,6 +27,12 @@ module.exports = function(opts, callback) {
     var hasArgs = opts.url.indexOf('?') !== -1;
     opts.url += (hasArgs ? '&' : '?') + '_nonce=' + Date.now();
   }
+
+  if (!opts.headers) { opts.headers = {};}
+
+  var cookies = parseCookies(document.cookie);
+  var csrf = cookies['CouchDB-CSRF'] ? cookies['CouchDB-CSRF'] : 'true';
+  opts.headers['X-CouchDB-CSRF'] = csrf;
 
   return ajax(opts, callback);
 };


### PR DESCRIPTION
This adds support for the csrf protection implemented in CouchDB 2.
Currently this will not work with CORS as PouchDB does not have access
to the required cookies.

Adding this as a starting point for #4147. Currently all tests will fail as this won't work with CORS. Ideally if we could only enable this for requests that are not CORS requests that would be great start. I'm not quite sure of the best way of doing that.