### PR TITLE
Throws an Error in txn.onerror

### DIFF
--- a/src/adapters/idb/utils.js
+++ b/src/adapters/idb/utils.js
@@ -243,7 +243,7 @@ function compactRevs(revs, docId, txn) {
 function openTransactionSafely(idb, stores, mode) {
   try {
     var txn = idb.transaction(stores, mode);
-    txn.onerror = function(e) {
+    txn.onerror = function() {
       throw new Error("Database has a global failure");
     };
     return {

--- a/src/adapters/idb/utils.js
+++ b/src/adapters/idb/utils.js
@@ -242,8 +242,12 @@ function compactRevs(revs, docId, txn) {
 
 function openTransactionSafely(idb, stores, mode) {
   try {
+    var txn = idb.transaction(stores, mode);
+    txn.onerror = function(e) {
+      throw new Error("Database has a global failure");
+    };
     return {
-      txn: idb.transaction(stores, mode)
+      txn: txn
     };
   } catch (err) {
     return {


### PR DESCRIPTION
Throws an Error in txn.onerror to let the rest of the code know about
it. Use "window.onerror" and look for "Database has a global failure"
to handle that error. Note that you can override the onerror if you
want.

This follows https://github.com/pouchdb/pouchdb/issues/4977