### PR TITLE
(#4288) - refactor changes() in idb/index.js

### DIFF
--- a/lib/adapters/idb/index.js
+++ b/lib/adapters/idb/index.js
@@ -417,7 +417,6 @@ function init(api, opts, callback) {
     }
 
     var docIds = opts.doc_ids && new utils.Set(opts.doc_ids);
-    var descending = opts.descending ? 'prev' : null;
 
     opts.since = opts.since || 0;
     var lastSeq = opts.since;
@@ -441,6 +440,7 @@ function init(api, opts, callback) {
     var txn;
     var bySeqStore;
     var docStore;
+    var docIdRevIndex;
 
     function onGetCursor(cursor) {
 
@@ -470,10 +470,9 @@ function init(api, opts, callback) {
 
       function fetchWinningDoc() {
         var docIdRev = doc._id + '::' + metadata.winningRev;
-        var req = bySeqStore.index('_doc_id_rev').openCursor(
-          IDBKeyRange.bound(docIdRev, docIdRev + '\uffff'));
+        var req = docIdRevIndex.get(docIdRev);
         req.onsuccess = function (e) {
-          onGetWinningDoc(decodeDoc(e.target.result.value));
+          onGetWinningDoc(decodeDoc(e.target.result));
         };
       }
 
@@ -539,16 +538,14 @@ function init(api, opts, callback) {
 
       bySeqStore = txn.objectStore(BY_SEQ_STORE);
       docStore = txn.objectStore(DOC_STORE);
+      docIdRevIndex = bySeqStore.index('_doc_id_rev');
 
       var req;
 
-      if (descending) {
-        req = bySeqStore.openCursor(
-
-          null, descending);
+      if (opts.descending) {
+        req = bySeqStore.openCursor(null, 'prev');
       } else {
-        req = bySeqStore.openCursor(
-          IDBKeyRange.lowerBound(opts.since, true));
+        req = bySeqStore.openCursor(IDBKeyRange.lowerBound(opts.since, true));
       }
 
       req.onsuccess = onsuccess;


### PR DESCRIPTION
1. Use `store.get()` instead of `store.openCursor()` - it was unnecessary.
2. Just some general refactoring to make the code tighter.