### PR TITLE
(#4268) - Remove gender specific language

### DIFF
--- a/docs/_guides/documents.md
+++ b/docs/_guides/documents.md
@@ -141,14 +141,14 @@ If you fail to include the correct `_rev`, you will get the following sad error:
 Updating documents correctly
 -----------
 
-So to update Mittens' age, we will first need to fetch Mittens from the database, to ensure that we have the correct `_rev` before we put him back. We don't need to manually assign the `_rev` value here (like we did above), as it is already in the `doc` we're fetching. 
+So to update Mittens' age, we will first need to fetch Mittens from the database, to ensure that we have the correct `_rev` before we put them back. We don't need to manually assign the `_rev` value here (like we did above), as it is already in the `doc` we're fetching. 
 
 ```js
 // fetch mittens
 db.get('mittens').then(function (doc) {
-  // update his age
+  // update their age
   doc.age = 4;
-  // put him back
+  // put them back
   return db.put(doc);
 }).then(function () {
   // fetch mittens again
@@ -183,7 +183,7 @@ Now you should see the following:
 }
 ```
 
-As you can see, we have successfully updated Mittens' age to 4 (they grow up so fast!), and his revision marker has also changed to `"2-3e3fd988b331193beeeea2d4221b57e7"`. If we wanted to increment his age to 5, we would need to supply this new revision marker.
+As you can see, we have successfully updated Mittens' age to 4 (they grow up so fast!), and their revision marker has also changed to `"2-3e3fd988b331193beeeea2d4221b57e7"`. If we wanted to increment their age to 5, we would need to supply this new revision marker.
 
 Related API documentation
 --------

--- a/docs/_guides/setup-couchdb.md
+++ b/docs/_guides/setup-couchdb.md
@@ -5,7 +5,7 @@ title: Setting up CouchDB
 sidebar: guides_nav.html
 ---
 
-CouchDB: PouchDB's big brother
+CouchDB: PouchDB's older sibling
 --------
 
 One of the main benefits of learning PouchDB is that it's exactly the same as CouchDB. In fact, PouchDB is a shameless plagiarist: all of the API methods are the same, with only slight modifications to make it more JavaScript-y.


### PR DESCRIPTION
Done by running [alexjs.com](http://alexjs.com) against this repository and amending the warnings that came up.

The following errors remain but they are blog posts rather than documentation. I would update the blog posts too, but I'd like to know how others feel about that first.

```shell
docs/_posts/2014-07-25-pouchdb-levels-up.md
  41:120-41:122  warning  `he` may be insensitive, use `they`, `it` instead
  41:281-41:283  warning  `he` may be insensitive, use `they`, `it` instead
  63:94-63:99    warning  `crazy` may be insensitive, use `person with mental illness`, `person with symptoms of mental illness`, `rude`, `mean`, `disgusting`, `vile` instead
  71:19-71:24    warning  `crazy` may be insensitive, use `person with mental illness`, `person with symptoms of mental illness`, `rude`, `mean`, `disgusting`, `vile` instead
```

```shell
docs/_posts/2014-06-17-12-pro-tips-for-better-code-with-pouchdb.md
  137:44-137:49    warning  `crazy` may be insensitive, use `person with mental illness`, `person with symptoms of mental illness`, `rude`, `mean`, `disgusting`, `vile` instead
  217:328-217:330  warning  `he` may be insensitive, use `they`, `it` instead
  217:348-217:353  warning  `crazy` may be insensitive, use `person with mental illness`, `person with symptoms of mental illness`, `rude`, `mean`, `disgusting`, `vile` instead
  219:111-219:114  warning  `him` may be insensitive, use `their`, `theirs` instead
```

Note that this was just checking `.md` files in the root of the repo, and in the `docs` folder. I am trying to see if there is a way to check all files in all folders in an easy manner.

:cat2: 