### PR TITLE
(#4963) Fail entire replication batch if any docs within the batch fail

### DIFF
--- a/src/replicate/getDocs.js
+++ b/src/replicate/getDocs.js
@@ -34,7 +34,8 @@ function createBulkGetOpts(diffs) {
 function getDocs(src, diffs, state) {
   diffs = clone(diffs); // we do not need to modify this
 
-  var resultDocs = [];
+  var resultDocs = [],
+      ok = true;
 
   function getAllDocs() {
 
@@ -53,7 +54,11 @@ function getDocs(src, diffs, state) {
         bulkGetInfo.docs.forEach(function (doc) {
           if (doc.ok) {
             resultDocs.push(doc.ok);
+          } else if (doc.error !== undefined) {
+            ok = false;
           }
+          // else: when AUTO_COMPACTION is set, docs can be returned which look
+          // like this: {"missing":"1-7c3ac256b693c462af8442f992b83696"}
         });
       });
     });
@@ -99,14 +104,14 @@ function getDocs(src, diffs, state) {
     }
   }
 
-  function returnDocs() {
-    return resultDocs;
+  function returnResult() {
+    return { ok:ok, docs:resultDocs };
   }
 
   return Promise.resolve()
     .then(getRevisionOneDocs)
     .then(getAllDocs)
-    .then(returnDocs);
+    .then(returnResult);
 }
 
 export default getDocs;

--- a/src/replicate/replicate.js
+++ b/src/replicate/replicate.js
@@ -102,6 +102,9 @@ function replicate(src, target, opts, returnValue, result) {
   }
 
   function finishBatch() {
+    if (currentBatch.error) {
+      throw new Error('There was a problem getting docs.');
+    }
     result.last_seq = last_seq = currentBatch.seq;
     var outResult = clone(result);
     if (changedDocs.length) {
@@ -148,8 +151,9 @@ function replicate(src, target, opts, returnValue, result) {
   }
 
   function getBatchDocs() {
-    return getDocs(src, currentBatch.diffs, returnValue).then(function (docs) {
-      docs.forEach(function (doc) {
+    return getDocs(src, currentBatch.diffs, returnValue).then(function (got) {
+      currentBatch.error = !got.ok;
+      got.docs.forEach(function (doc) {
         delete currentBatch.diffs[doc._id];
         result.docs_read++;
         currentBatch.docs.push(doc);


### PR DESCRIPTION
A new fix for #4963.  If any docs in a replication batch fail, the successful docs are saved, but the batch itself is considered a failure.

* In contrast to #5029, this patch will still allow any successfully-downloaded docs to be saved locally.
* In contrast to #5033, this patch will consider the batch a failure.