### PR TITLE
(#4313) - fix options usage within http adapter

### DIFF
--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -63,7 +63,7 @@ function preprocessAttachments(doc) {
 
 // Get all the information you possibly can about the URI given by name and
 // return it as a suitable object.
-function getHost(name, opts) {
+function getHost(name) {
   // Prase the URI into all its little bits
   var uri = utils.parseUri(name);
 
@@ -83,8 +83,6 @@ function getHost(name, opts) {
   // Restore the path by joining all the remaining parts (all the parts
   // except for the database name) with '/'s
   uri.path = parts.join('/');
-  opts = opts || {};
-  opts = clone(opts);
 
   return uri;
 }
@@ -123,6 +121,8 @@ function HttpPouch(opts, callback) {
 
   var host = getHostFun(opts.name, opts);
   var dbUrl = genDBUrl(host, '');
+
+  opts = clone(opts);
   var ajaxOpts = opts.ajax || {};
 
   api.getUrl = function () { return dbUrl; };
@@ -134,8 +134,6 @@ function HttpPouch(opts, callback) {
     ajaxOpts.headers = ajaxOpts.headers || {};
     ajaxOpts.headers.Authorization = 'Basic ' + token;
   }
-
-  opts = clone(opts);
 
   function ajax(userOpts, options, callback) {
     var reqAjax = userOpts.ajax || {};


### PR DESCRIPTION
@daleharvey noticed some oddities in the diff from 3c964adbfb9a187af79d1685d63497bdc6b9ecc6

1st commit: `getHost` no longer uses `opts`. So in particular, we definitely dont need to clone them. Still passes `opts` to `getHostFn` in case the passed in implementation uses it.

2nd commit: after the change, the input `opts.ajax` is being modified within the `if (opts.auth || host.auth)` so this just moves the `clone` earlier

Can fix-up commit messages / add regression test for the second case, but was able to just do this quick to get it in front of you