### PR TITLE
(#4204) - avoid revs_limit stemming unless necessary

### DIFF
--- a/lib/deps/docs/processDocs.js
+++ b/lib/deps/docs/processDocs.js
@@ -85,8 +85,11 @@ function processDocs(docInfos, api, fetchedDocs, tx, results, writeDoc, opts,
           resultsIdx, docWritten, writeDoc, newEdits);
       } else {
         // Ensure stemming applies to new writes as well
-        var merged =  merge.merge([], currentDoc.metadata.rev_tree[0], 1000);
-        currentDoc.metadata.rev_tree = merged.tree;
+        if (parseInt(currentDoc.metadata.rev.split('-')[0], 10) > 1000) {
+          // Optimization: no need to stem if the rev is e.g. 1-a, 2-b, 3-c
+          var merged =  merge.merge([], currentDoc.metadata.rev_tree[0], 1000);
+          currentDoc.metadata.rev_tree = merged.tree;
+        }
         insertDoc(currentDoc, resultsIdx, docWritten);
       }
     }


### PR DESCRIPTION
This is a tiny performance optimization, but should
apply to the vast majority of users, whose revs are
never exceeding 1000.