### PR TITLE
(#4835) - test in phantomjs again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,16 +59,19 @@ env:
   # Test against pouchdb-express-router
   - CLIENT=node SERVER=pouchdb-express-router COMMAND=test
 
-  # Test in firefox running on travis
+  # Test in firefox/phantomjs running on travis
   - CLIENT=selenium:firefox:41.0.1 COMMAND=test
+  - CLIENT=selenium:phantomjs COMMAND=test
 
-  # Test auto-compaction in Node, and Firefox
+  # Test auto-compaction in Node, Phantom, and Firefox
   - AUTO_COMPACTION=true CLIENT=node COMMAND=test
   - AUTO_COMPACTION=true CLIENT=selenium:firefox:41.0.1 COMMAND=test
+  - AUTO_COMPACTION=true CLIENT=selenium:phantomjs COMMAND=test
 
   # Test map/reduce
   - TYPE=mapreduce CLIENT=node COMMAND=test
   - TYPE=mapreduce CLIENT=selenium:firefox:41.0.1 COMMAND=test
+  - TYPE=mapreduce CLIENT=selenium:phantomjs COMMAND=test
 
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome COMMAND=test

--- a/TESTING.md
+++ b/TESTING.md
@@ -57,15 +57,6 @@ or
 
     $ COUCH_HOST=http://user:pass@myname.host.com npm test
 
-#### Test with ES5 Shims + PhantomJS
-
-Some older browsers require [es5 shims](https://github.com/es-shims/es5-shim) to be installed and you will need to install phantomjs to test it:
-
-    $ npm install phantomjs es5-shim
-    $ ES5_SHIM=true CLIENT=selenium:phantomjs npm test
-
-or you can append it as `?es5shim=true` if you manually opened a browser window.
-
 #### Other test options
 
 * `SKIP_MIGRATION=1` should be used to skip the migration tests.

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -9,9 +9,6 @@ var spawn = require('child_process').spawn;
 
 var queryParams = {};
 
-if (process.env.ES5_SHIM || process.env.ES5_SHIMS) {
-  queryParams.es5shim = true;
-}
 if (process.env.ADAPTERS) {
   queryParams.adapters = process.env.ADAPTERS;
 }

--- a/bin/run-cordova.sh
+++ b/bin/run-cordova.sh
@@ -24,7 +24,7 @@ rm -fr $TESTS_DIR/www
 mkdir -p $TESTS_DIR/www
 
 mkdir -p $TESTS_DIR/www/node_modules
-cp -r node_modules/mocha node_modules/chai node_modules/es5-shim \
+cp -r node_modules/mocha node_modules/chai \
     $TESTS_DIR/www/node_modules
 mkdir -p $TESTS_DIR/www/tests/integration
 cp -r tests/integration/*{js,html} tests/integration/deps $TESTS_DIR/www/tests/integration
@@ -39,16 +39,6 @@ cp dist/pouchdb*js $TESTS_DIR/www/dist
 if [[ ! -z $GREP ]]; then
   ./node_modules/replace/bin/replace.js '<body>' \
     "<body><script>window.GREP = ""'"$GREP"'"";</script>" \
-    $TESTS_DIR/www/tests/integration/index.html
-fi
-
-if [[ ! -z $ES5_SHIMS ]]; then
-  ES5_SHIM=$ES5_SHIMS # synonym
-fi
-
-if [[ ! -z $ES5_SHIM ]]; then
-  ./node_modules/replace/bin/replace.js '<body>' \
-    "<body><script>window.ES5_SHIM = ""'"$ES5_SHIM"'"";</script>" \
     $TESTS_DIR/www/tests/integration/index.html
 fi
 

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -52,6 +52,10 @@ if [[ ! -z $SERVER ]]; then
   fi
 fi
 
+if [ "$CLIENT" == "selenium:phantomjs" ]; then
+  npm install phantomjs@2.1.2 # do this on-demand to avoid slow installs
+fi
+
 printf 'Waiting for host to start .'
 WAITING=0
 until $(curl --output /dev/null --silent --head --fail --max-time 2 $COUCH_HOST); do

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -61,9 +61,6 @@ if (process.env.GREP) {
 if (process.env.ADAPTERS) {
   qs.adapters = process.env.ADAPTERS;
 }
-if (process.env.ES5_SHIM || process.env.ES5_SHIMS) {
-  qs.es5shim = true;
-}
 if (process.env.AUTO_COMPACTION) {
   qs.autoCompaction = true;
 }

--- a/tests/integration/index.html
+++ b/tests/integration/index.html
@@ -7,12 +7,6 @@
   </head>
   <body>
     <div id="mocha"></div>
-    <script>
-      var val = window.location.search.match(/[&\?]es5shims?=([^&\?]+)/);
-      if (val && val[1] === 'true') {
-        document.write('<script src="../../node_modules/es5-shim/es5-shim.js"></' + 'script>');
-      }
-    </script>
     <script src="../../node_modules/mocha/mocha.js"></script>
     <script src="../../node_modules/chai/chai.js"></script>
     <script src="../../node_modules/chai-as-promised/lib/chai-as-promised.js"></script>

--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -137,20 +137,15 @@ function startTests() {
 if (window.cordova) {
   var hasGrep = window.GREP &&
       window.location.search.indexOf('grep=') === -1;
-  var hasEs5Shim = window.ES5_SHIM &&
-      window.location.search.indexOf('es5Shim=') === -1;
   var hasAutoCompaction = window.AUTO_COMPACTION &&
     window.location.search.indexOf('autoCompaction') === -1;
   var hasAdapters = window.ADAPTERS &&
     window.location.search.indexOf('adapters=') === -1;
 
-  if (hasGrep || hasEs5Shim || hasAutoCompaction || hasAdapters) {
+  if (hasGrep || hasAutoCompaction || hasAdapters) {
     var params = [];
     if (hasGrep) {
       params.push('grep=' + encodeURIComponent(window.GREP));
-    }
-    if (hasEs5Shim) {
-      params.push('es5Shim=' + encodeURIComponent(window.ES5_SHIM));
     }
     if (hasAutoCompaction) {
       params.push('autoCompaction=' +

--- a/tests/mapreduce/index.html
+++ b/tests/mapreduce/index.html
@@ -7,12 +7,6 @@
 </head>
 <body>
 <div id="mocha"></div>
-<script>
-  var val = window.location.search.match(/[&\?]es5shims?=([^&\?]+)/);
-  if (val && val[1] === 'true') {
-    document.write('<script src="../../node_modules/es5-shim/es5-shim.js"></' + 'script>');
-  }
-</script>
 <script src="../../node_modules/mocha/mocha.js"></script>
 <script src="../../node_modules/chai/chai.js"></script>
 <script src="../../node_modules/chai-as-promised/lib/chai-as-promised.js"></script>


### PR DESCRIPTION
I have high hopes that PhantomJS 2 is gonna work. As a bonus,
we no longer need the ES5 shims, because PhantomJS supports
ES5 fully. However, it does have the broken IndexedDB, so it
will test in WebSQL instead (I confirmed that it's doing this).

Basically I am proposing this because I want to test WebSQL, but
I don't want to test it in Chrome or Safari over Saucelabs, because
that's slow and flaky.