### PR TITLE
(#4801) - fix global PouchDB object usage

### DIFF
--- a/src/adapters/idb/index.js
+++ b/src/adapters/idb/index.js
@@ -57,7 +57,7 @@ function IdbPouch(opts, callback) {
     },
     callback: callback
   });
-  applyNext();
+  applyNext(api.constructor);
 }
 
 function init(api, opts, callback) {


### PR DESCRIPTION
I can confirm that this fixes the `PouchDB$1` issue.
Plus this is just clearly safer - we shouldn't rely
on `window.PouchDB` being globally available.