### PR TITLE
(#4770) - remove unnecessary deps from package.json

### DIFF
--- a/bin/test-webpack.sh
+++ b/bin/test-webpack.sh
@@ -8,7 +8,6 @@
 
 npm run build
 ./node_modules/.bin/webpack \
-  --module-bind json \
   --output-library PouchDB --output-library-target umd \
   . pouchdb-webpack.js
 POUCHDB_SRC='../../pouchdb-webpack.js' npm test

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "pouchdb"
   ],
   "dependencies": {
-    "add-cors-to-couchdb": "0.0.4",
     "argsarray": "0.0.1",
     "debug": "2.2.0",
     "double-ended-queue": "2.0.0-0",
@@ -67,7 +66,6 @@
     "istanbul": "0.4.1",
     "istanbul-coveralls": "1.0.3",
     "jshint": "2.8.0",
-    "json-loader": "0.5.4",
     "less": "2.5.3",
     "mkdirp": "0.5.1",
     "mocha": "2.3.4",
@@ -76,7 +74,6 @@
     "node-watch": "0.3.5",
     "phantomjs": "1.9.19",
     "pouchdb-express-router": "0.0.8",
-    "pouchdb-http-proxy": "0.10.4",
     "pouchdb-server": "1.0.0",
     "replace": "0.3.0",
     "rimraf": "2.5.0",


### PR DESCRIPTION
Our `package.json` is getting full of dependencies
that aren't strictly needed, and this is increasing
our `npm install` times. I'm removing some of them here.