### PR TITLE
#4788 implement proposed fix

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -755,6 +755,11 @@ AbstractPouchDB.prototype.id = adapterFun('id', function (callback) {
   return this._id(callback);
 });
 
+AbstractPouchDB.prototype.type = function () {
+  /* istanbul ignore next */
+  return (typeof this._type === 'function') ? this._type() : this.adapter;
+};
+
 AbstractPouchDB.prototype.bulkDocs =
   adapterFun('bulkDocs', function (req, opts, callback) {
   if (typeof opts === 'function') {

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -1043,6 +1043,10 @@ adapters.forEach(function (adapter) {
       db.type().should.be.a('string');
     });
 
+    it('#4788 db.type() is synchronous', function () {
+      new PouchDB(dbs.name).type.should.be.a('function');
+    });
+
     it('replace PouchDB.destroy() (express-pouchdb#203)', function (done) {
       var old = PouchDB.destroy;
       PouchDB.destroy = function (name, callback) {


### PR DESCRIPTION
Put back `.type()` in `adapter.js` to fix impredictible behavior with `idb` and `websql` adapters.