### PR TITLE
"views" in design documents take a map function

### DIFF
--- a/docs/_includes/api/replication.html
+++ b/docs/_includes/api/replication.html
@@ -261,11 +261,13 @@ First `put()` a design document in the remote database:
 {
   _id: '_design/mydesign',
   views: {
-    myview: function (doc) {
-      if (doc.type === 'marsupial') {
-        emit(doc._id);
-      }
-    }.toString()
+    myview: {
+      map: function(doc) {
+        if (doc.type === 'marsupial') {
+          emit(doc._id);
+        }
+      }.toString()
+    }
   }
 }
 {% endhighlight %}


### PR DESCRIPTION
Before, the above code caused couchDB to return an error http status code.

This is because the example map function was not in the "map" key in the design
document. Therefore Couch saved a view without a map function, aka the
`views` property when querying couch for the document showed just an empty
object.