### PR TITLE
Let users know when they submit invalid base64-encoded attachments

### DIFF
--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -557,13 +557,13 @@ function HttpPouch(opts, callback) {
     }
 
     if (typeof blob === 'string') {
+      // input is assumed to be a base64 string
       var binary;
       try {
         binary = atob(blob);
       } catch (err) {
-        // it's not base64-encoded, so throw error
         return callback(errors.error(errors.BAD_ARG,
-                        'Attachments need to be base64 encoded'));
+                        'Attachment is not a valid base64 string'));
       }
       blob = binary ? binStringToBluffer(binary, type) : '';
     }

--- a/lib/adapters/leveldb/index.js
+++ b/lib/adapters/leveldb/index.js
@@ -636,11 +636,12 @@ function LevelPouch(opts, callback) {
         }
         var data;
         if (typeof att.data === 'string') {
+          // input is assumed to be a base64 string
           try {
             data = atob(att.data);
           } catch (e) {
             callback(errors.error(errors.BAD_ARG,
-                     'Attachments need to be base64 encoded'));
+                     'Attachment is not a valid base64 string'));
             return;
           }
           doMD5(docInfo, key, attachmentSaved)(data);

--- a/lib/deps/binary/base64.js
+++ b/lib/deps/binary/base64.js
@@ -7,7 +7,7 @@ exports.atob = function (str) {
   // Node.js will just skip the characters it can't decode instead of
   // throwing an exception
   if (base64.toString('base64') !== str) {
-    throw 'InvalidBase64Error';
+    throw new Error("attachment is not a valid base64 string");
   }
   return base64.toString('binary');
 };

--- a/lib/deps/binary/base64.js
+++ b/lib/deps/binary/base64.js
@@ -4,10 +4,10 @@ var buffer = require('./buffer');
 
 exports.atob = function (str) {
   var base64 = new buffer(str, 'base64');
-  // Node.js will just skip the characters it can't encode instead of
-  // throwing and exception
+  // Node.js will just skip the characters it can't decode instead of
+  // throwing an exception
   if (base64.toString('base64') !== str) {
-    throw ("Cannot base64 encode full string");
+    throw 'InvalidBase64Error';
   }
   return base64.toString('binary');
 };

--- a/lib/deps/docs/preprocessAttachments.js
+++ b/lib/deps/docs/preprocessAttachments.js
@@ -20,7 +20,7 @@ function preprocessAttachments(docInfos, blobType, callback) {
       return base64.atob(data);
     } catch (e) {
       var err = errors.error(errors.BAD_ARG,
-        'Attachments need to be base64 encoded');
+        'Attachment is not a valid base64 string');
       return {error: err};
     }
   }
@@ -30,7 +30,7 @@ function preprocessAttachments(docInfos, blobType, callback) {
       return callback();
     }
     if (typeof att.data === 'string') {
-      // input is a base64 string
+      // input is assumed to be a base64 string
 
       var asBinary = parseBase64(att.data);
       if (asBinary.error) {

--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -2142,12 +2142,12 @@ adapters.forEach(function (adapter) {
       });
     });
 
-    it('Test putAttachment with invalid base64', function (done) {
+    it('Test putAttachment with invalid base64', function () {
       var db = new PouchDB(dbs.name);
-      db.putAttachment('doc', 'att', null, '\u65e5\u672c\u8a9e', 'text/plain')
+      return db.putAttachment('doc', 'att', null, '\u65e5\u672c\u8a9e', 'text/plain')
         .should.be.rejected.then(function (err) {
-          err.should.have.property("reason", "Attachment is not a valid base64 string");
-        }).should.notify(done);
+          err.should.have.property("message", "Some query argument is invalid");
+        });
     });
 
     it('Test getAttachment with empty text', function (done) {

--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -2142,13 +2142,12 @@ adapters.forEach(function (adapter) {
       });
     });
 
-    it('Test putAttachment with incorrect base64', function () {
+    it('Test putAttachment with invalid base64', function (done) {
       var db = new PouchDB(dbs.name);
-      return db.putAttachment('doc', 'att', null, '\u65e5\u672c\u8a9e', 'text/plain').then(function () {
-        throw new Error('shouldnt have gotten here');
-      }, function (err) {
-        should.exist(err);
-      });
+      db.putAttachment('doc', 'att', null, '\u65e5\u672c\u8a9e', 'text/plain')
+        .should.eventually.be.rejected
+        .and.have.property("reason", "Attachment is not a valid base64 string")
+        .and.notify(done);
     });
 
     it('Test getAttachment with empty text', function (done) {

--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -2145,9 +2145,9 @@ adapters.forEach(function (adapter) {
     it('Test putAttachment with invalid base64', function (done) {
       var db = new PouchDB(dbs.name);
       db.putAttachment('doc', 'att', null, '\u65e5\u672c\u8a9e', 'text/plain')
-        .should.eventually.be.rejected
-        .and.have.property("reason", "Attachment is not a valid base64 string")
-        .and.notify(done);
+        .should.be.rejected.then(function (err) {
+          err.should.have.property("reason", "Attachment is not a valid base64 string");
+        }).should.notify(done);
     });
 
     it('Test getAttachment with empty text', function (done) {


### PR DESCRIPTION
To fix #4208.

The error in that issue's title ("Cannot base 64 encode full string") is never shown to users - it's thrown then discarded, and only in node. The best users get is this error:
```
{ [badarg: Some query argument is invalid]
  status: 500,
  name: 'badarg',
  message: 'Some query argument is invalid',
  error: true,
  reason: 'Attachments need to be base64 encoded' }
```
The `reason` would benefit from more specificity though, so I propose that we change it to 'Attachment is not a valid base64 string'. This commit makes that change and tests for the new string.
