### PR TITLE
(#4737) - add "license" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "PouchDB is a pocket-sized database.",
   "main": "./lib/index.js",
   "homepage": "http://pouchdb.com/",
+  "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
   "tonicExampleFilename": "tonic-example.js",
   "keywords": [


### PR DESCRIPTION
I'm tired of npm complaining about this during `npm install`.