### PR TITLE
WIP: (#4480) - Service workers instead of Appcache for the website

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" manifest="/manifest.appcache">
-
+<html lang="en" manifest="/manifest.appcache" >
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -211,6 +210,13 @@
         applicationCache.addEventListener('cached', onCached, false);
         applicationCache.addEventListener('noupdate', giveIntro, false);
         applicationCache.addEventListener('updateready', offerToReload, false);
+      }
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('{{ site.baseurl }}/serviceWorker.js').then(function(registration) {
+          console.log('ServiceWorker registration successful with scope: ', registration.scope);
+        }).catch(function(err) {
+          console.log('ServiceWorker registration failed: ', err);
+        });
       }
     </script>
     <button type="button" class="js-update-notification btn btn-primary btn-update btn-update-hidden">

--- a/docs/offline.md
+++ b/docs/offline.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Looks like you're offline...
+edit: false
+---
+
+<div class="band">
+  <div class="container">
+    <p>You need to be online to see this page, once you've seen it once however it'll be available offline in the future!</p>
+  </div>
+</div>  

--- a/docs/serviceWorker.js
+++ b/docs/serviceWorker.js
@@ -11,11 +11,6 @@ var criticalAssets = [
   '/offline.html'
   '/static/css/pouchdb.css',
   '/static/favicon.ico',
-  '/static/js/code.min.js',
-
-  'http://code.jquery.com/jquery.min.js',
-  'http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js',
-  'http://cdn.jsdelivr.net/pouchdb/latest/pouchdb.min.js',
 ];
 
 var pages = [
@@ -37,11 +32,17 @@ var blogPosts = [
 
 // Only cache the first blog page
 var nonCriticalAssets =
-  pages
-    .filter(function(file) {
-      return file.indexOf('/blog/page') === -1;
-    })
-    .concat(blogPosts.slice(0, 5)); // Let's only cache the first five by default
+  [
+    '/static/js/code.min.js',
+    'http://code.jquery.com/jquery.min.js',
+    'http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js',
+    'http://cdn.jsdelivr.net/pouchdb/latest/pouchdb.min.js',
+  ]
+  .concat(pages)
+  .filter(function(file) {
+    return file.indexOf('/blog/page') === -1;
+  })
+  .concat(blogPosts.slice(0, 5)); // Let's only cache the first five by default
 
 self.addEventListener('install', function(event) {
   event.waitUntil(

--- a/docs/serviceWorker.js
+++ b/docs/serviceWorker.js
@@ -1,0 +1,90 @@
+---
+---
+
+// Useful resources:
+// - https://eduardoboucas.com/blog/2015/06/04/supercharging-jekyll-with-a-serviceworker.html
+// - https://jakearchibald.com/2014/offline-cookbook
+
+var newCacheName = 'pouchdb-assets-cache-v{{ site.time }}';
+
+var criticalAssets = [
+  '/offline.html'
+  '/static/css/pouchdb.css',
+  '/static/favicon.ico',
+  '/static/js/code.min.js',
+
+  'http://code.jquery.com/jquery.min.js',
+  'http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js',
+  'http://cdn.jsdelivr.net/pouchdb/latest/pouchdb.min.js',
+];
+
+var pages = [
+  {% for page in site.pages %}
+    {% if page.url != '/manifest.appcache' %}
+      '{{ page.url | replace:'index.html','' }}',
+    {% endif %}
+  {% endfor %}
+  {% for page in site.guides %}
+    '{{ page.url | replace:'index.html','' }}',
+  {% endfor %}
+];
+
+var blogPosts = [
+  {% for page in site.posts %}
+    '{{ page.url | replace:'index.html','' }}',
+  {% endfor %}
+];
+
+// Only cache the first blog page
+var nonCriticalAssets =
+  pages
+    .filter(function(file) {
+      return file.indexOf('/blog/page') === -1;
+    })
+    .concat(blogPosts.slice(0, 5)); // Let's only cache the first five by default
+
+self.addEventListener('install', function(event) {
+  event.waitUntil(
+    caches.open(newCacheName).then(function(cache) {
+      cache.addAll(nonCriticalAssets);
+      // Only return the criticalAssets to waitUntil
+      // This will allow the noncritical assets to fail
+      return cache.addAll(criticalAssets);
+    })
+  );
+});
+
+self.addEventListener('activate', function(event) {
+  // remove caches beginning "pouchdb-" that aren't the new cache
+  event.waitUntil(
+    caches.keys().then(function(cacheNames) {
+      return Promise.all(
+        cacheNames.map(function(cacheName) {
+          if (!/^pouchdb-/.test(cacheName)) {
+            return;
+          }
+          if (newCacheName !== cacheName) {
+            return caches.delete(cacheName);
+          }
+        })
+      );
+    })
+  );
+});
+
+self.addEventListener('fetch', function(event) {
+  // Try the cache, if it's not in there try the network, then cache that response
+  // if that network request fails show the offline.html page.
+  event.respondWith(
+    caches.open(newCacheName).then(function(cache) {
+      return cache.match(event.request).then(function (response) {
+        return response || fetch(event.request).then(function(response) {
+          cache.put(event.request, response.clone());
+          return response;
+        }).catch(function () {
+          return cache.match('/offline.html');
+        });
+      });
+   })
+  );
+});


### PR DESCRIPTION
Just started this WIP branch...

Approach with this:
- Critical assets that must be cached to install the service worker.
- Non critical assets such as the guide etc are optional
- If a page isn't cached it can be added if you visit it while online
- If you try to visit a page that is not cached while offline you'll see an offline message.

Some initial thoughts:
- Appcache seems to still do it's thing even though I thought Service Worker stopped it.
- [] Need to check the old caches are being removed properly
- [x] We would need to set pouchdb up with SSL
- [] Need to handle refresh of content like we do in appcache