### PR TITLE
(#4731) - remove lib/dist before publish

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -10,6 +10,7 @@ VERSION=$(node --eval "console.log(require('./package.json').version);")
 # Build
 git checkout -b build
 
+rm -r lib dist
 npm run build
 
 # Publish npm release with tests/scripts/goodies


### PR DESCRIPTION
This is the safest thing to do, because other operations
(such as `run build-as-modular-es5`) might leave messy
stuff in the lib/ or dist/ directory.