### PR TITLE
(#4278) - Remove use of 'crazy' in documentation and tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -220,7 +220,7 @@ The `adapters` list is a comma-separated list that will be used for `PouchDB.pre
 
     http://localhost:8000/tests/index.html?adapters=websql
 
-Or even make the `preferredAdapters` list any crazy thing you want:
+Or even make the `preferredAdapters` list anything you want:
 
     # loads websql, then memory, then idb, then localstorage
     http://localhost:8000/tests/index.html?adapters=websql,memory,idb,localstorage

--- a/docs/_posts/2014-06-17-12-pro-tips-for-better-code-with-pouchdb.md
+++ b/docs/_posts/2014-06-17-12-pro-tips-for-better-code-with-pouchdb.md
@@ -134,7 +134,7 @@ myDoc._id = pouchCollate.toIndexableString(
   [myDoc.age, myDoc.male, mydoc.lastName, mydoc.firstName]);
 ```
 
-In the above example, the doc ID will be a crazy string, which will sort correctly in both CouchDB and PouchDB:
+In the above example, the doc ID will be a strange string, which will sort correctly in both CouchDB and PouchDB:
 
 ```js
 '5323256.70000000000000017764\u000021\u00004McDuck\u00004Scrooge\u0000\u0000'

--- a/docs/_posts/2014-07-25-pouchdb-levels-up.md
+++ b/docs/_posts/2014-07-25-pouchdb-levels-up.md
@@ -60,7 +60,7 @@ However, the fact that we can have dozens of PouchDB backends, while only mainta
 
 ### Conclusion
 
-PouchDB has a bright future as part of the LevelUP ecosystem. What would have sounded like a crazy dream half a year ago is now a verifiable reality, with unit tests to boot.  Today you can write an app that:
+PouchDB has a bright future as part of the LevelUP ecosystem. What would have sounded like a dream half a year ago is now a verifiable reality, with unit tests to boot.  Today you can write an app that:
 
 * Syncs from CouchDB to an in-memory [PouchDB Server](https://github.com/pouchdb/pouchdb-server),
 * Then syncs to LocalStorage on IE 8,
@@ -68,7 +68,7 @@ PouchDB has a bright future as part of the LevelUP ecosystem. What would have so
 * Then syncs to a PhoneGap app using the [SQLite Plugin](https://github.com/brodysoft/Cordova-SQLitePlugin),
 * Then syncs to any one of Redis, Riak, SQLite, LevelDB, MySQL, PostgreSQL, and potentially [many more](https://github.com/rvagg/node-levelup/wiki/Modules#storage-back-ends).
 
-Or whatever other crazy combination you can cook up!
+Or whatever other combination you can cook up!
 
 The marriage of PouchDB and LevelUP has essentially resulted in a marriage of the CouchDB sync protocol to the LevelUP API. Any database that exposes a LevelUP interface is now a full-fledged CouchDB replication target, which is a huge win for application developers.
 

--- a/docs/_posts/2015-04-05-filtered-replication.md
+++ b/docs/_posts/2015-04-05-filtered-replication.md
@@ -85,7 +85,7 @@ Now, this looks easy, and it is, but there are a few gotchas:
 * Since we're doing live replication, the `complete` event will not trigger, so use `paused` instead.
 * Documents will come in batches, so you might not get the whole `_changes` feed at once.
 * You cannot really delete documents in the local database. Purging is a feature the PouchDB team is [still working on](https://github.com/pouchdb/pouchdb/issues/802).
-* If you change something on the server side to cause the document to no longer pass the filter, then the document won't pass the filter. Crazy, right? CouchDB won't check the last two versions of the document &ndash; just the last one. This simply means that those documents will persist on the client and never be present in the `_changes` feed.
+* If you change something on the server side to cause the document to no longer pass the filter, then the document won't pass the filter. Weird, right? CouchDB won't check the last two versions of the document &ndash; just the last one. This simply means that those documents will persist on the client and never be present in the `_changes` feed.
 * Watch how you delete your documents! Simply going into Futon and happily clicking "Delete Document&hellip;" won't replicate the deletion. What you want to do is update the document, adding a `_deleted: true` field. From the [CouchDB docs](https://wiki.apache.org/couchdb/Replication):
 
 > When using filtered replication, you should not use the `DELETE` method to remove documents, but instead use `PUT` and add a `_deleted:true`

--- a/tests/integration/test.all_docs.js
+++ b/tests/integration/test.all_docs.js
@@ -464,8 +464,8 @@ adapters.forEach(function (adapter) {
 
     it('test escaped startkey/endkey', function (done) {
       var db = new PouchDB(dbs.name);
-      var id1 = '"crazy id!" a';
-      var id2 = '"crazy id!" z';
+      var id1 = '"weird id!" a';
+      var id2 = '"weird id!" z';
       var docs = {
         docs: [
           {

--- a/tests/mapreduce/test.mapreduce.js
+++ b/tests/mapreduce/test.mapreduce.js
@@ -1433,7 +1433,7 @@ function tests(suiteName, dbName, dbType, viewType) {
             opts.keys = [2, 1, 2, 3, 2];
             return db.query(queryFun, opts);
           }).then(function (data) {
-            // duplicates and unknowns at the same time, for maximum crazy
+            // duplicates and unknowns at the same time, for maximum weirdness
             data.rows.should.have.length(4, 'returns 2 docs with duplicates/unknowns');
             data.rows[0].doc._id.should.equal('doc_2');
             data.rows[1].doc._id.should.equal('doc_1');
@@ -1504,7 +1504,7 @@ function tests(suiteName, dbName, dbType, viewType) {
             emit(doc.bar);
             emit(doc.foo);
             emit(doc.bar, 'multiple values!');
-            emit(doc.bar, 'crazy!');
+            emit(doc.bar, 'crayon!');
           }
         }).then(function (mapFunction) {
           return db.bulkDocs({
@@ -1535,7 +1535,7 @@ function tests(suiteName, dbName, dbType, viewType) {
           should.not.exist(data.rows[4].value);
           data.rows[5].key.should.equal('bar');
           data.rows[5].id.should.equal('doc1');
-          data.rows[5].value.should.equal('crazy!');
+          data.rows[5].value.should.equal('crayon!');
           data.rows[6].key.should.equal('bar');
           data.rows[6].id.should.equal('doc1');
           data.rows[6].value.should.equal('multiple values!');
@@ -1545,7 +1545,7 @@ function tests(suiteName, dbName, dbType, viewType) {
           should.not.exist(data.rows[7].value);
           data.rows[8].key.should.equal('bar');
           data.rows[8].id.should.equal('doc2');
-          data.rows[8].value.should.equal('crazy!');
+          data.rows[8].value.should.equal('crayon!');
           data.rows[9].key.should.equal('bar');
           data.rows[9].id.should.equal('doc2');
           data.rows[9].value.should.equal('multiple values!');
@@ -2044,9 +2044,9 @@ function tests(suiteName, dbName, dbType, viewType) {
           emit(doc.foo, 'fooValue');
           emit(doc.foo);
           emit(doc.bar);
-          emit(doc.bar, 'crazy!');
+          emit(doc.bar, 'crayon!');
           emit(doc.bar, 'multiple values!');
-          emit(doc.bar, 'crazy!');
+          emit(doc.bar, 'crayon!');
         }
       }).then(function (mapFun) {
 
@@ -2056,8 +2056,8 @@ function tests(suiteName, dbName, dbType, viewType) {
           res.rows.should.have.length(12, 'correctly return rows');
           res.total_rows.should.equal(12, 'correctly return total_rows');
           res.rows.map(getValues).should.deep.equal(
-            [null, 'crazy!', 'crazy!', 'multiple values!',
-              null, 'crazy!', 'crazy!', 'multiple values!',
+            [null, 'crayon!', 'crayon!', 'multiple values!',
+              null, 'crayon!', 'crayon!', 'multiple values!',
               null, 'fooValue', null, 'fooValue']);
           res.rows.map(getIds).should.deep.equal(
             ['doc1', 'doc1', 'doc1', 'doc1',


### PR DESCRIPTION
Seems alexjs isn't as robust as I would like it to be (it skips a lot of files) so I found these with a manual lookup in my files.

:sunny: 