### PR TITLE
(#4898) - allow creating databases with reserved words

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -1,7 +1,7 @@
 import { extend as extend } from 'js-extend';
 import Promise from './deps/promise';
 import pick from './deps/pick';
-import collections from 'pouchdb-collections';
+import { Map } from 'pouchdb-collections';
 import inherits from 'inherits';
 import getArguments from 'argsarray';
 import adapterFun from './deps/adapterFun';
@@ -358,7 +358,7 @@ AbstractPouchDB.prototype.revsDiff =
   }
 
   var count = 0;
-  var missing = new collections.Map();
+  var missing = new Map();
 
   function addToMissing(id, revId) {
     if (!missing.has(id)) {

--- a/src/adapters/idb/bulkDocs.js
+++ b/src/adapters/idb/bulkDocs.js
@@ -1,4 +1,4 @@
-import collections from 'pouchdb-collections';
+import { Map } from 'pouchdb-collections';
 import { createError, MISSING_STUB } from '../../deps/errors';
 import preprocessAttachments from '../../deps/docs/preprocessAttachments';
 import processDocs from '../../deps/docs/processDocs';
@@ -48,7 +48,7 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, idbChanges, callback) {
   }
 
   var results = new Array(docInfos.length);
-  var fetchedDocs = new collections.Map();
+  var fetchedDocs = new Map();
   var preconditionErrored = false;
   var blobType = api._meta.blobSupport ? 'blob' : 'base64';
 

--- a/src/adapters/leveldb/index.js
+++ b/src/adapters/leveldb/index.js
@@ -5,7 +5,7 @@ import { obj as through } from 'through2';
 import clone from '../../deps/clone';
 import Changes from '../../changesHandler';
 import uuid from '../../deps/uuid';
-import collections from 'pouchdb-collections';
+import { Map, Set } from 'pouchdb-collections';
 import filterChange from '../../deps/filterChange';
 import getArguments from 'argsarray';
 import safeJsonParse from '../../deps/safeJsonParse';
@@ -48,7 +48,7 @@ var META_STORE = 'meta-store';
 
 // leveldb barks if we try to open a db multiple times
 // so we cache opened connections here for initstore()
-var dbStores = new collections.Map();
+var dbStores = new Map();
 
 // store the value of update_seq in the by-sequence store the key name will
 // never conflict, since the keys in the by-sequence store are integers
@@ -187,7 +187,7 @@ function LevelPouch(opts, callback) {
   if (dbStores.has(leveldownName)) {
     dbStore = dbStores.get(leveldownName);
   } else {
-    dbStore = new collections.Map();
+    dbStore = new Map();
     dbStores.set(leveldownName, dbStore);
   }
   if (dbStore.has(name)) {
@@ -446,8 +446,8 @@ function LevelPouch(opts, callback) {
   api._bulkDocs = writeLock(function (req, opts, callback) {
     var newEdits = opts.new_edits;
     var results = new Array(req.docs.length);
-    var fetchedDocs = new collections.Map();
-    var stemmedRevs = new collections.Map();
+    var fetchedDocs = new Map();
+    var stemmedRevs = new Map();
 
     var txn = new LevelTransaction();
     var docCountDelta = 0;
@@ -573,7 +573,7 @@ function LevelPouch(opts, callback) {
     }
 
     function autoCompact(callback) {
-      var revsMap = new collections.Map();
+      var revsMap = new Map();
       fetchedDocs.forEach(function (metadata, docId) {
         revsMap.set(docId, compactTree(metadata));
       });
@@ -1005,9 +1005,9 @@ function LevelPouch(opts, callback) {
       streamOpts.start = formatSeq(opts.since || 0);
     }
 
-    var docIds = opts.doc_ids && new collections.Set(opts.doc_ids);
+    var docIds = opts.doc_ids && new Set(opts.doc_ids);
     var filter = filterChange(opts);
-    var docIdsToMetadata = new collections.Map();
+    var docIdsToMetadata = new Map();
 
     var returnDocs;
     if ('return_docs' in opts) {
@@ -1269,7 +1269,7 @@ function LevelPouch(opts, callback) {
             finish(overallErr);
           }
         }
-        var refsToDelete = new collections.Map();
+        var refsToDelete = new Map();
         revs.forEach(function (rev) {
           refsToDelete.set(docId + '@' + rev, true);
         });

--- a/src/adapters/leveldb/transaction.js
+++ b/src/adapters/leveldb/transaction.js
@@ -3,14 +3,14 @@
 // things in-memory and then does a big batch() operation
 // when you're done
 
-import collections from 'pouchdb-collections';
+import { Map, Set } from 'pouchdb-collections';
 
 function getCacheFor(transaction, store) {
   var prefix = store.prefix()[0];
   var cache = transaction._cache;
   var subCache = cache.get(prefix);
   if (!subCache) {
-    subCache = new collections.Map();
+    subCache = new Map();
     cache.set(prefix, subCache);
   }
   return subCache;
@@ -18,7 +18,7 @@ function getCacheFor(transaction, store) {
 
 function LevelTransaction() {
   this._batch = [];
-  this._cache = new collections.Map();
+  this._cache = new Map();
 }
 
 LevelTransaction.prototype.get = function (store, key, callback) {
@@ -64,7 +64,7 @@ LevelTransaction.prototype.batch = function (batch) {
 
 LevelTransaction.prototype.execute = function (db, callback) {
 
-  var keys = new collections.Set();
+  var keys = new Set();
   var uniqBatches = [];
 
   // remove duplicates; last one wins

--- a/src/adapters/websql/bulkDocs.js
+++ b/src/adapters/websql/bulkDocs.js
@@ -1,4 +1,4 @@
-import collections from 'pouchdb-collections';
+import { Map } from 'pouchdb-collections';
 import preprocessAttachments from '../../deps/docs/preprocessAttachments';
 import isLocalId from '../../deps/docs/isLocalId';
 import processDocs from '../../deps/docs/processDocs';
@@ -48,7 +48,7 @@ function websqlBulkDocs(dbOpts, req, opts, api, db, websqlChanges, callback) {
 
   var tx;
   var results = new Array(docInfos.length);
-  var fetchedDocs = new collections.Map();
+  var fetchedDocs = new Map();
 
   var preconditionErrored;
   function complete() {

--- a/src/adapters/websql/utils.js
+++ b/src/adapters/websql/utils.js
@@ -1,4 +1,4 @@
-import collections from 'pouchdb-collections';
+import { Map, Set } from 'pouchdb-collections';
 import { createError, WSQ_ERROR } from '../../deps/errors';
 
 import {
@@ -108,7 +108,7 @@ function compactRevs(revs, docId, tx) {
           digestsToCheck.map(function () { return '?'; }).join(',') +
           ')';
         tx.executeSql(sql, digestsToCheck, function (tx, res) {
-          var nonOrphanedDigests = new collections.Set();
+          var nonOrphanedDigests = new Set();
           for (var i = 0; i < res.rows.length; i++) {
             nonOrphanedDigests.add(res.rows.item(i).digest);
           }
@@ -202,13 +202,14 @@ function openDBSafely(openDBFunction, opts) {
   }
 }
 
-var cachedDatabases = {};
+var cachedDatabases = new Map();
 
 function openDB(opts) {
-  var cachedResult = cachedDatabases[opts.name];
+  var cachedResult = cachedDatabases.get(opts.name);
   if (!cachedResult) {
     var openDBFun = createOpenDBFunction();
-    cachedResult = cachedDatabases[opts.name] = openDBSafely(openDBFun, opts);
+    cachedResult = openDBSafely(openDBFun, opts);
+    cachedDatabases.set(opts.name, cachedResult);
     if (cachedResult.db) {
       cachedResult.db._sqlitePlugin = typeof sqlitePlugin !== 'undefined';
     }

--- a/src/constructor.js
+++ b/src/constructor.js
@@ -29,8 +29,6 @@ function prepareForDestruction(self, opts) {
 
   function onDestroyed() {
     ctor.emit('destroyed', name);
-    //so we don't have to sift through all dbnames
-    ctor.emit(name, 'destroyed');
   }
 
   function onConstructorDestroyed() {

--- a/src/deps/docs/processDocs.js
+++ b/src/deps/docs/processDocs.js
@@ -4,7 +4,7 @@ import isDeleted from './isDeleted';
 import isLocalId from './isLocalId';
 import calculateWinningRev from '../../deps/merge/winningRev';
 import merge from '../../deps/merge/index';
-import collections from 'pouchdb-collections';
+import { Map } from 'pouchdb-collections';
 
 function rootIsMissing(docInfo) {
   return docInfo.metadata.rev_tree[0].ids[1].status === 'missing';
@@ -41,7 +41,7 @@ function processDocs(revLimit, docInfos, api, fetchedDocs, tx, results,
   }
 
   var newEdits = opts.new_edits;
-  var idsToDocs = new collections.Map();
+  var idsToDocs = new Map();
 
   var docsDone = 0;
   var docsToDo = docInfos.length;

--- a/src/setup.js
+++ b/src/setup.js
@@ -2,7 +2,7 @@ import { extend as extend } from 'js-extend';
 
 import PouchDB from "./constructor";
 import inherits from 'inherits';
-import collections from 'pouchdb-collections';
+import { Map } from 'pouchdb-collections';
 import { EventEmitter as EE } from 'events';
 import hasLocalStorage from './deps/env/hasLocalStorage';
 
@@ -22,7 +22,7 @@ function setUpEventEmitter(Pouch) {
 
   // these are created in constructor.js, and allow us to notify each DB with
   // the same name that it was destroyed, via the constructor object
-  var destructListeners = Pouch._destructionListeners = new collections.Map();
+  var destructListeners = Pouch._destructionListeners = new Map();
   Pouch.on('destroyed', function onConstructorDestroyed(name) {
     if (!destructListeners.has(name)) {
       return;

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -697,6 +697,13 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('Create a db with a reserved name', function () {
+      var db = new PouchDB('__proto__');
+      return db.info().then(function () {
+        return db.destroy();
+      });
+    });
+
     it('Error when document is not an object', function (done) {
       var db = new PouchDB(dbs.name);
       var doc1 = [{ _id: 'foo' }, { _id: 'bar' }];


### PR DESCRIPTION
Just cleaning house, noticed that we were using regular objects here when we should be using `Map`s. Some other small fixes inside, although nothing earth-shattering.