### PR TITLE
(#4329) - Add fruitdown as a supported adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,81 +54,82 @@ env:
 
   matrix:
   - CLIENT=node COMMAND=test
-  - CLIENT=node LEVEL_PREFIX=foo_ COMMAND=test
+  # - CLIENT=node LEVEL_PREFIX=foo_ COMMAND=test
 
   # Test against pouchdb-server
-  - CLIENT=node SERVER=pouchdb-server COMMAND=test
-  - CLIENT=selenium:firefox SERVER=pouchdb-server COMMAND=test
-  - SERVER_ADAPTER=memdown LEVEL_ADAPTER=memdown SERVER=pouchdb-server COMMAND=test
+  # - CLIENT=node SERVER=pouchdb-server COMMAND=test
+  # - CLIENT=selenium:firefox SERVER=pouchdb-server COMMAND=test
+  # - SERVER_ADAPTER=memdown LEVEL_ADAPTER=memdown SERVER=pouchdb-server COMMAND=test
 
   # Test against pouchdb-express-router
-  - CLIENT=node SERVER=pouchdb-express-router COMMAND=test
+  # - CLIENT=node SERVER=pouchdb-express-router COMMAND=test
 
   # Test in firefox/phantomjs running on travis
-  - CLIENT=selenium:firefox COMMAND=test
-  - CLIENT=selenium:phantomjs ES5_SHIM=true COMMAND=test
+  # - CLIENT=selenium:firefox COMMAND=test
+  # - CLIENT=selenium:phantomjs ES5_SHIM=true COMMAND=test
 
   # Test auto-compaction in Node, Phantom, and Firefox
-  - AUTO_COMPACTION=true CLIENT=node COMMAND=test
-  - AUTO_COMPACTION=true CLIENT=selenium:firefox COMMAND=test
-  - AUTO_COMPACTION=true CLIENT=selenium:phantomjs ES5_SHIM=true COMMAND=test
+  # - AUTO_COMPACTION=true CLIENT=node COMMAND=test
+  # - AUTO_COMPACTION=true CLIENT=selenium:firefox COMMAND=test
+  # - AUTO_COMPACTION=true CLIENT=selenium:phantomjs ES5_SHIM=true COMMAND=test
 
   # Test map/reduce
-  - TYPE=mapreduce CLIENT=node COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:firefox COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:phantomjs ES5_SHIM=true COMMAND=test
+  # - TYPE=mapreduce CLIENT=node COMMAND=test
+  # - TYPE=mapreduce CLIENT=selenium:firefox COMMAND=test
+  # - TYPE=mapreduce CLIENT=selenium:phantomjs ES5_SHIM=true COMMAND=test
 
   # Testing in saucelabs
-  - CLIENT=saucelabs:chrome:36 COMMAND=test
-  - CLIENT=saucelabs:chrome:37 COMMAND=test
-  - CLIENT=saucelabs:chrome COMMAND=test
-  - CLIENT=saucelabs:safari:6 COMMAND=test
-  - CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
-  - CLIENT="saucelabs:internet explorer:10:Windows 8" ADAPTERS=memory COMMAND=test
+  # - CLIENT=saucelabs:chrome:36 COMMAND=test
+  # - CLIENT=saucelabs:chrome:37 COMMAND=test
+  # - CLIENT=saucelabs:chrome COMMAND=test
+  # - CLIENT=saucelabs:safari:6 COMMAND=test
+  # - CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
+  # - CLIENT="saucelabs:internet explorer:10:Windows 8" ADAPTERS=memory COMMAND=test
 
   # split up the android+iphone tests as it goes over time
-  - GREP=suite2 INVERT=true SKIP_MIGRATION=true CLIENT="saucelabs:iphone:8.1:OS X 10.10" COMMAND=test
-  - GREP=suite2 SKIP_MIGRATION=true CLIENT="saucelabs:iphone:8.1:OS X 10.10" COMMAND=test
+  # - GREP=suite2 INVERT=true SKIP_MIGRATION=true CLIENT="saucelabs:iphone:8.1:OS X 10.10" COMMAND=test
+  # - GREP=suite2 SKIP_MIGRATION=true CLIENT="saucelabs:iphone:8.1:OS X 10.10" COMMAND=test
 
-  - GREP=suite2 CLIENT="saucelabs:Android:5.1:Linux" COMMAND=test
-  - GREP=suite2 INVERT=true CLIENT="saucelabs:Android:5.1:Linux" COMMAND=test
+  # - GREP=suite2 CLIENT="saucelabs:Android:5.1:Linux" COMMAND=test
+  # - GREP=suite2 INVERT=true CLIENT="saucelabs:Android:5.1:Linux" COMMAND=test
 
-  - CLIENT=selenium:firefox ADAPTERS=memory COMMAND=test
-  - CLIENT=selenium:firefox ADAPTERS=localstorage COMMAND=test
+  # - CLIENT=selenium:firefox ADAPTERS=memory COMMAND=test
+  # - CLIENT=selenium:firefox ADAPTERS=localstorage COMMAND=test
+  - CLIENT=selenium:firefox ADAPTERS=fruitdown COMMAND=test
 
   # Test CouchDB master (aka bigcouch branch)
-  - CLIENT=node SERVER=couchdb-master COMMAND=test
-  - SKIP_MIGRATION=true CLIENT=selenium:firefox SERVER=couchdb-master COMMAND=test
+  # - CLIENT=node SERVER=couchdb-master COMMAND=test
+  # - SKIP_MIGRATION=true CLIENT=selenium:firefox SERVER=couchdb-master COMMAND=test
 
   # Test Couchbase Sync Gateway
-  - GREP=test.replication.js CLIENT=node SERVER=sync-gateway BAIL=0 COMMAND=test
+  # - GREP=test.replication.js CLIENT=node SERVER=sync-gateway BAIL=0 COMMAND=test
 
   # Performance tests
-  - CLIENT=selenium:firefox PERF=1 COMMAND=test
-  - PERF=1 COMMAND=test
+  # - CLIENT=selenium:firefox PERF=1 COMMAND=test
+  # - PERF=1 COMMAND=test
 
-  - COMMAND=test-unit
-  - COMMAND=test-component
-  - COMMAND=test-fuzzy
-  - COMMAND=report-coverage
-  - COMMAND=verify-bundle-size
+  # - COMMAND=test-unit
+  # - COMMAND=test-component
+  # - COMMAND=test-fuzzy
+  # - COMMAND=report-coverage
+  # - COMMAND=verify-bundle-size
 
 matrix:
 
   allow_failures:
   # Expected failures
-  - env: GREP=test.replication.js CLIENT=node SERVER=sync-gateway BAIL=0 COMMAND=test
+  # - env: GREP=test.replication.js CLIENT=node SERVER=sync-gateway BAIL=0 COMMAND=test
 
   # Allowed failures
-  - env: CLIENT=node SERVER=couchdb-master COMMAND=test
-  - env: SKIP_MIGRATION=true CLIENT=selenium:firefox SERVER=couchdb-master COMMAND=test
-  - env: CLIENT=node SERVER=pouchdb-express-router COMMAND=test
-  - node_js: "iojs"
-    env: CLIENT=node COMMAND=test
-  - env: CLIENT=node SERVER=pouchdb-server COMMAND=test
-  - env: CLIENT=selenium:firefox SERVER=pouchdb-server COMMAND=test
-  - env: SERVER_ADAPTER=memdown LEVEL_ADAPTER=memdown SERVER=pouchdb-server COMMAND=test
-  - env: COMMAND=report-coverage
+  # - env: CLIENT=node SERVER=couchdb-master COMMAND=test
+  # - env: SKIP_MIGRATION=true CLIENT=selenium:firefox SERVER=couchdb-master COMMAND=test
+  # - env: CLIENT=node SERVER=pouchdb-express-router COMMAND=test
+  # - node_js: "iojs"
+  #   env: CLIENT=node COMMAND=test
+  # - env: CLIENT=node SERVER=pouchdb-server COMMAND=test
+  # - env: CLIENT=selenium:firefox SERVER=pouchdb-server COMMAND=test
+  # - env: SERVER_ADAPTER=memdown LEVEL_ADAPTER=memdown SERVER=pouchdb-server COMMAND=test
+  # - env: COMMAND=report-coverage
 
 
   fast_finish: true

--- a/TESTING.md
+++ b/TESTING.md
@@ -72,15 +72,15 @@ You may need to install `ant` in order for the Android tests to run (e.g. `brew 
 Run the tests against an iOS simulator:
 
     $ CLIENT=ios npm run cordova
-    
-Run the tests against a connected Android device, using the given COUCH_HOST    
-    
+
+Run the tests against a connected Android device, using the given COUCH_HOST
+
     $ CLIENT=android DEVICE=true COUCH_HOST=http://example.com:5984
 
 Run the tests against the FirefoxOS simulator:
 
     $ CLIENT=firefoxos npm run cordova
-    
+
 Run the tests against a BlackBerry 10 device:
 
     $ CLIENT=blackberry10 DEVICE=true npm run cordova
@@ -89,10 +89,10 @@ Use a custom Couch host:
 
     $ COUCH_HOST=http://myurl:5984 npm run cordova
 
-Grep some tests:    
+Grep some tests:
 
     $ GREP=basics npm run cordova
-    
+
 Test against the [SQLite Plugin](https://github.com/brodysoft/Cordova-SQLitePlugin):
 
     $ SQLITE_PLUGIN=true ADAPTERS=websql npm run cordova
@@ -112,7 +112,7 @@ You can also debug with Weinre by doing:
 
     $ npm install -g weinre
     $ weinre --boundHost=0.0.0.0
-    
+
 Then run the tests with:
 
     $ WEINRE_HOST=http://route.to.my.weinre:8080 npm run cordova
@@ -157,7 +157,7 @@ Some Level adapters also require a standard database name prefix (e.g. `riak://`
 To run the performance test suite in node.js:
 
     PERF=1 npm test
-    
+
 Or the automated browser runner:
 
     PERF=1 CLIENT=selenium:firefox npm test
@@ -178,7 +178,7 @@ You can specify a particular version of PouchDB or a particular adapter by doing
     http://localhost:8000/tests/performance/index.html?adapter=websql
     http://localhost:8000/tests/performance/index.html?adapter=idb&src=//site.com/pouchdb.js
 
-All of the browser plugin adapters (i.e. `memory`, and `localstorage`) are also available this way.
+All of the browser plugin adapters (i.e. `fruitdown`, `memory`, and `localstorage`) are also available this way.
 
 You can also specify particular tests by using `grep=`, e.g.:
 
@@ -196,8 +196,9 @@ Run `npm run dev`, then open it in Safari or iOS.
 Adapter plugins and adapter order
 --------------------------------------
 
-We are currently building two adapters-as-plugins: `memory` and `localstorage`.  All are based on the [LevelDOWN API](https://github.com/rvagg/abstract-leveldown):
+We are currently building three adapters-as-plugins: `fruitdown`, `memory` and `localstorage`.  All are based on the [LevelDOWN API](https://github.com/rvagg/abstract-leveldown):
 
+* `fruitdown`: based on [FruitDOWN](https://github.com/nolanlawson/fruitdown)
 * `memory`: based on [MemDOWN](https://github.com/rvagg/memdown)
 * `localstorage`: based on [localstorage-down](https://github.com/no9/localstorage-down)
 

--- a/bin/add-license.js
+++ b/bin/add-license.js
@@ -32,6 +32,14 @@ var comments = {
     '\n(c) 2012-' + currentYear + ' Dale Harvey and the PouchDB team' +
     '\nPouchDB may be freely distributed under the Apache license, version 2.0.' +
     '\nFor all details and documentation:' +
+    '\nhttp://pouchdb.com',
+
+  'pouchdb.fruitdown': 'PouchDB fruitdown plugin ' + version +
+    '\nBased on FruitDOWN: https://github.com/nolanlawson/fruitdown' +
+    '\n' +
+    '\n(c) 2012-' + currentYear + ' Dale Harvey and the PouchDB team' +
+    '\nPouchDB may be freely distributed under the Apache license, version 2.0.' +
+    '\nFor all details and documentation:' +
     '\nhttp://pouchdb.com'
 };
 
@@ -49,6 +57,3 @@ Object.keys(comments).forEach(function (name) {
     fs.writeFileSync(filename, contents);
   });
 });
-
-
-

--- a/bin/build-all-plugins.sh
+++ b/bin/build-all-plugins.sh
@@ -4,7 +4,7 @@ DEREQUIRE=./node_modules/.bin/derequire
 BROWSERIFY=./node_modules/.bin/browserify
 UGLIFY=./node_modules/.bin/uglifyjs
 
-for plugin in memory localstorage; do
+for plugin in memory localstorage fruitdown; do
   $BROWSERIFY ./extras/${plugin} \
       -x pouchdb \
       -p bundle-collapser/plugin \

--- a/docs/_includes/api/extras.html
+++ b/docs/_includes/api/extras.html
@@ -1,4 +1,4 @@
-{% include anchor.html edit="true" title="Extras" hash="extras" %} 
+{% include anchor.html edit="true" title="Extras" hash="extras" %}
 
 PouchDB offers some "extra" APIs that are designed for PouchDB plugin authors, or for those who want to use non-standard adapters like in-memory and LocalStorage.
 
@@ -7,6 +7,20 @@ These can be especially useful when you are using [Browserify](http://browserify
 ### Browser adapter plugins
 
 These adapters are alternatives to PouchDB's built-in IndexedDB/WebSQL adapters. They fully pass the PouchDB test suite.
+
+#### FruitDOWN adapter
+
+{% highlight js %}
+var PouchDB = require('pouchdb');
+require('pouchdb/extras/fruitdown');
+
+var db = new PouchDB('mydb', {adapter: 'fruitdown'});
+{% endhighlight %}
+
+PouchDB adapter using [FruitDOWN](https://github.com/nolanlawson/fruitdown).
+This is an alternative to the default IndexedDB adapter that ships with PouchDB, which works over all implementations of IndexedDB, including Apple's buggy version.
+
+You can also download this plugin [as a standalone script](https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb.fruitdown.js).
 
 #### In-memory adapter
 
@@ -56,7 +70,7 @@ So for instance, if the user loads PouchDB in a browser that does not support We
 
 ### APIs for plugin authors
 
-These APIs are designed for PouchDB plugin authors, who may want to re-use some PouchDB code to avoid duplication. 
+These APIs are designed for PouchDB plugin authors, who may want to re-use some PouchDB code to avoid duplication.
 
 To use these APIs, you should save PouchDB as a required npm dependency (`npm install --save pouchdb`) and then require them like so:
 

--- a/extras/fruitdown.js
+++ b/extras/fruitdown.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../lib/plugins/fruitdown');

--- a/lib/plugins/fruitdown/config.js
+++ b/lib/plugins/fruitdown/config.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  name: 'fruitdown',
+  valid: function () {
+    return !!global.indexedDB;
+  },
+  use_prefix: true
+};

--- a/lib/plugins/fruitdown/index.js
+++ b/lib/plugins/fruitdown/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var pluginBase = require('../base');
+var adapterConfig = require('./config');
+var downAdapter = require('fruitdown');
+pluginBase(adapterConfig, downAdapter);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "debug": "^2.1.2",
     "double-ended-queue": "^2.0.0-0",
     "es3ify": "^0.1.3",
+    "fruitdown": "^1.0.0",
     "inherits": "~2.0.1",
     "level-js": "^2.2.1",
     "level-sublevel": "^6.5.0",


### PR DESCRIPTION
I've commented out all tests but fruitdown and node to try it out.