### PR TITLE
Updated es5-shim to version 4.1.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cordova": "3.4.1-0.1.0",
     "corsproxy": "0.2.14",
     "derequire": "2.0.2",
-    "es5-shim": "4.1.13",
+    "es5-shim": "4.1.14",
     "express": "4.13.3",
     "express-pouchdb": "0.17.2",
     "glob": "3.2.11",


### PR DESCRIPTION
:rocket:

es5-shim just published version 4.1.14, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 7 commits (ahead by 7, behind by 0).

- [8199ac9](https://github.com/es-shims/es5-shim/commit/8199ac99c7fcea7d619fc7d851ec010f5e21e41e): v4.1.14
- [a1a6b3f](https://github.com/es-shims/es5-shim/commit/a1a6b3fb45bc3c8f98b87fdeea1ee363aa3520ba): [Dev Deps] update `eslint`, `jscs`
- [835757c](https://github.com/es-shims/es5-shim/commit/835757cc46385659f733922de168d7b623675a37): Use `ES.ToUint32` instead of inline `>>>`.
- [c543c3b](https://github.com/es-shims/es5-shim/commit/c543c3b8e1fc31feff091a7c7f0070620fa6eb5d): Wrap more things in a try/catch, because IE sucks and sometimes throws on [[Get]] of window.localStorage.
- [0bc64b8](https://github.com/es-shims/es5-shim/commit/0bc64b8b046040e2b203c2e83b5427d30353bd9a): s/\t/    /g
- [c2e68ba](https://github.com/es-shims/es5-shim/commit/c2e68ba239d160e8d22c663b6b35126d17480559): [Dev Deps] update `eslint`, `@ljharb/eslint-config`, `semver`
- [06f2574](https://github.com/es-shims/es5-shim/commit/06f2574b3a727067fa6b2a27c4932df2e8a102c2): [Tests] up to `node` `v4.1`

See the [full diff](https://github.com/es-shims/es5-shim/compare/917d93159a107f351945fd223b2bc86a42aaabe9...8199ac99c7fcea7d619fc7d851ec010f5e21e41e).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>