### PR TITLE
(#4702) - test Cloudant in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ env:
   - secure: "WYQbfTXYwPfqz7t3ycqpXIDQdZ7C9kQJAP+08OF0cuR8eqhm7HxCiu9LjSNqoLAdlDmc55ygeS16Kn3Oht3zZ/i2Y7Gm75HcQfzUIb1sDv1xVm3aQmqZDJfAQ/r7fN8upBCLii/W8IUkJr1k717MpbdsTerIjyfPOb27hw0kJTM="
   - secure: "Ut9pRqzbVJHxg8vt1Cx0bTv4HAroBkvOLjtHF+11f/OzfNnAORIEPnJFHqGbOTozCPOizmzgwvCGqq9gYL8SakrfiI0wBfaL+lk0ub/FPuJ1+hwrLDU0Ju4O5reL0OSu0JB+OTmXfILuRQQkD9/7uwUEbLDFId4phSq3cz1UsK0="
   - secure: "MiufQQKR/EBoS7kcau/I7oYenVilysEqwx37zdgLEKlEUe3SxVOe31uLZv/bhfLNZiRuLAfmIOZmhLGnhMf0LaBzR2yC5qhBxrVHcAiTuS3q6zxpzEf02jnu+hACvj1kJJEPjpOLpEVx7ghWL4McEO0qLbdtSbQlm2IkOX1ONg0="
+  - secure: "b8GsgkwaNEOHmJni/rPsc1f3S1/+SxbN6hnXMV7bkSIOiRZAvcf68s3I0Sdln/OPuBmyzeLm5hZ7R8nsA/jYsYD5JUgEzcmF8glcxAeuhMgh9z5jBAfqFo5oUM6B7sE9I7t3/RZkSSkBGqOXIk/43voX1ZGIZBL17VKVPfNcoZ8="
+  - secure: "SSRTzT8OTeTpkGCLga74EGRfGmmRtsmAXbiXm1Xkg6tgQQmahxQJcrxr5QwHkdGdWkEIEudTd53AvZ/5KPmokmX/HiWsamdIj3WkrLdYvbEF4+mfqNa4oBBfrWXtPgPOG0vP1u5jPCK76S8qd7Ih8YrmAPUvecb04TnpVcLy+JM="
 
   matrix:
   - CLIENT=node COMMAND=test
@@ -96,6 +98,9 @@ env:
   # Test Couchbase Sync Gateway
   - GREP=test.replication.js CLIENT=node SERVER=sync-gateway BAIL=0 COMMAND=test
 
+  # Test Cloudant
+  - CLIENT=selenium:firefox:41.0.1 SERVER=couchdb-master COUCH_HOST=https://$CLOUDANT_USERNAME:$CLOUDANT_PASSWORD@pouch.cloudant.com COMMAND=test
+
   # Performance tests
   - CLIENT=selenium:firefox:41.0.1 PERF=1 COMMAND=test
   - PERF=1 COMMAND=test
@@ -123,6 +128,7 @@ matrix:
   - env: CLIENT=selenium:phantomjs ES5_SHIM=true COMMAND=test
   - env: AUTO_COMPACTION=true CLIENT=selenium:phantomjs ES5_SHIM=true COMMAND=test
   - env: TYPE=mapreduce CLIENT=selenium:phantomjs ES5_SHIM=true COMMAND=test
+  - env: CLIENT=selenium:firefox:41.0.1 SERVER=couchdb-master COUCH_HOST=https://$CLOUDANT_USERNAME:$CLOUDANT_PASSWORD@pouch.cloudant.com COMMAND=test
 
   fast_finish: true
 

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -24,7 +24,9 @@ if [[ ! -z $SERVER ]]; then
     ./node_modules/.bin/pouchdb-server -n -p 6984 $FLAGS &
     export SERVER_PID=$!
   elif [ "$SERVER" == "couchdb-master" ]; then
-    export COUCH_HOST='http://127.0.0.1:15984'
+    if [ -z $COUCH_HOST ]; then
+      export COUCH_HOST='http://127.0.0.1:15984'
+    fi
   elif [ "$SERVER" == "pouchdb-express-router" ]; then
     node ./tests/misc/pouchdb-express-router.js &
     export SERVER_PID=$!


### PR DESCRIPTION
Adding it to the allowed failures, and using Firefox because I assume
most of our users will be using browser+Cloudant rather than
Node+Cloudant. We could also test Node, but I don't want to overload
Travis too badly, and this feels like more bang for the buck.