### PR TITLE
(#4256) - remove CORS warning message

### DIFF
--- a/lib/deps/ajax/ajax-core.js
+++ b/lib/deps/ajax/ajax-core.js
@@ -6,7 +6,6 @@ var errors = require('./../errors');
 var utils = require('../../utils');
 var applyTypeToBuffer = require('./applyTypeToBuffer');
 var defaultBody = require('./defaultBody');
-var explainCors = require('./explainCors');
 
 function ajax(options, callback) {
 
@@ -89,9 +88,6 @@ function ajax(options, callback) {
   return request(options, function (err, response, body) {
     if (err) {
       if (response) {
-        if (response.statusCode === 0) {
-          explainCors(); // statusCode 0 indicates a CORS error (405)
-        }
         err.status = response.statusCode;
       } else {
         err.status = 400;

--- a/lib/deps/ajax/explainCors-browser.js
+++ b/lib/deps/ajax/explainCors-browser.js
@@ -1,9 +1,0 @@
-'use strict';
-
-module.exports = function () {
-  if ('console' in global && 'error' in console) {
-    console.error('PouchDB error: the remote database does not seem to have ' +
-      'CORS enabled. To fix this, please enable CORS: ' +
-      'http://pouchdb.com/errors.html#no_access_control_allow_origin_header');
-  }
-};

--- a/lib/deps/ajax/explainCors.js
+++ b/lib/deps/ajax/explainCors.js
@@ -1,4 +1,0 @@
-'use strict';
-
-//Node users don't need to see this warning
-module.exports = function () {};

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "./lib/deps/ajax/createMultipartPart.js": "./lib/deps/ajax/createMultipartPart-browser.js",
     "./lib/deps/ajax/defaultBody.js": "./lib/deps/ajax/defaultBody-browser.js",
     "./lib/deps/ajax/explain404.js": "./lib/deps/ajax/explain404-browser.js",
-    "./lib/deps/ajax/explainCors.js": "./lib/deps/ajax/explainCors-browser.js",
     "./lib/deps/env/hasLocalStorage.js": "./lib/deps/env/hasLocalStorage-browser.js",
     "./lib/deps/env/isChromeApp.js": "./lib/deps/env/isChromeApp-browser.js",
     "./lib/deps/binary/base64StringToBlobOrBuffer.js": "./lib/deps/binary/base64StringToBlobOrBuffer-browser.js",


### PR DESCRIPTION
If we can't consistently detect CORS problems, then I'd rather just not print anything out at all. This was an effort to be helpful, but frankly false positives can be more dangerous than false negatives.

I know that a lot of newbie PouchDB users have run into this error and been hopelessly confused about what to do, and it's even bitten me as recently as a few weeks ago (not sure how I missed it, stupid me). Hopefully people will google the mysterious words they see in their console (`No 'Access-Control-Allow-Origin' header`) and come upon our error page: http://pouchdb.com/errors.html#no_access_control_allow_origin_header

As a side note, I really dislike CORS.