### PR TITLE
(#4545) - Remove CORS explanation

### DIFF
--- a/lib/deps/ajax/ajaxCore.js
+++ b/lib/deps/ajax/ajaxCore.js
@@ -6,7 +6,6 @@ var errors = require('./../errors');
 var clone = require('../../deps/clone');
 var applyTypeToBuffer = require('./applyTypeToBuffer');
 var defaultBody = require('./defaultBody');
-var explainCors = require('./explainCors');
 
 function ajax(options, callback) {
 
@@ -87,19 +86,7 @@ function ajax(options, callback) {
 
   return request(options, function (err, response, body) {
     if (err) {
-      // Node request only ever fires error or response, never both
-      /* istanbul ignore if */
-      if (response) {
-        var origin = (typeof document !== 'undefined') &&
-          document.location.origin;
-        var isCrossOrigin = origin && options.url.indexOf(origin) !== 0;
-        if (isCrossOrigin && response.statusCode === 0) {
-          explainCors();
-        }
-        err.status = response.statusCode;
-      } else {
-        err.status = 400;
-      }
+      err.status = response ? response.statusCode : 400;
       return onError(err, callback);
     }
 

--- a/lib/deps/ajax/explainCors-browser.js
+++ b/lib/deps/ajax/explainCors-browser.js
@@ -1,9 +1,0 @@
-'use strict';
-
-module.exports = function () {
-  if ('console' in global && 'warn' in console) {
-    console.warn('PouchDB: the remote database may not have CORS enabled.' +
-      'If not please enable CORS: ' +
-      'http://pouchdb.com/errors.html#no_access_control_allow_origin_header');
-  }
-};

--- a/lib/deps/ajax/explainCors.js
+++ b/lib/deps/ajax/explainCors.js
@@ -1,4 +1,0 @@
-'use strict';
-
-//Node users don't need to see this warning
-module.exports = function () {};


### PR DESCRIPTION
So the fact is CORS errors are designed to be undetectable, the false positives that are pretty much impossible to avoid were confusing uses, and the browsers are doing a better job at making cors errors more visible now anyway