### PR TITLE
(#4454) - remove more stuff from PouchDB.utils

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1,6 +1,11 @@
 "use strict";
 
 var utils = require('./utils');
+var pick = require('./deps/pick');
+var collections = require('pouchdb-collections');
+var inherits = require('inherits');
+var getArguments = require('argsarray');
+var adapterFun = require('./deps/adapterFun');
 var errors = require('./deps/errors');
 var EventEmitter = require('events').EventEmitter;
 var upsert = require('./deps/upsert');
@@ -13,10 +18,15 @@ var traverseRevTree = require('./deps/merge/traverseRevTree');
 var collectLeaves = require('./deps/merge/collectLeaves');
 var rootToLeaf = require('./deps/merge/rootToLeaf');
 var collectConflicts = require('./deps/merge/collectConflicts');
+var parseDoc = require('./deps/docs/parseDoc');
 
 /*
  * A generic pouch adapter
  */
+
+function compare(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
 
 // returns first element of arr satisfying callback predicate
 function arrayFirst(arr, callback) {
@@ -50,7 +60,7 @@ function cleanDocs(docs) {
       var atts = Object.keys(doc._attachments);
       for (var j = 0; j < atts.length; j++) {
         var att = atts[j];
-        doc._attachments[att] = utils.pick(doc._attachments[att],
+        doc._attachments[att] = pick(doc._attachments[att],
           ['data', 'digest', 'content_type', 'length', 'revpos', 'stub']);
       }
     }
@@ -59,13 +69,13 @@ function cleanDocs(docs) {
 
 // compare two docs, first by _id then by _rev
 function compareByIdThenRev(a, b) {
-  var idCompare = utils.compare(a._id, b._id);
+  var idCompare = compare(a._id, b._id);
   if (idCompare !== 0) {
     return idCompare;
   }
   var aStart = a._revisions ? a._revisions.start : 0;
   var bStart = b._revisions ? b._revisions.start : 0;
-  return utils.compare(aStart, bStart);
+  return compare(aStart, bStart);
 }
 
 // for every node in a revision tree computes its distance from the closest
@@ -166,7 +176,7 @@ function attachmentNameError(name) {
   return false;
 }
 
-utils.inherits(AbstractPouchDB, EventEmitter);
+inherits(AbstractPouchDB, EventEmitter);
 module.exports = AbstractPouchDB;
 
 function AbstractPouchDB() {
@@ -174,7 +184,7 @@ function AbstractPouchDB() {
 }
 
 AbstractPouchDB.prototype.post =
-  utils.adapterFun('post', function (doc, opts, callback) {
+  adapterFun('post', function (doc, opts, callback) {
   if (typeof opts === 'function') {
     callback = opts;
     opts = {};
@@ -186,7 +196,7 @@ AbstractPouchDB.prototype.post =
 });
 
 AbstractPouchDB.prototype.put =
-  utils.adapterFun('put', utils.getArguments(function (args) {
+  adapterFun('put', getArguments(function (args) {
   var temp, temptype, opts, callback;
   var doc = args.shift();
   var id = '_id' in doc;
@@ -212,7 +222,7 @@ AbstractPouchDB.prototype.put =
     }
   }
   opts = opts || {};
-  utils.invalidIdError(doc._id);
+  parseDoc.invalidIdError(doc._id);
   if (isLocalId(doc._id) && typeof this._putLocal === 'function') {
     if (doc._deleted) {
       return this._removeLocal(doc, callback);
@@ -224,7 +234,7 @@ AbstractPouchDB.prototype.put =
 }));
 
 AbstractPouchDB.prototype.putAttachment =
-  utils.adapterFun('putAttachment', function (docId, attachmentId, rev,
+  adapterFun('putAttachment', function (docId, attachmentId, rev,
                                               blob, type, callback) {
   var api = this;
   if (typeof type === 'function') {
@@ -268,7 +278,7 @@ AbstractPouchDB.prototype.putAttachment =
 });
 
 AbstractPouchDB.prototype.removeAttachment =
-  utils.adapterFun('removeAttachment', function (docId, attachmentId, rev,
+  adapterFun('removeAttachment', function (docId, attachmentId, rev,
                                                  callback) {
   var self = this;
   self.get(docId, function (err, obj) {
@@ -294,7 +304,7 @@ AbstractPouchDB.prototype.removeAttachment =
 });
 
 AbstractPouchDB.prototype.remove =
-  utils.adapterFun('remove', function (docOrId, optsOrRev, opts, callback) {
+  adapterFun('remove', function (docOrId, optsOrRev, opts, callback) {
   var doc;
   if (typeof optsOrRev === 'string') {
     // id, rev, opts, callback style
@@ -328,7 +338,7 @@ AbstractPouchDB.prototype.remove =
 });
 
 AbstractPouchDB.prototype.revsDiff =
-  utils.adapterFun('revsDiff', function (req, opts, callback) {
+  adapterFun('revsDiff', function (req, opts, callback) {
   if (typeof opts === 'function') {
     callback = opts;
     opts = {};
@@ -340,7 +350,7 @@ AbstractPouchDB.prototype.revsDiff =
   }
 
   var count = 0;
-  var missing = new utils.Map();
+  var missing = new collections.Map();
 
   function addToMissing(id, revId) {
     if (!missing.has(id)) {
@@ -405,7 +415,7 @@ AbstractPouchDB.prototype.revsDiff =
 // small). The http adapter overrides this in order
 // to do a more efficient single HTTP request.
 AbstractPouchDB.prototype.bulkGet =
-  utils.adapterFun('bulkGet', function (opts, callback) {
+  adapterFun('bulkGet', function (opts, callback) {
   bulkGetShim(this, opts, callback);
 });
 
@@ -413,7 +423,7 @@ AbstractPouchDB.prototype.bulkGet =
 // by compacting we mean removing all revisions which
 // are further from the leaf in revision tree than max_height
 AbstractPouchDB.prototype.compactDocument =
-  utils.adapterFun('compactDocument', function (docId, maxHeight, callback) {
+  adapterFun('compactDocument', function (docId, maxHeight, callback) {
   var self = this;
   this._getRevisionTree(docId, function (err, revTree) {
     /* istanbul ignore if */
@@ -442,7 +452,7 @@ AbstractPouchDB.prototype.compactDocument =
 // compact the whole database using single document
 // compaction
 AbstractPouchDB.prototype.compact =
-  utils.adapterFun('compact', function (opts, callback) {
+  adapterFun('compact', function (opts, callback) {
   if (typeof opts === 'function') {
     callback = opts;
     opts = {};
@@ -490,7 +500,7 @@ AbstractPouchDB.prototype._compact = function (opts, callback) {
 /* Begin api wrappers. Specific functionality to storage belongs in the
    _[method] */
 AbstractPouchDB.prototype.get =
-  utils.adapterFun('get', function (id, opts, callback) {
+  adapterFun('get', function (id, opts, callback) {
   if (typeof opts === 'function') {
     callback = opts;
     opts = {};
@@ -648,7 +658,7 @@ AbstractPouchDB.prototype.get =
 });
 
 AbstractPouchDB.prototype.getAttachment =
-  utils.adapterFun('getAttachment', function (docId, attachmentId, opts,
+  adapterFun('getAttachment', function (docId, attachmentId, opts,
                                               callback) {
   var self = this;
   if (opts instanceof Function) {
@@ -670,7 +680,7 @@ AbstractPouchDB.prototype.getAttachment =
 });
 
 AbstractPouchDB.prototype.allDocs =
-  utils.adapterFun('allDocs', function (opts, callback) {
+  adapterFun('allDocs', function (opts, callback) {
   if (typeof opts === 'function') {
     callback = opts;
     opts = {};
@@ -714,12 +724,12 @@ AbstractPouchDB.prototype.changes = function (opts, callback) {
 };
 
 AbstractPouchDB.prototype.close =
-  utils.adapterFun('close', function (callback) {
+  adapterFun('close', function (callback) {
   this._closed = true;
   return this._close(callback);
 });
 
-AbstractPouchDB.prototype.info = utils.adapterFun('info', function (callback) {
+AbstractPouchDB.prototype.info = adapterFun('info', function (callback) {
   var self = this;
   this._info(function (err, info) {
     if (err) {
@@ -733,7 +743,7 @@ AbstractPouchDB.prototype.info = utils.adapterFun('info', function (callback) {
   });
 });
 
-AbstractPouchDB.prototype.id = utils.adapterFun('id', function (callback) {
+AbstractPouchDB.prototype.id = adapterFun('id', function (callback) {
   return this._id(callback);
 });
 
@@ -743,7 +753,7 @@ AbstractPouchDB.prototype.type = function () {
 };
 
 AbstractPouchDB.prototype.bulkDocs =
-  utils.adapterFun('bulkDocs', function (req, opts, callback) {
+  adapterFun('bulkDocs', function (req, opts, callback) {
   if (typeof opts === 'function') {
     callback = opts;
     opts = {};
@@ -811,7 +821,7 @@ AbstractPouchDB.prototype.bulkDocs =
 });
 
 AbstractPouchDB.prototype.registerDependentDatabase =
-  utils.adapterFun('registerDependentDatabase', function (dependentDb,
+  adapterFun('registerDependentDatabase', function (dependentDb,
                                                           callback) {
   var depDB = new this.constructor(dependentDb, this.__opts);
 
@@ -830,7 +840,7 @@ AbstractPouchDB.prototype.registerDependentDatabase =
 });
 
 AbstractPouchDB.prototype.destroy =
-  utils.adapterFun('destroy', function (opts, callback) {
+  adapterFun('destroy', function (opts, callback) {
 
   if (typeof opts === 'function') {
     callback = opts;

--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -12,13 +12,20 @@ var supportsBulkGetMap = {};
 // TODO: we could measure the full URL to enforce exactly 2000 chars
 var MAX_URL_LENGTH = 1800;
 
+var uuid = require('../../deps/uuid');
+var pick = require('../../deps/pick');
+var filterChange = require('../../deps/filterChange');
+var coreAdapterFun = require('../../deps/adapterFun');
+var explainError = require('../../deps/ajax/explainError');
 var binStringToBluffer =
   require('../../deps/binary/binaryStringToBlobOrBuffer');
 var b64StringToBluffer =
   require('../../deps/binary/base64StringToBlobOrBuffer');
 var utils = require('../../utils');
-var Promise = utils.Promise;
-var clone = utils.clone;
+var Promise = require('../../deps/promise');
+var clone = require('../../deps/clone');
+var parseUri = require('../../deps/parseUri');
+var getArguments = require('argsarray');
 var base64 = require('../../deps/binary/base64');
 var btoa = base64.btoa;
 var atob = base64.atob;
@@ -70,7 +77,7 @@ function preprocessAttachments(doc) {
 // return it as a suitable object.
 function getHost(name) {
   // Prase the URI into all its little bits
-  var uri = utils.parseUri(name);
+  var uri = parseUri(name);
 
   // Store the user and password as a separate auth object
   if (uri.user || uri.password) {
@@ -159,7 +166,7 @@ function HttpPouch(opts, callback) {
   }
 
   function adapterFun(name, fun) {
-    return utils.adapterFun(name, utils.getArguments(function (args) {
+    return coreAdapterFun(name, getArguments(function (args) {
       setup().then(function (res) {
         return fun.apply(this, args);
       }).catch(function(e) {
@@ -189,7 +196,7 @@ function HttpPouch(opts, callback) {
     setupPromise = ajaxPromise({}, checkExists).catch(function(err) {
       if (err && err.status && err.status === 404) {
         // Doesnt exist, create it
-        utils.explainError(
+        explainError(
           404, 'PouchDB is just detecting if the remote exists.'
         );
         return ajaxPromise({}, create);
@@ -262,7 +269,7 @@ function HttpPouch(opts, callback) {
     });
   });
 
-  api.bulkGet = utils.adapterFun('bulkGet', function (opts, callback) {
+  api.bulkGet = coreAdapterFun('bulkGet', function (opts, callback) {
     var self = this;
 
     function doBulkGet(cb) {
@@ -308,7 +315,7 @@ function HttpPouch(opts, callback) {
       }
 
       for (var i = 0; i < numBatches; i++) {
-        var subOpts = utils.pick(opts, ['revs', 'attachments']);
+        var subOpts = pick(opts, ['revs', 'attachments']);
         subOpts.docs = opts.docs.slice(i * batchSize,
           Math.min(opts.docs.length, (i + 1) * batchSize));
         bulkGetShim(self, subOpts, onResult(i));
@@ -325,7 +332,7 @@ function HttpPouch(opts, callback) {
         if (err) {
           if (Math.floor(err.status / 100) === 4) { // 40x
             supportsBulkGetMap[dbUrl] = false;
-            utils.explainError(
+            explainError(
               err.status,
               'PouchDB is just detecting if the remote ' +
               'supports the _bulk_get API.'
@@ -598,7 +605,7 @@ function HttpPouch(opts, callback) {
 
   // Add the document given by doc (in JSON string format) to the database
   // given by host. This fails if the doc has no _id field.
-  api.put = adapterFun('put', utils.getArguments(function (args) {
+  api.put = adapterFun('put', getArguments(function (args) {
     var temp, temptype, opts;
     var doc = args.shift();
     var callback = args.pop();
@@ -691,7 +698,7 @@ function HttpPouch(opts, callback) {
       return callback(errors.error(errors.NOT_AN_OBJECT));
     }
     if (! ("_id" in doc)) {
-      doc._id = utils.uuid();
+      doc._id = uuid();
     }
     api.put(doc, opts, function (err, res) {
       if (err) {
@@ -1005,7 +1012,7 @@ function HttpPouch(opts, callback) {
         req.query = opts.query_params;
         res.results = res.results.filter(function (c) {
           leftToFetch--;
-          var ret = utils.filterChange(opts)(c);
+          var ret = filterChange(opts)(c);
           if (ret) {
             if (opts.include_docs && opts.attachments && opts.binary) {
               readAttachmentsAsBlobOrBuffer(c);

--- a/lib/adapters/idb/blobSupport.js
+++ b/lib/adapters/idb/blobSupport.js
@@ -2,7 +2,8 @@
 
 var utils = require('../../utils');
 var createBlob = require('../../deps/binary/blob');
-
+var ajax = require('../../deps/ajax/prequest');
+var explainError = require('../../deps/ajax/explainError');
 var idbConstants = require('./constants');
 var DETECT_BLOB_SUPPORT_STORE = idbConstants.DETECT_BLOB_SUPPORT_STORE;
 
@@ -47,7 +48,7 @@ function checkBlobSupport(txn, idb) {
         var storedBlob = e.target.result;
         var url = URL.createObjectURL(storedBlob);
 
-        utils.ajax({
+        ajax({
           url: url,
           cache: true,
           binary: true
@@ -59,7 +60,7 @@ function checkBlobSupport(txn, idb) {
           } else {
             resolve(!!(res && res.type === 'image/png'));
             if (err && err.status === 404) {
-              utils.explainError(
+              explainError(
                 404, 'PouchDB is just detecting blob URL support.'
               );
             }

--- a/lib/adapters/idb/bulkDocs.js
+++ b/lib/adapters/idb/bulkDocs.js
@@ -1,11 +1,13 @@
 'use strict';
 
-var utils = require('../../utils');
+var collections = require('pouchdb-collections');
 var errors = require('../../deps/errors');
 var preprocessAttachments =
   require('../../deps/docs/preprocessAttachments');
 var processDocs = require('../../deps/docs/processDocs');
 var isLocalId = require('../../deps/docs/isLocalId');
+var compactTree = require('../../deps/merge/compactTree');
+var parseDoc = require('../../deps/docs/parseDoc');
 var idbUtils = require('./utils');
 var idbConstants = require('./constants');
 
@@ -37,7 +39,7 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
     if (doc._id && isLocalId(doc._id)) {
       continue;
     }
-    doc = docInfos[i] = utils.parseDoc(doc, opts.new_edits);
+    doc = docInfos[i] = parseDoc.parseDoc(doc, opts.new_edits);
     if (doc.error && !docInfoError) {
       docInfoError = doc;
     }
@@ -48,7 +50,7 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
   }
 
   var results = new Array(docInfos.length);
-  var fetchedDocs = new utils.Map();
+  var fetchedDocs = new collections.Map();
   var preconditionErrored = false;
   var blobType = api._meta.blobSupport ? 'blob' : 'base64';
 
@@ -217,7 +219,7 @@ function idbBulkDocs(req, opts, api, idb, Changes, callback) {
 
   function autoCompact(docInfo) {
 
-    var revsToDelete = utils.compactTree(docInfo.metadata);
+    var revsToDelete = compactTree(docInfo.metadata);
     compactRevs(revsToDelete, docInfo.metadata.id, txn);
   }
 

--- a/lib/adapters/idb/index.js
+++ b/lib/adapters/idb/index.js
@@ -1,6 +1,10 @@
 'use strict';
 
 var utils = require('../../utils');
+var uuid = require('../../deps/uuid');
+var collections = require('pouchdb-collections');
+var filterChange = require('../../deps/filterChange');
+var toPromise = require('../../deps/toPromise');
 var isDeleted = require('../../deps/docs/isDeleted');
 var isLocalId = require('../../deps/docs/isLocalId');
 var errors = require('../../deps/errors');
@@ -12,6 +16,7 @@ var checkBlobSupport = require('./blobSupport');
 var hasLocalStorage = require('../../deps/env/hasLocalStorage');
 var calculateWinningRev = require('../../deps/merge/winningRev');
 var traverseRevTree = require('../../deps/merge/traverseRevTree');
+var Changes = require('../../changesHandler');
 
 var ADAPTER_VERSION = idbConstants.ADAPTER_VERSION;
 var ATTACH_AND_SEQ_STORE = idbConstants.ATTACH_AND_SEQ_STORE;
@@ -280,7 +285,7 @@ function init(api, opts, callback) {
     return 'idb';
   };
 
-  api._id = utils.toPromise(function (callback) {
+  api._id = toPromise(function (callback) {
     callback(null, api._meta.instanceId);
   });
 
@@ -406,7 +411,7 @@ function init(api, opts, callback) {
     opts = utils.clone(opts);
 
     if (opts.continuous) {
-      var id = dbName + ':' + utils.uuid();
+      var id = dbName + ':' + uuid();
       IdbPouch.Changes.addListener(dbName, id, api, opts);
       IdbPouch.Changes.notify(dbName);
       return {
@@ -416,7 +421,7 @@ function init(api, opts, callback) {
       };
     }
 
-    var docIds = opts.doc_ids && new utils.Set(opts.doc_ids);
+    var docIds = opts.doc_ids && new collections.Set(opts.doc_ids);
 
     opts.since = opts.since || 0;
     var lastSeq = opts.since;
@@ -434,8 +439,8 @@ function init(api, opts, callback) {
 
     var results = [];
     var numResults = 0;
-    var filter = utils.filterChange(opts);
-    var docIdsToMetadata = new utils.Map();
+    var filter = filterChange(opts);
+    var docIdsToMetadata = new collections.Map();
 
     var txn;
     var bySeqStore;
@@ -917,7 +922,7 @@ function init(api, opts, callback) {
         instanceId = meta[dbName + '_id'];
         checkSetupComplete();
       } else {
-        instanceId = utils.uuid();
+        instanceId = uuid();
         meta[dbName + '_id'] = instanceId;
         txn.objectStore(META_STORE).put(meta).onsuccess = function () {
           checkSetupComplete();
@@ -973,6 +978,6 @@ IdbPouch.valid = function () {
     typeof IDBKeyRange !== 'undefined';
 };
 
-IdbPouch.Changes = new utils.Changes();
+IdbPouch.Changes = new Changes();
 
 module.exports = IdbPouch;

--- a/lib/adapters/idb/utils.js
+++ b/lib/adapters/idb/utils.js
@@ -2,6 +2,9 @@
 
 var errors = require('../../deps/errors');
 var utils = require('../../utils');
+var pick = require('../../deps/pick');
+var safeJsonParse = require('../../deps/safeJsonParse');
+var safeJsonStringify = require('../../deps/safeJsonStringify');
 var base64 = require('../../deps/binary/base64');
 var btoa = base64.btoa;
 var constants = require('./constants');
@@ -56,7 +59,7 @@ exports.idbError = function (callback) {
 // format for the revision trees other than JSON.
 exports.encodeMetadata = function (metadata, winningRev, deleted) {
   return {
-    data: utils.safeJsonStringify(metadata),
+    data: safeJsonStringify(metadata),
     winningRev: winningRev,
     deletedOrLocal: deleted ? '1' : '0',
     seq: metadata.seq, // highest seq for this doc
@@ -68,7 +71,7 @@ exports.decodeMetadata = function (storedObject) {
   if (!storedObject) {
     return null;
   }
-  var metadata = utils.safeJsonParse(storedObject.data);
+  var metadata = safeJsonParse(storedObject.data);
   metadata.winningRev = storedObject.winningRev;
   metadata.deleted = storedObject.deletedOrLocal === '1';
   metadata.seq = storedObject.seq;
@@ -164,7 +167,7 @@ exports.postProcessAttachments = function (results, asBlob) {
         return new utils.Promise(function (resolve) {
           exports.readBlobData(body, type, asBlob, function (data) {
             row.doc._attachments[att] = utils.extend(
-              utils.pick(attObj, ['digest', 'content_type']),
+              pick(attObj, ['digest', 'content_type']),
               {data: data}
             );
             resolve();

--- a/lib/adapters/leveldb/index.js
+++ b/lib/adapters/leveldb/index.js
@@ -15,12 +15,21 @@ function requireLeveldown() {
 requireLeveldown();
 
 var errors = require('../../deps/errors');
-var utils = require('../../utils');
+var clone = require('../../deps/clone');
+var Changes = require('../../changesHandler');
+var uuid = require('../../deps/uuid');
+var collections = require('pouchdb-collections');
+var filterChange = require('../../deps/filterChange');
+var getArguments = require('argsarray');
+var safeJsonParse = require('../../deps/safeJsonParse');
+var safeJsonStringify = require('../../deps/safeJsonStringify');
 var calculateWinningRev = require('../../deps/merge/winningRev');
 var traverseRevTree = require('../../deps/merge/traverseRevTree');
+var compactTree = require('../../deps/merge/compactTree');
 var collectConflicts = require('../../deps/merge/collectConflicts');
 var isDeleted = require('../../deps/docs/isDeleted');
 var isLocalId = require('../../deps/docs/isLocalId');
+var parseDoc = require('../../deps/docs/parseDoc');
 var processDocs = require('../../deps/docs/processDocs');
 var md5 = require('../../deps/md5');
 var migrate = require('../../deps/migrate');
@@ -30,6 +39,7 @@ var functionName = require('../../deps/functionName');
 var readAsBluffer = require('./readAsBlobOrBuffer');
 var prepareAttachmentForStorage = require('./prepareAttachmentForStorage');
 var createEmptyBluffer = require('./createEmptyBlobOrBuffer');
+var Promise = require('../../deps/promise');
 
 var binStringToBluffer =
   require('../../deps/binary/binaryStringToBlobOrBuffer');
@@ -45,7 +55,7 @@ var META_STORE = 'meta-store';
 
 // leveldb barks if we try to open a db multiple times
 // so we cache opened connections here for initstore()
-var dbStores = new utils.Map();
+var dbStores = new collections.Map();
 
 // store the value of update_seq in the by-sequence store the key name will
 // never conflict, since the keys in the by-sequence store are integers
@@ -56,8 +66,8 @@ var UUID_KEY = '_local_uuid';
 var MD5_PREFIX = 'md5-';
 
 var safeJsonEncoding = {
-  encode: utils.safeJsonStringify,
-  decode: utils.safeJsonParse,
+  encode: safeJsonStringify,
+  decode: safeJsonParse,
   buffer: false,
   type: 'cheap-json'
 };
@@ -76,7 +86,7 @@ function getIsDeleted(metadata, winningRev) {
 
 function fetchAttachment(att, stores, opts) {
   var type = att.content_type;
-  return new utils.Promise(function (resolve, reject) {
+  return new Promise(function (resolve, reject) {
     stores.binaryStore.get(att.digest, function (err, buffer) {
       var data;
       if (err) {
@@ -121,13 +131,13 @@ function fetchAttachments(results, stores, opts) {
     });
   });
 
-  return utils.Promise.all(atts.map(function (att) {
+  return Promise.all(atts.map(function (att) {
     return fetchAttachment(att, stores, opts);
   }));
 }
 
 function LevelPouch(opts, callback) {
-  opts = utils.clone(opts);
+  opts = clone(opts);
   var api = this;
   var instanceId;
   var stores = {};
@@ -155,7 +165,7 @@ function LevelPouch(opts, callback) {
   if (dbStores.has(leveldownName)) {
     dbStore = dbStores.get(leveldownName);
   } else {
-    dbStore = new utils.Map();
+    dbStore = new collections.Map();
     dbStores.set(leveldownName, dbStore);
   }
   if (dbStore.has(name)) {
@@ -195,7 +205,7 @@ function LevelPouch(opts, callback) {
         stores.metaStore.get(DOC_COUNT_KEY, function (err, value) {
           db._docCount = !err ? value : 0;
           stores.metaStore.get(UUID_KEY, function (err, value) {
-            instanceId = !err ? value : utils.uuid();
+            instanceId = !err ? value : uuid();
             stores.metaStore.put(UUID_KEY, instanceId, function (err, value) {
               process.nextTick(function () {
                 callback(null, api);
@@ -269,7 +279,7 @@ function LevelPouch(opts, callback) {
     readTasks.forEach(function (readTask) {
       var args = readTask.args;
       var callback = args[args.length - 1];
-      args[args.length - 1] = utils.getArguments(function (cbArgs) {
+      args[args.length - 1] = getArguments(function (cbArgs) {
         callback.apply(null, cbArgs);
         if (++numDone === readTasks.length) {
           process.nextTick(function () {
@@ -290,7 +300,7 @@ function LevelPouch(opts, callback) {
   function runWriteOperation(firstTask) {
     var args = firstTask.args;
     var callback = args[args.length - 1];
-    args[args.length - 1] = utils.getArguments(function (cbArgs) {
+    args[args.length - 1] = getArguments(function (cbArgs) {
       callback.apply(null, cbArgs);
       process.nextTick(function () {
         db._queue.shift();
@@ -307,7 +317,7 @@ function LevelPouch(opts, callback) {
   // as e.g. compaction needing to have a lock on the database while
   // it updates stuff. in the future we can revisit this.
   function writeLock(fun) {
-    return utils.getArguments(function (args) {
+    return getArguments(function (args) {
       db._queue.push({
         fun: fun,
         args: args,
@@ -322,7 +332,7 @@ function LevelPouch(opts, callback) {
 
   // same as the writelock, but multiple can run at once
   function readLock(fun) {
-    return utils.getArguments(function (args) {
+    return getArguments(function (args) {
       db._queue.push({
         fun: fun,
         args: args,
@@ -344,7 +354,7 @@ function LevelPouch(opts, callback) {
   }
 
   api._get = readLock(function (id, opts, callback) {
-    opts = utils.clone(opts);
+    opts = clone(opts);
 
     stores.docStore.get(id, function (err, metadata) {
 
@@ -414,7 +424,7 @@ function LevelPouch(opts, callback) {
   api._bulkDocs = writeLock(function (req, opts, callback) {
     var newEdits = opts.new_edits;
     var results = new Array(req.docs.length);
-    var fetchedDocs = new utils.Map();
+    var fetchedDocs = new collections.Map();
     var txn = new LevelTransaction();
     var docCountDelta = 0;
     var newUpdateSeq = db._updateSeq;
@@ -425,7 +435,7 @@ function LevelPouch(opts, callback) {
       if (doc._id && isLocalId(doc._id)) {
         return doc;
       }
-      var newDoc = utils.parseDoc(doc, newEdits);
+      var newDoc = parseDoc.parseDoc(doc, newEdits);
 
       if (newDoc.metadata && !newDoc.metadata.rev_map) {
         newDoc.metadata.rev_map = {};
@@ -517,14 +527,14 @@ function LevelPouch(opts, callback) {
 
     function autoCompact(callback) {
 
-      var promise = utils.Promise.resolve();
+      var promise = Promise.resolve();
 
       fetchedDocs.forEach(function (metadata, docId) {
         // TODO: parallelize, for now need to be sequential to
         // pass orphaned attachment tests
         promise = promise.then(function () {
-          return new utils.Promise(function (resolve, reject) {
-            var revs = utils.compactTree(metadata);
+          return new Promise(function (resolve, reject) {
+            var revs = compactTree(metadata);
             api._doCompactionNoLock(docId, revs, {ctx: txn}, function (err) {
               /* istanbul ignore if */
               if (err) {
@@ -668,7 +678,7 @@ function LevelPouch(opts, callback) {
     function saveAttachmentRefs(id, rev, digest, callback) {
 
       function fetchAtt() {
-        return new utils.Promise(function (resolve, reject) {
+        return new Promise(function (resolve, reject) {
           txn.get(stores.attachmentStore, digest, function (err, oldAtt) {
             /* istanbul ignore if */
             if (err && err.name !== 'NotFoundError') {
@@ -696,7 +706,7 @@ function LevelPouch(opts, callback) {
           newAtt.refs[ref] = true;
         }
 
-        return new utils.Promise(function (resolve, reject) {
+        return new Promise(function (resolve, reject) {
           txn.batch([{
             type: 'put',
             prefix: stores.attachmentStore,
@@ -709,7 +719,7 @@ function LevelPouch(opts, callback) {
 
       // put attachments in a per-digest queue, to avoid two docs with the same
       // attachment overwriting each other
-      var queue = attachmentQueues[digest] || utils.Promise.resolve();
+      var queue = attachmentQueues[digest] || Promise.resolve();
       attachmentQueues[digest] = queue.then(function () {
         return fetchAtt().then(saveAtt).then(function (isNewAttachment) {
           callback(null, isNewAttachment);
@@ -802,7 +812,7 @@ function LevelPouch(opts, callback) {
     });
   });
   api._allDocs = readLock(function (opts, callback) {
-    opts = utils.clone(opts);
+    opts = clone(opts);
     countDocs(function (err, docCount) {
       /* istanbul ignore if */
       if (err) {
@@ -909,7 +919,7 @@ function LevelPouch(opts, callback) {
           allDocsInner();
         }
       }, function (next) {
-        utils.Promise.resolve().then(function () {
+        Promise.resolve().then(function () {
           if (opts.include_docs && opts.attachments){
             return fetchAttachments(results, stores, opts);
           }
@@ -932,10 +942,10 @@ function LevelPouch(opts, callback) {
   });
 
   api._changes = function (opts) {
-    opts = utils.clone(opts);
+    opts = clone(opts);
 
     if (opts.continuous) {
-      var id = name + ':' + utils.uuid();
+      var id = name + ':' + uuid();
       LevelPouch.Changes.addListener(name, id, api, opts);
       LevelPouch.Changes.notify(name);
       return {
@@ -960,9 +970,9 @@ function LevelPouch(opts, callback) {
       streamOpts.start = formatSeq(opts.since || 0);
     }
 
-    var docIds = opts.doc_ids && new utils.Set(opts.doc_ids);
-    var filter = utils.filterChange(opts);
-    var docIdsToMetadata = new utils.Map();
+    var docIds = opts.doc_ids && new collections.Set(opts.doc_ids);
+    var filter = filterChange(opts);
+    var docIdsToMetadata = new collections.Map();
 
     var returnDocs;
     if ('returnDocs' in opts) {
@@ -1216,7 +1226,7 @@ function LevelPouch(opts, callback) {
             finish(overallErr);
           }
         }
-        var refsToDelete = new utils.Map();
+        var refsToDelete = new collections.Map();
         revs.forEach(function (rev) {
           refsToDelete.set(docId + '@' + rev, true);
         });
@@ -1447,6 +1457,6 @@ LevelPouch.valid = function () {
 
 LevelPouch.use_prefix = false;
 
-LevelPouch.Changes = new utils.Changes();
+LevelPouch.Changes = new Changes();
 
 module.exports = LevelPouch;

--- a/lib/adapters/leveldb/transaction.js
+++ b/lib/adapters/leveldb/transaction.js
@@ -5,14 +5,14 @@
 // things in-memory and then does a big batch() operation
 // when you're done
 
-var utils = require('../../utils');
+var collections = require('pouchdb-collections');
 
 function getCacheFor(transaction, store) {
   var prefix = store.prefix()[0];
   var cache = transaction._cache;
   var subCache = cache.get(prefix);
   if (!subCache) {
-    subCache = new utils.Map();
+    subCache = new collections.Map();
     cache.set(prefix, subCache);
   }
   return subCache;
@@ -20,7 +20,7 @@ function getCacheFor(transaction, store) {
 
 function LevelTransaction() {
   this._batch = [];
-  this._cache = new utils.Map();
+  this._cache = new collections.Map();
 }
 
 LevelTransaction.prototype.get = function (store, key, callback) {
@@ -66,7 +66,7 @@ LevelTransaction.prototype.batch = function (batch) {
 
 LevelTransaction.prototype.execute = function (db, callback) {
 
-  var keys = new utils.Set();
+  var keys = new collections.Set();
   var uniqBatches = [];
 
   // remove duplicates; last one wins

--- a/lib/adapters/websql/bulkDocs.js
+++ b/lib/adapters/websql/bulkDocs.js
@@ -1,11 +1,15 @@
 'use strict';
 
-var utils = require('../../utils');
+var collections = require('pouchdb-collections');
 var errors = require('../../deps/errors');
 var preprocessAttachments =
   require('../../deps/docs/preprocessAttachments');
 var isLocalId = require('../../deps/docs/isLocalId');
 var processDocs = require('../../deps/docs/processDocs');
+var safeJsonParse = require('../../deps/safeJsonParse');
+var safeJsonStringify = require('../../deps/safeJsonStringify');
+var compactTree = require('../../deps/merge/compactTree');
+var parseDoc = require('../../deps/docs/parseDoc');
 
 var websqlUtils = require('./utils');
 var websqlConstants = require('./constants');
@@ -29,7 +33,7 @@ function websqlBulkDocs(req, opts, api, db, Changes, callback) {
     if (doc._id && isLocalId(doc._id)) {
       return doc;
     }
-    var newDoc = utils.parseDoc(doc, newEdits);
+    var newDoc = parseDoc.parseDoc(doc, newEdits);
     return newDoc;
   });
 
@@ -42,7 +46,7 @@ function websqlBulkDocs(req, opts, api, db, Changes, callback) {
 
   var tx;
   var results = new Array(docInfos.length);
-  var fetchedDocs = new utils.Map();
+  var fetchedDocs = new collections.Map();
 
   var preconditionErrored;
   function complete() {
@@ -219,7 +223,7 @@ function websqlBulkDocs(req, opts, api, db, Changes, callback) {
         return; // nothing to do
       }
       var id = docInfo.metadata.id;
-      var revsToDelete = utils.compactTree(docInfo.metadata);
+      var revsToDelete = compactTree(docInfo.metadata);
       compactRevs(revsToDelete, id, tx);
     }
 
@@ -235,7 +239,7 @@ function websqlBulkDocs(req, opts, api, db, Changes, callback) {
       ' WHERE doc_id=' + DOC_STORE + '.id AND rev=?) WHERE id=?'
         : 'INSERT INTO ' + DOC_STORE +
       ' (id, winningseq, max_seq, json) VALUES (?,?,?,?);';
-      var metadataStr = utils.safeJsonStringify(docInfo.metadata);
+      var metadataStr = safeJsonStringify(docInfo.metadata);
       var id = docInfo.metadata.id;
       var params = isUpdate ?
         [metadataStr, seq, winningRev, id] :
@@ -277,7 +281,7 @@ function websqlBulkDocs(req, opts, api, db, Changes, callback) {
       tx.executeSql('SELECT json FROM ' + DOC_STORE +
       ' WHERE id = ?', [id], function (tx, result) {
         if (result.rows.length) {
-          var metadata = utils.safeJsonParse(result.rows.item(0).json);
+          var metadata = safeJsonParse(result.rows.item(0).json);
           fetchedDocs.set(id, metadata);
         }
         checkDone();

--- a/lib/adapters/websql/index.js
+++ b/lib/adapters/websql/index.js
@@ -1,6 +1,9 @@
 'use strict';
 
 var utils = require('../../utils');
+var uuid = require('../../deps/uuid');
+var pick = require('../../deps/pick');
+var filterChange = require('../../deps/filterChange');
 var isDeleted = require('../../deps/docs/isDeleted');
 var isLocalId = require('../../deps/docs/isLocalId');
 var errors = require('../../deps/errors');
@@ -9,6 +12,11 @@ var binStringToBlob = require('../../deps/binary/binaryStringToBlobOrBuffer');
 var hasLocalStorage = require('../../deps/env/hasLocalStorage');
 var collectConflicts = require('../../deps/merge/collectConflicts');
 var traverseRevTree = require('../../deps/merge/traverseRevTree');
+var safeJsonParse = require('../../deps/safeJsonParse');
+var safeJsonStringify = require('../../deps/safeJsonStringify');
+var Changes = require('../../changesHandler');
+var isCordova = require('../../deps/isCordova');
+var toPromise = require('../../deps/toPromise');
 
 var websqlConstants = require('./constants');
 var websqlUtils = require('./utils');
@@ -49,7 +57,7 @@ function fetchAttachmentsIfNecessary(doc, opts, api, txn, cb) {
     var attOpts = {binary: opts.binary, ctx: txn};
     api._getAttachment(attObj, attOpts, function (_, data) {
       doc._attachments[att] = utils.extend(
-        utils.pick(attObj, ['digest', 'content_type']),
+        pick(attObj, ['digest', 'content_type']),
         { data: data }
       );
       checkDone();
@@ -421,7 +429,7 @@ function WebSqlPouch(opts, callback) {
             // mark the db version, and new dbid
             var initSeq = 'INSERT INTO ' + META_STORE +
               ' (db_version, dbid) VALUES (?,?)';
-            instanceId = utils.uuid();
+            instanceId = uuid();
             var initSeqArgs = [ADAPTER_VERSION, instanceId];
             tx.executeSql(initSeq, initSeqArgs, function () {
               onGetInstanceId();
@@ -502,7 +510,7 @@ function WebSqlPouch(opts, callback) {
     });
   }
 
-  if (utils.isCordova()) {
+  if (isCordova()) {
     //to wait until custom api is made in pouch.adapters before doing setup
     window.addEventListener(api._name + '_pouch', function cordova_init() {
       window.removeEventListener(api._name + '_pouch', cordova_init, false);
@@ -516,7 +524,7 @@ function WebSqlPouch(opts, callback) {
     return 'websql';
   };
 
-  api._id = utils.toPromise(function (callback) {
+  api._id = toPromise(function (callback) {
     callback(null, instanceId);
   });
 
@@ -580,7 +588,7 @@ function WebSqlPouch(opts, callback) {
         return finish();
       }
       var item = results.rows.item(0);
-      metadata = utils.safeJsonParse(item.metadata);
+      metadata = safeJsonParse(item.metadata);
       if (item.deleted && !opts.rev) {
         err = errors.error(errors.MISSING_DOC, 'deleted');
         return finish();
@@ -674,7 +682,7 @@ function WebSqlPouch(opts, callback) {
         tx.executeSql(sql, sqlArgs, function (tx, result) {
           for (var i = 0, l = result.rows.length; i < l; i++) {
             var item = result.rows.item(i);
-            var metadata = utils.safeJsonParse(item.metadata);
+            var metadata = safeJsonParse(item.metadata);
             var id = metadata.id;
             var data = unstringifyDoc(item.data, id, item.rev);
             var winningRev = data._rev;
@@ -716,7 +724,7 @@ function WebSqlPouch(opts, callback) {
     opts = utils.clone(opts);
 
     if (opts.continuous) {
-      var id = api._name + ':' + utils.uuid();
+      var id = api._name + ':' + uuid();
       WebSqlPouch.Changes.addListener(api._name, id, api, opts);
       WebSqlPouch.Changes.notify(api._name);
       return {
@@ -770,7 +778,7 @@ function WebSqlPouch(opts, callback) {
 
       var sql = select(selectStmt, from, joiner, criteria, orderBy);
 
-      var filter = utils.filterChange(opts);
+      var filter = filterChange(opts);
       if (!opts.view && !opts.filter) {
         // we can just limit in the query
         sql += ' LIMIT ' + limit;
@@ -786,7 +794,7 @@ function WebSqlPouch(opts, callback) {
           }
           for (var i = 0, l = result.rows.length; i < l; i++) {
             var item = result.rows.item(i);
-            var metadata = utils.safeJsonParse(item.metadata);
+            var metadata = safeJsonParse(item.metadata);
             lastSeq = item.maxSeq;
 
             var doc = unstringifyDoc(item.winningDoc, metadata.id,
@@ -868,7 +876,7 @@ function WebSqlPouch(opts, callback) {
         if (!result.rows.length) {
           callback(errors.error(errors.MISSING_DOC));
         } else {
-          var data = utils.safeJsonParse(result.rows.item(0).metadata);
+          var data = safeJsonParse(result.rows.item(0).metadata);
           callback(null, data.rev_tree);
         }
       });
@@ -884,7 +892,7 @@ function WebSqlPouch(opts, callback) {
       // update doc store
       var sql = 'SELECT json AS metadata FROM ' + DOC_STORE + ' WHERE id = ?';
       tx.executeSql(sql, [docId], function (tx, result) {
-        var metadata = utils.safeJsonParse(result.rows.item(0).metadata);
+        var metadata = safeJsonParse(result.rows.item(0).metadata);
         traverseRevTree(metadata.rev_tree, function (isLeaf, pos,
                                                            revHash, ctx, opts) {
           var rev = pos + '-' + revHash;
@@ -894,7 +902,7 @@ function WebSqlPouch(opts, callback) {
         });
 
         var sql = 'UPDATE ' + DOC_STORE + ' SET json = ? WHERE id = ?';
-        tx.executeSql(sql, [utils.safeJsonStringify(metadata), docId]);
+        tx.executeSql(sql, [safeJsonStringify(metadata), docId]);
       });
 
       compactRevs(revs, docId, tx);
@@ -1024,6 +1032,6 @@ function WebSqlPouch(opts, callback) {
 
 WebSqlPouch.valid = websqlUtils.valid;
 
-WebSqlPouch.Changes = new utils.Changes();
+WebSqlPouch.Changes = new Changes();
 
 module.exports = WebSqlPouch;

--- a/lib/adapters/websql/utils.js
+++ b/lib/adapters/websql/utils.js
@@ -1,8 +1,7 @@
 'use strict';
 
-var utils = require('../../utils');
 var errors = require('../../deps/errors');
-
+var collections = require('pouchdb-collections');
 var websqlConstants = require('./constants');
 
 var BY_SEQ_STORE = websqlConstants.BY_SEQ_STORE;
@@ -110,7 +109,7 @@ function compactRevs(revs, docId, tx) {
           digestsToCheck.map(function () { return '?'; }).join(',') +
           ')';
         tx.executeSql(sql, digestsToCheck, function (tx, res) {
-          var nonOrphanedDigests = new utils.Set();
+          var nonOrphanedDigests = new collections.Set();
           for (var i = 0; i < res.rows.length; i++) {
             nonOrphanedDigests.add(res.rows.item(i).digest);
           }

--- a/lib/changes.js
+++ b/lib/changes.js
@@ -1,6 +1,9 @@
 'use strict';
 var utils = require('./utils');
 var isDeleted = require('./deps/docs/isDeleted');
+var inherits = require('inherits');
+var getArguments = require('argsarray');
+var once = require('./deps/once');
 var errors = require('./deps/errors');
 var EE = require('events').EventEmitter;
 var evalFilter = require('./evalFilter');
@@ -11,14 +14,14 @@ var normalizeDdocFunctionName =
 var collectLeaves = require('./deps/merge/collectLeaves');
 var collectConflicts = require('./deps/merge/collectConflicts');
 module.exports = Changes;
-utils.inherits(Changes, EE);
+inherits(Changes, EE);
 
 function Changes(db, opts, callback) {
   EE.call(this);
   var self = this;
   this.db = db;
   opts = opts ? utils.clone(opts) : {};
-  var complete = opts.complete = utils.once(function (err, resp) {
+  var complete = opts.complete = once(function (err, resp) {
     if (err) {
       self.emit('error', err);
     } else {
@@ -176,7 +179,7 @@ Changes.prototype.doChanges = function (opts) {
   var newPromise = this.db._changes(opts);
   if (newPromise && typeof newPromise.cancel === 'function') {
     var cancel = self.cancel;
-    self.cancel = utils.getArguments(function (args) {
+    self.cancel = getArguments(function (args) {
       newPromise.cancel();
       cancel.apply(this, args);
     });

--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -2,10 +2,11 @@
 "use strict";
 
 var debug = require('debug');
-
+var inherits = require('inherits');
 var Adapter = require('./adapter');
 var utils = require('./utils');
 var TaskQueue = require('./taskqueue');
+var isCordova = require('./deps/isCordova');
 var Promise = utils.Promise;
 
 function defaultCallback(err) {
@@ -50,7 +51,7 @@ function prepareForDestruction(self, opts) {
   destructionListeners.get(name).push(onConstructorDestroyed);
 }
 
-utils.inherits(PouchDB, Adapter);
+inherits(PouchDB, Adapter);
 function PouchDB(name, opts, callback) {
 
   if (!(this instanceof PouchDB)) {
@@ -168,7 +169,7 @@ function PouchDB(name, opts, callback) {
     });
 
     /* istanbul ignore next */
-    if (utils.isCordova()) {
+    if (isCordova()) {
       //to inform websql adapter that we can use api
       cordova.fireWindowEvent(opts.name + "_pouch", {});
     }

--- a/lib/deps/adapterFun.js
+++ b/lib/deps/adapterFun.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var Promise = require('./promise');
+var toPromise = require('./toPromise');
+var getArguments = require('argsarray');
+
+module.exports = function adapterFun(name, callback) {
+  var log = require('debug')('pouchdb:api');
+
+  function logApiCall(self, name, args) {
+    /* istanbul ignore if */
+    if (log.enabled) {
+      var logArgs = [self._db_name, name];
+      for (var i = 0; i < args.length - 1; i++) {
+        logArgs.push(args[i]);
+      }
+      log.apply(null, logArgs);
+
+      // override the callback itself to log the response
+      var origCallback = args[args.length - 1];
+      args[args.length - 1] = function (err, res) {
+        var responseArgs = [self._db_name, name];
+        responseArgs = responseArgs.concat(
+          err ? ['error', err] : ['success', res]
+        );
+        log.apply(null, responseArgs);
+        origCallback(err, res);
+      };
+    }
+  }
+
+  return toPromise(getArguments(function (args) {
+    if (this._closed) {
+      return Promise.reject(new Error('database is closed'));
+    }
+    var self = this;
+    logApiCall(self, name, args);
+    if (!this.taskqueue.isReady) {
+      return new Promise(function (fulfill, reject) {
+        self.taskqueue.addTask(function (failed) {
+          if (failed) {
+            reject(failed);
+          } else {
+            fulfill(self[name].apply(self, args));
+          }
+        });
+      });
+    }
+    return callback.apply(this, args);
+  }));
+};

--- a/lib/deps/filterChange.js
+++ b/lib/deps/filterChange.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var errors = require('./errors');
+
+function tryFilter(filter, doc, req) {
+  try {
+    return !filter(doc, req);
+  } catch (err) {
+    var msg = 'Filter function threw: ' + err.toString();
+    return errors.error(errors.BAD_REQUEST, msg);
+  }
+}
+
+module.exports = function filterChange(opts) {
+  var req = {};
+  var hasFilter = opts.filter && typeof opts.filter === 'function';
+  req.query = opts.query_params;
+
+  return function filter(change) {
+    if (!change.doc) {
+      // CSG sends events on the changes feed that don't have documents,
+      // this hack makes a whole lot of existing code robust.
+      change.doc = {};
+    }
+
+    var filterReturn = hasFilter && tryFilter(opts.filter, change.doc, req);
+
+    if (typeof filterReturn === 'object') {
+      return filterReturn;
+    }
+
+    if (filterReturn) {
+      return false;
+    }
+
+    if (!opts.include_docs) {
+      delete change.doc;
+    } else if (!opts.attachments) {
+      for (var att in change.doc._attachments) {
+        /* istanbul ignore else */
+        if (change.doc._attachments.hasOwnProperty(att)) {
+          change.doc._attachments[att].stub = true;
+        }
+      }
+    }
+    return true;
+  };
+};

--- a/lib/deps/isCordova.js
+++ b/lib/deps/isCordova.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = function isCordova() {
+  return (typeof cordova !== "undefined" ||
+  typeof PhoneGap !== "undefined" ||
+  typeof phonegap !== "undefined");
+};

--- a/lib/deps/merge/compactTree.js
+++ b/lib/deps/merge/compactTree.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var traverseRevTree = require('./traverseRevTree');
+// compact a tree by marking its non-leafs as missing,
+// and return a list of revs to delete
+module.exports = function compactTree(metadata) {
+  var revs = [];
+  traverseRevTree(metadata.rev_tree, function (isLeaf, pos,
+                                               revHash, ctx, opts) {
+    if (opts.status === 'available' && !isLeaf) {
+      revs.push(pos + '-' + revHash);
+      opts.status = 'missing';
+    }
+  });
+  return revs;
+};

--- a/lib/deps/safeJsonParse.js
+++ b/lib/deps/safeJsonParse.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var vuvuzela = require('vuvuzela');
+
+module.exports = function safeJsonParse(str) {
+  try {
+    return JSON.parse(str);
+  } catch (e) {
+    /* istanbul ignore next */
+    return vuvuzela.parse(str);
+  }
+};

--- a/lib/deps/safeJsonStringify.js
+++ b/lib/deps/safeJsonStringify.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var vuvuzela = require('vuvuzela');
+
+module.exports = function safeJsonStringify(json) {
+  try {
+    return JSON.stringify(json);
+  } catch (e) {
+    /* istanbul ignore next */
+    return vuvuzela.stringify(json);
+  }
+};

--- a/lib/plugins/levelalt.js
+++ b/lib/plugins/levelalt.js
@@ -1,12 +1,14 @@
 'use strict';
 
 var LevelPouch = require('../adapters/leveldb/index');
-var utils = require('../utils');
+var toPromise = require('../deps/toPromise');
+var extend = require('../deps/extend');
+
 module.exports = altFactory;
 function altFactory(adapterConfig, downAdapter) {
 
   function LevelPouchAlt(opts, callback) {
-    var _opts = utils.extend({
+    var _opts = extend({
       db: downAdapter
     }, opts);
 
@@ -19,12 +21,12 @@ function altFactory(adapterConfig, downAdapter) {
   };
   LevelPouchAlt.use_prefix = adapterConfig.use_prefix;
 
-  LevelPouchAlt.destroy = utils.toPromise(function (name, opts, callback) {
+  LevelPouchAlt.destroy = toPromise(function (name, opts, callback) {
     if (typeof opts === 'function') {
       callback = opts;
       opts = {};
     }
-    var _opts = utils.extend({
+    var _opts = extend({
       db: downAdapter
     }, opts);
 

--- a/lib/replicate/replicate.js
+++ b/lib/replicate/replicate.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var utils = require('./../utils');
+var uuid = require('../deps/uuid');
+var filterChange = require('../deps/filterChange');
 var Checkpointer = require('./checkpointer');
 var backOff = require('./backoff');
 var generateReplicationId = require('./generateReplicationId');
@@ -28,7 +30,7 @@ function replicate(src, target, opts, returnValue, result) {
   var allErrors = [];
   var changedDocs = [];
   // Like couchdb, every replication gets a unique session id
-  var session = utils.uuid();
+  var session = uuid();
 
   result = result || {
     ok: true,
@@ -266,7 +268,7 @@ function replicate(src, target, opts, returnValue, result) {
     if (returnValue.cancelled) {
       return completeReplication();
     }
-    var filter = utils.filterChange(opts)(change);
+    var filter = filterChange(opts)(change);
     if (!filter) {
       return;
     }

--- a/lib/replicate/replication.js
+++ b/lib/replicate/replication.js
@@ -3,10 +3,11 @@
 var utils = require('./../utils');
 var EE = require('events').EventEmitter;
 var Promise = utils.Promise;
+var inherits = require('inherits');
 
 // We create a basic promise so the caller can cancel the replication possibly
 // before we have actually started listening to changes etc
-utils.inherits(Replication, EE);
+inherits(Replication, EE);
 function Replication() {
   EE.call(this);
   this.cancelled = false;

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -2,6 +2,8 @@
 
 var PouchDB = require("./constructor");
 var utils = require('./utils');
+var inherits = require('inherits');
+var collections = require('pouchdb-collections');
 var EE = require('events').EventEmitter;
 var hasLocalStorage = require('./deps/env/hasLocalStorage');
 
@@ -21,15 +23,15 @@ function setUpEventEmitter(Pouch) {
 
   // these are created in constructor.js, and allow us to notify each DB with
   // the same name that it was destroyed, via the constructor object
-  var destructionListeners = Pouch._destructionListeners = new utils.Map();
+  var destructListeners = Pouch._destructionListeners = new collections.Map();
   Pouch.on('destroyed', function onConstructorDestroyed(name) {
-    if (!destructionListeners.has(name)) {
+    if (!destructListeners.has(name)) {
       return;
     }
-    destructionListeners.get(name).forEach(function (callback) {
+    destructListeners.get(name).forEach(function (callback) {
       callback();
     });
-    destructionListeners.delete(name);
+    destructListeners.delete(name);
   });
 }
 
@@ -123,7 +125,7 @@ PouchDB.defaults = function (defaultOpts) {
     PouchDB.call(this, name, opts, callback);
   }
 
-  utils.inherits(PouchAlt, PouchDB);
+  inherits(PouchAlt, PouchDB);
 
   setUpEventEmitter(PouchAlt);
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -2,10 +2,11 @@
 
 var utils = require('./utils');
 var replication = require('./replicate');
+var inherits = require('inherits');
 var replicate = replication.replicate;
 var EE = require('events').EventEmitter;
 
-utils.inherits(Sync, EE);
+inherits(Sync, EE);
 module.exports = sync;
 function sync(src, target, opts, callback) {
   if (typeof opts === 'function') {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,180 +1,37 @@
-/*jshint strict: false */
-var traverseRevTree = require('./deps/merge/traverseRevTree');
-exports.ajax = require('./deps/ajax/prequest');
-exports.uuid = require('./deps/uuid');
-exports.getArguments = require('argsarray');
-var collections = require('pouchdb-collections');
-exports.Map = collections.Map;
-exports.Set = collections.Set;
-var parseDoc = require('./deps/docs/parseDoc');
+'use strict';
 
+//
+// PouchDB.utils is basically a throwback to the pre-Browserify days,
+// when this was the easiest way to access global utilities from anywhere
+// in the project. For code cleanliness, we're trying to remove this file,
+// but for practical reasons (legacy code, test code, etc.) this is still here.
+//
+
+// TODO: only used by the integration tests, which have
+// some tests that explicitly override PouchDB.utils.ajax
+exports.ajax = require('./deps/ajax/prequest');
+
+// TODO: only used by the integration tests
+exports.parseUri = require('./deps/parseUri');
+
+// TODO: only used by the integration tests
+exports.uuid = require('./deps/uuid');
+
+// TODO: used by the integration tests and elsewhere, possibly
+// even in the PouchDB guide and example code
 var Promise = require('./deps/promise');
 exports.Promise = Promise;
 
+// TODO: only used by the integration tests
 var base64 = require('./deps/binary/base64');
-var errors = require('./deps/errors');
-
-// TODO: don't export these
 exports.atob = base64.atob;
 exports.btoa = base64.btoa;
 
-var binStringToBlobOrBuffer =
-  require('./deps/binary/binaryStringToBlobOrBuffer');
-
 // TODO: only used by the integration tests
-exports.binaryStringToBlobOrBuffer = binStringToBlobOrBuffer;
+var binToBluffer = require('./deps/binary/binaryStringToBlobOrBuffer');
+exports.binaryStringToBlobOrBuffer = binToBluffer;
 
+// TODO: pretty sure these are in widespread use by Hoodie and others,
+// also in the integration tests
 exports.clone = require('./deps/clone');
 exports.extend = require('./deps/extend');
-
-exports.pick = require('./deps/pick');
-exports.inherits = require('inherits');
-
-function tryFilter(filter, doc, req) {
-  try {
-    return !filter(doc, req);
-  } catch (err) {
-    var msg = 'Filter function threw: ' + err.toString();
-    return errors.error(errors.BAD_REQUEST, msg);
-  }
-}
-
-exports.filterChange = function filterChange(opts) {
-  var req = {};
-  var hasFilter = opts.filter && typeof opts.filter === 'function';
-  req.query = opts.query_params;
-
-  return function filter(change) {
-    if (!change.doc) {
-      // CSG sends events on the changes feed that don't have documents,
-      // this hack makes a whole lot of existing code robust.
-      change.doc = {};
-    }
-
-    var filterReturn = hasFilter && tryFilter(opts.filter, change.doc, req);
-
-    if (typeof filterReturn === 'object') {
-      return filterReturn;
-    }
-
-    if (filterReturn) {
-      return false;
-    }
-
-    if (!opts.include_docs) {
-      delete change.doc;
-    } else if (!opts.attachments) {
-      for (var att in change.doc._attachments) {
-        /* istanbul ignore else */
-        if (change.doc._attachments.hasOwnProperty(att)) {
-          change.doc._attachments[att].stub = true;
-        }
-      }
-    }
-    return true;
-  };
-};
-
-exports.parseDoc = parseDoc.parseDoc;
-exports.invalidIdError = parseDoc.invalidIdError;
-
-exports.isCordova = function () {
-  return (typeof cordova !== "undefined" ||
-          typeof PhoneGap !== "undefined" ||
-          typeof phonegap !== "undefined");
-};
-
-exports.Changes = require('./changesHandler');
-
-exports.once = require('./deps/once');
-
-exports.toPromise = require('./deps/toPromise');
-
-exports.adapterFun = function (name, callback) {
-  var log = require('debug')('pouchdb:api');
-
-  function logApiCall(self, name, args) {
-    /* istanbul ignore if */
-    if (log.enabled) {
-      var logArgs = [self._db_name, name];
-      for (var i = 0; i < args.length - 1; i++) {
-        logArgs.push(args[i]);
-      }
-      log.apply(null, logArgs);
-
-      // override the callback itself to log the response
-      var origCallback = args[args.length - 1];
-      args[args.length - 1] = function (err, res) {
-        var responseArgs = [self._db_name, name];
-        responseArgs = responseArgs.concat(
-          err ? ['error', err] : ['success', res]
-        );
-        log.apply(null, responseArgs);
-        origCallback(err, res);
-      };
-    }
-  }
-
-  return exports.toPromise(exports.getArguments(function (args) {
-    if (this._closed) {
-      return Promise.reject(new Error('database is closed'));
-    }
-    var self = this;
-    logApiCall(self, name, args);
-    if (!this.taskqueue.isReady) {
-      return new Promise(function (fulfill, reject) {
-        self.taskqueue.addTask(function (failed) {
-          if (failed) {
-            reject(failed);
-          } else {
-            fulfill(self[name].apply(self, args));
-          }
-        });
-      });
-    }
-    return callback.apply(this, args);
-  }));
-};
-
-exports.explainError = require('./deps/ajax/explainError');
-
-exports.parseUri = require('./deps/parseUri');
-
-exports.compare = function (left, right) {
-  return left < right ? -1 : left > right ? 1 : 0;
-};
-
-
-// compact a tree by marking its non-leafs as missing,
-// and return a list of revs to delete
-exports.compactTree = function compactTree(metadata) {
-  var revs = [];
-  traverseRevTree(metadata.rev_tree, function (isLeaf, pos,
-                                                     revHash, ctx, opts) {
-    if (opts.status === 'available' && !isLeaf) {
-      revs.push(pos + '-' + revHash);
-      opts.status = 'missing';
-    }
-  });
-  return revs;
-};
-
-var vuvuzela = require('vuvuzela');
-
-exports.safeJsonParse = function safeJsonParse(str) {
-  try {
-    return JSON.parse(str);
-  } catch (e) {
-    /* istanbul ignore next */
-    return vuvuzela.parse(str);
-  }
-};
-
-exports.safeJsonStringify = function safeJsonStringify(json) {
-  try {
-    return JSON.stringify(json);
-  } catch (e) {
-    /* istanbul ignore next */
-    return vuvuzela.stringify(json);
-  }
-};

--- a/tests/unit/test.once.js
+++ b/tests/unit/test.once.js
@@ -2,19 +2,20 @@
 'use strict';
 
 var should = require('chai').should();
-var utils = require('../../lib/utils.js');
+var once = require('../../lib/deps/once');
+var toPromise = require('../../lib/deps/toPromise');
 
 describe('test.once.js', function () {
 
   it('Only call once ... once', function () {
-    var myFun = utils.once(function () { });
+    var myFun = once(function () { });
     myFun();
     should.throw(myFun);
   });
 
   it('Once wrapped in a promise', function (done) {
     var callback = function () {};
-    var myFun = utils.toPromise(function (callback) {
+    var myFun = toPromise(function (callback) {
       setTimeout(function () {
         callback();
         should.throw(callback);


### PR DESCRIPTION
This removes nearly all the unnecessary stuff from
`utils.js`. The remaining stuff is either dangerous to
remove because of widespread (mis-)use (myself included here),
or because it's in the tests somewhere. Ultimately I hope
to start browserifying the tests themselves, so we don't
need to hook stuff onto this global `utils` object.