### PR TITLE
(#4423) - fix timeouts in mapreduce tests

### DIFF
--- a/tests/mapreduce/test.mapreduce.js
+++ b/tests/mapreduce/test.mapreduce.js
@@ -2024,7 +2024,6 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should query correctly with skip/limit and multiple keys/values', function () {
-      this.timeout(20000);
       var db = new PouchDB(dbName);
       var docs = {
         docs: [
@@ -3071,7 +3070,6 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should update the emitted value', function () {
-      this.timeout(30000);
       return new PouchDB(dbName).then(function (db) {
         var docs = [];
         for (var i = 0; i < 300; i++) {

--- a/tests/mapreduce/test.persisted.js
+++ b/tests/mapreduce/test.persisted.js
@@ -249,7 +249,7 @@ function tests(suiteName, dbName, dbType) {
     });
 
     it('many simultaneous persisted views', function () {
-      this.timeout(90000);
+      this.timeout(120000);
       var db = new PouchDB(dbName);
 
       var views = [];
@@ -302,7 +302,6 @@ function tests(suiteName, dbName, dbType) {
     });
 
     it('should query correctly when stale', function () {
-      this.timeout(20000);
       return new PouchDB(dbName).then(function (db) {
         return createView(db, {
           map : function (doc) {
@@ -367,7 +366,6 @@ function tests(suiteName, dbName, dbType) {
     });
 
     it('should query correctly with stale update_after', function () {
-      this.timeout(20000);
       var pouch = new PouchDB(dbName);
 
       return createView(pouch, {map: function (doc) {


### PR DESCRIPTION
`worker-pouch`'s tests are failing, because these timeouts
are actually lower than the global default for mapreduce
(100000). (And `worker-pouch` takes a bit longer to run the tests.)

I suggest removing them and then upping the
one that is likely to take a long time (the "many persisted"
test).