### PR TITLE
fixed _bulk_get headers

### DIFF
--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -272,19 +272,23 @@ function HttpPouch(opts, callback) {
     var self = this;
 
     function doBulkGet(cb) {
-      var params = {};
+      var params = {},
+          ajaxParams = {
+            method: 'POST',
+            body: { docs: opts.docs}
+          };
       if (opts.revs) {
         params.revs = true;
       }
       if (opts.attachments) {
         params.attachments = true;
       }
-      ajax({}, {
-        headers: host.headers,
-        url: genDBUrl(host, '_bulk_get' + paramsToStr(params)),
-        method: 'POST',
-        body: { docs: opts.docs}
-      }, cb);
+      if (host.headers) {
+        ajaxParams.headers = host.headers;
+      }
+
+      ajaxParams.url = genDBUrl(host, '_bulk_get' + paramsToStr(params));
+      ajax({}, ajaxParams, cb);
     }
 
     function doBulkGetShim() {

--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -272,20 +272,18 @@ function HttpPouch(opts, callback) {
     var self = this;
 
     function doBulkGet(cb) {
-      var params = {},
-          ajaxParams = {
-            method: 'POST',
-            body: { docs: opts.docs}
-          };
+      var params = {};
       if (opts.revs) {
         params.revs = true;
       }
       if (opts.attachments) {
         params.attachments = true;
       }
-
-      ajaxParams.url = genDBUrl(host, '_bulk_get' + paramsToStr(params));
-      ajax({}, ajaxParams, cb);
+      ajax({}, {
+        url: genDBUrl(host, '_bulk_get' + paramsToStr(params)),
+        method: 'POST',
+        body: { docs: opts.docs}
+      }, cb);
     }
 
     function doBulkGetShim() {

--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -283,9 +283,6 @@ function HttpPouch(opts, callback) {
       if (opts.attachments) {
         params.attachments = true;
       }
-      if (host.headers) {
-        ajaxParams.headers = host.headers;
-      }
 
       ajaxParams.url = genDBUrl(host, '_bulk_get' + paramsToStr(params));
       ajax({}, ajaxParams, cb);


### PR DESCRIPTION
If host.headers is undefined, don't add it to the ajax call because it will perform the _bulk_get call without basic headers (like the authorization one).

When this problem happens, _bulk_get is done without authorization header and a CORS is thrown even if credentials are passed from the application and CORS are enabled on the server.