### PR TITLE
(#4422) - Dont test for specific error messages

### DIFF
--- a/tests/integration/test.bulk_docs.js
+++ b/tests/integration/test.bulk_docs.js
@@ -141,8 +141,6 @@ adapters.forEach(function (adapter) {
       db.bulkDocs({ docs: docs }, function (err, info) {
         err.status.should.equal(PouchDB.Errors.RESERVED_ID.status,
                                 'correct error status returned');
-        err.message.should.equal(PouchDB.Errors.RESERVED_ID.message,
-                                 'correct error message returned');
         should.not.exist(info, 'info is empty');
         done();
       });
@@ -158,8 +156,6 @@ adapters.forEach(function (adapter) {
       db.bulkDocs({ docs: docs }, function (err, info) {
         err.status.should.equal(PouchDB.Errors.RESERVED_ID.status,
                                 'correct error returned');
-        err.message.should.equal(PouchDB.Errors.RESERVED_ID.message,
-                                 'correct error message returned');
         should.not.exist(info, 'info is empty');
         done();
       });

--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -667,6 +667,10 @@ adapters.forEach(function (adapter) {
           changes.on('error', resolve);
           changes.on('change', reject);
         });
+      }).catch(function (err) {
+        // CouchDB Master has changed behaviour and now rejects invalid
+        // design documents
+        err.status.should.equal(400);
       });
     });
 


### PR DESCRIPTION
Couch 2.0 changed its error message for these, we have had problems checking for specific error messages before so removed the check