### PR TITLE
fixed cors error

### DIFF
--- a/lib/deps/ajax/ajaxCore.js
+++ b/lib/deps/ajax/ajaxCore.js
@@ -87,19 +87,9 @@ function ajax(options, callback) {
 
   return request(options, function (err, response, body) {
     if (err) {
-      // Node request only ever fires error or response, never both
-      /* istanbul ignore if */
-      if (response) {
-        var origin = (typeof document !== 'undefined') &&
-          document.location.origin;
-        var isCrossOrigin = origin && options.url.indexOf(origin) !== 0;
-        if (isCrossOrigin && response.statusCode === 0) {
-          explainCors();
-        }
-        err.status = response.statusCode;
-      } else {
-        err.status = 400;
-      }
+      // if the response.statusCode is different from 0, use 400 because there's no way to check if
+      // the backend has enabled CORS
+      err.status = response.statusCode === 0 ? 400 : response.statusCode;
       return onError(err, callback);
     }
 


### PR DESCRIPTION
There's no way to check if the backend has CORS enabled or not.
Checking the origin for a cross-domain request is a bad solution: in fact, if the server has CORS enabled, it will throw a CORS error/warning and that's wrong.

The problem happens with PouchDB 5.1 on the _bulk_get request because sometime's ignored and sometime's not: when it's not ignored, the replication stops (db.replicate.from).
Using status 400 with response.statusCode equal to 0, it works fine and the replication goes on.