### PR TITLE
(#4963) Don't skip docs that fail to replicate

### DIFF
--- a/src/replicate/getDocs.js
+++ b/src/replicate/getDocs.js
@@ -49,11 +49,18 @@ function getDocs(src, diffs, state) {
       if (state.cancelled) {
         throw new Error('cancelled');
       }
+      var allSuccessful = true;
       bulkGetResponse.results.forEach(function (bulkGetInfo) {
         bulkGetInfo.docs.forEach(function (doc) {
-          if (doc.ok) {
+          if (allSuccessful && doc.ok) {
             resultDocs.push(doc.ok);
+          } else if (doc.error) {
+            // This doc failed so ignore the rest of the docs
+            allSuccessful = false;
           }
+          // else: When AUTO_COMPACTION is set, docs can be returned which look
+          // like this: {"missing":"1-7c3ac256b693c462af8442f992b83696"}
+          // These can be safely skipped over.
         });
       });
     });

--- a/src/replicate/replicate.js
+++ b/src/replicate/replicate.js
@@ -101,7 +101,26 @@ function replicate(src, target, opts, returnValue, result) {
     });
   }
 
+  function findLatestSeq() {
+    var lastId = currentBatch.docs[currentBatch.docs.length - 1]._id;
+    for (var i = 0; i < currentBatch.changes.length; i++) {
+      var change = currentBatch.changes[i];
+      if (change.id === lastId) {
+        return change.seq;
+      }
+    }
+  }
+
   function finishBatch() {
+    if (Object.keys(currentBatch.diffs).length) {
+      if (!currentBatch.docs.length) {
+        // changes expected by none written - don't update checkpoint
+        return;
+      } else {
+        // check for partial success
+        currentBatch.seq = findLatestSeq();
+      }
+    }
     result.last_seq = last_seq = currentBatch.seq;
     var outResult = clone(result);
     if (changedDocs.length) {

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -2119,7 +2119,7 @@ adapters.forEach(function (adapters) {
               second_replicate();
               return;
             }
-            db.get(doc.id, function (err, exists) {
+            db.get(doc.id, function (err) {
               if (doc.expected) {
                 should.not.exist(err);
               } else {
@@ -2162,7 +2162,7 @@ adapters.forEach(function (adapters) {
               });
               return;
             }
-            db.get(doc.id, function (err, result) {
+            db.get(doc.id, function (err) {
               if (doc.expected) {
                 should.not.exist(err);
               } else {

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -2048,7 +2048,7 @@ adapters.forEach(function (adapters) {
       });
     });
 
-    it.skip('(#1240) - get error', function (done) {
+    it('#1240 do not skip failed docs on replication', function (done) {
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
       // 10 test documents
@@ -2057,163 +2057,135 @@ adapters.forEach(function (adapters) {
       for (var i = 0; i < num; i++) {
         docs.push({
           _id: 'doc_' + i,
-          foo: 'bar_' + i
+          foo: 'bar_' + i,
+          // needed to cause the code to fetch using get
+          _attachments: {
+            text: {
+              content_type: 'text\/plain',
+              data: "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ="
+            }
+          }
         });
       }
+
       // Initialize remote with test documents
-      remote.bulkDocs({ docs: docs }, {}, function () {
-        var get = remote.get;
-        function first_replicate() {
-          // Mock remote.get to fail writing doc_3 (fourth doc)
-          remote.get = function () {
-            // Simulate failure to get the document with id 'doc_4'
-            // This should block the replication at seq 4
-            if (arguments[0] === 'doc_4') {
-              arguments[2].apply(null, [{}]);
-            } else {
-              get.apply(this, arguments);
-            }
-          };
-          // Replicate and confirm failure, docs_written and target docs
-          db.replicate.from(remote, function (err, result) {
-            should.exist(err);
-            should.exist(result);
-            result.docs_written.should.equal(4);
-            function check_docs(id) {
-              if (!id) {
-                second_replicate();
-                return;
-              }
-              db.get(id, function (err, exists) {
-                if (exists) {
-                  should.not.exist(err);
-                } else {
-                  should.exist(err);
-                }
-                check_docs(docs.shift());
-              });
-            }
-            var docs = [
-              [
-                'doc_0',
-                true
-              ],
-              [
-                'doc_1',
-                true
-              ],
-              [
-                'doc_2',
-                true
-              ],
-              [
-                'doc_3',
-                false
-              ],
-              [
-                'doc_4',
-                false
-              ],
-              [
-                'doc_5',
-                false
-              ],
-              [
-                'doc_6',
-                false
-              ],
-              [
-                'doc_7',
-                false
-              ],
-              [
-                'doc_8',
-                false
-              ],
-              [
-                'doc_9',
-                false
-              ]
-            ];
-            check_docs(docs.shift());
-          });
+      // can't use bulkDocs because order is important
+      var results = [];
+      function save_doc(i) {
+        if (i >= docs.length) {
+          first_replicate();
+          return;
         }
-        function second_replicate() {
-          // Restore remote.get to original
-          remote.get = get;
-          // Replicate and confirm success, docs_written and target docs
-          db.replicate.from(remote, function (err, result) {
-            should.not.exist(err);
-            should.exist(result);
-            result.docs_written.should.equal(6);
-            function check_docs(id, exists) {
-              if (!id) {
-                db.info(function (err, info) {
-                  verifyInfo(info, {
-                    update_seq: 6,
-                    doc_count: 6
-                  });
-                  done();
+        remote.put(docs[i])
+          .then(function(result) {
+            results.push(result);
+            save_doc(++i);
+          })
+          .catch(function(err) {
+            console.error('Error saving doc', err);
+          });
+      }
+      save_doc(0);
+
+      var bulkGet = remote.bulkGet;
+      function first_replicate() {
+        remote.bulkGet = function () {
+          var getResults = [];
+          for (var i = 0; i < docs.length; i++) {
+            var doc = docs[i];
+            getResults.push({
+              id: doc._id,
+              docs: [ {
+                ok: {
+                  _id: doc._id,
+                  foo: doc.foo,
+                  _attachments: doc._attachments,
+                  _rev: results[i].rev
+                }
+              } ]
+            });
+          }
+          // Mock remote.get to fail getting doc_3 (fourth doc)
+          getResults[3].docs[0] = { error: new Error('timeout') };
+          return Promise.resolve({ results: getResults });
+        };
+        // Replicate and confirm failure, docs_written and target docs
+        db.replicate.from(remote, function (err, result) {
+          should.not.exist(err);
+          should.exist(result);
+          result.docs_written.should.equal(3);
+          function check_docs(doc) {
+            if (!doc) {
+              second_replicate();
+              return;
+            }
+            db.get(doc.id, function (err, exists) {
+              if (doc.expected) {
+                should.not.exist(err);
+              } else {
+                should.exist(err);
+              }
+              check_docs(docs.shift());
+            });
+          }
+          var docs = [
+            { id: 'doc_0', expected: true },
+            { id: 'doc_1', expected: true },
+            { id: 'doc_2', expected: true },
+            { id: 'doc_3', expected: false },
+            { id: 'doc_4', expected: false },
+            { id: 'doc_5', expected: false },
+            { id: 'doc_6', expected: false },
+            { id: 'doc_7', expected: false },
+            { id: 'doc_8', expected: false },
+            { id: 'doc_9', expected: false }
+          ];
+          check_docs(docs.shift());
+        });
+      }
+      function second_replicate() {
+        // Restore remote.bulkGet to original
+        remote.bulkGet = bulkGet;
+        // Replicate and confirm success, docs_written and target docs
+        db.replicate.from(remote, function (err, result) {
+          should.not.exist(err);
+          should.exist(result);
+          result.docs_written.should.equal(7);
+          function check_docs(doc) {
+            if (!doc) {
+              db.info(function (err, info) {
+                verifyInfo(info, {
+                  update_seq: 10,
+                  doc_count: 10
                 });
-                return;
-              }
-              db.get(id, function (err) {
-                if (exists) {
-                  should.not.exist(err);
-                } else {
-                  should.exist(err);
-                }
-                check_docs(docs.shift());
+                done();
               });
+              return;
             }
-            var docs = [
-              [
-                'doc_0',
-                true
-              ],
-              [
-                'doc_1',
-                true
-              ],
-              [
-                'doc_2',
-                true
-              ],
-              [
-                'doc_3',
-                true
-              ],
-              [
-                'doc_4',
-                true
-              ],
-              [
-                'doc_5',
-                true
-              ],
-              [
-                'doc_6',
-                true
-              ],
-              [
-                'doc_7',
-                true
-              ],
-              [
-                'doc_8',
-                true
-              ],
-              [
-                'doc_9',
-                true
-              ]
-            ];
-            check_docs(docs.shift());
-          });
-        }
-        // Done the test
-        first_replicate();
-      });
+            db.get(doc.id, function (err, result) {
+              if (doc.expected) {
+                should.not.exist(err);
+              } else {
+                should.exist(err);
+              }
+              check_docs(docs.shift());
+            });
+          }
+          var docs = [
+            { id: 'doc_0', expected: true },
+            { id: 'doc_1', expected: true },
+            { id: 'doc_2', expected: true },
+            { id: 'doc_3', expected: true },
+            { id: 'doc_4', expected: true },
+            { id: 'doc_5', expected: true },
+            { id: 'doc_6', expected: true },
+            { id: 'doc_7', expected: true },
+            { id: 'doc_8', expected: true },
+            { id: 'doc_9', expected: true }
+          ];
+          check_docs(docs.shift());
+        });
+      }
     });
 
     it.skip('Get error 2', function (done) {

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -2079,7 +2079,7 @@ adapters.forEach(function (adapters) {
         remote.put(docs[i])
           .then(function(result) {
             results.push(result);
-            save_doc(++i);
+            save_doc(i + 1);
           })
           .catch(function(err) {
             console.error('Error saving doc', err);
@@ -2107,7 +2107,7 @@ adapters.forEach(function (adapters) {
           }
           // Mock remote.get to fail getting doc_3 (fourth doc)
           getResults[3].docs[0] = { error: new Error('timeout') };
-          return Promise.resolve({ results: getResults });
+          return PouchDB.utils.Promise.resolve({ results: getResults });
         };
         // Replicate and confirm failure, docs_written and target docs
         db.replicate.from(remote, function (err, result) {


### PR DESCRIPTION
When replicating a batch and one doc fails save the docs that successfully downloaded up to that point, then proceed to the next batch starting with the one that failed.

This is an alternative approach to #5029 which attempts to solve the same problem by discarding the entire batch. The problem with that solution is if a large batch fails every time the replication will never make any progress. This patch attempts to resolve that issue by writing as many of the successful docs as possible so they don't need to be downloaded again next time.