### PR TITLE
Updated watchify to version 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "ua-parser-js": "0.6.2",
     "uglify-js": "2.4.24",
     "watch-glob": "0.1.3",
-    "watchify": "2.6.2",
+    "watchify": "3.4.0",
     "wd": "0.3.12"
   },
   "scripts": {


### PR DESCRIPTION
:rocket:

watchify just published version 3.4.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 62 commits (ahead by 62, behind by 0).

- [a7ca3f4](https://github.com/substack/watchify/commit/a7ca3f4998c33b8b815f4f857f8c52fd9b2bf91e): 3.4.0
- [478b8af](https://github.com/substack/watchify/commit/478b8afa782ccc502cb9a3a9067560576f0604b9): Merge pull request #258 from substack/throttle-update
- [ded6f4b](https://github.com/substack/watchify/commit/ded6f4b8d6c8d8d0cd8b9d63286fefcfbd097267): Merge pull request #261 from kahlil/patch-1
- [f4f3d39](https://github.com/substack/watchify/commit/f4f3d392e7a90c82ef7b896d4229ac87c1bb12a9): changed `w.on('log', function (msg) {})` description
- [63eab02](https://github.com/substack/watchify/commit/63eab024131704ca781821bcdb187c95f584b3a0): re-schedule update when invalidating during bundling
- [cdf1315](https://github.com/substack/watchify/commit/cdf1315a76b8defee619b5820805a3be9d48749d): debounce "update" event
- [5c846c0](https://github.com/substack/watchify/commit/5c846c0edcc89cfeafe4c54d75d2becd95d65aaa): decrease delay to 100ms
- [cf0e356](https://github.com/substack/watchify/commit/cf0e356395a2d6b61a68d53f094f0548c77fd970): wrap
- [341360d](https://github.com/substack/watchify/commit/341360d9a7653ca45a48caa8617332a8912f42ac): Fixes #254
- [664f2c3](https://github.com/substack/watchify/commit/664f2c3ef04848718504f7b0ca003e76439801fd): 3.3.1
- [ef5a250](https://github.com/substack/watchify/commit/ef5a250293022e43cf068da1e486232b60fc922b): move updating=true back up, fixed issue upstream in browserify
- [edc6fc3](https://github.com/substack/watchify/commit/edc6fc3ed113f1d3c7b2a1da768ae5044fe865e9): reverted setting updated=true in bundle event, setting updated=true in bundle event causes test suite to fail
- [227be4e](https://github.com/substack/watchify/commit/227be4e3849fc8b35d35d017f2091975a846d2aa): set updating=true in bundle event
- [847c549](https://github.com/substack/watchify/commit/847c5490c15a53cec456491442e08e092535d04d): track updating status to remove race condition that deletes watchers
- [a9788af](https://github.com/substack/watchify/commit/a9788afbf7ebcf6cf1dea92694cd55e583e736b0): formatting


There are 62 commits in total. See the [full diff](https://github.com/substack/watchify/compare/8009c76545a89f4c86549a06a0e7d2404651eed5...a7ca3f4998c33b8b815f4f857f8c52fd9b2bf91e).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>