### PR TITLE
4530 - do not require explicit revs to be specified when calling bulkGet

### DIFF
--- a/docs/_includes/api/bulk_get.html
+++ b/docs/_includes/api/bulk_get.html
@@ -12,9 +12,9 @@ Given a set of document/revision IDs, returns the document bodies (and, optional
   - `id`: ID of the document to fetch.
   - `rev`: Revision of the document to fetch. If this is not specified, all available revisions are fetched.
   - `atts_since`: Optional and supported by the http adapter only. Includes attachments only since specified revisions. Doesn’t includes attachments for specified revisions.
-* `options.revs`: Each returned revision body will include its revision history as a `_revisions` property. Default is `true`.
-* `options.attachments`: Include attachments in the response. Default is `true`.
-* `options.binary`: Return attachment data as Blobs/Buffers, instead of as base64-encoded strings.
+* `options.revs`: Each returned revision body will include its revision history as a `_revisions` property. Default is `false`.
+* `options.attachments`: Include attachment data in the response. Default is `false`, resulting in only stubs being returned.
+* `options.binary`: Return attachment data as Blobs/Buffers, instead of as base64-encoded strings. Default is `false`.
 
 
 
@@ -68,7 +68,7 @@ db.bulkGet({
         }
       }
     }],
-    "id": "good-doc"
+    "id": "doc-that-exists"
   },
   {
     "docs": [

--- a/lib/deps/bulkGetShim.js
+++ b/lib/deps/bulkGetShim.js
@@ -56,9 +56,28 @@ function bulkGet(db, opts, callback) {
     // Also, atts_since is aspirational, since we don't support it yet.
     var docOpts = pick(docRequests[0], ['atts_since', 'attachments']);
     docOpts.open_revs = docRequests.map(function (request) {
-      // rev is required, open_revs disallowed
+      // rev is optional, open_revs disallowed
       return request.rev;
     });
+
+    // remove falsey / undefined revisions
+    docOpts.open_revs = docOpts.open_revs.filter(function (e) { return e; });
+
+    var formatResult = function (result) { return result; };
+
+    if (docOpts.open_revs.length === 0) {
+      delete docOpts.open_revs;
+
+      // when fetching only the "winning" leaf,
+      // transform the result so it looks like an open_revs
+      // request
+      formatResult = function (result) {
+        return [{
+          ok: result
+        }];
+      };
+    }
+
     // globally-supplied options
     ['revs', 'attachments', 'binary'].forEach(function (param) {
       if (param in opts) {
@@ -66,7 +85,7 @@ function bulkGet(db, opts, callback) {
       }
     });
     db.get(docId, docOpts, function (err, res) {
-      gotResult(i, docId, err ? [{error: err}] : res);
+      gotResult(i, docId, err ? [{error: err}] : formatResult(res));
     });
   });
 }

--- a/tests/integration/index.html
+++ b/tests/integration/index.html
@@ -35,6 +35,7 @@
     <script src='test.constructor.js'></script>
     <script src='test.changes.js'></script>
     <script src='test.bulk_docs.js'></script>
+    <script src='test.bulk_get.js'></script>
     <script src='test.all_docs.js'></script>
     <script src='test.events.js'></script>
     <script src='test.conflicts.js'></script>

--- a/tests/integration/test.bulk_get.js
+++ b/tests/integration/test.bulk_get.js
@@ -1,0 +1,184 @@
+'use strict';
+
+var adapters = ['http', 'local'];
+
+adapters.forEach(function (adapter) {
+  describe('test.bulk_get.js-' + adapter, function () {
+
+    var dbs = {};
+    beforeEach(function (done) {
+      dbs = {name: testUtils.adapterUrl(adapter, 'testdb')};
+      testUtils.cleanup([dbs.name], done);
+    });
+
+    afterEach(function (done) {
+      testUtils.cleanup([dbs.name], done);
+    });
+
+    it('test bulk get with rev specified', function (done) {
+      var db = new PouchDB(dbs.name);
+      db.put({_id: 'foo', val: 1}).then(function (response) {
+        var rev = response.rev;
+        db.bulkGet({
+          docs: [
+            {id: 'foo', rev: rev}
+          ]
+        }).then(function (response) {
+          var result = response.results[0];
+          result.id.should.equal("foo");
+          result.docs[0].ok._rev.should.equal(rev);
+          done();
+        });
+      });
+    });
+
+    it('test bulk get with no rev specified', function (done) {
+      var db = new PouchDB(dbs.name);
+      db.put({_id: 'foo', val: 1}).then(function (response) {
+        var rev = response.rev;
+        db.bulkGet({
+          docs: [
+            {id: 'foo'}
+          ]
+        }).then(function (response) {
+          var result = response.results[0];
+          result.id.should.equal("foo");
+          result.docs[0].ok._rev.should.equal(rev);
+          done();
+        });
+      });
+    });
+
+    it('_revisions is not returned by default', function (done) {
+      var db = new PouchDB(dbs.name);
+      db.put({_id: 'foo', val: 1}).then(function (response) {
+        var rev = response.rev;
+        db.bulkGet({
+          docs: [
+            {id: 'foo', rev: rev}
+          ]
+        }).then(function (response) {
+          var result = response.results[0];
+          should.not.exist(result.docs[0].ok._revisions);
+          done();
+        });
+      });
+    });
+
+    it('_revisions is returned when specified', function (done) {
+      var db = new PouchDB(dbs.name);
+      db.put({_id: 'foo', val: 1}).then(function (response) {
+        var rev = response.rev;
+        db.bulkGet({
+          docs: [
+            {id: 'foo', rev: rev}
+          ],
+          revs: true
+        }).then(function (response) {
+          var result = response.results[0];
+          result.docs[0].ok._revisions.ids[0].should.equal(rev.substring(2));
+          done();
+        });
+      });
+    });
+
+    it('_revisions is returned when specified, using implicit rev',
+    function (done) {
+      var db = new PouchDB(dbs.name);
+      db.put({_id: 'foo', val: 1}).then(function (response) {
+        var rev = response.rev;
+        db.bulkGet({
+          docs: [
+            {id: 'foo'}
+          ],
+          revs: true
+        }).then(function (response) {
+          var result = response.results[0];
+          result.docs[0].ok._revisions.ids[0].should.equal(rev.substring(2));
+          done();
+        });
+      });
+    });
+
+    it('attachments are not included by default', function (done) {
+      var db = new PouchDB(dbs.name);
+
+      db.put({
+        _id: 'foo',
+        _attachments: {
+          'foo.txt': {
+            content_type: 'text/plain',
+            data: 'VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ='
+          }
+        }
+      }).then(function (response) {
+        var rev = response.rev;
+
+        db.bulkGet({
+          docs: [
+            {id: 'foo', rev: rev}
+          ]
+        }).then(function (response) {
+          var result = response.results[0];
+          result.docs[0].ok._attachments['foo.txt'].stub.should.equal(true);
+          done();
+        });
+      });
+    });
+
+    it('attachments are included when specified', function (done) {
+      var db = new PouchDB(dbs.name);
+
+      db.put({
+        _id: 'foo',
+        _attachments: {
+          'foo.txt': {
+            content_type: 'text/plain',
+            data: 'VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ='
+          }
+        }
+      }).then(function (response) {
+        var rev = response.rev;
+
+        db.bulkGet({
+          docs: [
+            {id: 'foo', rev: rev}
+          ],
+          attachments: true
+        }).then(function (response) {
+          var result = response.results[0];
+          result.docs[0].ok._attachments['foo.txt'].data
+            .should.equal("VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ=");
+          done();
+        });
+      });
+    });
+
+    it('attachments are included when specified, using implicit rev',
+    function (done) {
+      var db = new PouchDB(dbs.name);
+
+      db.put({
+        _id: 'foo',
+        _attachments: {
+          'foo.txt': {
+            content_type: 'text/plain',
+            data: 'VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ='
+          }
+        }
+      }).then(function (response) {
+        db.bulkGet({
+          docs: [
+            {id: 'foo'}
+          ],
+          attachments: true
+        }).then(function (response) {
+          var result = response.results[0];
+          result.docs[0].ok._attachments['foo.txt'].data
+            .should.equal("VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ=");
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds some basic tests for bulkGet (which triggered some documentation updates!) and allows bulkGet to be called without explicitly specifying the rev for each document (similar to CouchDB).