### PR TITLE
Add support for a 'persistentIndexedDB' option when creating a PouchDB

### DIFF
--- a/lib/adapters/idb/index.js
+++ b/lib/adapters/idb/index.js
@@ -806,7 +806,12 @@ function init(api, opts, callback) {
     return;
   }
 
-  var req = indexedDB.open(dbName, ADAPTER_VERSION);
+  var req;
+  if (opts.persistentIndexedDB) {
+    req = indexedDB.open(dbName, {version: ADAPTER_VERSION, storage: 'persistent'});
+  } else {
+    req = indexedDB.open(dbName, ADAPTER_VERSION);
+  }
 
   if (!('openReqList' in IdbPouch)) {
     IdbPouch.openReqList = {};

--- a/lib/adapters/idb/index.js
+++ b/lib/adapters/idb/index.js
@@ -808,7 +808,8 @@ function init(api, opts, callback) {
 
   var req;
   if (opts.storage) {
-    req = indexedDB.open(dbName, {version: ADAPTER_VERSION, storage: opts.storage});
+    req = indexedDB.open(dbName, {version: ADAPTER_VERSION,
+      storage: opts.storage});
   } else {
     req = indexedDB.open(dbName, ADAPTER_VERSION);
   }

--- a/lib/adapters/idb/index.js
+++ b/lib/adapters/idb/index.js
@@ -807,8 +807,8 @@ function init(api, opts, callback) {
   }
 
   var req;
-  if (opts.persistentIndexedDB) {
-    req = indexedDB.open(dbName, {version: ADAPTER_VERSION, storage: 'persistent'});
+  if (opts.storage) {
+    req = indexedDB.open(dbName, {version: ADAPTER_VERSION, storage: opts.storage});
   } else {
     req = indexedDB.open(dbName, ADAPTER_VERSION);
   }


### PR DESCRIPTION
This option will enable persistent storage on Firefox only. See https://github.com/pouchdb/pouchdb/issues/4315.