### PR TITLE
remove the 'use strict' statement from evalFunc.

### DIFF
--- a/lib/mapreduce/evalfunc.js
+++ b/lib/mapreduce/evalfunc.js
@@ -2,5 +2,5 @@
 
 module.exports = function (func, emit, sum, log, isArray, toJSON) {
   /*jshint evil:true,unused:false */
-  return eval("'use strict'; (" + func.replace(/;\s*$/, "") + ");");
+  return eval("(" + func.replace(/;\s*$/, "") + ");");
 };


### PR DESCRIPTION
see https://botbot.me/freenode/pouchdb/2014-11-05/?msg=24904932&page=2 and https://github.com/pouchdb/mapreduce/pull/272#issuecomment-140621453