### PR TITLE
2709 revpos support

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -322,10 +322,12 @@ AbstractPouchDB.prototype.putAttachment =
   }
 
   function createAttachment(doc) {
+    var prevrevpos = '_rev' in doc ? parseInt(doc._rev, 10) : 0;
     doc._attachments = doc._attachments || {};
     doc._attachments[attachmentId] = {
       content_type: type,
-      data: blob
+      data: blob,
+      revpos: ++prevrevpos
     };
     return api.put(doc);
   }

--- a/src/adapters/idb/bulkDocs.js
+++ b/src/adapters/idb/bulkDocs.js
@@ -301,6 +301,7 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, idbChanges, callback) {
       if (!att.stub) {
         var data = att.data;
         delete att.data;
+        att.revpos = parseInt(winningRev, 10);
         var digest = att.digest;
         saveAttachment(digest, data, attachmentSaved);
       } else {

--- a/src/adapters/leveldb/index.js
+++ b/src/adapters/leveldb/index.js
@@ -769,6 +769,7 @@ function LevelPouch(opts, callback) {
       att.length = data.length;
       var id = docInfo.metadata.id;
       var rev = docInfo.metadata.rev;
+      att.revpos = parseInt(rev, 10);
 
       saveAttachmentRefs(id, rev, digest, function (err, isNewAttachment) {
         /* istanbul ignore if */

--- a/src/adapters/websql/bulkDocs.js
+++ b/src/adapters/websql/bulkDocs.js
@@ -208,6 +208,7 @@ function websqlBulkDocs(dbOpts, req, opts, api, db, websqlChanges, callback) {
       if (!att.stub) {
         var data = att.data;
         delete att.data;
+        att.revpos = parseInt(winningRev, 10);
         var digest = att.digest;
         saveAttachment(digest, data, attachmentSaved);
       } else {


### PR DESCRIPTION
Add the `revpos` property to attachment stubs on save. `revpos` is the doc's `rev` prefix (a sequential number) from when the attachment was added or updated. It is used during replication in the CouchDB replicator (and others including CouchBase Lite) to avoid fetching attachments that have not changed since last replication.

This solves a problem with attachments created in PouchDB, which are then replicated to an Apache CouchDB instance. They end up having a `revpos` property set to `0`. When the doc is later pull replicated from an iOS application using CouchBase Lite it is skipped and does not get replicated. This is because [CBL rejects attachments with invalid attachment stub](https://github.com/couchbase/couchbase-lite-ios/issues/1200). `revpos:0` is [considered invalid in CBL](https://github.com/couchbase/couchbase-lite-ios/blob/57689c75345a526289afa3dcf842e13649a9b42f/Source/CBL_Attachment.m#L173-L174).

Also this improves replication performance of documents with attachments created by PouchDB, when they are later replicated using Apache CouchDBs own replicator. The Apache CouchDB replicator itself handles `revpos:0` docs without a problem. But the replication of those docs cannot be optimized; the attachments get copied over again for every revision, even if they did not change.

Closes #2709