### PR TITLE
(4979) - allow passing any option to websql

### DIFF
--- a/src/adapters/websql/index.js
+++ b/src/adapters/websql/index.js
@@ -120,12 +120,13 @@ function WebSqlPouch(opts, callback) {
 
   api._docCount = -1; // cache sqlite count(*) for performance
   api._name = opts.name;
-
+  console.log(opts)
   var openDBResult = openDB({
     name: api._name,
     version: POUCH_VERSION,
     description: api._name,
     size: size,
+    key: opts.key,
     location: opts.location,
     createFromLocation: opts.createFromLocation,
     androidDatabaseImplementation: opts.androidDatabaseImplementation


### PR DESCRIPTION
Closes #4979

Cordova's sqlcipher-adapter requires a key to be passed in order
to encrypt the DB. This PR allows for not only the key to be passed,
but for any future options that could be added.