### PR TITLE
(#4540) - Add timeout option to replication

### DIFF
--- a/docs/_includes/api/replication.html
+++ b/docs/_includes/api/replication.html
@@ -26,6 +26,7 @@ All options default to `false` unless otherwise specified.
 
 * `options.since`: Replicate changes after the given sequence number.
 * `options.heartbeat`: Configure the heartbeat supported by CouchDB which keeps the change connection alive.
+* `options.timeout`: Request timeout (in milliseconds).
 * `options.batch_size`: Number of documents to process at a time. Defaults to 100. This affects the number of docs held in memory and the number sent at a time to the target server. You may need to adjust downward if targeting devices with low amounts of memory (e.g. phones) or if the documents are large in size (e.g. with attachments). If your documents are small in size, then increasing this number will probably speed replication up.
 * `options.batches_limit`: Number of batches to process at a time. Defaults to 10. This (along wtih `batch_size`) controls how many docs are kept in memory at a time, so the maximum docs in memory at once would equal `batch_size` &times; `batches_limit`.
 * `options.back_off_function`: backoff function to be used in `retry` replication. This is a function that takes the current backoff as input (or 0 the first time) and returns a new backoff in milliseconds. You can use this to tweak when and how replication will try to reconnect to a remote database when the user goes offline. Defaults to a function that chooses a random backoff between 0 and 2 seconds and doubles every time it fails to connect. (See [Customizing retry replication](#customizing-retry-replication) below.)

--- a/lib/replicate/replicate.js
+++ b/lib/replicate/replicate.js
@@ -376,7 +376,7 @@ function replicate(src, target, opts, returnValue, result) {
         if ('heartbeat' in opts) {
           changesOpts.heartbeat = opts.heartbeat;
         }
-        if (opts.timeout) {
+        if ('timeout' in opts) {
           changesOpts.timeout = opts.timeout;
         }
         if (opts.query_params) {

--- a/lib/replicate/replicate.js
+++ b/lib/replicate/replicate.js
@@ -376,6 +376,9 @@ function replicate(src, target, opts, returnValue, result) {
         if ('heartbeat' in opts) {
           changesOpts.heartbeat = opts.heartbeat;
         }
+        if (opts.timeout) {
+          changesOpts.timeout = opts.timeout;
+        }
         if (opts.query_params) {
           changesOpts.query_params = opts.query_params;
         }


### PR DESCRIPTION
Passes through a timeout option to the changes feed so longpoll requests can be kept alive for longer than the default 30 seconds.