### PR TITLE
(#5010) update cache-busting for new version of Safari

### DIFF
--- a/src/deps/ajax/prequest-browser.js
+++ b/src/deps/ajax/prequest-browser.js
@@ -1,6 +1,6 @@
 import ajaxCore from './ajaxCore';
 
-function ajax(opts, callback) {
+function ajax (opts, callback) {
 
   // cache-buster, specifically designed to work around IE's aggressive caching
   // see http://www.dashbay.com/2011/05/internet-explorer-caches-ajax/
@@ -12,8 +12,10 @@ function ajax(opts, callback) {
   var isIE = ua.indexOf('msie') !== -1;
   var isEdge = ua.indexOf('edge') !== -1;
 
-  var shouldCacheBust = (isSafari && opts.method === 'POST') ||
-    ((isIE || isEdge) && opts.method === 'GET');
+  // it appears the new version of safari also caches GETs,
+  // see https://github.com/pouchdb/pouchdb/issues/5010
+  var shouldCacheBust = (isSafari ||
+    ((isIE || isEdge) && opts.method === 'GET'));
 
   var cache = 'cache' in opts ? opts.cache : true;
 

--- a/src/deps/ajax/prequest-browser.js
+++ b/src/deps/ajax/prequest-browser.js
@@ -19,7 +19,9 @@ function ajax (opts, callback) {
 
   var cache = 'cache' in opts ? opts.cache : true;
 
-  if (shouldCacheBust || !cache) {
+  var isBlobUrl = /^blob:/.test(opts.url); // don't append nonces for blob URLs
+
+  if (!isBlobUrl && (shouldCacheBust || !cache)) {
     var hasArgs = opts.url.indexOf('?') !== -1;
     opts.url += (hasArgs ? '&' : '?') + '_nonce=' + Date.now();
   }


### PR DESCRIPTION
Rebased version of #5111 with blob URL fix, to test in CI.