### PR TITLE
(#4920) Note reverse order of startkey and endkey

### DIFF
--- a/docs/_includes/api/batch_fetch.html
+++ b/docs/_includes/api/batch_fetch.html
@@ -18,7 +18,7 @@ All options default to `false` unless otherwise specified.
 * `options.inclusive_end`: Include documents having an ID equal to the given `options.endkey`. Default: `true`.
 * `options.limit`: Maximum number of documents to return.
 * `options.skip`: Number of docs to skip before returning (warning: poor performance on IndexedDB/LevelDB!).
-* `options.descending`: Reverse the order of the output documents.
+* `options.descending`: Reverse the order of the output documents. Note that the order of `startkey` and `endkey` is reversed when `descending`:`true`.
 * `options.key`: Only return documents with IDs matching this string key.
 * `options.keys`: Array of string keys to fetch in a single shot.
     - Neither `startkey` nor `endkey` can be specified with this option.


### PR DESCRIPTION
Documented the reverse ordering of startkey and endkey
when descending is set to true

Fixes #4920 