### PR TITLE
(#4195) - remove vuvuzela

### DIFF
--- a/lib/adapters/idb/utils.js
+++ b/lib/adapters/idb/utils.js
@@ -54,7 +54,7 @@ exports.idbError = function (callback) {
 // format for the revision trees other than JSON.
 exports.encodeMetadata = function (metadata, winningRev, deleted) {
   return {
-    data: utils.safeJsonStringify(metadata),
+    data: JSON.stringify(metadata),
     winningRev: winningRev,
     deletedOrLocal: deleted ? '1' : '0',
     seq: metadata.seq, // highest seq for this doc
@@ -66,7 +66,7 @@ exports.decodeMetadata = function (storedObject) {
   if (!storedObject) {
     return null;
   }
-  var metadata = utils.safeJsonParse(storedObject.data);
+  var metadata = JSON.parse(storedObject.data);
   metadata.winningRev = storedObject.winningRev;
   metadata.deleted = storedObject.deletedOrLocal === '1';
   metadata.seq = storedObject.seq;

--- a/lib/adapters/leveldb/index.js
+++ b/lib/adapters/leveldb/index.js
@@ -55,13 +55,6 @@ var UUID_KEY = '_local_uuid';
 
 var MD5_PREFIX = 'md5-';
 
-var safeJsonEncoding = {
-  encode: utils.safeJsonStringify,
-  decode: utils.safeJsonParse,
-  buffer: false,
-  type: 'cheap-json'
-};
-
 // winningRev and deleted are performance-killers, but
 // in newer versions of PouchDB, they are cached on the metadata
 function getWinningRev(metadata) {
@@ -176,7 +169,7 @@ function LevelPouch(opts, callback) {
   }
 
   function afterDBCreated() {
-    stores.docStore = db.sublevel(DOC_STORE, {valueEncoding: safeJsonEncoding});
+    stores.docStore = db.sublevel(DOC_STORE, {valueEncoding: 'json'});
     stores.bySeqStore = db.sublevel(BY_SEQ_STORE, {valueEncoding: 'json'});
     stores.attachmentStore =
       db.sublevel(ATTACHMENT_STORE, {valueEncoding: 'json'});

--- a/lib/adapters/websql/bulkDocs.js
+++ b/lib/adapters/websql/bulkDocs.js
@@ -235,7 +235,7 @@ function websqlBulkDocs(req, opts, api, db, Changes, callback) {
       ' WHERE doc_id=' + DOC_STORE + '.id AND rev=?) WHERE id=?'
         : 'INSERT INTO ' + DOC_STORE +
       ' (id, winningseq, max_seq, json) VALUES (?,?,?,?);';
-      var metadataStr = utils.safeJsonStringify(docInfo.metadata);
+      var metadataStr = JSON.stringify(docInfo.metadata);
       var id = docInfo.metadata.id;
       var params = isUpdate ?
         [metadataStr, seq, winningRev, id] :
@@ -277,7 +277,7 @@ function websqlBulkDocs(req, opts, api, db, Changes, callback) {
       tx.executeSql('SELECT json FROM ' + DOC_STORE +
       ' WHERE id = ?', [id], function (tx, result) {
         if (result.rows.length) {
-          var metadata = utils.safeJsonParse(result.rows.item(0).json);
+          var metadata = JSON.parse(result.rows.item(0).json);
           fetchedDocs.set(id, metadata);
         }
         checkDone();

--- a/lib/adapters/websql/index.js
+++ b/lib/adapters/websql/index.js
@@ -578,7 +578,7 @@ function WebSqlPouch(opts, callback) {
         return finish();
       }
       var item = results.rows.item(0);
-      metadata = utils.safeJsonParse(item.metadata);
+      metadata = JSON.parse(item.metadata);
       if (item.deleted && !opts.rev) {
         err = errors.error(errors.MISSING_DOC, 'deleted');
         return finish();
@@ -672,7 +672,7 @@ function WebSqlPouch(opts, callback) {
         tx.executeSql(sql, sqlArgs, function (tx, result) {
           for (var i = 0, l = result.rows.length; i < l; i++) {
             var item = result.rows.item(i);
-            var metadata = utils.safeJsonParse(item.metadata);
+            var metadata = JSON.parse(item.metadata);
             var id = metadata.id;
             var data = unstringifyDoc(item.data, id, item.rev);
             var winningRev = data._rev;
@@ -784,7 +784,7 @@ function WebSqlPouch(opts, callback) {
           }
           for (var i = 0, l = result.rows.length; i < l; i++) {
             var item = result.rows.item(i);
-            var metadata = utils.safeJsonParse(item.metadata);
+            var metadata = JSON.parse(item.metadata);
             lastSeq = item.maxSeq;
 
             var doc = unstringifyDoc(item.winningDoc, metadata.id,
@@ -866,7 +866,7 @@ function WebSqlPouch(opts, callback) {
         if (!result.rows.length) {
           callback(errors.error(errors.MISSING_DOC));
         } else {
-          var data = utils.safeJsonParse(result.rows.item(0).metadata);
+          var data = JSON.parse(result.rows.item(0).metadata);
           callback(null, data.rev_tree);
         }
       });
@@ -882,7 +882,7 @@ function WebSqlPouch(opts, callback) {
       // update doc store
       var sql = 'SELECT json AS metadata FROM ' + DOC_STORE + ' WHERE id = ?';
       tx.executeSql(sql, [docId], function (tx, result) {
-        var metadata = utils.safeJsonParse(result.rows.item(0).metadata);
+        var metadata = JSON.parse(result.rows.item(0).metadata);
         traverseRevTree(metadata.rev_tree, function (isLeaf, pos,
                                                            revHash, ctx, opts) {
           var rev = pos + '-' + revHash;
@@ -892,7 +892,7 @@ function WebSqlPouch(opts, callback) {
         });
 
         var sql = 'UPDATE ' + DOC_STORE + ' SET json = ? WHERE id = ?';
-        tx.executeSql(sql, [utils.safeJsonStringify(metadata), docId]);
+        tx.executeSql(sql, [JSON.stringify(metadata), docId]);
       });
 
       compactRevs(revs, docId, tx);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -159,21 +159,3 @@ exports.compactTree = function compactTree(metadata) {
   });
   return revs;
 };
-
-var vuvuzela = require('vuvuzela');
-
-exports.safeJsonParse = function safeJsonParse(str) {
-  try {
-    return JSON.parse(str);
-  } catch (e) {
-    return vuvuzela.parse(str);
-  }
-};
-
-exports.safeJsonStringify = function safeJsonStringify(json) {
-  try {
-    return JSON.stringify(json);
-  } catch (e) {
-    return vuvuzela.stringify(json);
-  }
-};

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "pouchdb-collections": "^1.0.0",
     "request": "^2.61.0",
     "spark-md5": "0.0.5",
-    "through2": "^2.0.0",
-    "vuvuzela": "^1.0.0"
+    "through2": "^2.0.0"
   },
   "optionalDependencies": {
     "leveldown": "^1.4.1"


### PR DESCRIPTION
Been dong some more performance profiling, and this is
still a drag, mostly due to the try/catch deoptimization
in V8. I would also like to reduce the bundle size.

If this is passing in all our Saucelabs browsers, then I
am happy to remove it. If we're lucky, the recent fixes to
actually respect revs_limit at 1000 will mean this will
work now.

Keep in mind, though, that these tests are disabled for
Safari/iOS due to the popup, so we should probably double-check
them manually (specifically the #2543 tests).