### PR TITLE
Make sync comment on 'denied' like other sync comments

### DIFF
--- a/docs/_includes/api/sync.html
+++ b/docs/_includes/api/sync.html
@@ -39,7 +39,7 @@ var sync = PouchDB.sync('mydb', 'http://localhost:5984/mydb', {
 }).on('active', function () {
   // replicate resumed (e.g. user went back online)
 }).on('denied', function (info) {
-  // a document failed to replicate, e.g. due to permissions
+  // a document failed to replicate (e.g. due to permissions)
 }).on('complete', function (info) {
   // handle complete
 }).on('error', function (err) {


### PR DESCRIPTION
Just a tiny tiny documentation upgrade. 

No tests or special commit messages required as in [CONTRIBUTING](https://github.com/pouchdb/pouchdb/blob/master/CONTRIBUTING.md) (as far as I can see =] ).