### PR TITLE
(#4625) a complete example for npm's "Try it out"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./lib/index.js",
   "homepage": "http://pouchdb.com/",
   "repository": "https://github.com/pouchdb/pouchdb",
+  "tonicExampleFilename": "tonic-example.js",
   "keywords": [
     "db",
     "couchdb",

--- a/tonic-example.js
+++ b/tonic-example.js
@@ -1,0 +1,49 @@
+// see documentation for more detail: http://pouchdb.com/api.html
+
+const PouchDB = require('pouchdb')
+require('pouchdb/extras/memory') /* this is used here just for compatibility with Tonic.
+                                    you can omit this line and the {adapter: 'memory'}
+                                    in the next, then your databases will be saved to disk or
+                                    browser storage.
+                                  */
+// create a database (here with memory storage):
+const db = new PouchDB('test', {adapter: 'memory'})
+
+// create a new doc with an _id of 'mydoc':
+let response = await db.put({
+  _id: 'mydoc',
+  title: 'Heroes'
+})
+
+// update an existing doc using _rev
+await db.put({
+  _id: 'mydoc',
+  _rev: response.rev,
+  title: "Sound and Vision",
+})
+
+// later you can fetch your doc
+console.log(await db.get('mydoc'))
+
+// or add many more docs
+response = await db.bulkDocs([
+    {_id: 'myotherdoc', title: 'The Magisters', type: "fake band"},
+    {_id: 'another', title: 'Kowabunga', type: "fake band"},
+    {title: 'Without an _id', type: null}
+])
+console.log('bulkDocs response: ' + JSON.stringify(response, null, 2))
+
+// and query them
+await db.put({
+  _id: '_design/fakebands',
+  views: {
+    fakebands: {
+      map: (function (doc) {
+        if (doc.type == "fake band") {
+          emit(doc.title)
+        }
+      }).toString()
+    }
+  }
+})
+await db.query('fakebands', {include_docs: true})


### PR DESCRIPTION
Just a suggestion. Or a initial version.

According to http://blog.tonicdev.com/2015/10/28/npm-plus-tonic.html, by doing this `package.json` trick the npm link (https://tonicdev.com/npm/pouchdb) currently blank will start with this example.

Here's the live example: https://tonicdev.com/fiatjaf/pouchdb-intro