### PR TITLE
(#4372) Pruning rev_map at compaction for leveldb

### DIFF
--- a/src/adapters/idb/bulkDocs.js
+++ b/src/adapters/idb/bulkDocs.js
@@ -235,7 +235,10 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, Changes, callback) {
     function afterPutDoc(e) {
       if (isUpdate && api.auto_compaction) {
         autoCompact(docInfo);
+      } else if (docInfo.stemmedRevs.length) {
+        compactRevs(docInfo.stemmedRevs, docInfo.metadata.id, txn);
       }
+
       metadata.seq = e.target.result;
       // Current _rev is calculated from _rev_tree on read
       delete metadata.rev;

--- a/src/adapters/leveldb/index.js
+++ b/src/adapters/leveldb/index.js
@@ -582,7 +582,7 @@ function LevelPouch(opts, callback) {
       if (api.auto_compaction) {
         return autoCompact(complete);
       } else {
-          compact(stemmedRevs, complete);
+        compact(stemmedRevs, complete);
       }
     }
 
@@ -604,7 +604,7 @@ function LevelPouch(opts, callback) {
       }
 
       if (docInfo.stemmedRevs.length) {
-          stemmedRevs.set(docInfo.metadata.id, docInfo.stemmedRevs);
+        stemmedRevs.set(docInfo.metadata.id, docInfo.stemmedRevs);
       }
 
       var attachments = docInfo.data._attachments ?
@@ -953,7 +953,7 @@ function LevelPouch(opts, callback) {
         }
       }, function (next) {
         Promise.resolve().then(function () {
-          if (opts.include_docs && opts.attachments){
+          if (opts.include_docs && opts.attachments) {
             return fetchAttachments(results, stores, opts);
           }
         }).then(function () {
@@ -1200,7 +1200,7 @@ function LevelPouch(opts, callback) {
       if (err) {
         return callback(err);
       }
-      var seqs = revs.map(function(rev) {
+      var seqs = revs.map(function (rev) {
         var seq = metadata.rev_map[rev];
         delete metadata.rev_map[rev];
         return seq;

--- a/src/adapters/leveldb/index.js
+++ b/src/adapters/leveldb/index.js
@@ -1188,7 +1188,11 @@ function LevelPouch(opts, callback) {
       if (err) {
         return callback(err);
       }
-      var seqs = metadata.rev_map; // map from rev to seq
+      var seqs = revs.map(function(rev) {
+        var seq = metadata.rev_map[rev];
+        delete metadata.rev_map[rev];
+        return seq;
+      });
       traverseRevTree(metadata.rev_tree, function (isLeaf, pos,
                                                          revHash, ctx, opts) {
         var rev = pos + '-' + revHash;
@@ -1196,6 +1200,7 @@ function LevelPouch(opts, callback) {
           opts.status = 'missing';
         }
       });
+
       var batch = [];
       batch.push({
         key: metadata.id,
@@ -1294,8 +1299,7 @@ function LevelPouch(opts, callback) {
         });
       }
 
-      revs.forEach(function (rev) {
-        var seq = seqs[rev];
+      seqs.forEach(function (seq) {
         batch.push({
           key: formatSeq(seq),
           type: 'del',

--- a/src/adapters/websql/bulkDocs.js
+++ b/src/adapters/websql/bulkDocs.js
@@ -222,7 +222,7 @@ function websqlBulkDocs(dbOpts, req, opts, api, db, Changes, callback) {
 
     function dataWritten(tx, seq) {
       var id = docInfo.metadata.id;
-      if (!isUpdate || !api.auto_compaction) {
+      if (isUpdate && api.auto_compaction) {
         compactRevs(compactTree(docInfo.metadata), id, tx);
       } else if (docInfo.stemmedRevs.length) {
         compactRevs(docInfo.stemmedRevs, id, tx);

--- a/src/deps/docs/processDocs.js
+++ b/src/deps/docs/processDocs.js
@@ -96,6 +96,7 @@ function processDocs(revLimit, docInfos, api, fetchedDocs, tx, results,
         // Ensure stemming applies to new writes as well
         var merged = merge([], currentDoc.metadata.rev_tree[0], revLimit);
         currentDoc.metadata.rev_tree = merged.tree;
+        currentDoc.stemmedRevs = merged.stemmedRevs || [];
         insertDoc(currentDoc, resultsIdx, docWritten);
       }
     }

--- a/src/deps/docs/updateDoc.js
+++ b/src/deps/docs/updateDoc.js
@@ -42,6 +42,7 @@ function updateDoc(revLimit, prev, docInfo, results,
 
   var newRev = docInfo.metadata.rev;
   docInfo.metadata.rev_tree = merged.tree;
+  docInfo.stemmedRevs = merged.stemmedRevs || [];
   /* istanbul ignore else */
   if (prev.rev_map) {
     docInfo.metadata.rev_map = prev.rev_map; // used only by leveldb

--- a/src/deps/merge/index.js
+++ b/src/deps/merge/index.js
@@ -201,8 +201,8 @@ function stem(tree, depth) {
     };
 
     for (var s = 0; s < numStemmed; s++) {
-        var rev = (path.pos + s) + '-' + stemmed[s].id;
-        maybeStem[rev] = true;
+      var rev = (path.pos + s) + '-' + stemmed[s].id;
+      maybeStem[rev] = true;
     }
 
     // Then we remerge all those flat trees together, ensuring that we dont
@@ -215,13 +215,13 @@ function stem(tree, depth) {
   }
 
   traverseRevTree(result, function (isLeaf, pos, revHash) {
-      // some revisions may have been removed in a branch but not in another
-      delete maybeStem[pos + '-' + revHash];
+    // some revisions may have been removed in a branch but not in another
+    delete maybeStem[pos + '-' + revHash];
   });
 
   return {
-      tree: result,
-      revs: Object.keys(maybeStem),
+    tree: result,
+    revs: Object.keys(maybeStem),
   };
 }
 

--- a/tests/integration/test.bulk_docs.js
+++ b/tests/integration/test.bulk_docs.js
@@ -1005,6 +1005,11 @@ adapters.forEach(function (adapter) {
 
       var db = new PouchDB(dbs.name, {revs_limit: 2});
 
+      // old revisions are always deleted with auto compaction
+      if (db.auto_compaction) {
+        return done();
+      }
+
       var revs = [];
       db.put({v: 1}, 'doc').then(function (v1) {
         revs.push(v1.rev);
@@ -1016,6 +1021,8 @@ adapters.forEach(function (adapter) {
         // the v2 revision is still in the db
         return db.get('doc', {rev: revs[1]});
       }).then(function (v2) {
+        v2.v.should.equal(2);
+
         return db.get('doc', {rev: revs[0]}).then(function (v1) {
           // the v1 revision is not in the db anymore
           done(new Error('v1 should be missing'));

--- a/tests/unit/test.merge.js
+++ b/tests/unit/test.merge.js
@@ -75,6 +75,7 @@ describe('test.merge.js', function () {
   it('Merging a path into an empty tree is the path', function () {
     merge([], simple, 10).should.deep.equal({
       tree: [simple],
+      stemmedRevs: [],
       conflicts: 'new_leaf'
     });
   });
@@ -82,6 +83,7 @@ describe('test.merge.js', function () {
   it('Remerge path into path is reflexive', function () {
     merge([simple], simple, 10).should.deep.equal({
       tree: [simple],
+      stemmedRevs: [],
       conflicts: 'internal_node'
     });
   });
@@ -89,6 +91,7 @@ describe('test.merge.js', function () {
   it('Merging a path with multiple entries is the path', function () {
     merge([], two0, 10).should.deep.equal({
       tree: [two0],
+      stemmedRevs: [],
       conflicts: 'new_leaf'
     });
   });
@@ -96,6 +99,7 @@ describe('test.merge.js', function () {
   it('Merging a path with multiple entries is reflexive', function () {
     merge([two0], two0, 10).should.deep.equal({
       tree: [two0],
+      stemmedRevs: [],
       conflicts: 'internal_node'
     });
   });
@@ -103,6 +107,7 @@ describe('test.merge.js', function () {
   it('Merging a subpath into a path results in the path', function () {
     merge([two0], simple, 10).should.deep.equal({
       tree: [two0],
+      stemmedRevs: [],
       conflicts: 'internal_node'
     });
   });
@@ -110,6 +115,7 @@ describe('test.merge.js', function () {
   it('Merging a new leaf gives us a new leaf', function () {
     merge([two0], newleaf, 10).should.deep.equal({
       tree: [withnewleaf],
+      stemmedRevs: [],
       conflicts: 'new_leaf'
     });
   });
@@ -117,6 +123,7 @@ describe('test.merge.js', function () {
   it('Merging a new branch returns a proper tree', function () {
     merge([two0], two1, 10).should.deep.equal({
       tree: [newbranch],
+      stemmedRevs: [],
       conflicts: 'new_branch'
     });
   });
@@ -124,6 +131,7 @@ describe('test.merge.js', function () {
   it('Order of merging does not affect the resulting tree', function () {
     merge([two1], two0, 10).should.deep.equal({
       tree: [newbranch],
+      stemmedRevs: [],
       conflicts: 'new_branch'
     });
   });
@@ -132,6 +140,7 @@ describe('test.merge.js', function () {
      function () {
     merge([newbranch], newleaf, 10).should.deep.equal({
       tree: [newbranchleaf],
+      stemmedRevs: [],
       conflicts: 'new_leaf'
     });
   });
@@ -139,6 +148,7 @@ describe('test.merge.js', function () {
   it('Merging a deep branch with branches works', function () {
     merge([newbranchleaf], newdeepbranch, 10).should.deep.equal({
       tree: [newbranchleafbranch],
+      stemmedRevs: [],
       conflicts: 'new_branch'
     });
   });
@@ -146,6 +156,7 @@ describe('test.merge.js', function () {
   it('New information reconnects steming induced conflicts', function () {
     merge(stemmedconflicts, withnewleaf, 10).should.deep.equal({
       tree: [withnewleaf],
+      stemmedRevs: [],
       conflicts: 'new_leaf'
     });
   });
@@ -153,6 +164,7 @@ describe('test.merge.js', function () {
   it('Simple stemming works', function () {
     merge([two0], newleaf, 2).should.deep.equal({
       tree: [newleaf],
+      stemmedRevs: ['1-1'],
       conflicts: 'new_leaf'
     });
   });
@@ -160,6 +172,7 @@ describe('test.merge.js', function () {
   it('Merge with stemming works correctly for branches', function () {
     merge([newbranchleafbranch], simple, 2).should.deep.equal({
       tree: stemmed2,
+      stemmedRevs: [],
       conflicts: 'internal_node'
     });
   });
@@ -167,6 +180,7 @@ describe('test.merge.js', function () {
   it('Merge with stemming to leaves works fine', function () {
     merge([newbranchleafbranch], simple, 1).should.deep.equal({
       tree: stemmed3,
+      stemmedRevs: ['1-1', '2-2_0'],
       conflicts: 'internal_node'
     });
   });
@@ -175,6 +189,7 @@ describe('test.merge.js', function () {
      function () {
     merge(stemmed3, withnewleaf, 10).should.deep.equal({
       tree: partialrecover,
+      stemmedRevs: [],
       conflicts: 'internal_node'
     });
   });
@@ -223,6 +238,7 @@ describe('test.merge.js', function () {
   it('The empty tree is the identity for merge.', function () {
     merge([], one, 10).should.deep.equal({
       tree: [one],
+      stemmedRevs: [],
       conflicts: 'new_leaf'
     });
   });
@@ -230,6 +246,7 @@ describe('test.merge.js', function () {
   it('Merging is reflexive', function () {
     merge([one], one, 10).should.deep.equal({
       tree: [one],
+      stemmedRevs: [],
       conflicts: 'internal_node'
     });
   });
@@ -239,6 +256,7 @@ describe('test.merge.js', function () {
   it('Merging a prefix of a tree with the tree yields the tree.', function () {
     merge(twoSibs, one, 10).should.deep.equal({
       tree: twoSibs,
+      stemmedRevs: [],
       conflicts: 'internal_node'
     });
   });
@@ -248,6 +266,7 @@ describe('test.merge.js', function () {
   it('Merging a third unrelated branch leads to a conflict.', function () {
     merge(twoSibs, three, 10).should.deep.equal({
       tree: threeSibs,
+      stemmedRevs: [],
       conflicts: 'internal_node'
     });
   });
@@ -260,6 +279,7 @@ describe('test.merge.js', function () {
   it('Merging two children is still reflexive.', function () {
     merge([twoChild], twoChild, 10).should.deep.equal({
       tree: [twoChild],
+      stemmedRevs: [],
       conflicts: 'internal_node'
     });
   });
@@ -271,6 +291,7 @@ describe('test.merge.js', function () {
   it('Merging a tree to itself is itself.', function () {
     merge([twoChildSibs], twoChildSibs, 10).should.deep.equal({
       tree: [twoChildSibs],
+      stemmedRevs: [],
       conflicts: 'internal_node'
     });
   });
@@ -284,6 +305,7 @@ describe('test.merge.js', function () {
   it('Merging tree of uneven length at node 2.', function () {
     merge([twoChild], twoChildSibs, 10).should.deep.equal({
       tree: [twoChildPlusSibs],
+      stemmedRevs: [],
       conflicts: 'new_branch'
     });
   });
@@ -292,6 +314,7 @@ describe('test.merge.js', function () {
   it('Merging a tree with a stem.', function () {
     merge([twoChildSibs], stemmed1b, 10).should.deep.equal({
       tree: [twoChildSibs],
+      stemmedRevs: [],
       conflicts: 'internal_node'
     });
   });
@@ -306,6 +329,7 @@ describe('test.merge.js', function () {
   it('Merging a stem at a deeper level.', function () {
     merge([twoChildPlusSibs2], stemmed1bb, 10).should.deep.equal({
       tree: [twoChildPlusSibs2],
+      stemmedRevs: [],
       conflicts: 'internal_node'
     });
   });
@@ -318,6 +342,7 @@ describe('test.merge.js', function () {
      function () {
     merge(stemmedTwoChildSibs2, stemmed1bb, 10).should.deep.equal({
       tree: stemmedTwoChildSibs2,
+      stemmedRevs: [],
       conflicts: 'internal_node'
     });
   });
@@ -326,6 +351,7 @@ describe('test.merge.js', function () {
   it("Merging a single tree with a deeper stem.", function () {
     merge([twoChild], stemmed1aa, 10).should.deep.equal({
       tree: [twoChild],
+      stemmedRevs: [],
       conflicts: 'internal_node'
     });
   });
@@ -334,6 +360,7 @@ describe('test.merge.js', function () {
   it('Merging a larger stem.', function () {
     merge([twoChild], stemmed1a, 10).should.deep.equal({
       tree: [twoChild],
+      stemmedRevs: [],
       conflicts: 'internal_node'
     });
   });
@@ -341,6 +368,7 @@ describe('test.merge.js', function () {
   it('More merging.', function () {
     merge([stemmed1a], stemmed1aa, 10).should.deep.equal({
       tree: [stemmed1a],
+      stemmedRevs: [],
       conflicts: 'internal_node'
     });
   });
@@ -349,6 +377,7 @@ describe('test.merge.js', function () {
   it('Merging should create conflicts.', function () {
     merge([oneChild], stemmed1aa, 10).should.deep.equal({
       tree: [oneChild, stemmed1aa],
+      stemmedRevs: [],
       conflicts: 'internal_node'
     });
   });
@@ -356,6 +385,7 @@ describe('test.merge.js', function () {
   it('Merging should have no conflicts.', function () {
     merge([oneChild, stemmed1aa], twoChild, 10).should.deep.equal({
       tree: [twoChild],
+      stemmedRevs: [],
       conflicts: 'new_leaf'
     });
   });
@@ -379,6 +409,7 @@ describe('test.merge.js', function () {
   it('Merging trees with conflicts ought to behave.', function () {
     merge([foo], bar, 10).should.deep.equal({
       tree: [fooBar],
+      stemmedRevs: [],
       conflicts: 'new_leaf'
     });
   });


### PR DESCRIPTION
We only keep the revision - sequence map for revisions that have a
document in the database.