### PR TITLE
Firefox in "private browsing" mode always fails to open idb.

### DIFF
--- a/lib/adapters/idb/constants.js
+++ b/lib/adapters/idb/constants.js
@@ -24,3 +24,5 @@ exports.META_STORE = 'meta-store';
 exports.LOCAL_STORE = 'local-store';
 // Where we detect blob support
 exports.DETECT_BLOB_SUPPORT_STORE = 'detect-blob-support';
+// Where we detect general support
+exports.DETECT_SUPPORT_STORE = 'detect-support';

--- a/lib/adapters/idb/index.js
+++ b/lib/adapters/idb/index.js
@@ -23,6 +23,7 @@ var ATTACH_AND_SEQ_STORE = idbConstants.ATTACH_AND_SEQ_STORE;
 var ATTACH_STORE = idbConstants.ATTACH_STORE;
 var BY_SEQ_STORE = idbConstants.BY_SEQ_STORE;
 var DETECT_BLOB_SUPPORT_STORE = idbConstants.DETECT_BLOB_SUPPORT_STORE;
+var DETECT_SUPPORT_STORE = idbConstants.DETECT_SUPPORT_STORE;
 var DOC_STORE = idbConstants.DOC_STORE;
 var LOCAL_STORE = idbConstants.LOCAL_STORE;
 var META_STORE = idbConstants.META_STORE;
@@ -977,8 +978,21 @@ IdbPouch.valid = function () {
 
   // some outdated implementations of IDB that appear on Samsung
   // and HTC Android devices <4.4 are missing IDBKeyRange
-  return !isSafari && typeof indexedDB !== 'undefined' &&
-    typeof IDBKeyRange !== 'undefined';
+  if (!isSafari && typeof indexedDB !== 'undefined' &&
+    typeof IDBKeyRange !== 'undefined') {
+
+    // Firefox in private browsing mode will always fail to open
+    var db;
+    try {
+      db = indexedDB.open(DETECT_SUPPORT_STORE);
+      db.close();
+      return true;
+    } catch(e) {
+      return false;
+    }
+  }
+
+  return false;
 };
 
 IdbPouch.Changes = new Changes();


### PR DESCRIPTION
'Common' way to detect "private browsing" (that I found) is by checking if idb can open a DB.

Not sure if there's any way to add a test for this, and I'm having a hard time running the tests to begin with ... :/