### PR TITLE
(#4519) add documentation for bulk_get endpoint

### DIFF
--- a/docs/_includes/api.html
+++ b/docs/_includes/api.html
@@ -17,6 +17,7 @@
 <li><a href="#database_information">Database info</a></li>
 <li><a href="#compaction">Compaction</a></li>
 <li><a href="#revisions_diff">Revision diff</a></li>
+<li><a href="#bulk_get">Bulk get</a></li>
 <li><a href="#events">Events</a></li>
 <li><a href="#defaults">Default settings</a></li>
 <li><a href="#plugins">Plugins</a></li>

--- a/docs/_includes/api/bulk_get.html
+++ b/docs/_includes/api/bulk_get.html
@@ -1,0 +1,101 @@
+{% include anchor.html edit="true" title="Document bulk get" hash="bulk_get" %}
+
+{% highlight js %}
+db.bulkGet(options, [callback])
+{% endhighlight %}
+
+Given a set of document/revision IDs, returns the document bodies (and, optionally, attachment data) for each ID/revision pair specified.
+
+### Options
+
+* `options.docs`: An array of `id` and `rev` pairs representing the revisions to fetch.
+  - `id`: ID of the document to fetch.
+  - `rev`: Revision of the document to fetch. If this is not specified, all available revisions are fetched.
+  - `atts_since`: Optional and supported by the http adapter only. Includes attachments only since specified revisions. Doesn’t includes attachments for specified revisions.
+* `options.revs`: Each returned revision body will include its revision history as a `_revisions` property. Default is `true`.
+* `options.attachments`: Include attachments in the response. Default is `true`.
+* `options.binary`: Return attachment data as Blobs/Buffers, instead of as base64-encoded strings.
+
+
+
+#### Example Usage:
+
+{% include code/start.html id="bulkget1" type="callback" %}
+{% highlight js %}
+db.bulkGet({
+  docs: [
+    { id: "existing-doc", rev: "1-b2e54331db828310f3c772d6e042ac9c"},
+    { id: "foo", rev: "2-3a24009a9525bde9e4bfa8a99046b00d"},
+    { id: "bar", rev: "1-3a24009a9525bde9e4bfa8a99046b00d"}
+  ]
+}, function (err, result) {
+  if (err) { return console.log(err); }
+  // handle result
+});
+{% endhighlight %}
+{% include code/end.html %}
+{% include code/start.html id="bulkget1" type="promise" %}
+{% highlight js %}
+db.bulkGet({
+    docs: [
+      { id: "doc-that-exists", rev: "1-967a00dff5e02add41819138abb3284d"},
+      { id: "doc-that-does-not-exist", rev: "1-3a24009a9525bde9e4bfa8a99046b00d"},
+      { id: "doc-that-exists", rev: "1-bad_rev"}
+    ]
+}).then(function (result) {
+  // handle result
+}).catch(function (err) {
+  console.log(err);
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+#### Example Response:
+{% highlight js %}
+{
+  "results": [
+  {
+    "docs": [
+    {
+      "ok": {
+        "_id": "doc-that-exists",
+        "_rev": "1-967a00dff5e02add41819138abb3284d",
+        "_revisions": {
+          "ids": [
+            "967a00dff5e02add41819138abb3284d"
+          ],
+          "start": 1
+        }
+      }
+    }],
+    "id": "good-doc"
+  },
+  {
+    "docs": [
+    {
+      "error": {
+        "error": "not_found",
+        "id": "doc-that-does-not-exist",
+        "reason": "missing",
+        "rev": "undefined"
+      }
+    }],
+    "id": "doc-that-does-not-exist"
+  },
+  {
+    "docs": [
+    {
+      "error": {
+        "error": "not_found",
+        "id": "doc-that-exists",
+        "reason": "missing",
+        "rev": "1-badrev"
+      }
+    }
+    ],
+    "id": "doc-that-exists"
+  }]
+}
+{% endhighlight %}
+
+

--- a/docs/api.html
+++ b/docs/api.html
@@ -26,6 +26,7 @@ edit: false
 {% include api/database_information.html %}
 {% include api/compaction.html %}
 {% include api/revisions_diff.html %}
+{% include api/bulk_get.html %}
 {% include api/events.html %}
 {% include api/defaults.html %}
 {% include api/plugins.html %}


### PR DESCRIPTION
Add documentation for the bulk_get endpoint, introduced in PouchDB 5.0.

The PouchDB implementation currently differs from the CouchDB implementation slightly (no atts_since support and rev is a required parameter for each id/rev pair). The documentation reflects the current PouchDB behaviour.