### PR TITLE
(#4915) - support WebSQL in Node via node-websql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,9 @@ env:
   - CLIENT=node COMMAND=test
   - CLIENT=node LEVEL_PREFIX=foo_ COMMAND=test
 
+  # Test WebSQL in Node (using node-websql)
+  - CLIENT=node ADAPTER=websql COMMAND=test
+
   # Test against pouchdb-server
   - CLIENT=node SERVER=pouchdb-server COMMAND=test
   - CLIENT=selenium:firefox:41.0.1 SERVER=pouchdb-server COMMAND=test

--- a/TESTING.md
+++ b/TESTING.md
@@ -158,6 +158,10 @@ Some Level adapters also require a standard database name prefix (e.g. `riak://`
 
     LEVEL_PREFIX=riak://localhost:8087/
 
+To run the node-websql test in Node, run the tests with:
+
+    ADAPTER=websql
+
 ### Performance tests
 
 To run the performance test suite in node.js:

--- a/bin/build.js
+++ b/bin/build.js
@@ -34,6 +34,7 @@ var extras = {
   'src/replicate/checkpointer.js': 'checkpointer.js',
   'src/replicate/generateReplicationId.js': 'generateReplicationId.js',
   'src/deps/ajax/prequest.js': 'ajax.js',
+  'src/plugins/websql/index.js': 'websql.js',
   'src_browser/deps/ajax/prequest.js': 'ajax-browser.js',
   'src_browser/replicate/checkpointer.js': 'checkpointer-browser.js',
   'src_browser/replicate/generateReplicationId.js':

--- a/docs/_includes/api/extras.html
+++ b/docs/_includes/api/extras.html
@@ -70,6 +70,21 @@ It is slower and more inefficient than PouchDB's default IndexedDB adapter, but 
 
 You can also download this plugin [as a standalone script](https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb.fruitdown.js).
 
+#### node-websql adapter
+
+{% highlight js %}
+var PouchDB = require('pouchdb');
+require('pouchdb/extras/websql');
+
+var db = new PouchDB('mydatabase.db', {adapter: 'websql'});
+{% endhighlight %}
+
+PouchDB adapter using WebSQL in Node, via [node-websql](https://github.com/nolanlawson/node-websql).
+This allows you to use the efficient WebSQL-based PouchDB directly over SQLite.
+
+Unlike the LocalStorage/memory/FruitDOWN adapters, this adapter is designed only
+to run in Node.js. In the browser, PouchDB already comes with WebSQL support.
+
 ### APIs for plugin authors
 
 These APIs are designed for PouchDB plugin authors, who may want to re-use some PouchDB code to avoid duplication.

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -267,6 +267,23 @@ var pouch = new PouchDB('riak://localhost:8087/somebucket', {db: require('riakdo
 
 There are many other LevelDOWN-based plugins &ndash; far too many to list here. You can find a [mostly-complete list on Github](https://github.com/rvagg/node-levelup/wiki/Modules#storage-back-ends) that includes implementations on top of MySQL, Windows Azure Table Storage, and SQLite.
 
+#### node-websql adapter
+
+In addition to the LevelDOWN-based adapters, you can also use PouchDB over
+[SQLite3](https://github.com/mapbox/node-sqlite3) in Node, using the WebSQL adapter and
+[node-websql](https://github.com/nolanlawson/node-websql):
+
+```js
+var PouchDB = require('pouchdb');
+require('pouchdb/extras/websql');
+
+var db = new PouchDB('mydatabase.db', {adapter: 'websql'});
+```
+
+This should be more efficient than something like [sqldown](https://github.com/calvinmetcalf/SQLdown), because
+instead of using a LevelDB-esque adapter over SQLite, PouchDB is directly using
+SQLite queries to build the database.
+
 
 {% include alert/start.html variant="warning"%}
 We do not currently test against any LevelDOWN adapters other than LevelDB and MemDOWN, so the other backends should be considered experimental.

--- a/extras/websql.js
+++ b/extras/websql.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../lib/extras/websql');

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "spark-md5": "2.0.0",
     "sublevel-pouchdb": "1.0.0",
     "through2": "2.0.1",
-    "vuvuzela": "1.0.2"
+    "vuvuzela": "1.0.2",
+    "websql": "0.1.0"
   },
   "jspm": {
     "main": "dist/pouchdb.js"

--- a/src/adapters/websql/createOpenDBFunction-browser.js
+++ b/src/adapters/websql/createOpenDBFunction-browser.js
@@ -1,0 +1,20 @@
+'use strict';
+
+function createOpenDBFunction() {
+  if (typeof sqlitePlugin !== 'undefined') {
+    // The SQLite Plugin started deviating pretty heavily from the
+    // standard openDatabase() function, as they started adding more features.
+    // It's better to just use their "new" format and pass in a big ol'
+    // options object.
+    return sqlitePlugin.openDatabase.bind(sqlitePlugin);
+  }
+
+  if (typeof openDatabase !== 'undefined') {
+    return function openDB(opts) {
+      // Traditional WebSQL API
+      return openDatabase(opts.name, opts.version, opts.description, opts.size);
+    };
+  }
+}
+
+export default createOpenDBFunction;

--- a/src/adapters/websql/createOpenDBFunction.js
+++ b/src/adapters/websql/createOpenDBFunction.js
@@ -1,0 +1,11 @@
+'use strict';
+
+import openDatabase from 'websql'; // nodejs version of websql
+
+function createOpenDBFunction() {
+  return function openDB(opts) {
+    return openDatabase(opts.name, opts.version, opts.description, opts.size);
+  };
+}
+
+export default createOpenDBFunction;

--- a/src/adapters/websql/utils.js
+++ b/src/adapters/websql/utils.js
@@ -1,5 +1,7 @@
 import { Map, Set } from 'pouchdb-collections';
 import { createError, WSQ_ERROR } from '../../deps/errors';
+import createOpenDBFunction from './createOpenDBFunction';
+import valid from './valid';
 
 import {
   BY_SEQ_STORE,
@@ -169,25 +171,9 @@ function getSize(opts) {
   // In Android <=4.3, this value is actually used as an
   // honest-to-god ceiling for data, so we need to
   // set it to a decently high number.
-  var isAndroid = /Android/.test(window.navigator.userAgent);
+  var isAndroid = typeof navigator !== 'undefined' &&
+    /Android/.test(navigator.userAgent);
   return isAndroid ? 5000000 : 1; // in PhantomJS, if you use 0 it will crash
-}
-
-function createOpenDBFunction() {
-  if (typeof sqlitePlugin !== 'undefined') {
-    // The SQLite Plugin started deviating pretty heavily from the
-    // standard openDatabase() function, as they started adding more features.
-    // It's better to just use their "new" format and pass in a big ol'
-    // options object.
-    return sqlitePlugin.openDatabase.bind(sqlitePlugin);
-  }
-
-  if (typeof openDatabase !== 'undefined') {
-    return function openDB(opts) {
-      // Traditional WebSQL API
-      return openDatabase(opts.name, opts.version, opts.description, opts.size);
-    };
-  }
 }
 
 function openDBSafely(openDBFunction, opts) {
@@ -215,14 +201,6 @@ function openDB(opts) {
     }
   }
   return cachedResult;
-}
-
-function valid() {
-  // SQLitePlugin leaks this global object, which we can use
-  // to detect if it's installed or not. The benefit is that it's
-  // declared immediately, before the 'deviceready' event has fired.
-  return typeof openDatabase !== 'undefined' ||
-    typeof SQLitePlugin !== 'undefined';
 }
 
 export {

--- a/src/adapters/websql/valid-browser.js
+++ b/src/adapters/websql/valid-browser.js
@@ -1,0 +1,9 @@
+function valid() {
+  // SQLitePlugin leaks this global object, which we can use
+  // to detect if it's installed or not. The benefit is that it's
+  // declared immediately, before the 'deviceready' event has fired.
+  return typeof openDatabase !== 'undefined' ||
+    typeof SQLitePlugin !== 'undefined';
+}
+
+export default valid;

--- a/src/adapters/websql/valid.js
+++ b/src/adapters/websql/valid.js
@@ -1,0 +1,5 @@
+function valid() {
+  return true; // in Node, this is always true
+}
+
+export default valid;

--- a/src/deps/binary/arrayBufferToBase64-browser.js
+++ b/src/deps/binary/arrayBufferToBase64-browser.js
@@ -1,0 +1,8 @@
+import arrayBufferToBinaryString from './arrayBufferToBinaryString';
+import { btoa } from './base64';
+
+function arrayBufferToBase64(buffer) {
+  return btoa(arrayBufferToBinaryString(buffer));
+}
+
+export default arrayBufferToBase64;

--- a/src/deps/binary/arrayBufferToBase64.js
+++ b/src/deps/binary/arrayBufferToBase64.js
@@ -1,6 +1,6 @@
 // In Node, this is just a Buffer rather than an ArrayBuffer
-function arrayBufferToBinaryString(buffer) {
+function arrayBufferToBase64(buffer) {
   return buffer.toString('binary');
 }
 
-export default arrayBufferToBinaryString;
+export default arrayBufferToBase64;

--- a/src/deps/binary/arrayBufferToBinaryString-browser.js
+++ b/src/deps/binary/arrayBufferToBinaryString-browser.js
@@ -1,0 +1,14 @@
+//Can't find original post, but this is close
+//http://stackoverflow.com/questions/6965107/ (continues on next line)
+//converting-between-strings-and-arraybuffers
+function arrayBufferToBinaryString(buffer) {
+  var binary = '';
+  var bytes = new Uint8Array(buffer);
+  var length = bytes.byteLength;
+  for (var i = 0; i < length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return binary;
+}
+
+export default arrayBufferToBinaryString;

--- a/src/deps/binary/readAsArrayBuffer-browser.js
+++ b/src/deps/binary/readAsArrayBuffer-browser.js
@@ -1,0 +1,17 @@
+// simplified API. universal browser support is assumed
+function readAsArrayBuffer(blob, callback) {
+  if (typeof FileReader === 'undefined') {
+    // fix for Firefox in a web worker:
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=901097
+    return callback(new FileReaderSync().readAsArrayBuffer(blob));
+  }
+
+  var reader = new FileReader();
+  reader.onloadend = function (e) {
+    var result = e.target.result || new ArrayBuffer(0);
+    callback(result);
+  };
+  reader.readAsArrayBuffer(blob);
+}
+
+export default readAsArrayBuffer;

--- a/src/deps/binary/readAsArrayBuffer.js
+++ b/src/deps/binary/readAsArrayBuffer.js
@@ -1,17 +1,10 @@
-// simplified API. universal browser support is assumed
-function readAsArrayBuffer(blob, callback) {
-  if (typeof FileReader === 'undefined') {
-    // fix for Firefox in a web worker:
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=901097
-    return callback(new FileReaderSync().readAsArrayBuffer(blob));
-  }
-
-  var reader = new FileReader();
-  reader.onloadend = function (e) {
-    var result = e.target.result || new ArrayBuffer(0);
-    callback(result);
-  };
-  reader.readAsArrayBuffer(blob);
+// In Node.js, just convert the Buffer to a Buffer rather than
+// convert a Blob to an ArrayBuffer. This function is just a convenience
+// function so we can easily switch Node vs browser environments.
+function readAsArrayBuffer(buffer, callback) {
+  process.nextTick(function () {
+    callback(buffer);
+  });
 }
 
 export default readAsArrayBuffer;

--- a/src/deps/docs/preprocessAttachments.js
+++ b/src/deps/docs/preprocessAttachments.js
@@ -2,6 +2,7 @@ import { atob, btoa } from '../binary/base64';
 import arrayBuffToBinString from '../binary/arrayBufferToBinaryString';
 import readAsArrayBuffer from '../binary/readAsArrayBuffer';
 import binStringToBlobOrBuffer from '../binary/binaryStringToBlobOrBuffer';
+import arrayBuffToB64 from '../binary/arrayBufferToBase64';
 import { createError, BAD_ARG } from '../errors';
 import md5 from '../md5';
 
@@ -52,7 +53,7 @@ function preprocessAttachments(docInfos, blobType, callback) {
         if (blobType === 'binary') {
           att.data = arrayBuffToBinString(buff);
         } else if (blobType === 'base64') {
-          att.data = btoa(arrayBuffToBinString(buff));
+          att.data = arrayBuffToB64(buff);
         }
         md5(buff).then(function (result) {
           att.digest = 'md5-' + result;

--- a/src/plugins/websql/index.js
+++ b/src/plugins/websql/index.js
@@ -1,0 +1,6 @@
+// Allows using WebSQL in Node via node-websql
+
+import websql from '../../adapters/websql/index';
+
+var PouchDB = require('../../lib'); // relative to ./lib/extras/websql.js
+PouchDB.adapter('websql', websql, true);

--- a/tests/integration/test.issue915.js
+++ b/tests/integration/test.issue915.js
@@ -1,6 +1,8 @@
 'use strict';
 if (!process.env.LEVEL_ADAPTER &&
-    !process.env.LEVEL_PREFIX && !process.env.AUTO_COMPACTION) {
+    !process.env.LEVEL_PREFIX &&
+    !process.env.AUTO_COMPACTION &&
+    !process.env.ADAPTER) {
   // these tests don't make sense for anything other than default leveldown
   var fs = require('fs');
   describe('Remove DB', function () {

--- a/tests/integration/test.migration.js
+++ b/tests/integration/test.migration.js
@@ -1,6 +1,8 @@
 'use strict';
 if (!process.env.LEVEL_ADAPTER &&
-    !process.env.LEVEL_PREFIX && !process.env.AUTO_COMPACTION) {
+    !process.env.LEVEL_PREFIX &&
+    !process.env.AUTO_COMPACTION &&
+    !process.env.ADAPTER) {
   // these tests don't make sense for anything other than default leveldown
   var fs = require('fs');
   var ncp = require('ncp').ncp;

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -305,7 +305,6 @@ testUtils.promisify = function (fun, context) {
   };
 };
 
-var testDir;
 if (typeof module !== 'undefined' && module.exports) {
   global.PouchDB = require('../../lib');
   if (process.env.LEVEL_ADAPTER || process.env.LEVEL_PREFIX) {
@@ -325,10 +324,17 @@ if (typeof module !== 'undefined' && module.exports) {
     global.PouchDB = global.PouchDB.defaults({auto_compaction: true});
   }
   if (typeof process !== 'undefined') {
-    testDir = process.env.TESTS_DIR ? process.env.TESTS_DIR : './tmp';
-    testDir = testDir.slice(-1) === '/' ? testDir : testDir + '/';
-    global.PouchDB.prefix = testDir + global.PouchDB.prefix;
-    global.PouchDB.adapters.leveldb.use_prefix = true;
+    if (process.env.ADAPTER === 'websql') {
+      // test WebSQL in Node
+      require('../../extras/websql');
+      global.PouchDB.preferredAdapters = ['websql'];
+      global.PouchDB.prefix = './tmp/' + global.PouchDB.prefix;
+      require('mkdirp').sync('./tmp');
+    } else {
+      // test regular LevelDB in Node
+      global.PouchDB.prefix = './tmp/' + global.PouchDB.prefix;
+      global.PouchDB.adapters.leveldb.use_prefix = true;
+    }
   }
   module.exports = testUtils;
 }


### PR DESCRIPTION
Contains three major changes:

1. Modifications to the `websql` adapter to allow it to run in either Node or the browser. In particular, checks for `window.navigator` had to be made optional, and any manipulation of Blobs had to be made to support Buffers as well (see `preprocessAttachments.js`)
2. Changes to the Travis tests, to run the full PouchDB test suite against `node-websql`. I realize I could have made a separate repo for this and run my tests over there, but I think it's reasonable to add this to the PouchDB project, because it's just much simpler than maintaining a fork. The test is also pretty speedy.
3. Addition of a new `extras` API: `require('pouchdb/extras/websql')`, which allows users to use the WebSQL adapter in Node. I know we're planning on removing the `extras` API, but my current thinking about that is that the best approach will be a monorepo with separate modules (e.g. using [Lerna](https://www.npmjs.com/package/lerna), ala Babel), meaning that we would still want this adapter to be hosted in this repo.

I realize this is a big change to propose out of the blue, so I'm happy to discuss further, but the good news is that my weekend hacking has resulted in a fully working PouchDB adapter that directly uses SQLite in Node. :)