### PR TITLE
(#4018) - catch errors from websql openDatabase()

### DIFF
--- a/lib/adapters/websql/bulkDocs.js
+++ b/lib/adapters/websql/bulkDocs.js
@@ -18,7 +18,7 @@ var ATTACH_AND_SEQ_STORE = websqlConstants.ATTACH_AND_SEQ_STORE;
 var select = websqlUtils.select;
 var stringifyDoc = websqlUtils.stringifyDoc;
 var compactRevs = websqlUtils.compactRevs;
-var unknownError = websqlUtils.unknownError;
+var unknownError = websqlUtils.websqlError;
 
 function websqlBulkDocs(req, opts, api, db, Changes, callback) {
   var newEdits = opts.new_edits;

--- a/lib/adapters/websql/index.js
+++ b/lib/adapters/websql/index.js
@@ -27,7 +27,7 @@ var stringifyDoc = websqlUtils.stringifyDoc;
 var unstringifyDoc = websqlUtils.unstringifyDoc;
 var select = websqlUtils.select;
 var compactRevs = websqlUtils.compactRevs;
-var unknownError = websqlUtils.unknownError;
+var websqlError = websqlUtils.websqlError;
 var getSize = websqlUtils.getSize;
 var openDB = websqlUtils.openDB;
 
@@ -104,7 +104,7 @@ function WebSqlPouch(opts, callback) {
   api._docCount = -1; // cache sqlite count(*) for performance
   api._name = opts.name;
 
-  var db = openDB({
+  var openDBResult = openDB({
     name: api._name,
     version: POUCH_VERSION,
     description: api._name,
@@ -113,9 +113,11 @@ function WebSqlPouch(opts, callback) {
     createFromLocation: opts.createFromLocation,
     androidDatabaseImplementation: opts.androidDatabaseImplementation
   });
-  if (!db) {
-    return callback(errors.error(errors.UNKNOWN_ERROR));
-  } else if (typeof db.readTransaction !== 'function') {
+  if (openDBResult.error) {
+    return websqlError(callback)(openDBResult.error);
+  }
+  var db = openDBResult.db;
+  if (typeof db.readTransaction !== 'function') {
     // doesn't exist in sqlite plugin
     db.readTransaction = db.transaction;
   }
@@ -473,7 +475,7 @@ function WebSqlPouch(opts, callback) {
         // then get the version
         fetchVersion(tx);
       });
-    }, unknownError(callback), dbCreated);
+    }, websqlError(callback), dbCreated);
   }
 
   function fetchVersion(tx) {
@@ -533,7 +535,7 @@ function WebSqlPouch(opts, callback) {
           });
         });
       });
-    }, unknownError(callback));
+    }, websqlError(callback));
   };
 
   api._bulkDocs = function (req, opts, callback) {
@@ -701,7 +703,7 @@ function WebSqlPouch(opts, callback) {
           }
         });
       });
-    }, unknownError(callback), function () {
+    }, websqlError(callback), function () {
       callback(null, {
         total_rows: totalRows,
         offset: opts.skip,
@@ -816,7 +818,7 @@ function WebSqlPouch(opts, callback) {
             }
           }
         });
-      }, unknownError(opts.complete), function () {
+      }, websqlError(opts.complete), function () {
         if (!opts.continuous) {
           opts.complete(null, {
             results: results,
@@ -896,7 +898,7 @@ function WebSqlPouch(opts, callback) {
       });
 
       compactRevs(revs, docId, tx);
-    }, unknownError(callback), function () {
+    }, websqlError(callback), function () {
       callback();
     });
   };
@@ -962,7 +964,7 @@ function WebSqlPouch(opts, callback) {
     if (opts.ctx) {
       putLocal(opts.ctx);
     } else {
-      db.transaction(putLocal, unknownError(callback), function () {
+      db.transaction(putLocal, websqlError(callback), function () {
         if (ret) {
           callback(null, ret);
         }
@@ -994,7 +996,7 @@ function WebSqlPouch(opts, callback) {
     if (opts.ctx) {
       removeLocal(opts.ctx);
     } else {
-      db.transaction(removeLocal, unknownError(callback), function () {
+      db.transaction(removeLocal, websqlError(callback), function () {
         if (ret) {
           callback(null, ret);
         }
@@ -1010,7 +1012,7 @@ function WebSqlPouch(opts, callback) {
       stores.forEach(function (store) {
         tx.executeSql('DROP TABLE IF EXISTS ' + store, []);
       });
-    }, unknownError(callback), function () {
+    }, websqlError(callback), function () {
       if (hasLocalStorage()) {
         delete window.localStorage['_pouch__websqldb_' + api._name];
         delete window.localStorage[api._name];

--- a/lib/adapters/websql/utils.js
+++ b/lib/adapters/websql/utils.js
@@ -147,8 +147,9 @@ function compactRevs(revs, docId, tx) {
   });
 }
 
-function unknownError(callback) {
+function websqlError(callback) {
   return function (event) {
+    console.error('WebSQL threw an error', event);
     // event may actually be a SQLError object, so report is as such
     var errorNameMatch = event && event.constructor.toString()
         .match(/function ([^\(]+)/);
@@ -191,18 +192,30 @@ function createOpenDBFunction() {
   }
 }
 
+function openDBSafely(openDBFunction, opts) {
+  try {
+    return {
+      db: openDBFunction(opts)
+    };
+  } catch (err) {
+    return {
+      error: err
+    };
+  }
+}
+
 var cachedDatabases = {};
 
 function openDB(opts) {
-
-  var openDBFunction = createOpenDBFunction();
-
-  var db = cachedDatabases[opts.name];
-  if (!db) {
-    db = cachedDatabases[opts.name] = openDBFunction(opts);
-    db._sqlitePlugin = typeof sqlitePlugin !== 'undefined';
+  var cachedResult = cachedDatabases[opts.name];
+  if (!cachedResult) {
+    var openDBFun = createOpenDBFunction();
+    cachedResult = cachedDatabases[opts.name] = openDBSafely(openDBFun, opts);
+    if (cachedResult.db) {
+      cachedResult.db._sqlitePlugin = typeof sqlitePlugin !== 'undefined';
+    }
   }
-  return db;
+  return cachedResult;
 }
 
 function valid() {
@@ -221,7 +234,7 @@ module.exports = {
   qMarks: qMarks,
   select: select,
   compactRevs: compactRevs,
-  unknownError: unknownError,
+  websqlError: websqlError,
   getSize: getSize,
   openDB: openDB,
   valid: valid


### PR DESCRIPTION
This is impossible to test in integration as far as I can tell,
but I can confirm manually that this will catch synchronous
errors thrown by `openDatabase()` in cases like e.g. DOM Exception
18 (in WKWebView or Android WebView if WebSQL is disallowed) or
if the wrong arguments are passed in to `openDatabase()`.