### PR TITLE
(#4289) - Added push/pull replication options (e.g. filters) to sync().

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -27,8 +27,11 @@ function Sync(src, target, opts, callback) {
   var self = this;
   this.canceled = false;
 
-  this.push = replicate(src, target, opts);
-  this.pull = replicate(target, src, opts);
+  var optsPush = opts.push ? utils.extend({}, opts, opts.push) : opts;
+  var optsPull = opts.pull ? utils.extend({}, opts, opts.pull) : opts;
+
+  this.push = replicate(src, target, optsPush);
+  this.pull = replicate(target, src, optsPull);
 
   function pullChange(change) {
     self.emit('change', {


### PR DESCRIPTION
Attempted to write a unit test using a SinonJS spy to watch the replication() calls in sync(), however this won't work as these lines in sync.js ... 

    var replication = require('./replicate');
    var replicate = replication.replicate;

.. bind the replicate() function before it can be intercepted by the unit test.

I have run the `sync()` code via unit tests and added console.log(pushOpts)` and `console.log(pullOpts)`  to confirm that the correct args are being sent to the `replicate()` method.
