### PR TITLE
eslint: enfore semicolons

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
 
   "rules": {
     "no-empty": 0,
-    "no-console": 0
+    "no-console": 0,
+    "semi": ["error", "always"]
   }
 }


### PR DESCRIPTION
semicolons are currently not enforced, `npm run eslint` does not throw errors when we miss them.
Docs for eslint option: http://eslint.org/docs/rules/semi#always

follow up for https://github.com/pouchdb/pouchdb/pull/5018#issuecomment-205357297