### PR TITLE
Revert "(#4305) - Temporarily revert to old travis infra"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ services:
 git:
   depth: 30
 
-# sudo: false
+sudo: false
 
-# cache:
-#   directories:
-#     - node_modules
-#     - /tmp/phantomjs
+cache:
+  directories:
+    - node_modules
+    - /tmp/phantomjs
 
 addons:
   apt:


### PR DESCRIPTION
This reverts commit 8f606e16ce57f2224a615a797d08d404317004fc.

Maybe if we're lucky, we'll no longer get an OOM because
we're on Node 0.12? If this is red for `report-coverage`, though,
then I don't want to merge it.