### PR TITLE
(#4849) - test latest firefox instead of 41

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo:
   false
 
 addons:
-  firefox: "41.0.1"
+  firefox: "latest"
 
 before_install:
 
@@ -53,22 +53,22 @@ env:
 
   # Test against pouchdb-server
   - CLIENT=node SERVER=pouchdb-server COMMAND=test
-  - CLIENT=selenium:firefox:41.0.1 SERVER=pouchdb-server COMMAND=test
+  - CLIENT=selenium:firefox SERVER=pouchdb-server COMMAND=test
   - SERVER_ADAPTER=memdown LEVEL_ADAPTER=memdown SERVER=pouchdb-server COMMAND=test
 
   # Test against pouchdb-express-router
   - CLIENT=node SERVER=pouchdb-express-router COMMAND=test
 
   # Test in firefox running on travis
-  - CLIENT=selenium:firefox:41.0.1 COMMAND=test
+  - CLIENT=selenium:firefox COMMAND=test
 
   # Test auto-compaction in Node, and Firefox
   - AUTO_COMPACTION=true CLIENT=node COMMAND=test
-  - AUTO_COMPACTION=true CLIENT=selenium:firefox:41.0.1 COMMAND=test
+  - AUTO_COMPACTION=true CLIENT=selenium:firefox COMMAND=test
 
   # Test map/reduce
   - TYPE=mapreduce CLIENT=node COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:firefox:41.0.1 COMMAND=test
+  - TYPE=mapreduce CLIENT=selenium:firefox COMMAND=test
 
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome COMMAND=test
@@ -85,24 +85,24 @@ env:
   - GREP=suite2 CLIENT="saucelabs:Android:5.1:Linux" COMMAND=test
   - GREP=suite2 INVERT=true CLIENT="saucelabs:Android:5.1:Linux" COMMAND=test
 
-  - CLIENT=selenium:firefox:41.0.1 ADAPTERS=memory COMMAND=test
-  - CLIENT=selenium:firefox:41.0.1 ADAPTERS=localstorage COMMAND=test
+  - CLIENT=selenium:firefox ADAPTERS=memory COMMAND=test
+  - CLIENT=selenium:firefox ADAPTERS=localstorage COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:41.0.1 COMMAND=test-webpack
+  - CLIENT=selenium:firefox COMMAND=test-webpack
 
   # Test CouchDB master (aka bigcouch branch)
   - COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:41.0.1 SERVER=couchdb-master COMMAND=test
+  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox SERVER=couchdb-master COMMAND=test
 
   # Test Couchbase Sync Gateway
   - GREP=test.replication.js CLIENT=node SERVER=sync-gateway BAIL=0 COMMAND=test
 
   # Test Cloudant
-  - CLIENT=selenium:firefox:41.0.1 SERVER=couchdb-master COUCH_HOST=https://$CLOUDANT_USERNAME:$CLOUDANT_PASSWORD@pouch.cloudant.com COMMAND=test
+  - CLIENT=selenium:firefox SERVER=couchdb-master COUCH_HOST=https://$CLOUDANT_USERNAME:$CLOUDANT_PASSWORD@pouch.cloudant.com COMMAND=test
 
   # Performance tests
-  - CLIENT=selenium:firefox:41.0.1 PERF=1 COMMAND=test
+  - CLIENT=selenium:firefox PERF=1 COMMAND=test
   - PERF=1 COMMAND=test
 
   - COMMAND=test-extras
@@ -120,13 +120,13 @@ matrix:
 
   # Allowed failures
   - env: COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:41.0.1 SERVER=couchdb-master COMMAND=test
+  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox SERVER=couchdb-master COMMAND=test
   - env: CLIENT=node SERVER=pouchdb-express-router COMMAND=test
   - env: CLIENT=node SERVER=pouchdb-server COMMAND=test
-  - env: CLIENT=selenium:firefox:41.0.1 SERVER=pouchdb-server COMMAND=test
+  - env: CLIENT=selenium:firefox SERVER=pouchdb-server COMMAND=test
   - env: SERVER_ADAPTER=memdown LEVEL_ADAPTER=memdown SERVER=pouchdb-server COMMAND=test
   - env: COMMAND=report-coverage
-  - env: CLIENT=selenium:firefox:41.0.1 SERVER=couchdb-master COUCH_HOST=https://$CLOUDANT_USERNAME:$CLOUDANT_PASSWORD@pouch.cloudant.com COMMAND=test
+  - env: CLIENT=selenium:firefox SERVER=couchdb-master COUCH_HOST=https://$CLOUDANT_USERNAME:$CLOUDANT_PASSWORD@pouch.cloudant.com COMMAND=test
 
   fast_finish: true
 


### PR DESCRIPTION
If this fails, it's because Travis or Selenium is somehow
not choosing the latest firefox, and falling back to
the default Firefox 31, which doesn't pass our tests
due to bugs in the web worker implementation.