### PR TITLE
(#4677) - Consider changes erroring a valid result

### DIFF
--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -1044,17 +1044,12 @@ adapters.forEach(function (adapter) {
 
     it('Kill database while listening to live changes', function (done) {
       var db = new PouchDB(dbs.name);
-      var count = 0;
-      db.changes({
-        live: true
-      }).on('complete', function (result) {
-        done();
-      }).on('change', function (change) {
-        count++;
-        if (count === 1) {
-          db.destroy();
-        }
-      });
+
+      db.changes({live: true})
+        .on('error', function () { done(); })
+        .on('complete', function () { done(); })
+        .on('change', function () { db.destroy().catch(done); });
+
       db.post({ test: 'adoc' });
     });
 


### PR DESCRIPTION
What was happening was that when we destroyed the database we kill the changes connection, most of the time it exited cleanly however occasionally socket could not be closed cleanly and triggered an xhr error in turn an changes error.

We cant make assuptions about the underlying state of the socket connection, its pretty much always possible for an abort to trigger a parse error in the xhr request so throwing an error is valid here as long as something is notified to the changes user

