### PR TITLE
Updated pouchdb-server to version 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "phantomjs": "1.9.18",
     "pouchdb-express-router": "0.0.8",
     "pouchdb-http-proxy": "0.10.4",
-    "pouchdb-server": "0.9.0",
+    "pouchdb-server": "1.0.0",
     "replace": "0.3.0",
     "rimraf": "2.2.8",
     "sauce-connect-launcher": "0.11.1",


### PR DESCRIPTION
:rocket:

pouchdb-server just published version 1.0.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 3 commits (ahead by 3, behind by 0).

- [1e5659e](https://github.com/pouchdb/pouchdb-server/commit/1e5659e16761dafcf9ef972c301371aa32c624bd): 1.0.0
- [6e7377b](https://github.com/pouchdb/pouchdb-server/commit/6e7377b3bdff556d989d2c848adf44412944b44f): pouchdb -> 5.0.0, express-pouchdb -> 1.0.0
- [d2254f9](https://github.com/pouchdb/pouchdb-server/commit/d2254f96b42519f5fd23f557b336edd7ddc07c2e): (pouchdb/express-pouchdb#255) - switch to node 0.12 in travis

See the [full diff](https://github.com/pouchdb/pouchdb-server/compare/e49ce76be4001df46697cf5ad807556dd52b23d8...1e5659e16761dafcf9ef972c301371aa32c624bd).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>