### PR TITLE
Updated express-pouchdb to version 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "derequire": "2.0.2",
     "es5-shim": "4.1.14",
     "express": "4.13.3",
-    "express-pouchdb": "0.17.3",
+    "express-pouchdb": "1.0.0",
     "glob": "3.2.11",
     "http-server": "0.8.5",
     "istanbul": "0.3.22",


### PR DESCRIPTION
:rocket:

express-pouchdb just published version 1.0.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 1 commits (ahead by 1, behind by 0).

- [c730133](https://github.com/pouchdb/express-pouchdb/commit/c730133680e24c8b4527f010dd618550ed0ba1b2): 1.0.0

See the [full diff](https://github.com/pouchdb/express-pouchdb/compare/b48a0b14d6b44cb85354dc81f63acdb9b8246ec0...c730133680e24c8b4527f010dd618550ed0ba1b2).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>