### PR TITLE
(pouchdb/express-pouchdb#247) - fix http url with port 80

### DIFF
--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -113,8 +113,9 @@ function genUrl(opts, path) {
 
   // If the host already has a path, then we need to have a path delimiter
   // Otherwise, the path delimiter is the empty string
-  return opts.protocol + '://' + opts.host + ':' + opts.port + '/' +
-         opts.path + pathDel + path;
+  return opts.protocol + '://' + opts.host +
+         (opts.port ? (':' + opts.port) : '') +
+         '/' + opts.path + pathDel + path;
 }
 
 function paramsToStr(params) {


### PR DESCRIPTION
This is one of those issues that's so fundamental, it makes me
wonder if anybody's actually using our library.

If you create a PouchDB over http without a port specified,
it won't work. This PR fixes that, which I've confirmed manually.

Kinda hard to write a test for this one, because we'd have to
depend on a CouchDB exposed via port 80. I'd prefer not to add a test;
Istanbul 100% coverage won't break, though, because this switch is
a one-liner.