### PR TITLE
Update batch_create.html with explicit order

### DIFF
--- a/docs/_includes/api/batch_create.html
+++ b/docs/_includes/api/batch_create.html
@@ -92,6 +92,8 @@ will be provided individually like so:
 ]
 {% endhighlight %}
 
+The results are returned in the same order as the supplied "docs" array.
+
 Note that `bulkDocs()` is not transactional, and that you may get
 back a mixed array of errors/non-errors. In CouchDB/PouchDB, the smallest
 atomic unit is the document.


### PR DESCRIPTION
This information is found in the CouchDB docs but it would be nice to specify that guarantee here so users of PouchDB know there is a 1-1 in the output results array from the input docs array.