### PR TITLE
(#4467) - Dont create a database just to delete it

### DIFF
--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -194,22 +194,15 @@ function HttpPouch(opts, callback) {
     }
 
     var checkExists = {method: 'GET', url: dbUrl};
-    var create = {method: 'PUT', url: dbUrl};
     setupPromise = ajaxPromise({}, checkExists).catch(function(err) {
       if (err && err.status && err.status === 404) {
         // Doesnt exist, create it
-        explainError(
-          404, 'PouchDB is just detecting if the remote exists.'
-        );
-        return ajaxPromise({}, create);
+        explainError(404, 'PouchDB is just detecting if the remote exists.');
+        return ajaxPromise({}, {method: 'PUT', url: dbUrl});
       } else {
         return Promise.reject(err);
       }
     }).catch(function(err) {
-      // If we get an authorisation error
-      if (err && err.status && err.status === 401) {
-        return ajaxPromise({}, checkExists);
-      }
       // If we try to create a database that already exists
       if (err && err.status && err.status === 412) {
         return true;
@@ -1095,21 +1088,17 @@ function HttpPouch(opts, callback) {
   };
 
   api._destroy = function (options, callback) {
-    setup().then(function() {
-      ajax(options, {
-        url: genDBUrl(host, ''),
-        method: 'DELETE'
-      }, function (err, resp) {
-        /* istanbul ignore next */
-        if (err) {
-          api.emit('error', err);
-          return callback(err);
-        }
-        api.emit('destroyed');
-        api.constructor.emit('destroyed', opts.name);
-        callback(null, resp);
-      });
-    }).catch(callback);
+    ajax(options, {
+      url: genDBUrl(host, ''),
+      method: 'DELETE'
+    }, function (err, resp) {
+      if (err && err.status && err.status !== 404) {
+        return callback(err);
+      }
+      api.emit('destroyed');
+      api.constructor.emit('destroyed', opts.name);
+      callback(null, resp);
+    });
   };
 }
 

--- a/tests/integration/test.http.js
+++ b/tests/integration/test.http.js
@@ -189,18 +189,16 @@ describe('test.http.js', function () {
 
   it('4358 db.info rejects when server is down', function() {
     var db = new PouchDB('http://example.com/foo');
-    return db.info()
-      .catch(function(err) {
-        err.name.should.equal('unknown_error');
-      });
+    return db.info().catch(function(err) {
+      err.name.should.equal('unknown_error');
+    });
   });
 
   it('4358 db.destroy rejects when server is down', function() {
     var db = new PouchDB('http://example.com/foo');
-    return db.destroy()
-      .catch(function(err) {
-        err.name.should.equal('unknown_error');
-      });
+    return db.destroy().catch(function(err) {
+      err.name.should.equal('unknown_error');
+    });
   });
 
 });

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -153,16 +153,16 @@ testUtils.adapterUrl = function (adapter, name) {
 
 // Delete specified databases
 testUtils.cleanup = function (dbs, done) {
-
   dbs = uniq(dbs);
   var num = dbs.length;
+  var finished = function() {
+    if (--num === 0) {
+      done();
+    }
+  };
 
   dbs.forEach(function(db) {
-    new PouchDB(db).destroy(function() {
-      if (--num === 0) {
-        done();
-      }
-    });
+    new PouchDB(db).destroy(finished, finished);
   });
 };
 


### PR DESCRIPTION
Was something I noticed when doing the stateless constructor, may speed up our tests a fair bit, is cleaner and removes an untested code path :)