### PR TITLE
Protect for missing doc

### DIFF
--- a/src/adapters/leveldb/index.js
+++ b/src/adapters/leveldb/index.js
@@ -1124,7 +1124,7 @@ function LevelPouch(opts, callback) {
       // metadata not cached, have to go fetch it
       stores.docStore.get(doc._id, function (err, metadata) {
         /* istanbul ignore if */
-        if (opts.cancelled || opts.done || db.isClosed() ||
+        if (err || opts.cancelled || opts.done || db.isClosed() ||
           isLocalId(metadata.id)) {
           return next();
         }


### PR DESCRIPTION
I found this is my logs, on safari mac, using fruitdown adapter. 

` TypeError: undefined is not an object (evaluating 'metadata.id')` on line 1128

Clearly there is no error check, but I have no clue of further implications of my modification downstream.