### PR TITLE
(#4700) - fix and test Webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ phantomjsdriver.log
 tests/pouchdb_server
 tests/performance-bundle.js
 dist/*
+pouchdb-webpack.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,9 @@ env:
   - CLIENT=selenium:firefox:41.0.1 ADAPTERS=memory COMMAND=test
   - CLIENT=selenium:firefox:41.0.1 ADAPTERS=localstorage COMMAND=test
 
+  # Test Webpack bundle
+  - CLIENT=selenium:firefox:41.0.1 COMMAND=test-webpack
+
   # Test CouchDB master (aka bigcouch branch)
   - CLIENT=node SERVER=couchdb-master COMMAND=test
   - SKIP_MIGRATION=true CLIENT=selenium:firefox:41.0.1 SERVER=couchdb-master COMMAND=test

--- a/TESTING.md
+++ b/TESTING.md
@@ -57,6 +57,12 @@ or e.g.:
 
 or you can append it as `?es5shim=true` if you manually opened a browser window.
 
+#### Other test options
+
+* `SKIP_MIGRATION=1` should be used to skip the migration tests.
+* `POUCHDB_SRC=../../dist/pouchdb.js` can be used to treat another file as the PouchDB source file.
+* `npm run test-webpack` will build with Webpack and then test that in a browser.
+
 #### Run the map/reduce tests
 
 The map/reduce tests are done separately from the normal integration tests, because

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -34,6 +34,9 @@ if (process.env.ADAPTERS) {
 if (process.env.AUTO_COMPACTION) {
   queryParams.autoCompaction = true;
 }
+if (process.env.POUCHDB_SRC) {
+  queryParams.src = process.env.POUCHDB_SRC;
+}
 
 var indexfile = "./lib/index.js";
 var outfile = "./dist/pouchdb.js";

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -73,6 +73,9 @@ if (process.env.SERVER) {
 if (process.env.SKIP_MIGRATION) {
   qs.SKIP_MIGRATION = process.env.SKIP_MIGRATION;
 }
+if (process.env.POUCHDB_SRC) {
+  qs.src = process.env.POUCHDB_SRC;
+}
 
 testUrl += '?';
 testUrl += querystring.stringify(qs);

--- a/bin/test-webpack.sh
+++ b/bin/test-webpack.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+#
+# Build PouchDB with Webpack instead of Browserify, and test that.
+# We have this test because there are enough differences between
+# Webpack and Browserify to justify it.
+#
+
+./node_modules/.bin/webpack \
+  --module-bind json \
+  --output-library PouchDB --output-library-target umd \
+  ./lib/index.js pouchdb-webpack.js
+POUCHDB_SRC='../../pouchdb-webpack.js' npm test

--- a/lib/deps/ajax/ajaxCore.js
+++ b/lib/deps/ajax/ajaxCore.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var request = require('request');
+var request = require('./request');
 var extend = require('js-extend').extend;
 var errors = require('./../errors');
 var clone = require('../../deps/clone');

--- a/lib/deps/ajax/request.js
+++ b/lib/deps/ajax/request.js
@@ -1,0 +1,5 @@
+'use strict';
+
+// May seem redundant, but this is to allow switching with
+// request-browser.js.
+module.exports = require('request');

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ PouchDB.utils = require('./utils');
 PouchDB.Errors = require('./deps/errors');
 PouchDB.replicate = require('./replicate').replicate;
 PouchDB.sync = require('./sync');
-PouchDB.version = require('./version');
+PouchDB.version = require('../package.json').version;
 var httpAdapter = require('./adapters/http');
 PouchDB.adapter('http', httpAdapter);
 PouchDB.adapter('https', httpAdapter);

--- a/lib/version-browser.js
+++ b/lib/version-browser.js
@@ -1,2 +1,0 @@
-// handled automatically by browserify-versionify
-module.exports = '__VERSION__';

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,1 +1,0 @@
-module.exports = require('../package.json').version;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   ],
   "dependencies": {
     "argsarray": "0.0.1",
-    "browserify-versionify": "^1.0.6",
     "debug": "2.2.0",
     "double-ended-queue": "2.0.0-0",
     "es3ify": "0.1.4",
@@ -31,6 +30,7 @@
     "lie": "3.0.1",
     "localstorage-down": "0.6.3",
     "memdown": "1.1.0",
+    "package-json-versionify": "^1.0.0",
     "pouchdb-collate": "1.2.0",
     "pouchdb-collections": "1.0.1",
     "request": "2.67.0",
@@ -60,6 +60,7 @@
     "istanbul": "0.4.1",
     "istanbul-coveralls": "1.0.3",
     "jshint": "2.8.0",
+    "json-loader": "^0.5.4",
     "less": "2.5.3",
     "mkdirp": "0.5.1",
     "mocha": "2.3.4",
@@ -81,7 +82,8 @@
     "uglify-js": "2.6.1",
     "watch-glob": "0.1.3",
     "watchify": "3.6.1",
-    "wd": "0.4.0"
+    "wd": "0.4.0",
+    "webpack": "^1.12.9"
   },
   "scripts": {
     "build-js": "npm run build-main-js && npm run min && npm run build-plugins",
@@ -106,7 +108,8 @@
     "build-site": "node ./bin/build-site.js",
     "report-coverage": "COVERAGE=1 npm test && istanbul-coveralls --no-rm",
     "build-perf": "browserify tests/performance/*.js > tests/performance-bundle.js",
-    "verify-bundle-size": "sh bin/verify-bundle-size.sh"
+    "verify-bundle-size": "sh bin/verify-bundle-size.sh",
+    "test-webpack": "sh bin/test-webpack.sh"
   },
   "browser": {
     "./adapters/levelalt": false,
@@ -116,15 +119,14 @@
     "./lib/adapters/leveldb/prepareAttachmentForStorage.js": "./lib/adapters/leveldb/prepareAttachmentForStorage-browser.js",
     "./lib/adapters/leveldb/readAsBlobOrBuffer.js": "./lib/adapters/leveldb/readAsBlobOrBuffer-browser.js",
     "./lib/adapters/preferredAdapters.js": "./lib/adapters/preferredAdapters-browser.js",
-    "./lib/deps/ajax/prequest.js": "./lib/deps/ajax/prequest-browser.js",
     "./lib/deps/ajax/applyTypeToBuffer.js": "./lib/deps/ajax/applyTypeToBuffer-browser.js",
     "./lib/deps/ajax/createBlobOrBufferFromParts.js": "./lib/deps/ajax/createBlobOrBufferFromParts-browser.js",
     "./lib/deps/ajax/createMultipartPart.js": "./lib/deps/ajax/createMultipartPart-browser.js",
     "./lib/deps/ajax/defaultBody.js": "./lib/deps/ajax/defaultBody-browser.js",
-    "./lib/deps/ajax/explainError.js": "./lib/deps/ajax/explainError-browser.js",
     "./lib/deps/ajax/explainCors.js": "./lib/deps/ajax/explainCors-browser.js",
-    "./lib/deps/env/hasLocalStorage.js": "./lib/deps/env/hasLocalStorage-browser.js",
-    "./lib/deps/env/isChromeApp.js": "./lib/deps/env/isChromeApp-browser.js",
+    "./lib/deps/ajax/explainError.js": "./lib/deps/ajax/explainError-browser.js",
+    "./lib/deps/ajax/prequest.js": "./lib/deps/ajax/prequest-browser.js",
+    "./lib/deps/ajax/request.js": "./lib/deps/ajax/request-browser.js",
     "./lib/deps/binary/base64.js": "./lib/deps/binary/base64-browser.js",
     "./lib/deps/binary/base64StringToBlobOrBuffer.js": "./lib/deps/binary/base64StringToBlobOrBuffer-browser.js",
     "./lib/deps/binary/binaryStringToBlobOrBuffer.js": "./lib/deps/binary/binaryStringToBlobOrBuffer-browser.js",
@@ -132,18 +134,18 @@
     "./lib/deps/binary/buffer.js": "./lib/deps/binary/buffer-browser.js",
     "./lib/deps/binary/cloneBinaryObject.js": "./lib/deps/binary/cloneBinaryObject-browser.js",
     "./lib/deps/binary/isBinaryObject.js": "./lib/deps/binary/isBinaryObject-browser.js",
+    "./lib/deps/env/hasLocalStorage.js": "./lib/deps/env/hasLocalStorage-browser.js",
+    "./lib/deps/env/isChromeApp.js": "./lib/deps/env/isChromeApp-browser.js",
     "./lib/deps/md5.js": "./lib/deps/md5-browser.js",
     "./lib/deps/migrate.js": "./lib/deps/migrate-browser.js",
     "./lib/mapreduce/md5.js": "./lib/mapreduce/md5-browser.js",
-    "./lib/version.js": "./lib/version-browser.js",
     "crypto": false,
     "fs": false,
-    "leveldown": false,
-    "request": "./lib/deps/ajax/request-browser.js"
+    "leveldown": false
   },
   "browserify": {
     "transform": [
-      "browserify-versionify"
+      "package-json-versionify"
     ]
   }
 }

--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -5,7 +5,13 @@
 // use query parameter pluginFile if present,
 // eg: test.html?pluginFile=memory.pouchdb.js
 var preferredAdapters = window.location.search.match(/[?&]adapters=([^&]+)/);
-var scriptsToLoad = ['../../dist/pouchdb.js'];
+var pouchdbSrc = window.location.search.match(/[?&]src=([^&]+)/);
+if (pouchdbSrc) {
+  pouchdbSrc = decodeURIComponent(pouchdbSrc[1]);
+} else {
+  pouchdbSrc = '../../dist/pouchdb.js';
+}
+var scriptsToLoad = [pouchdbSrc];
 if (preferredAdapters) {
   preferredAdapters = preferredAdapters[1].split(',');
   preferredAdapters.forEach(function (adapter) {


### PR DESCRIPTION
This fixes Webpack support, and additionally it tests Webpack in CI.

There were (surprisingly) quite a few changes that needed to be made to support this:

* `require('request')` needed to be isolated to its own file and then swapped with the `-browser` version at that level
* `browserify-versionify` wasn't working at all with Webpack and was breaking the tests, since Webpack just left the `'__VERSION__'` string in there as-is. So I swapped it out for a new Browserify transform that I wrote - [package-json-versionify](https://github.com/nolanlawson/package-json-versionify), which simply removes everything from `package.json` except for `"version"`. Webpack will ignore this transform, meaning that Webpack users are punished with a larger bundle size, but it still works.
* Unfortunately, once you start doing `require('../package.json')`, Webpack loses its mind and you suddenly need a `json-loader`. AFAICT from [this discussion](https://github.com/webpack/webpack/issues/378), this is expected behavior and they intend for end-users to include custom loaders to deal with this stuff. So unfortunately our users are going to have to do that. Hopefully they've run into it enough times before that it won't surprise them. (WTF, why can't you just `require()` a JSON file without any additional configuration?)

I think moving forward it is super important that we test Webpack in CI, because I *cannot believe* how much bending over backwards you have to do to support it and Browserify simultaneously.