### PR TITLE
WIP - (#5042) include timeout and cache options in bulkGetShim get() calls

### DIFF
--- a/src/adapters/http/index.js
+++ b/src/adapters/http/index.js
@@ -305,6 +305,7 @@ function HttpPouch(opts, callback) {
 
       for (var i = 0; i < numBatches; i++) {
         var subOpts = pick(opts, ['revs', 'attachments']);
+        subOpts.ajax = ajaxOpts;
         subOpts.docs = opts.docs.slice(i * batchSize,
           Math.min(opts.docs.length, (i + 1) * batchSize));
         bulkGetShim(self, subOpts, onResult(i));

--- a/src/deps/bulkGetShim.js
+++ b/src/deps/bulkGetShim.js
@@ -77,7 +77,7 @@ function bulkGet(db, opts, callback) {
     }
 
     // globally-supplied options
-    ['revs', 'attachments', 'binary'].forEach(function (param) {
+    ['revs', 'attachments', 'binary', 'ajax'].forEach(function (param) {
       if (param in opts) {
         docOpts[param] = opts[param];
       }


### PR DESCRIPTION
Allow override of the default timeout in bulk-get calls.

Fix for #5042.