### PR TITLE
(#4283) - update es5-shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "cordova": "~3.4.1-0.1.0",
     "corsproxy": "~0.2.13",
     "derequire": "^2.0.0",
-    "es5-shim": "^3.1.1",
+    "es5-shim": "^4.1.11",
     "express": "^4.10.4",
     "express-pouchdb": "^0.17.0",
     "glob": "~3.2.9",


### PR DESCRIPTION
The warning about es5-shim v3.0.0 has been stealing mental cycles from me every time I install pouchdb:

> npm WARN deprecated es5-shim@3.4.0: v4.0.0 no longer shims Array#splice with ES5 behavior, makes shims non-enumerable when possible, and fixes a bug in ES3 browsers referencing String#indexOf/lastIndexOf before polyfilling it