### PR TITLE
(pouchdb/express-pouchdb#255) - use node 0.12 as default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "0.10"
+  - "0.12"
 
 services:
   - couchdb
@@ -134,9 +134,9 @@ matrix:
   fast_finish: true
 
   include:
-    - node_js: "0.11"
+    - node_js: "0.10"
       env: CLIENT=node COMMAND=test
-    - node_js: "0.12"
+    - node_js: "0.11"
       env: CLIENT=node COMMAND=test
     - node_js: "stable"
       env: CXX=g++-4.8 CLIENT=node COMMAND=test


### PR DESCRIPTION
I'm not really motivated to fix a PouchDB Server bug that only
occurs in Node 0.10. Let's just make 0.12 the default and
then test CouchDB using 0.10.