### PR TITLE
(#4339) - Throw useful error when instance is destroyed rather than h…

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -936,6 +936,7 @@ AbstractPouchDB.prototype.destroy =
       if (err) {
         return callback(err);
       }
+      self._destroyed = true;
       self.emit('destroyed');
       callback(null, resp || { 'ok': true });
     });

--- a/src/deps/adapterFun.js
+++ b/src/deps/adapterFun.js
@@ -31,6 +31,9 @@ function adapterFun(name, callback) {
     if (this._closed) {
       return Promise.reject(new Error('database is closed'));
     }
+    if (this._destroyed) {
+      return Promise.reject(new Error('database is destroyed'));
+    }
     var self = this;
     logApiCall(self, name, args);
     if (!this.taskqueue.isReady) {

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -73,6 +73,22 @@ adapters.forEach(function (adapter) {
       return new PouchDB(dbs.name).destroy({});
     });
 
+    it('4339 throw useful error if method called on stale instance', function () {
+      var db = new PouchDB(dbs.name);
+
+      return db.put({
+        _id: 'cleanTest'
+      }).then(function () {
+        return db.destroy();
+      }).then(function () {
+        return db.get('cleanTest');
+      }).then(function () {
+        throw new Error('.get should return an error');
+      }, function (err) {
+        should.equal(err instanceof Error, true, 'should be an error');
+      });
+    });
+
     it('destroy a pouch, with a promise', function (done) {
       new PouchDB(dbs.name, function (err, db) {
         should.exist(db);


### PR DESCRIPTION
…anging

Something to note here is previously if you were using the HTTP adapter, it would return a 404 whereas the browser adapters will hang.

So this could technically be breaking functionality if someone was relying on that behaviour and they were *only* using PouchDB as a HTTP adapter.

This changes it so they all return the same result, a error message.