### PR TITLE
Improve replication for read-only source databases

### DIFF
--- a/tests/component/test.read_only_replication.js
+++ b/tests/component/test.read_only_replication.js
@@ -1,0 +1,76 @@
+'use strict';
+
+var PouchDB = require('../../lib');
+var Checkpointer = require('../../lib/extras/checkpointer');
+
+var express = require('express');
+var bodyParser = require('body-parser');
+
+var app = express();
+
+app.use(bodyParser.json());
+
+var replicationDoc;
+
+function reject(req, res, next) {
+  replicationDoc = req.body.docs[0];
+  res.status(403).send({error: true, message: 'Unauthorized'});
+}
+
+app.post('*', reject);
+app.delete('*', reject);
+app.put('*', reject);
+app.use(require('pouchdb-express-router')(PouchDB));
+
+require('chai').should();
+
+describe('test.read_only_replication.js', function () {
+  var server;
+
+  before(function () {
+    server = app.listen(0);
+  });
+
+  after(function () {
+    return server.close();
+  });
+
+  it('Test checkpointer handles error codes', function () {
+    var db = new PouchDB('test');
+
+    // These are the same, but one goes over HTTP so that we have the
+    // above access control
+    var remote = new PouchDB('remote');
+    var remoteHTTP = new PouchDB('http://127.0.0.1:' + server.address().port +
+                                 '/remote');
+
+    var expectedLastSeq;
+    var checkpointer;
+
+    return remote.bulkDocs([{_id: 'foo'}, {_id: 'bar'}]).then(function() {
+      return db.replicate.from(remoteHTTP);
+    }).then(function(replicationResult) {
+      expectedLastSeq = replicationResult.last_seq;
+      checkpointer = new Checkpointer(remoteHTTP, db, replicationDoc._id,
+                                      replicationResult);
+
+      return checkpointer.getCheckpoint().then(function(actualLastSeq) {
+        actualLastSeq.should.equal(expectedLastSeq);
+      });
+    }).then(function() {
+      return remote.destroy();
+    }).then(function() {
+      // By now, the checkpointer should have marked the source database
+      // read-only, and make no other request to read or write a
+      // replication log from or rather to it. We therefore expect
+      // `checkpointer.getCheckpoint()` to resolve with the same result
+      // as previously, even though the source database has now been
+      // destroyed.
+      return checkpointer.getCheckpoint().then(function(actualLastSeq) {
+        actualLastSeq.should.equal(expectedLastSeq);
+      });
+    }).then(function() {
+      return db.destroy();
+    });
+  });
+});


### PR DESCRIPTION
This improves detection of read-only source databases. Before this
change, there were two different checks for read-only source databases.
One version was checking for `4xx` response status codes when trying to
update the replication log in the source database. The other version only
checked for a `401` status code when trying to create a new replication
log in the source database. We now always check for any client error
status code (`4xx`). This avoids problems when the source database
responds with client error status codes other than `401` to replication
log write requests.

This commit also adds an early return if the source database is
read-only. The goal is to avoid that the checkpointer unnecessarily
reattempts reading and writing checkpoints.