### PR TITLE
(#4721) - improve code coverage, functions at 100%

### DIFF
--- a/bin/build-as-modular-es5.sh
+++ b/bin/build-as-modular-es5.sh
@@ -14,8 +14,7 @@ npm run build
 # that doesn't oblige use to do require('foo').default for every module.
 
 ./node_modules/.bin/babel \
-  --presets es2015 \
-  --plugins add-module-exports \
+  --plugins add-module-exports,transform-es2015-modules-commonjs \
   --out-dir lib src
 
 # Add a version number to both files (equivalent to build.sh)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "babel-cli": "^6.3.17",
     "babel-plugin-add-module-exports": "^0.1.2",
-    "babel-preset-es2015": "^6.3.13",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.3.16",
     "browserify": "12.0.1",
     "bundle-collapser": "1.2.1",
     "chai": "3.4.1",

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -755,11 +755,6 @@ AbstractPouchDB.prototype.id = adapterFun('id', function (callback) {
   return this._id(callback);
 });
 
-AbstractPouchDB.prototype.type = function () {
-  /* istanbul ignore next */
-  return (typeof this._type === 'function') ? this._type() : this.adapter;
-};
-
 AbstractPouchDB.prototype.bulkDocs =
   adapterFun('bulkDocs', function (req, opts, callback) {
   if (typeof opts === 'function') {
@@ -886,14 +881,13 @@ AbstractPouchDB.prototype.destroy =
     var dependentDbs = localDoc.dependentDbs;
     var PouchDB = self.constructor;
     var deletedMap = Object.keys(dependentDbs).map(function (name) {
+      // use_prefix is only false in the browser
+      /* istanbul ignore next */
       var trueName = usePrefix ?
         name.replace(new RegExp('^' + PouchDB.prefix), '') : name;
       return new PouchDB(trueName, self.__opts).destroy();
     });
-    Promise.all(deletedMap).then(destroyDb, function (error) {
-      /* istanbul ignore next */
-      callback(error);
-    });
+    Promise.all(deletedMap).then(destroyDb, callback);
   });
 });
 

--- a/src/changes.js
+++ b/src/changes.js
@@ -39,10 +39,7 @@ function Changes(db, opts, callback) {
     self.on('complete', function (resp) {
       callback(null, resp);
     });
-    self.on('error', function (err) {
-      /* istanbul ignore next */
-      callback(err);
-    });
+    self.on('error', callback);
   }
   function onDestroy() {
     self.cancel();

--- a/src/changesHandler.js
+++ b/src/changesHandler.js
@@ -57,6 +57,11 @@ Changes.prototype.addListener = function (dbName, id, db, opts) {
       'doc_ids', 'view', 'since', 'query_params', 'binary'
     ]);
 
+    /* istanbul ignore next */
+    function onError() {
+      inprogress = false;
+    }
+
     db.changes(changesOpts).on('change', function (c) {
       if (c.seq > opts.since && !opts.cancelled) {
         opts.since = c.seq;
@@ -69,10 +74,7 @@ Changes.prototype.addListener = function (dbName, id, db, opts) {
         },0);
       }
       inprogress = false;
-    }).on('error', function () {
-      /* istanbul ignore next */
-      inprogress = false;
-    });
+    }).on('error', onError);
   }
   this._listeners[id] = eventFunction;
   this.on(dbName, eventFunction);

--- a/src/deps/functionName.js
+++ b/src/deps/functionName.js
@@ -1,7 +1,10 @@
 // shim for Function.prototype.name,
 // for browsers that don't support it like IE
 
-var hasName = (function f() {}).name;
+/* istanbul ignore next */
+function f() {}
+
+var hasName = f.name;
 var res;
 
 // We dont run coverage in IE

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -1037,6 +1037,11 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('db.type() returns a type', function () {
+      var db = new PouchDB(dbs.name);
+      db.type().should.be.a('string');
+    });
+
     it('replace PouchDB.destroy() (express-pouchdb#203)', function (done) {
       var old = PouchDB.destroy;
       PouchDB.destroy = function (name, callback) {


### PR DESCRIPTION
Here is the coverage after this fix:

```
Statements   : 100% ( 4954/4954 ), 162 ignored
Branches     : 95.53% ( 2328/2437 ), 124 ignored
Functions    : 100% ( 836/836 ), 20 ignored
Lines        : 100% ( 4899/4899 )
```

We are also no longer using the Babel `es2012` preset, because
we don't need it to simulate Rollup - we just need two small
plugins that convert ES6 modules to CJS.