### PR TITLE
(#4700) - ignore pouchdb-webpack.js in npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ tests/cordova/www
 phantomjsdriver.log
 bower_components
 ./docs/
+pouchdb-webpack.js


### PR DESCRIPTION
Forgot to do this in #4701.