### PR TITLE
(#1526) - Remove put implementation and fix local doc handling

### DIFF
--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -32,9 +32,7 @@ var btoa = base64.btoa;
 var atob = base64.atob;
 var errors = require('../../deps/errors');
 var log = require('debug')('pouchdb:http');
-var createMultipart = require('../../deps/ajax/multipart');
 var blufferToBase64 = require('../../deps/binary/blobOrBufferToBase64');
-var parseDoc = require('../../deps/docs/parseDoc');
 var bulkGetShim = require('../../deps/bulkGetShim');
 var flatten = require('../../deps/flatten');
 
@@ -577,87 +575,6 @@ function HttpPouch(opts, callback) {
     // Add the attachment
     ajax({}, opts, callback);
   });
-
-  // Add the document given by doc (in JSON string format) to the database
-  // given by host. This fails if the doc has no _id field.
-  api.put = adapterFun('put', getArguments(function (args) {
-    var temp, temptype, opts;
-    var doc = args.shift();
-    var callback = args.pop();
-
-    if (typeof doc !== 'object' || Array.isArray(doc)) {
-      return callback(errors.error(errors.NOT_AN_OBJECT));
-    }
-
-    var id = '_id' in doc;
-    doc = clone(doc);
-
-    preprocessAttachments(doc).then(function () {
-      while (true) {
-        temp = args.shift();
-        temptype = typeof temp;
-        if (temptype === "string" && !id) {
-          doc._id = temp;
-          id = true;
-        } else if (temptype === "string" && id && !('_rev' in doc)) {
-          doc._rev = temp;
-        } else if (temptype === "object") {
-          opts = clone(temp);
-        }
-        if (!args.length) {
-          break;
-        }
-      }
-      opts = opts || {};
-
-      // check for any errors
-      // TODO: rename this function
-      parseDoc.invalidIdError(doc._id);
-
-      // List of parameter to add to the PUT request
-      var params = [];
-
-      // If it exists, add the opts.new_edits value to the list of parameters.
-      // If new_edits = false then the database will NOT assign this document a
-      // new revision number
-      if (opts && typeof opts.new_edits !== 'undefined') {
-        params.push('new_edits=' + opts.new_edits);
-      }
-
-      // Format the list of parameters into a valid URI query string
-      params = params.join('&');
-      if (params !== '') {
-        params = '?' + params;
-      }
-
-      var ajaxOpts = {
-        method: 'PUT',
-        url: genDBUrl(host, encodeDocId(doc._id)) + params,
-        body: doc
-      };
-
-      return Promise.resolve().then(function () {
-        var hasNonStubAttachments = doc._attachments &&
-          Object.keys(doc._attachments).filter(function (att) {
-            return !doc._attachments[att].stub;
-          }).length;
-        if (hasNonStubAttachments) {
-          // use multipart/related for more efficient attachment uploading
-          var multipart = createMultipart(doc);
-          ajaxOpts.body = multipart.body;
-          ajaxOpts.processData = false;
-          ajaxOpts.headers = multipart.headers;
-        }
-      }).catch(function () {
-        throw new Error('Did you forget to base64-encode an attachment?');
-      }).then(function () {
-        return ajaxPromise(opts, ajaxOpts);
-      }).then(function (res) {
-        res.ok = true; // smooths out cloudant not doing this
-        callback(null, res);
-      });
-    }).catch(callback);
-  }));
 
   // Update/create multiple documents given by req in the database
   // given by host.

--- a/lib/deps/docs/processDocs.js
+++ b/lib/deps/docs/processDocs.js
@@ -42,15 +42,11 @@ function processDocs(docInfos, api, fetchedDocs, tx, results, writeDoc, opts,
   docInfos.forEach(function (currentDoc, resultsIdx) {
 
     if (currentDoc._id && isLocalId(currentDoc._id)) {
-      api[currentDoc._deleted ? '_removeLocal' : '_putLocal'](
-        currentDoc, {ctx: tx}, function (err) {
-          if (err) {
-            results[resultsIdx] = err;
-          } else {
-            results[resultsIdx] = {ok: true};
-          }
-          checkAllDocsDone();
-        });
+      var fun = currentDoc._deleted ? '_removeLocal' : '_putLocal';
+      api[fun](currentDoc, {ctx: tx}, function (err, res) {
+        results[resultsIdx] = err || res;
+        checkAllDocsDone();
+      });
       return;
     }
 

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -2825,6 +2825,11 @@ adapters.forEach(function (adapters) {
             // mock a successful write for the first
             // document and a failed write for the second
             var doc = content.docs[0];
+
+            if (/^_local/.test(doc._id)) {
+              return bulkDocs.apply(remote, [content, opts, callback]);
+            }
+
             if (bulkDocsCallCount === 0) {
               bulkDocsCallCount++;
               callback(null, [{ok: true, id: doc._id, rev: doc._rev}]);


### PR DESCRIPTION
I know and agree we want to keep multipart, but its main benefit is during replication and right now it is not being used during replication. I dont want implementing it in bulkDocs to block improvements to the rest of the code.

Our special handling of these API's in the http adapter is causing bugs to be hidden, with this one we were previously sending back a `{ok: true}` for local documents written via bulkDocs and away to file another one in which we handle deletions in bulkDocs inconsistently (as well as consistency issues like https://github.com/pouchdb/pouchdb/issues/2344)
