### PR TITLE
(#3535) Document and alias skipSetup (skip_setup)

### DIFF
--- a/docs/_includes/api/create_database.html
+++ b/docs/_includes/api/create_database.html
@@ -21,6 +21,7 @@ This method creates a database or opens an existing one. If you use a URL like `
 * `ajax.cache`: Appends a random string to the end of all HTTP GET requests to avoid them being cached on IE. Set this to `true` to prevent this happening.
 * `ajax.headers`: The `ajax.headers` option allows you to customise headers that are sent to the remote HTTP Server.
 * `auth.username` + `auth.password`: You can specify HTTP auth parameters either by using a database with a name in the form `http://user:pass@host/name` or via the `auth.username` + `auth.password` options.
+* `skip_setup`: Initially PouchDB checks if the database exists, and tries to create it, if it does not exist yet. Set this to `true` to skip this setup.
 
 **WebSQL-only options:**
 

--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -172,8 +172,8 @@ function HttpPouch(opts, callback) {
   var setupPromise;
 
   function setup() {
-
-    if (opts.skipSetup) {
+    // TODO: Remove `skipSetup` in favor of `skip_setup` in a future release
+    if (opts.skipSetup || opts.skip_setup) {
       return Promise.resolve();
     }
 

--- a/tests/integration/test.http.js
+++ b/tests/integration/test.http.js
@@ -13,8 +13,8 @@ describe('test.http.js', function () {
     testUtils.cleanup([dbs.name], done);
   });
 
-
-  it('Create a pouch without DB setup', function (done) {
+  // TODO: Remove `skipSetup` in favor of `skip_setup` in a future release
+  it('Create a pouch without DB setup (skipSetup)', function (done) {
     var instantDB;
     testUtils.isCouchDB(function (isCouchDB) {
       if (!isCouchDB) {
@@ -23,6 +23,25 @@ describe('test.http.js', function () {
       new PouchDB(dbs.name).then(function (db) {
         db.destroy(function () {
           instantDB = new PouchDB(dbs.name, { skipSetup: true });
+          instantDB.post({ test: 'abc' }, function (err, info) {
+            should.exist(err);
+            err.name.should.equal('not_found', 'Skipped setup of database');
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  it('Create a pouch without DB setup (skip_setup)', function (done) {
+    var instantDB;
+    testUtils.isCouchDB(function (isCouchDB) {
+      if (!isCouchDB) {
+        return done();
+      }
+      new PouchDB(dbs.name).then(function (db) {
+        db.destroy(function () {
+          instantDB = new PouchDB(dbs.name, { skip_setup: true });
           instantDB.post({ test: 'abc' }, function (err, info) {
             should.exist(err);
             err.name.should.equal('not_found', 'Skipped setup of database');


### PR DESCRIPTION
This tries to solve https://github.com/pouchdb/pouchdb/issues/3535.

I left `skipSetup` in here for compatibility reasons, but added a `TODO` to remove this in a future (major) release.

Let me know, if this works for you.