### PR TITLE
(#4474) - avoid empty bulkGet()

### DIFF
--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -288,10 +288,6 @@ function HttpPouch(opts, callback) {
     }
 
     function doBulkGetShim() {
-      if (!opts.docs.length) {
-        return callback(null, {results: []});
-      }
-
       // avoid "url too long error" by splitting up into multiple requests
       var batchSize = MAX_SIMULTANEOUS_REVS;
       var numBatches = Math.ceil(opts.docs.length / batchSize);

--- a/lib/deps/bulkGetShim.js
+++ b/lib/deps/bulkGetShim.js
@@ -5,9 +5,6 @@ var pick = require('../deps/pick');
 // shim for P/CouchDB adapters that don't directly implement _bulk_get
 function bulkGet(db, opts, callback) {
   var requests = Array.isArray(opts) ? opts : opts.docs;
-  if (!requests.length) {
-    return callback(null, {results: []});
-  }
 
   // consolidate into one request per doc if possible
   var requestsById = {};

--- a/lib/deps/upsert.js
+++ b/lib/deps/upsert.js
@@ -7,10 +7,6 @@ var Promise = require('./promise');
 // the doc, or false if it doesn't need to do an update after all
 var upsert = module.exports = function upsert(db, docId, diffFun) {
   return new Promise(function (fulfill, reject) {
-    if (typeof docId !== 'string') {
-      return reject(new Error('doc id is required'));
-    }
-
     db.get(docId, function (err, doc) {
       if (err) {
         /* istanbul ignore next */

--- a/lib/replicate/getDocs.js
+++ b/lib/replicate/getDocs.js
@@ -42,6 +42,10 @@ function getDocs(src, diffs, state) {
 
     var bulkGetOpts = createBulkGetOpts(diffs);
 
+    if (!bulkGetOpts.docs.length) { // optimization: skip empty requests
+      return;
+    }
+
     return src.bulkGet(bulkGetOpts).then(function (bulkGetResponse) {
       /* istanbul ignore if */
       if (state.cancelled) {


### PR DESCRIPTION
Kinda embarrassed we missed this one, but it's fixed now!
Avoids an empty request when there's no point in doing
a `bulkGet()`.