### PR TITLE
(#4732) - add `npm run build` as prepublish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ before_script:
     # Fail early so we dont run hours of saucelabs if we know there
     # is a lint failure
   - npm run jshint
-    # build before each test
-  - npm run build
 
 script: npm run $COMMAND
 

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -10,9 +10,8 @@ VERSION=$(node --eval "console.log(require('./package.json').version);")
 # Build
 git checkout -b build
 
-npm run build
-
 # Publish npm release with tests/scripts/goodies
+# `npm run build` is run as a prepublish step
 npm publish
 
 # Create git tag, which is also the Bower/Github release

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "launch-dev-server": "node ./bin/dev-server.js",
     "test": "bash bin/run-test.sh",
     "posttest": "npm run jshint",
+    "prepublish": "npm run build",
     "release": "sh bin/release.sh",
     "publish-site": "sh bin/publish-site.sh",
     "build-site": "node ./bin/build-site.js",


### PR DESCRIPTION
This allows people to use the `pouchdb/pouchdb` version
of PouchDB. It will build it automatically for them.