### PR TITLE
(#4412) - pouchdb 5.0.0 blog post

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "pouchdb",
-  "version": "4.0.4-prerelease",
+  "version": "5.0.1-prerelease",
   "description": "PouchDB is a pocket-sized database.",
   "repo": "daleharvey/pouchdb",
   "keywords": [

--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
   "name": "pouchdb",
-  "version": "4.0.4-prerelease",
+  "version": "5.0.1-prerelease",
   "description": "PouchDB is a pocket-sized database.",
   "repo": "daleharvey/pouchdb",
   "keywords": [

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,7 +4,7 @@ url: http://pouchdb.com
 highlighter: pygments
 markdown: redcarpet
 baseurl:
-version: 4.0.3
+version: 5.0.0
 paginate: 5
 paginate_path: "blog/page:num"
 github:

--- a/docs/_posts/2015-10-05-pouchdb-5.0.0-five-years-of-pouchdb.md
+++ b/docs/_posts/2015-10-05-pouchdb-5.0.0-five-years-of-pouchdb.md
@@ -1,0 +1,90 @@
+---
+layout: post
+
+title: PouchDB 5.0.0 - Five years of PouchDB
+author: Nolan Lawson
+
+---
+
+Fitting with the fact that [PouchDB turned five years old this year](https://github.com/pouchdb/pouchdb/commit/d600081962d3f54b410e5cfcf78cd413ad94abb9), we're proud to announce PouchDB 5.0.0. This release contains the usual number of bugfixes and improvements, as well as several deprecations, since it is a major version bump.
+
+The biggest news in terms of features is support for [\_bulk\_get](https://mail-archives.apache.org/mod_mbox/couchdb-dev/201509.mbox/%3CCA%2BvSmEYjimR3emsgHOTkNqdBcN_Rvh-V9gQZtDBVAEEcMO1TQQ%40mail.gmail.com%3E), which is a new CouchDB API that enables vastly faster replication, set to be debuted in CouchDB 2.0. This API is also shipped in the newly-released PouchDB Server 1.0.0, meaning you can test out the faster replication now.
+
+### Deprecations
+
+* Remove `PouchDB.destroy()` ([#4223](http://github.com/pouchdb/pouchdb/issues/4223))
+
+Having a `destroy()` function on the `PouchDB` object was always a little awkward, which is why we introduced the `db.destroy()` alternative. So now that `PouchDB.destroy()` is out, upgrading your code should be easy:
+
+```js
+PouchDB.destroy('mydb');
+```
+
+becomes:
+
+```js
+new PouchDB('mydb').destroy();
+```
+
+Keep in mind that the `PouchDB` object is no longer usable after you `destroy()` it. So you should call `new PouchDB()` again if you want to re-use it.
+
+* Remove CRUD events ([#4224](http://github.com/pouchdb/pouchdb/issues/4224))
+
+These events (`'create'`, `'update'`, and `'delete'`) were intended to make the `changes()` API easier to work with, but they ended up being too ambitious and confusing, so 5.0.0 removes them.
+
+If you are relying on these events, then you can upgrade like so:
+
+```js
+db.changes({live: true})
+  .on('create', createListener)
+  .on('update', updateListener)
+  .on('delete', deleteListener);
+```
+
+becomes:
+
+
+```js
+db.changes({live: true})
+  .on('change', function (change) {
+    if (change.deleted) {
+      deleteListener(change);
+    } else if (change.changes.length === 1 &&
+               /^1-/.test(change.changes[0].rev)) {
+      createListener(change);
+    } else {
+      updateListener(change);
+    }
+  });
+```
+
+Keep in mind that this "update vs. create" test is not foolproof (what happens if a `2-` document is the first version that gets synced? what happens if two conflicting `1-` revisions are synced?), but it will match the old behavior.
+
+Most of the time, your UI should be able to handle document "updates" or "creates" equivalently, so `change.deleted` becomes the only special case. See [Efficiently managing UI state with PouchDB](http://pouchdb.com/2015/02/28/efficiently-managing-ui-state-in-pouchdb.html) for some details about how to do this.
+
+* Remove `idb-alt` plugin ([#4222](http://github.com/pouchdb/pouchdb/issues/4222))
+
+This was an alternative IndexedDB adapter based on [Level.js](https://github.com/maxogden/level.js), which was experimental and probably unused by anyone except the PouchDB developers themselves.
+
+### New features
+
+* Implement `bulkGet()` ([#3424](http://github.com/pouchdb/pouchdb/issues/3424))
+* Allow user to specify Firefox persistent storage ([#4315](http://github.com/pouchdb/pouchdb/issues/4315))
+* Allow setting http options per request ([#3941](http://github.com/pouchdb/pouchdb/issues/3941))
+
+### Bugfixes
+
+* Maintain canceled state in replicator better ([#4276](http://github.com/pouchdb/pouchdb/issues/4276))
+* Don't mutate binary objects provided by the user ([#3955](http://github.com/pouchdb/pouchdb/issues/3955) [#4273](http://github.com/pouchdb/pouchdb/issues/4273))
+* Fire events on sync, eensure we only fire one active event ([#4251](http://github.com/pouchdb/pouchdb/issues/4251))
+* Catch errors from WebSQL `openDatabase()` ([#4018](http://github.com/pouchdb/pouchdb/issues/4018))
+* Ensure setup errors propagate to the API ([#4358](http://github.com/pouchdb/pouchdb/issues/4358))
+* Prevent replication firing extra events ([#4293](http://github.com/pouchdb/pouchdb/issues/4293))
+* Proper propagation of quota exceeded errors ([#4018](http://github.com/pouchdb/pouchdb/issues/4018))
+* Remove `'use strict'` from `eval()` ([#4344](http://github.com/pouchdb/pouchdb/issues/4344))
+* Alias `skip_setup` to `skipSetup` ([#3535](http://github.com/pouchdb/pouchdb/issues/3535))
+* Fix options usage within http adapter ([#4313](http://github.com/pouchdb/pouchdb/issues/4313))
+
+### Get in touch
+
+Please [file issues](https://github.com/pouchdb/pouchdb/issues) or [tell us what you think](https://github.com/pouchdb/pouchdb/blob/master/CONTRIBUTING.md#get-in-touch). And as always, a big thanks to all of our [new and existing contributors](https://github.com/pouchdb/pouchdb/graphs/contributors)!

--- a/lib/version-browser.js
+++ b/lib/version-browser.js
@@ -1,1 +1,1 @@
-module.exports = "4.0.4-prerelease";
+module.exports = "5.0.1-prerelease";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pouchdb",
-  "version": "4.0.4-prerelease",
+  "version": "5.0.1-prerelease",
   "description": "PouchDB is a pocket-sized database.",
   "main": "./lib/index.js",
   "homepage": "http://pouchdb.com/",


### PR DESCRIPTION
Not my favorite blog post ever. I wish I had had the time to run some numbers on just how much faster the new `_bulk_get` replication is, but I just didn't have time this weekend. So I wrote a pretty compulsory blog post that just lists out the deprecations/bugfixes/features.

If anybody would like to write a separate blog post about the new replication with some numbers about how much faster it is, that would be much appreciated. :)