### PR TITLE
(#4337) - replace level-sublevel with sublevel-pouchdb

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -25,7 +25,7 @@ var spawn = require('child_process').spawn;
 var pkg = require('../package.json');
 var version = pkg.version;
 var external = Object.keys(pkg.dependencies).concat([
- 'fs', 'crypto', 'events', 'path', 'pouchdb', 'level-sublevel/legacy'
+ 'fs', 'crypto', 'events', 'path', 'pouchdb'
 ]);
 
 var plugins = ['fruitdown', 'localstorage', 'memory'];

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "fruitdown": "1.0.1",
     "inherits": "2.0.1",
     "js-extend": "1.0.1",
-    "level-sublevel": "6.5.4",
     "level-write-stream": "1.0.0",
     "levelup": "1.3.1",
     "lie": "3.0.2",
@@ -36,6 +35,7 @@
     "request": "2.69.0",
     "scope-eval": "0.0.3",
     "spark-md5": "2.0.0",
+    "sublevel-pouchdb": "1.0.0",
     "through2": "2.0.0",
     "vuvuzela": "1.0.2"
   },

--- a/src/adapters/leveldb/index.js
+++ b/src/adapters/leveldb/index.js
@@ -1,5 +1,5 @@
 import levelup from 'levelup';
-import sublevel from 'level-sublevel/legacy';
+import sublevel from 'sublevel-pouchdb';
 import { obj as through } from 'through2';
 
 import clone from '../../deps/clone';


### PR DESCRIPTION
I forked [level-sublevel](http://github.com/dominictarr/level-sublevel) into [sublevel-pouchdb](http://github.com/nolanlawson/sublevel-pouchdb) and removed what we weren't using, including a lot of extra dependencies from `levelup` itself that were adding to the Browserify size. As a result, our level-based plugins have gone from 192K minified to 184K (gzipped: 56.2K -> 53.7K).

This also increases our performance a bit, because I was able to optimize two of the hot functions (`decode`/`encode` in `sublevel/codec/legacy.js`) which had some unnecessary checks for non-string keys and complex keys. Since all of our keys are just a single String prefix, I could replace all the array operations with basic string concatenation.

As a result, a `PERF=1` run using `LEVEL_ADAPTER=memdown` on Node 5.3.0 went from 24.67s to 22.65s. The biggest gain comes from reading the database as a stream (i.e. `allDocs()`); I saw that the `all-docs-skip-limit` test went from 4.726s to 3.763s. Upping the iterations on that test from 50 to 500 for better granularity, I got 41.080s -> 29.571s (28% faster), which is pretty awesome.

Keep in mind that all the above perf numbers are for the MemDOWN adapter, so the difference will probably be less stark for LevelDB/localstorage-down/fruitdown.