### PR TITLE
Correct parameter names in replication example

### DIFF
--- a/docs/_includes/api/replication.html
+++ b/docs/_includes/api/replication.html
@@ -39,11 +39,11 @@ var rep = PouchDB.replicate('mydb', 'http://localhost:5984/mydb', {
   retry: true
 }).on('change', function (info) {
   // handle change
-}).on('paused', function () {
-  // replication paused (e.g. user went offline)
+}).on('paused', function (err) {
+  // replication paused (e.g. replication up to date, user went offline)
 }).on('active', function () {
-  // replicate resumed (e.g. user went back online)
-}).on('denied', function (info) {
+  // replicate resumed (e.g. new changes replicating, user went back online)
+}).on('denied', function (err) {
   // a document failed to replicate, e.g. due to permissions
 }).on('complete', function (info) {
   // handle complete


### PR DESCRIPTION
Use the same parameter names in the example as in the docs below. Also make clear that a paused event is emitted when the sync is up to date.