### PR TITLE
(#3356) - put try/catch inside own function

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,6 +30,15 @@ exports.extend = require('./deps/extend');
 exports.pick = require('./deps/pick');
 exports.inherits = require('inherits');
 
+function tryFilter(filter, doc, req) {
+  try {
+    return !filter(doc, req);
+  } catch (err) {
+    var msg = 'Filter function threw: ' + err.toString();
+    return errors.error(errors.BAD_REQUEST, msg);
+  }
+}
+
 exports.filterChange = function filterChange(opts) {
   var req = {};
   var hasFilter = opts.filter && typeof opts.filter === 'function';
@@ -42,13 +51,7 @@ exports.filterChange = function filterChange(opts) {
       change.doc = {};
     }
 
-    var filterReturn;
-    try {
-      filterReturn = hasFilter && !opts.filter.call(this, change.doc, req);
-    } catch (err) {
-      var msg = 'Filter function threw: ' + err.toString();
-      filterReturn = errors.error(errors.BAD_REQUEST, msg);
-    }
+    var filterReturn = hasFilter && tryFilter(opts.filter, change.doc, req);
 
     if (typeof filterReturn === 'object') {
       return filterReturn;


### PR DESCRIPTION
This ensures that the deoptimized try/catch only affects
users who are actually filtering.