### PR TITLE
(#4879) - docs: no 'paused' event on changes

### DIFF
--- a/docs/_includes/api/changes.html
+++ b/docs/_includes/api/changes.html
@@ -203,7 +203,7 @@ db.changes({
 When `live` is `false`, the returned object is also an event emitter as well as a promise,
 and will fire the `'complete'` event when the results are ready.
 
-Note that this `'complete'` event only fires when you aren't doing live changes. With live changes, use the `'paused'` event instead.
+Note that this `'complete'` event only fires when you aren't doing live changes.
 
 #### Filtered changes
 


### PR DESCRIPTION
Small documentation fix: let me know if I didn't get the commit message format or whatever right!