### PR TITLE
(#4894) - avoid unnecessarily exporting Changes object

### DIFF
--- a/src/adapters/idb/bulkDocs.js
+++ b/src/adapters/idb/bulkDocs.js
@@ -23,7 +23,7 @@ import {
   openTransactionSafely
 } from './utils';
 
-function idbBulkDocs(dbOpts, req, opts, api, idb, Changes, callback) {
+function idbBulkDocs(dbOpts, req, opts, api, idb, idbChanges, callback) {
   var docInfos = req.docs;
   var txn;
   var docStore;
@@ -133,7 +133,7 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, Changes, callback) {
       return;
     }
 
-    Changes.notify(api._meta.name);
+    idbChanges.notify(api._meta.name);
     api._meta.docCount += docCountDelta;
     callback(null, results);
   }

--- a/src/adapters/leveldb/index.js
+++ b/src/adapters/leveldb/index.js
@@ -65,6 +65,8 @@ var safeJsonEncoding = {
   type: 'cheap-json'
 };
 
+var levelChanges = new Changes();
+
 // require leveldown. provide verbose output on error as it is the default
 // nodejs adapter, which we do not provide for the user
 /* istanbul ignore next */
@@ -819,7 +821,7 @@ function LevelPouch(opts, callback) {
         }
         db._docCount += docCountDelta;
         db._updateSeq = newUpdateSeq;
-        LevelPouch.Changes.notify(name);
+        levelChanges.notify(name);
         process.nextTick(function () {
           callback(null, results);
         });
@@ -979,11 +981,11 @@ function LevelPouch(opts, callback) {
 
     if (opts.continuous) {
       var id = name + ':' + uuid();
-      LevelPouch.Changes.addListener(name, id, api, opts);
-      LevelPouch.Changes.notify(name);
+      levelChanges.addListener(name, id, api, opts);
+      levelChanges.notify(name);
       return {
         cancel: function () {
-          LevelPouch.Changes.removeListener(name, id);
+          levelChanges.removeListener(name, id);
         }
       };
     }
@@ -1470,7 +1472,7 @@ function LevelPouch(opts, callback) {
 
     /* istanbul ignore else */
     if (dbStore.has(name)) {
-      LevelPouch.Changes.removeAllListeners(name);
+      levelChanges.removeAllListeners(name);
 
       dbStore.get(name).close(function () {
         dbStore.delete(name);
@@ -1496,7 +1498,5 @@ LevelPouch.valid = function () {
 };
 
 LevelPouch.use_prefix = false;
-
-LevelPouch.Changes = new Changes();
 
 export default LevelPouch;

--- a/src/adapters/websql/bulkDocs.js
+++ b/src/adapters/websql/bulkDocs.js
@@ -26,7 +26,7 @@ import {
   escapeBlob
 } from './utils';
 
-function websqlBulkDocs(dbOpts, req, opts, api, db, Changes, callback) {
+function websqlBulkDocs(dbOpts, req, opts, api, db, websqlChanges, callback) {
   var newEdits = opts.new_edits;
   var userDocs = req.docs;
 
@@ -55,7 +55,7 @@ function websqlBulkDocs(dbOpts, req, opts, api, db, Changes, callback) {
     if (preconditionErrored) {
       return callback(preconditionErrored);
     }
-    Changes.notify(api._name);
+    websqlChanges.notify(api._name);
     api._docCount = -1; // invalidate
     callback(null, results);
   }


### PR DESCRIPTION
There's no reason to export these `Changes` objects, and anyway it will minify smaller if we just use a regular variable instead of attaching it to the exported object.