### PR TITLE
(#4435) explain http error caused by check for _bulk_get

### DIFF
--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -189,7 +189,9 @@ function HttpPouch(opts, callback) {
     setupPromise = ajaxPromise({}, checkExists).catch(function(err) {
       if (err && err.status && err.status === 404) {
         // Doesnt exist, create it
-        utils.explain404('PouchDB is just detecting if the remote exists.');
+        utils.explainError(
+          404, 'PouchDB is just detecting if the remote exists.'
+        );
         return ajaxPromise({}, create);
       } else {
         return Promise.reject(err);
@@ -323,6 +325,11 @@ function HttpPouch(opts, callback) {
         if (err) {
           if (Math.floor(err.status / 100) === 4) { // 40x
             supportsBulkGetMap[dbUrl] = false;
+            utils.explainError(
+              err.status,
+              'PouchDB is just detecting if the remote ' +
+              'supports the _bulk_get API.'
+            );
             doBulkGetShim();
           } else {
             callback(err);

--- a/lib/adapters/idb/blobSupport.js
+++ b/lib/adapters/idb/blobSupport.js
@@ -59,7 +59,9 @@ function checkBlobSupport(txn, idb) {
           } else {
             resolve(!!(res && res.type === 'image/png'));
             if (err && err.status === 404) {
-              utils.explain404('PouchDB is just detecting blob URL support.');
+              utils.explainError(
+                404, 'PouchDB is just detecting blob URL support.'
+              );
             }
           }
           URL.revokeObjectURL(url);

--- a/lib/deps/ajax/explain404-browser.js
+++ b/lib/deps/ajax/explain404-browser.js
@@ -1,9 +1,0 @@
-'use strict';
-
-// designed to give info to browser users, who are disturbed
-// when they see 404s in the console
-module.exports = function explain404(str) {
-  if ('console' in global && 'info' in console) {
-    console.info('The above 404 is totally normal. ' + str);
-  }
-};

--- a/lib/deps/ajax/explain404.js
+++ b/lib/deps/ajax/explain404.js
@@ -1,4 +1,0 @@
-'use strict';
-
-// we assume Node users don't need to see this warning
-module.exports = function () {};

--- a/lib/deps/ajax/explainError-browser.js
+++ b/lib/deps/ajax/explainError-browser.js
@@ -1,0 +1,9 @@
+'use strict';
+
+// designed to give info to browser users, who are disturbed
+// when they see http errors in the console
+module.exports = function explainError(status, str) {
+  if ('console' in global && 'info' in console) {
+    console.info('The above ' + status + ' is totally normal. ' + str);
+  }
+};

--- a/lib/deps/ajax/explainError.js
+++ b/lib/deps/ajax/explainError.js
@@ -1,0 +1,4 @@
+'use strict';
+
+// We assume Node users don't need to see this warning
+module.exports = function () {};

--- a/lib/replicate/checkpointer.js
+++ b/lib/replicate/checkpointer.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Promise = require('./../deps/promise');
-var explain404 = require('./../deps/ajax/explain404');
+var explainError = require('./../deps/ajax/explainError');
 var pouchCollate = require('pouchdb-collate');
 var collate = pouchCollate.collate;
 
@@ -21,7 +21,9 @@ function updateCheckpoint(db, id, checkpoint, session, returnValue) {
   return db.get(id).catch(function (err) {
     if (err.status === 404) {
       if (db.type() === 'http') {
-        explain404('PouchDB is just checking if a remote checkpoint exists.');
+        explainError(
+          404, 'PouchDB is just checking if a remote checkpoint exists.'
+        );
       }
       return {
         session_id: session,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -136,7 +136,7 @@ exports.adapterFun = function (name, callback) {
   }));
 };
 
-exports.explain404 = require('./deps/ajax/explain404');
+exports.explainError = require('./deps/ajax/explainError');
 
 exports.parseUri = require('./deps/parseUri');
 

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "./lib/deps/ajax/createBlobOrBufferFromParts.js": "./lib/deps/ajax/createBlobOrBufferFromParts-browser.js",
     "./lib/deps/ajax/createMultipartPart.js": "./lib/deps/ajax/createMultipartPart-browser.js",
     "./lib/deps/ajax/defaultBody.js": "./lib/deps/ajax/defaultBody-browser.js",
-    "./lib/deps/ajax/explain404.js": "./lib/deps/ajax/explain404-browser.js",
+    "./lib/deps/ajax/explainError.js": "./lib/deps/ajax/explainError-browser.js",
     "./lib/deps/ajax/explainCors.js": "./lib/deps/ajax/explainCors-browser.js",
     "./lib/deps/env/hasLocalStorage.js": "./lib/deps/env/hasLocalStorage-browser.js",
     "./lib/deps/env/isChromeApp.js": "./lib/deps/env/isChromeApp-browser.js",


### PR DESCRIPTION
I kept `explain404` around in order to not break the public `utils` API.