### PR TITLE
(#4346) Document and alias return_docs (returnDocs)

### DIFF
--- a/docs/_includes/api/changes.html
+++ b/docs/_includes/api/changes.html
@@ -33,7 +33,7 @@ All options default to `false` unless otherwise specified.
 
 **Advanced Options:**
 
-* `options.returnDocs`: Is available for non-http databases and defaults to `true`. Passing `false` prevents the changes feed from keeping all the documents in memory &ndash; in other words complete always has an empty results array, and the `change` event is the only way to get the event. Useful for large change sets where otherwise you would run out of memory.
+* `options.returnDocs` (deprecated in favor of `options.return_docs`): Is available for non-http databases and defaults to `true`. Passing `false` prevents the changes feed from keeping all the documents in memory &ndash; in other words complete always has an empty results array, and the `change` event is the only way to get the event. Useful for large change sets where otherwise you would run out of memory.
 * `options.batch_size`: Only available for http databases, this configures how many changes to fetch at a time. Increasing this can reduce the number of requests made. Default is 25.
 * `options.style`: Specifies how many revisions are returned in the changes array. The default, `'main_only'`, will only return the current "winning" revision; `'all_docs'` will return all leaf revisions (including conflicts and deleted former conflicts). Most likely you won't need this unless you're writing a replicator.
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -470,7 +470,7 @@ AbstractPouchDB.prototype.compact =
 AbstractPouchDB.prototype._compact = function (opts, callback) {
   var self = this;
   var changesOpts = {
-    returnDocs: false,
+    return_docs: false,
     last_seq: opts.last_seq || 0
   };
   var promises = [];

--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -871,7 +871,10 @@ function HttpPouch(opts, callback) {
     var params = { timeout: opts.timeout - (5 * 1000) };
     var limit = (typeof opts.limit !== 'undefined') ? opts.limit : false;
     var returnDocs;
-    if ('returnDocs' in opts) {
+    if ('return_docs' in opts) {
+      returnDocs = opts.return_docs;
+    } else if ('returnDocs' in opts) {
+      // TODO: Remove 'returnDocs' in favor of 'return_docs' in a future release
       returnDocs = opts.returnDocs;
     } else {
       returnDocs = true;

--- a/lib/adapters/idb/index.js
+++ b/lib/adapters/idb/index.js
@@ -431,7 +431,10 @@ function init(api, opts, callback) {
       limit = 1; // per CouchDB _changes spec
     }
     var returnDocs;
-    if ('returnDocs' in opts) {
+    if ('return_docs' in opts) {
+      returnDocs = opts.return_docs;
+    } else if ('returnDocs' in opts) {
+      // TODO: Remove 'returnDocs' in favor of 'return_docs' in a future release
       returnDocs = opts.returnDocs;
     } else {
       returnDocs = true;

--- a/lib/adapters/leveldb/index.js
+++ b/lib/adapters/leveldb/index.js
@@ -975,7 +975,10 @@ function LevelPouch(opts, callback) {
     var docIdsToMetadata = new collections.Map();
 
     var returnDocs;
-    if ('returnDocs' in opts) {
+    if ('return_docs' in opts) {
+      returnDocs = opts.return_docs;
+    } else if ('returnDocs' in opts) {
+      // TODO: Remove 'returnDocs' in favor of 'return_docs' in a future release
       returnDocs = opts.returnDocs;
     } else {
       returnDocs = true;

--- a/lib/adapters/websql/index.js
+++ b/lib/adapters/websql/index.js
@@ -745,7 +745,10 @@ function WebSqlPouch(opts, callback) {
     }
 
     var returnDocs;
-    if ('returnDocs' in opts) {
+    if ('return_docs' in opts) {
+      returnDocs = opts.return_docs;
+    } else if ('returnDocs' in opts) {
+      // TODO: Remove 'returnDocs' in favor of 'return_docs' in a future release
       returnDocs = opts.returnDocs;
     } else {
       returnDocs = true;

--- a/lib/replicate/replicate.js
+++ b/lib/replicate/replicate.js
@@ -362,7 +362,7 @@ function replicate(src, target, opts, returnValue, result) {
           batch_size: batch_size,
           style: 'all_docs',
           doc_ids: doc_ids,
-          returnDocs: true // required so we know when we're done
+          return_docs: true // required so we know when we're done
         };
         if (opts.filter) {
           if (typeof opts.filter !== 'string') {

--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -2332,6 +2332,34 @@ adapters.forEach(function (adapter) {
       db.post({key: 'value'});
     });
 
+    it('supports return_docs=false', function (done) {
+      var db = new PouchDB(dbs.name);
+      var docs = [];
+      var num = 10;
+      for (var i = 0; i < num; i++) {
+        docs.push({ _id: 'doc_' + i, });
+      }
+      var changes = 0;
+      db.bulkDocs({ docs: docs }, function (err, info) {
+        if (err) {
+          return done(err);
+        }
+        db.changes({
+          descending: true,
+          return_docs: false
+        }).on('change', function (change) {
+          changes++;
+        }).on('complete', function (results) {
+          results.results.should.have.length(0, '0 results returned');
+          changes.should.equal(num, 'correct number of changes');
+          done();
+        }).on('error', function (err) {
+          done(err);
+        });
+      });
+    });
+
+    // TODO: Remove 'returnDocs' in favor of 'return_docs' in a future release
     it('supports returnDocs=false', function (done) {
       var db = new PouchDB(dbs.name);
       var docs = [];
@@ -2346,7 +2374,7 @@ adapters.forEach(function (adapter) {
         }
         db.changes({
           descending: true,
-          returnDocs : false
+          returnDocs: false
         }).on('change', function (change) {
           changes++;
         }).on('complete', function (results) {


### PR DESCRIPTION
Adds `options.return_docs` to the Changes API, and adds a deprecation
notice for `options.returnDocs` in the docs.