### PR TITLE
(#4712) - generate conflict error when using inserting doc with unrecognised _rev

### DIFF
--- a/lib/deps/docs/processDocs.js
+++ b/lib/deps/docs/processDocs.js
@@ -15,12 +15,25 @@ function processDocs(revLimit, docInfos, api, fetchedDocs, tx, results,
   // Default to 1000 locally
   revLimit = revLimit || 1000;
 
+  function rootIsMissing(docInfo) {
+    return docInfo.metadata.rev_tree[0].ids[1].status === "missing";
+  }
+
   function insertDoc(docInfo, resultsIdx, callback) {
     // Cant insert new deleted documents
     var winningRev = calculateWinningRev(docInfo.metadata);
     var deleted = isDeleted(docInfo.metadata, winningRev);
     if ('was_delete' in opts && deleted) {
       results[resultsIdx] = errors.error(errors.MISSING_DOC, 'deleted');
+      return callback();
+    }
+
+    // 4712 - detect whether a new document was inserted with a _rev
+    var inConflict = newEdits && rootIsMissing(docInfo);
+
+    if (inConflict) {
+      var err = errors.error(errors.REV_CONFLICT);
+      results[resultsIdx] = err;
       return callback();
     }
 

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -1064,6 +1064,26 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('4712 invalid rev for new doc generates conflict', function (done) {
+      // CouchDB 1.X has a bug which allows this insertion via bulk_docs
+      // (which PouchDB uses for all document insertions)
+      if (adapter === 'http' && !testUtils.isCouchMaster()) {
+        return done();
+      }
+
+      var db = new PouchDB(dbs.name);
+      var newdoc = {
+        '_id': 'foobar',
+        '_rev': '1-123'
+      };
+
+      db.put(newdoc, function (err, result) {
+        should.not.exist(result);
+        err.should.have.property('name', 'conflict');
+        done();
+      });
+    });
+
     if (adapter === 'local') {
       // TODO: this test fails in the http adapter in Chrome
       it('should allow unicode doc ids', function (done) {

--- a/tests/integration/test.bulk_docs.js
+++ b/tests/integration/test.bulk_docs.js
@@ -996,6 +996,23 @@ adapters.forEach(function (adapter) {
       }).catch(done);
     });
 
+    it('4712 invalid rev for new doc generates conflict', function (done) {
+      // CouchDB 1.X has a bug which allows this insertion via bulk_docs
+      // (which PouchDB uses for all document insertions)
+      if (adapter === 'http' && !testUtils.isCouchMaster()) {
+        return done();
+      }
 
+      var db = new PouchDB(dbs.name);
+      var newdoc = {
+        '_id': 'foobar',
+        '_rev': '1-123'
+      };
+
+      db.bulkDocs({ docs: [newdoc] }, function (err, results) {
+        results[0].should.have.property('name', 'conflict');
+        done();
+      });
+    });
   });
 });

--- a/tests/integration/test.issue221.js
+++ b/tests/integration/test.issue221.js
@@ -22,11 +22,12 @@ adapters.forEach(function (adapters) {
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });
 
-    var doc = {_id: '0', integer: 0};
 
     it('Testing issue #221', function (done) {
       var local = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
+      var doc = {_id: '0', integer: 0};
+
       // Write a doc in CouchDB.
       remote.put(doc, function (err, results) {
         // Update the doc.
@@ -57,6 +58,8 @@ adapters.forEach(function (adapters) {
       }
       var local = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
+      var doc = {_id: '0', integer: 0};
+
       // Write a doc in CouchDB.
       remote.put(doc, function (err, results) {
         doc._rev = results.rev;


### PR DESCRIPTION
When inserting a new document with a specific _rev, we previously
allowed the insertion instead of generating a conflict error
(as CouchDB does).

It was a bit fiddly to figure out where to add this check but I settled
on processDocs.js. This commit adds a test that when inserting a document
new to the database (and new_edits is true), the root of the revision tree
must not be missing. Normally, PouchDB will generate a new, available
root node so the lack of this indicates that the user specified a _rev
that the database doesn't recognise.

Updates to a document which the database already knows about will not
flow down this code path - instead they go to updateDoc.js which performs
its own conflict test.