### PR TITLE
(#4453) - simpler blobSupport check

### DIFF
--- a/lib/adapters/idb/blobSupport.js
+++ b/lib/adapters/idb/blobSupport.js
@@ -1,29 +1,25 @@
 'use strict';
 
-var utils = require('../../utils');
 var createBlob = require('../../deps/binary/blob');
-
+var Promise = require('../../deps/promise');
 var idbConstants = require('./constants');
 var DETECT_BLOB_SUPPORT_STORE = idbConstants.DETECT_BLOB_SUPPORT_STORE;
 
 //
-// Detect blob support. Chrome didn't support it until version 38.
-// In version 37 they had a broken version where PNGs (and possibly
-// other binary types) aren't stored correctly, because when you fetch
-// them, the content type is always null.
+// Blobs are not supported in all versions of IndexedDB, notably
+// Chrome <37 and Android <5. In those versions, storing a blob will throw.
 //
-// Furthermore, they have some outstanding bugs where blobs occasionally
-// are read by FileReader as null, or by ajax as 404s.
+// Various other blob bugs exist in Chrome v37-42 (inclusive).
+// Detecting them is expensive and confusing to users, and Chrome 37-42
+// is at very low usage worldwide, so we do a hacky userAgent check instead.
 //
-// Sadly we use the 404 bug to detect the FileReader bug, so if they
-// get fixed independently and released in different versions of Chrome,
-// then the bug could come back. So it's worthwhile to watch these issues:
+// content-type bug: https://code.google.com/p/chromium/issues/detail?id=408120
 // 404 bug: https://code.google.com/p/chromium/issues/detail?id=447916
 // FileReader bug: https://code.google.com/p/chromium/issues/detail?id=447836
 //
-function checkBlobSupport(txn, idb) {
-  return new utils.Promise(function (resolve, reject) {
-    var blob = createBlob([''], {type: 'image/png'});
+function checkBlobSupport(txn) {
+  return new Promise(function (resolve, reject) {
+    var blob = createBlob(['']);
     txn.objectStore(DETECT_BLOB_SUPPORT_STORE).put(blob, 'key');
 
     txn.onabort = function (e) {
@@ -35,38 +31,8 @@ function checkBlobSupport(txn, idb) {
     };
 
     txn.oncomplete = function () {
-      // have to do it in a separate transaction, else the correct
-      // content type is always returned
-      var blobTxn = idb.transaction([DETECT_BLOB_SUPPORT_STORE],
-        'readwrite');
-      var getBlobReq = blobTxn.objectStore(
-        DETECT_BLOB_SUPPORT_STORE).get('key');
-      getBlobReq.onerror = reject;
-      getBlobReq.onsuccess = function (e) {
-
-        var storedBlob = e.target.result;
-        var url = URL.createObjectURL(storedBlob);
-
-        utils.ajax({
-          url: url,
-          cache: true,
-          binary: true
-        }, function (err, res) {
-          if (err && err.status === 405) {
-            // firefox won't let us do that. but firefox doesn't
-            // have the blob type bug that Chrome does, so that's ok
-            resolve(true);
-          } else {
-            resolve(!!(res && res.type === 'image/png'));
-            if (err && err.status === 404) {
-              utils.explainError(
-                404, 'PouchDB is just detecting blob URL support.'
-              );
-            }
-          }
-          URL.revokeObjectURL(url);
-        });
-      };
+      var matched = navigator.userAgent.match(/Chrome\/(\d+)/);
+      resolve(!matched || parseInt(matched[1], 10) >= 43);
     };
   }).catch(function () {
     return false; // error, so assume unsupported

--- a/lib/adapters/idb/index.js
+++ b/lib/adapters/idb/index.js
@@ -930,7 +930,7 @@ function init(api, opts, callback) {
 
       if (!blobSupportPromise) {
         // make sure blob support is only checked once
-        blobSupportPromise = checkBlobSupport(txn, idb);
+        blobSupportPromise = checkBlobSupport(txn);
       }
 
       blobSupportPromise.then(function (val) {


### PR DESCRIPTION
I know @daleharvey has wanted something like this for awhile. I've been holding onto it mostly due to sentimentality about the amount of time I had to spend to write the fix :stuck_out_tongue:.

According to [caniuse stats](http://caniuse.com/usage-table), Chrome 37-42 is at 1.36% of all browser users, which is a lot, but not enough to justify the expensive ajax-based check here. I also don't like the dependency of `idb` on `ajax` given the new custom builds, where local-only builds should not have to include `ajax`.

The `userAgent` check I'm proposing is honestly only slightly less hacky than the present solution, since we are using one bug to detect the presence of another. Let's simplify the code and do a straight-up `userAgent` check.

Note this will also get rid of the confusing "PouchDB is only detecting blob support..." message, as well as the fetching of the Blob URL (which also confused people IMO).