### PR TITLE
Throws an Error in idb.onabort

### DIFF
--- a/src/adapters/idb/index.js
+++ b/src/adapters/idb/index.js
@@ -881,6 +881,7 @@ function init(api, opts, callback) {
       console.error('Database has a global failure', e.target.error);
       idb.close();
       cachedDBs.delete(dbName);
+      throw new Error("Database has a global failure " +  e.target.error.message);
     };
 
     var txn = idb.transaction([


### PR DESCRIPTION
Throws an Error in idb.onabort to let the rest of the code know about
it. Use "window.onerror" and look for "Database has a global failure"
to handle that error.

This follows https://github.com/pouchdb/pouchdb/issues/4977