### PR TITLE
(#4522) - fix coverage, correctly clean up test DB

### DIFF
--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -37,7 +37,9 @@ adapters.forEach(function (adapter) {
 
     it('4314 Create a pouch with + in name', function () {
       var db = new PouchDB(dbs.name + '+suffix');
-      return db.info();
+      return db.info().then(function () {
+        return db.destroy();
+      });
     });
 
     it('Catch an error when creating a pouch with a promise', function (done) {


### PR DESCRIPTION
The tests were failing because this extra `+suffix` DB
was not being destroyed. This should fix the coverage
reporting and get us back up to 100%. :)