### PR TITLE
(#4858) - add browser alts for checkpointer/genReplId

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -34,7 +34,10 @@ var extras = {
   'src/replicate/checkpointer.js': 'checkpointer.js',
   'src/replicate/generateReplicationId.js': 'generateReplicationId.js',
   'src/deps/ajax/prequest.js': 'ajax.js',
-  'src_browser/deps/ajax/prequest.js': 'ajax-browser.js'
+  'src_browser/deps/ajax/prequest.js': 'ajax-browser.js',
+  'src_browser/replicate/checkpointer.js': 'checkpointer-browser.js',
+  'src_browser/replicate/generateReplicationId.js':
+    'generateReplicationId-browser.js'
 };
 
 var currentYear = new Date().getFullYear();

--- a/package.json
+++ b/package.json
@@ -117,6 +117,8 @@
   "browser": {
     "./lib/index.js": "./lib/index-browser.js",
     "./lib/extras/ajax.js": "./lib/extras/ajax-browser.js",
+    "./lib/extras/checkpointer.js": "./lib/extras/checkpointer-browser.js",
+    "./lib/extras/generateReplicationId.js": "./lib/extras/generateReplicationId-browser.js",
     "crypto": false,
     "fs": false,
     "leveldown": false


### PR DESCRIPTION
Not adding a test because it would involve some kind of wacko test to browserify a package with a dependency on the extras and then grep the source code to make sure there's no `'crypto'` or anything like that.