### PR TITLE
(#4861) - faster json parse

### DIFF
--- a/src/deps/safeJsonParse.js
+++ b/src/deps/safeJsonParse.js
@@ -1,12 +1,28 @@
 import vuvuzela from 'vuvuzela';
 
-function safeJsonParse(str) {
+function slowJsonParse(str) {
   try {
     return JSON.parse(str);
   } catch (e) {
     /* istanbul ignore next */
     return vuvuzela.parse(str);
   }
+}
+
+function safeJsonParse(str) {
+  // try/catch is deoptimized in V8, leading to slower
+  // times than we'd like to have. Most documents are _not_
+  // huge, and do not require a slower code path just to parse them.
+  // We can be pretty sure that a document under 50000 characters
+  // will not be so deeply nested as to throw a stack overflow error
+  // (depends on the engine and available memory, though, so this is
+  // just a hunch). 50000 was chosen based on the average length
+  // of this string in our test suite, to try to find a number that covers
+  // most of our test cases (26 over this size, 26378 under it).
+  if (str.length < 50000) {
+    return JSON.parse(str);
+  }
+  return slowJsonParse(str);
 }
 
 export default safeJsonParse;


### PR DESCRIPTION
I've been looking into easy ways to make PouchDB faster, especially when using the in-memory adapter (because it highlights issues in the JS runtime, independent of LevelDB/IndexedDB/WebSQL stuff).

Using learnings from https://github.com/npm/npm/issues/11283#issuecomment-175246823, I ran some V8 tools on our code to see what popped up. One of the biggest sources of slowdowns is, surprisingly, the `try/catch` to do a `JSON.parse()` vs a vuvuzela parse if the JSON is too deeply recursive. `try/catch` is apparently still deoptimized in V8 (including Node v5), and I'm not sure when the Turbofan fixes are going to land (some discussion here: https://github.com/petkaantonov/bluebird/issues/848#issuecomment-154006514). So for the time being, I think it makes sense to micro-optimize this.

The commit itself might looks hacky, but this actually speeds up the tests quite a bit. Testing in Node 5.3.0 on my MBA using `LEVEL_ADAPTER=memdown time npm run test-node`, I get 150.90s before and 138.14s after (8.4% speedup). Not bad for a couple lines of code!

Opening a PR because I would like to see this passing on multiple browsers before/if we merge it. The stack overflow error that this is preventing is notoriously difficult to track down, since it varies from browser to browser and depends on available memory, but if it passes in Travis I'll be satisfied.