### PR TITLE
Updated express-pouchdb to version 0.17.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "derequire": "2.0.2",
     "es5-shim": "4.1.14",
     "express": "4.13.3",
-    "express-pouchdb": "0.17.2",
+    "express-pouchdb": "0.17.3",
     "glob": "3.2.11",
     "http-server": "0.8.5",
     "istanbul": "0.3.21",


### PR DESCRIPTION
:rocket:

express-pouchdb just published version 0.17.3, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 5 commits (ahead by 5, behind by 0).

- [b48a0b1](https://github.com/pouchdb/express-pouchdb/commit/b48a0b14d6b44cb85354dc81f63acdb9b8246ec0): 0.17.3
- [4eda703](https://github.com/pouchdb/express-pouchdb/commit/4eda7032619682ed95867fff39c797c1cbbfea78): update pouchdb-server version
- [87c86a9](https://github.com/pouchdb/express-pouchdb/commit/87c86a93e5ef0ce738634b367ae8e40ca0c194eb): (#240) - allow GETing a user's document as the user
- [1808abd](https://github.com/pouchdb/express-pouchdb/commit/1808abd579675aac8dfc4def703683ff5640a8bb): (#255) - switch to 0.12 as default
- [00e836f](https://github.com/pouchdb/express-pouchdb/commit/00e836f9d171e35b6005a9a43508e144ba561bfd): (#257) - Redirect /_utils/ to /_utils

See the [full diff](https://github.com/pouchdb/express-pouchdb/compare/6684d30b9005171c27557da8ac9f59a6c3ba3e8f...b48a0b14d6b44cb85354dc81f63acdb9b8246ec0).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>