### PR TITLE
(#5069) - fix eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,9 @@
   "rules": {
     "no-empty": 0,
     "no-console": 0,
-    "semi": ["error", "always"]
+    "semi": ["error", "always"],
+    "curly": ["error", "all"],
+    "space-unary-ops": ["error", {"words": true}],
+    "space-before-function-paren": ["error", {"anonymous": "always", "named": "never"}]
   }
 }

--- a/bin/build.js
+++ b/bin/build.js
@@ -134,7 +134,7 @@ function doRollup(entry, fileOut) {
 
 // build for Node (index.js)
 function buildForNode() {
-  return mkdirp('lib').then(function() {
+  return mkdirp('lib').then(function () {
     return doRollup('src/index.js', 'lib/index.js');
   });
 }
@@ -163,7 +163,7 @@ function buildForBrowserify() {
 
 // build for the browser (dist)
 function buildForBrowser() {
-  return mkdirp('dist').then(function() {
+  return mkdirp('dist').then(function () {
     return doBrowserify('.', {standalone: 'PouchDB'});
   }).then(function (code) {
     code = comments.pouchdb + code;
@@ -188,7 +188,7 @@ function cleanup() {
 }
 
 function buildPluginsForBrowserify() {
-  return mkdirp('lib/extras').then(function() {
+  return mkdirp('lib/extras').then(function () {
     return Promise.all(plugins.map(function (plugin) {
       return doRollup('src_browser/plugins/' + plugin + '/index.js',
                       'lib/extras/' + plugin + '.js');
@@ -197,7 +197,7 @@ function buildPluginsForBrowserify() {
 }
 
 function buildExtras() {
-  return mkdirp('lib/extras').then(function() {
+  return mkdirp('lib/extras').then(function () {
     return Promise.all(Object.keys(extras).map(function (entry) {
       var target = extras[entry];
       return doRollup(entry, 'lib/extras/' + target);
@@ -206,7 +206,7 @@ function buildExtras() {
 }
 
 function buildPluginsForBrowser() {
-  return mkdirp('lib/extras').then(function() {
+  return mkdirp('lib/extras').then(function () {
     return Promise.all(plugins.map(function (plugin) {
       var source = 'lib/extras/' + plugin + '.js';
       return doBrowserify(source, {}, 'pouchdb').then(function (code) {

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -137,12 +137,12 @@ function testComplete(result) {
 function startSelenium(callback) {
   // Start selenium
   var opts = {version: SELENIUM_VERSION};
-  selenium.install(opts, function(err) {
+  selenium.install(opts, function (err) {
     if (err) {
       console.error('Failed to install selenium');
       process.exit(1);
     }
-    selenium.start(opts, function() {
+    selenium.start(opts, function () {
       sauceClient = wd.promiseChainRemote();
       callback();
     });

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -192,7 +192,7 @@ function cacheUpdateRequired(api, cache, designDocName, callback) {
     limit: 1,
     since: cache.seq
   };
-  api.changes(changesOpts).then(function(res) {
+  api.changes(changesOpts).then(function (res) {
     var latestSeq = res.results && res.results.length && res.results[0].seq;
     if (latestSeq && latestSeq > cache.seq) {
       // invalidate the cache
@@ -207,7 +207,7 @@ function getDesignDocCache(api, designDocName, callback) {
   api._ddocCache = api._ddocCache || {};
   api._ddocCache[designDocName] = api._ddocCache[designDocName] || {};
   var cache = api._ddocCache[designDocName];
-  cacheUpdateRequired(api, cache, designDocName, function(err) {
+  cacheUpdateRequired(api, cache, designDocName, function (err) {
     if (err) {
       return callback(err);
     }
@@ -218,14 +218,14 @@ function getDesignDocCache(api, designDocName, callback) {
             return reject(err);
           }
           var cache = {};
-          ['views', 'filters'].forEach(function(propertyName) {
+          ['views', 'filters'].forEach(function (propertyName) {
             cache[propertyName] = res.doc[propertyName];
           });
           resolve(cache);
         });
       });
     }
-    cache.promise.then(function(cache) {
+    cache.promise.then(function (cache) {
       callback(null, cache);
     }).catch(callback);
   });
@@ -233,7 +233,7 @@ function getDesignDocCache(api, designDocName, callback) {
 
 function getDesignDocProperty(api, designDocName, propertyName,
                               propertyElement, callback) {
-  getDesignDocCache(api, designDocName, function(err, designDoc) {
+  getDesignDocCache(api, designDocName, function (err, designDoc) {
     if (err) {
       return callback(err);
     }
@@ -629,7 +629,7 @@ AbstractPouchDB.prototype.get =
         for (var i = 0; i < leaves.length; i++) {
           var l = leaves[i];
           // looks like it's the only thing couchdb checks
-          if (!(typeof(l) === "string" && /^\d+-/.test(l))) {
+          if (!(typeof (l) === "string" && /^\d+-/.test(l))) {
             return callback(createError(INVALID_REV));
           }
         }
@@ -860,7 +860,7 @@ AbstractPouchDB.prototype.bulkDocs =
   }
 
   var attachmentError;
-  req.docs.forEach(function(doc) {
+  req.docs.forEach(function (doc) {
     if (doc._attachments) {
       Object.keys(doc._attachments).forEach(function (name) {
         attachmentError = attachmentError || attachmentNameError(name);

--- a/src/adapters/http/index.js
+++ b/src/adapters/http/index.js
@@ -175,7 +175,7 @@ function HttpPouch(opts, callback) {
     return coreAdapterFun(name, getArguments(function (args) {
       setup().then(function () {
         return fun.apply(this, args);
-      }).catch(function(e) {
+      }).catch(function (e) {
         var callback = args.pop();
         callback(e);
       });
@@ -198,7 +198,7 @@ function HttpPouch(opts, callback) {
     }
 
     var checkExists = {method: 'GET', url: dbUrl};
-    setupPromise = ajaxPromise({}, checkExists).catch(function(err) {
+    setupPromise = ajaxPromise({}, checkExists).catch(function (err) {
       if (err && err.status && err.status === 404) {
         // Doesnt exist, create it
         explainError(404, 'PouchDB is just detecting if the remote exists.');
@@ -206,7 +206,7 @@ function HttpPouch(opts, callback) {
       } else {
         return Promise.reject(err);
       }
-    }).catch(function(err) {
+    }).catch(function (err) {
       // If we try to create a database that already exists
       if (err && err.status && err.status === 412) {
         return true;
@@ -214,14 +214,14 @@ function HttpPouch(opts, callback) {
       return Promise.reject(err);
     });
 
-    setupPromise.catch(function() {
+    setupPromise.catch(function () {
       setupPromise = null;
     });
 
     return setupPromise;
   }
 
-  setTimeout(function() {
+  setTimeout(function () {
     callback(null, api);
   });
 
@@ -351,7 +351,7 @@ function HttpPouch(opts, callback) {
   //    couchdb: A welcome string
   //    version: The version of CouchDB it is running
   api._info = function (callback) {
-    setup().then(function() {
+    setup().then(function () {
       ajax({}, {
         method: 'GET',
         url: genDBUrl(host, '')
@@ -846,7 +846,7 @@ function HttpPouch(opts, callback) {
       }
 
       // Get the changes
-      setup().then(function() {
+      setup().then(function () {
         xhr = ajax(opts, xhrOpts, callback);
       }).catch(callback);
     };

--- a/src/adapters/idb/bulkDocs.js
+++ b/src/adapters/idb/bulkDocs.js
@@ -354,7 +354,7 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, idbChanges, callback) {
 
 
     var getKeyReq = attachStore.count(digest);
-    getKeyReq.onsuccess = function(e) {
+    getKeyReq.onsuccess = function (e) {
       var count = e.target.result;
       if (count) {
         return callback(); // already exists

--- a/src/adapters/idb/index.js
+++ b/src/adapters/idb/index.js
@@ -960,7 +960,7 @@ function init(api, opts, callback) {
     };
   };
 
-  req.onerror = function() {
+  req.onerror = function () {
     var msg = 'Failed to open indexedDB, are you in private browsing mode?';
     console.error(msg);
     callback(createError(IDB_ERROR, msg));

--- a/src/changesHandler.js
+++ b/src/changesHandler.js
@@ -69,7 +69,7 @@ Changes.prototype.addListener = function (dbName, id, db, opts) {
       }
     }).on('complete', function () {
       if (inprogress === 'waiting') {
-        setTimeout(function(){
+        setTimeout(function (){
           eventFunction();
         },0);
       }

--- a/src/deps/ajax/prequest-browser.js
+++ b/src/deps/ajax/prequest-browser.js
@@ -1,6 +1,6 @@
 import ajaxCore from './ajaxCore';
 
-function ajax (opts, callback) {
+function ajax(opts, callback) {
 
   // cache-buster, specifically designed to work around IE's aggressive caching
   // see http://www.dashbay.com/2011/05/internet-explorer-caches-ajax/

--- a/src/deps/ajax/request-browser.js
+++ b/src/deps/ajax/request-browser.js
@@ -7,7 +7,7 @@ import Promise from '../../deps/promise';
 function wrappedFetch() {
   var wrappedPromise = {};
 
-  var promise = new Promise(function(resolve, reject) {
+  var promise = new Promise(function (resolve, reject) {
     wrappedPromise.resolve = resolve;
     wrappedPromise.reject = reject;
   });
@@ -22,9 +22,9 @@ function wrappedFetch() {
 
   Promise.resolve().then(function () {
     return fetch.apply(null, args);
-  }).then(function(response) {
+  }).then(function (response) {
     wrappedPromise.resolve(response);
-  }).catch(function(error) {
+  }).catch(function (error) {
     wrappedPromise.reject(error);
   });
 
@@ -62,7 +62,7 @@ function fetchRequest(options, callback) {
     fetchOptions.body = null;
   }
 
-  Object.keys(options.headers).forEach(function(key) {
+  Object.keys(options.headers).forEach(function (key) {
     if (options.headers.hasOwnProperty(key)) {
       headers.set(key, options.headers[key]);
     }
@@ -71,13 +71,13 @@ function fetchRequest(options, callback) {
   wrappedPromise = wrappedFetch(options.url, fetchOptions);
 
   if (options.timeout > 0) {
-    timer = setTimeout(function() {
+    timer = setTimeout(function () {
       wrappedPromise.reject(new Error('Load timeout for resource: ' +
         options.url));
     }, options.timeout);
   }
 
-  wrappedPromise.promise.then(function(fetchResponse) {
+  wrappedPromise.promise.then(function (fetchResponse) {
     response = {
       statusCode: fetchResponse.status
     };
@@ -91,13 +91,13 @@ function fetchRequest(options, callback) {
     }
 
     return fetchResponse.json();
-  }).then(function(result) {
+  }).then(function (result) {
     if (response.statusCode >= 200 && response.statusCode < 300) {
       callback(null, response, result);
     } else {
       callback(result, response);
     }
-  }).catch(function(error) {
+  }).catch(function (error) {
     callback(error, response);
   });
 
@@ -165,8 +165,9 @@ function xhRequest(options, callback) {
     timer = setTimeout(timeoutReq, options.timeout);
     xhr.onprogress = function () {
       clearTimeout(timer);
-      if(xhr.readyState !== 4)
+      if(xhr.readyState !== 4) {
         timer = setTimeout(timeoutReq, options.timeout);
+      }
     };
     if (typeof xhr.upload !== 'undefined') { // does not exist in ie9
       xhr.upload.onprogress = xhr.onprogress;

--- a/src/mapreduce/index.js
+++ b/src/mapreduce/index.js
@@ -188,7 +188,7 @@ function addHttpParam(paramName, opts, params, asJson) {
   }
 }
 
-function coerceInteger (integerCandidate) {
+function coerceInteger(integerCandidate) {
   if (typeof integerCandidate !== 'undefined') {
     var asNumber = Number(integerCandidate);
     // prevents e.g. '1foo' or '1.1' being coerced to 1
@@ -207,7 +207,7 @@ function coerceOptions(opts) {
   return opts;
 }
 
-function checkPositiveInteger (number) {
+function checkPositiveInteger(number) {
   if (number) {
     if (typeof number !== 'number') {
       return  new QueryParseError('Invalid value for integer: "' +

--- a/src/replicate/checkpointer.js
+++ b/src/replicate/checkpointer.js
@@ -104,7 +104,7 @@ Checkpointer.prototype.updateSource = function (checkpoint, session) {
 };
 
 var comparisons = {
-  "undefined": function(targetDoc, sourceDoc) {
+  "undefined": function (targetDoc, sourceDoc) {
     // This is the previous comparison function
     if (collate(targetDoc.last_seq, sourceDoc.last_seq) === 0) {
       return sourceDoc.last_seq;
@@ -112,7 +112,7 @@ var comparisons = {
     /* istanbul ignore next */
     return 0;
   },
-  "1": function(targetDoc, sourceDoc) {
+  "1": function (targetDoc, sourceDoc) {
     // This is the comparison function ported from CouchDB
     return compareReplicationLogs(sourceDoc, targetDoc).last_seq;
   }
@@ -174,7 +174,7 @@ Checkpointer.prototype.getCheckpoint = function () {
 // they come from here:
 // https://github.com/apache/couchdb-couch-replicator/blob/master/src/couch_replicator.erl#L863-L906
 
-function compareReplicationLogs (srcDoc, tgtDoc) {
+function compareReplicationLogs(srcDoc, tgtDoc) {
   if (srcDoc.session_id === tgtDoc.session_id) {
     return {
       last_seq: srcDoc.last_seq,
@@ -187,7 +187,7 @@ function compareReplicationLogs (srcDoc, tgtDoc) {
   return compareReplicationHistory(sourceHistory, targetHistory);
 }
 
-function compareReplicationHistory (sourceHistory, targetHistory) {
+function compareReplicationHistory(sourceHistory, targetHistory) {
   // the erlang loop via function arguments is not so easy to repeat in JS
   // therefore, doing this as recursion
   var S = sourceHistory[0];
@@ -222,7 +222,7 @@ function compareReplicationHistory (sourceHistory, targetHistory) {
   return compareReplicationHistory(sourceRest, targetRest);
 }
 
-function hasSessionId (sessionId, history) {
+function hasSessionId(sessionId, history) {
   var props = history[0];
   var rest = history.slice(1);
 
@@ -237,7 +237,7 @@ function hasSessionId (sessionId, history) {
   return hasSessionId(sessionId, rest);
 }
 
-function isForbiddenError (err) {
+function isForbiddenError(err) {
   return typeof err.status === 'number' && Math.floor(err.status / 100) === 4;
 }
 

--- a/src/replicate/replicate.js
+++ b/src/replicate/replicate.js
@@ -80,7 +80,7 @@ function replicate(src, target, opts, returnValue, result) {
         return error.name !== 'unauthorized' && error.name !== 'forbidden';
       });
 
-      docs.forEach(function(doc) {
+      docs.forEach(function (doc) {
         var error = errorsById[doc._id];
         if (error) {
           returnValue.emit('denied', clone(error));

--- a/tests/component/test.auth.js
+++ b/tests/component/test.auth.js
@@ -26,14 +26,14 @@ describe('test.auth.js', function () {
   it('Test auth headers are sent correctly', function () {
     var opts = {auth: {username: 'foo', password: 'bar'}};
     var url = 'http://127.0.0.1:' + PORT;
-    return new PouchDB(url, opts).info().then(function() {
+    return new PouchDB(url, opts).info().then(function () {
       should.equal(headers.authorization, 'Basic Zm9vOmJhcg==');
     });
   });
 
   it('Test auth headers via url are sent correctly', function () {
     var url = 'http://foo:bar@127.0.0.1:' + PORT;
-    return new PouchDB(url).info().then(function() {
+    return new PouchDB(url).info().then(function () {
       should.equal(headers.authorization, 'Basic Zm9vOmJhcg==');
     });
   });
@@ -41,7 +41,7 @@ describe('test.auth.js', function () {
   it('Test auth with unicode', function () {
     var opts = {auth: {username: 'Иванов И.И.', password: 'Секрет'}};
     var url = 'http://127.0.0.1:' + PORT;
-    return new PouchDB(url, opts).info().then(function() {
+    return new PouchDB(url, opts).info().then(function () {
       should.equal(headers.authorization,
                    'Basic 0JjQstCw0L3QvtCyINCYLtCYLjrQodC10LrRgNC10YI=');
     });

--- a/tests/component/test.headers.js
+++ b/tests/component/test.headers.js
@@ -26,7 +26,7 @@ describe('test.headers.js', function () {
   it('Test headers are sent correctly', function () {
     var opts = {ajax: {headers: {foo: 'bar'}}};
     var url = 'http://127.0.0.1:' + PORT;
-    return new PouchDB(url, opts).info().then(function() {
+    return new PouchDB(url, opts).info().then(function () {
       should.equal(headers.foo, 'bar');
     });
   });
@@ -34,54 +34,54 @@ describe('test.headers.js', function () {
   it('Test auth params are sent correctly', function () {
     var opts = {auth: {username: 'foo', password: 'bar'}};
     var url = 'http://127.0.0.1:' + PORT;
-    return new PouchDB(url, opts).info().then(function() {
+    return new PouchDB(url, opts).info().then(function () {
       should.equal(typeof headers.authorization, 'string');
     });
   });
 
-  it('Test headers are sent correctly on GET request', function() {
+  it('Test headers are sent correctly on GET request', function () {
     var db = new PouchDB('http://127.0.0.1:' + PORT);
     var opts = { ajax: { headers: { ick: "slick" } } };
-    return db.get('fake', opts).then(function() {
+    return db.get('fake', opts).then(function () {
       should.equal(headers.ick, 'slick');
     });
   });
 
-  it('3491 Test headers are sent correctly on put', function() {
+  it('3491 Test headers are sent correctly on put', function () {
     var db = new PouchDB('http://127.0.0.1:' + PORT);
     var opts = { ajax: { headers: { ick: "slick" } } };
-    return db.post({'fake': 'obj'}, opts).then(function() {
+    return db.post({'fake': 'obj'}, opts).then(function () {
       should.equal(headers.ick, 'slick');
     });
   });
 
-  it('3491 Test headers are sent correctly on changes', function() {
+  it('3491 Test headers are sent correctly on changes', function () {
     var db = new PouchDB('http://127.0.0.1:' + PORT);
     var opts = { ajax: { headers: { ick: "slick" } } };
-    return db.changes(opts).then(function() {
+    return db.changes(opts).then(function () {
       should.equal(headers.ick, 'slick');
     });
   });
 
-  it('3491 Test headers are sent correctly on destroy', function() {
+  it('3491 Test headers are sent correctly on destroy', function () {
     var db = new PouchDB('http://127.0.0.1:' + PORT);
     var opts = { ajax: { headers: { ick: "slick" } } };
-    return db.destroy(opts).then(function() {
+    return db.destroy(opts).then(function () {
       should.equal(headers.ick, 'slick');
     });
   });
 
-  it('Test that we combine local and global ajax options', function() {
+  it('Test that we combine local and global ajax options', function () {
     var opts = { ajax: { headers: { aheader: 'whyyes' } } };
     var db = new PouchDB('http://127.0.0.1:' + PORT, opts);
     var getOpts = {ajax: { headers: { ick: "slick", aheader: "override!" } } };
-    return db.get('fake', getOpts).then(function() {
+    return db.get('fake', getOpts).then(function () {
       should.equal(headers.ick, 'slick');
       should.equal(headers.aheader, 'override!');
     });
   });
 
-  it('4450 Test headers are sent correctly on put', function() {
+  it('4450 Test headers are sent correctly on put', function () {
     var opts = {auth: {username: 'foo', password: 'bar'}};
     var db = new PouchDB('http://127.0.0.1:' + PORT, opts);
     return db.put({
@@ -92,7 +92,7 @@ describe('test.headers.js', function () {
           data: new Buffer(['Is there life on Mars?'], {type: 'text/plain'})
         }
       }
-    }).then(function() {
+    }).then(function () {
       should.equal(headers.authorization, 'Basic Zm9vOmJhcg==');
     });
   });

--- a/tests/component/test.params.js
+++ b/tests/component/test.params.js
@@ -27,28 +27,28 @@ describe('test.params.js', function () {
 
   it('Test default heartbeat', function () {
     var url = 'http://127.0.0.1:' + PORT;
-    return new PouchDB(url).changes().then(function() {
+    return new PouchDB(url).changes().then(function () {
       should.exist(params.heartbeat);
     });
   });
 
   it('Test custom heartbeat', function () {
     var url = 'http://127.0.0.1:' + PORT;
-    return new PouchDB(url).changes({heartbeat: 10}).then(function() {
+    return new PouchDB(url).changes({heartbeat: 10}).then(function () {
       should.equal(params.heartbeat, '10');
     });
   });
 
   it('Test disable heartbeat', function () {
     var url = 'http://127.0.0.1:' + PORT;
-    return new PouchDB(url).changes({heartbeat: false}).then(function() {
+    return new PouchDB(url).changes({heartbeat: false}).then(function () {
       should.not.exist(params.heartbeat);
     });
   });
 
   it('Test disable timeout', function () {
     var url = 'http://127.0.0.1:' + PORT;
-    return new PouchDB(url).changes({timeout: false}).then(function() {
+    return new PouchDB(url).changes({timeout: false}).then(function () {
       should.not.exist(params.timeout);
     });
   });

--- a/tests/component/test.read_only_replication.js
+++ b/tests/component/test.read_only_replication.js
@@ -47,29 +47,29 @@ describe('test.read_only_replication.js', function () {
     var expectedLastSeq;
     var checkpointer;
 
-    return remote.bulkDocs([{_id: 'foo'}, {_id: 'bar'}]).then(function() {
+    return remote.bulkDocs([{_id: 'foo'}, {_id: 'bar'}]).then(function () {
       return db.replicate.from(remoteHTTP);
-    }).then(function(replicationResult) {
+    }).then(function (replicationResult) {
       expectedLastSeq = replicationResult.last_seq;
       checkpointer = new Checkpointer(remoteHTTP, db, replicationDoc._id,
                                       replicationResult);
 
-      return checkpointer.getCheckpoint().then(function(actualLastSeq) {
+      return checkpointer.getCheckpoint().then(function (actualLastSeq) {
         actualLastSeq.should.equal(expectedLastSeq);
       });
-    }).then(function() {
+    }).then(function () {
       return remote.destroy();
-    }).then(function() {
+    }).then(function () {
       // By now, the checkpointer should have marked the source database
       // read-only, and make no other request to read or write a
       // replication log from or rather to it. We therefore expect
       // `checkpointer.getCheckpoint()` to resolve with the same result
       // as previously, even though the source database has now been
       // destroyed.
-      return checkpointer.getCheckpoint().then(function(actualLastSeq) {
+      return checkpointer.getCheckpoint().then(function (actualLastSeq) {
         actualLastSeq.should.equal(expectedLastSeq);
       });
-    }).then(function() {
+    }).then(function () {
       return db.destroy();
     });
   });

--- a/tests/fuzzy/test.fuzzy.js
+++ b/tests/fuzzy/test.fuzzy.js
@@ -28,13 +28,13 @@ var actionCount = 100;
 var actions = {
 
   // Create a random document
-  'create': function(a) {
+  'create': function (a) {
     return a.post({'a': 'newdoc'});
   },
 
   // Pick from an existing document and updated it
-  'update': function(a) {
-    return randomDoc(a).then(function(doc) {
+  'update': function (a) {
+    return randomDoc(a).then(function (doc) {
       if (doc) {
         doc.updated = Date.now();
         return a.put(doc);
@@ -43,8 +43,8 @@ var actions = {
   },
 
   // Remove a random document
-  'remove': function(a) {
-    return randomDoc(a).then(function(doc) {
+  'remove': function (a) {
+    return randomDoc(a).then(function (doc) {
       if (doc) {
         return a.remove(doc);
       }
@@ -53,19 +53,19 @@ var actions = {
 
   // Generate a conflict by writing a document with the same id to
   // both databases
-  'conflict': function(a, b) {
+  'conflict': function (a, b) {
     var doc = {
       _id: 'random-' + Date.now(),
       foo: 'bar'
     };
-    return a.put(doc).then(function() {
+    return a.put(doc).then(function () {
       doc.baz = 'fubar';
       return b.put(doc);
     });
   },
 
   // Perform a one off replication
-  'replicate': function(a, b) {
+  'replicate': function (a, b) {
     return a.replicate.to(b);
   }
 };
@@ -73,7 +73,7 @@ var actions = {
 // Utilities
 
 function randomDoc(db) {
-  return db.allDocs({include_docs: true}).then(function(res) {
+  return db.allDocs({include_docs: true}).then(function (res) {
     var row = arrayRandom(res.rows);
     if (row) {
       return row.doc;
@@ -113,7 +113,7 @@ describe('chaos-monkey', function () {
     Promise = PouchDB.utils.Promise;
     var aname = testUtils.adapterUrl('local', 'testdb');
     var bname = testUtils.adapterUrl('http', 'test_repl_remote');
-    testUtils.cleanup([aname, bname], function() {
+    testUtils.cleanup([aname, bname], function () {
       a = new PouchDB(aname);
       b = new PouchDB(bname);
       done();
@@ -121,7 +121,7 @@ describe('chaos-monkey', function () {
   });
 
   after(function () {
-    return a.destroy().then(function() {
+    return a.destroy().then(function () {
       return b.destroy();
     });
   });
@@ -137,7 +137,7 @@ describe('chaos-monkey', function () {
       var dbs = Math.round(Math.random()) ? [a, b] : [b, a];
       var called = actions[action].apply(null, dbs);
       // This is probably making a big stack, should fix
-      called.then(function() {
+      called.then(function () {
         doit(resolve);
       });
     });
@@ -152,12 +152,12 @@ describe('chaos-monkey', function () {
     return Promise.all([
       a.allDocs({include_docs: true}),
       b.allDocs({include_docs: true})
-    ]).then(function(res) {
+    ]).then(function (res) {
       res[0].should.deep.equal(res[1]);
     });
   }
 
-  it('Do a fuzzy replication run', function() {
+  it('Do a fuzzy replication run', function () {
     // This gives us 100ms for each action, should hopefully be enough
     this.timeout(actionCount * 1000);
     return dbActions()

--- a/tests/integration/test.ajax.js
+++ b/tests/integration/test.ajax.js
@@ -7,13 +7,13 @@ adapters.forEach(function (adapter) {
 
   describe('test.ajax.js-' + adapter, function () {
 
-    it('#5061 ajax returns ETIMEDOUT error on timeout', function(done) {
+    it('#5061 ajax returns ETIMEDOUT error on timeout', function (done) {
       this.timeout(240000);
       PouchDB.ajax({
         method: 'GET',
         url: 'http://192.0.2.1/',
         timeout: 10
-      }, function(err, res) {
+      }, function (err, res) {
         // here's the test, we should get an 'err' response
         should.exist(err);
         err.status.should.equal(400);

--- a/tests/integration/test.all_docs.js
+++ b/tests/integration/test.all_docs.js
@@ -145,9 +145,9 @@ adapters.forEach(function (adapter) {
 
     it('Testing allDocs invalid opts.keys', function () {
       var db = new PouchDB(dbs.name);
-      return db.allDocs({keys: 1234}).then(function() {
+      return db.allDocs({keys: 1234}).then(function () {
         throw 'should not be here';
-      }).catch(function(err) {
+      }).catch(function (err) {
         should.exist(err);
       });
     });
@@ -309,7 +309,7 @@ adapters.forEach(function (adapter) {
     it('3883 start_key end_key aliases', function () {
       var db = new PouchDB(dbs.name);
       var docs = [{_id: 'a', foo: 'a'}, {_id: 'z', foo: 'z'}];
-      return db.bulkDocs(docs).then(function() {
+      return db.bulkDocs(docs).then(function () {
         return db.allDocs({start_key: 'z', end_key: 'z'});
       }).then(function (result) {
         result.rows.should.have.length(1, 'Exclude a result');

--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -93,9 +93,9 @@ adapters.forEach(function (adapter) {
           data: testUtils.btoa('text1')
         }
       }};
-      return db.put(doc).then(function() {
+      return db.put(doc).then(function () {
         done('Should not succeed');
-      }).catch(function(err) {
+      }).catch(function (err) {
         err.name.should.equal('bad_request');
         done();
       });
@@ -228,7 +228,7 @@ adapters.forEach(function (adapter) {
       var db = new PouchDB(dbs.name);
       var docs = [binAttDoc, binAttDoc2, pngAttDoc];
       return db.bulkDocs(docs).then(function () {
-        return PouchDB.utils.Promise.all(docs.map(function(doc) {
+        return PouchDB.utils.Promise.all(docs.map(function (doc) {
           var attName = Object.keys(doc._attachments)[0];
           var expected = doc._attachments[attName];
           return db.get(doc._id, {
@@ -253,7 +253,7 @@ adapters.forEach(function (adapter) {
       var db = new PouchDB(dbs.name);
       var docs = [binAttDoc, binAttDoc2, pngAttDoc, {_id: 'foo'}];
       return db.bulkDocs(docs).then(function () {
-        return PouchDB.utils.Promise.all(docs.map(function(doc) {
+        return PouchDB.utils.Promise.all(docs.map(function (doc) {
           var atts = doc._attachments;
           var attName = atts && Object.keys(atts)[0];
           var expected = atts && atts[attName];
@@ -3451,7 +3451,7 @@ repl_adapters.forEach(function (adapters) {
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
 
-      return remote.bulkDocs({ docs: docs1 }).then(function() {
+      return remote.bulkDocs({ docs: docs1 }).then(function () {
         return db.replicate.from(remote);
       }).then(function () {
         return db.get('bin_doc', {attachments: true, binary: true});
@@ -3851,7 +3851,7 @@ repl_adapters.forEach(function (adapters) {
 
       db.put(doc).then(function () {
         return db.get('x');
-      }).then(function(doc){
+      }).then(function (doc){
         var digests = Object.keys(doc._attachments).map(function (a) {
           return doc._attachments[a].digest;
         });

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -100,14 +100,14 @@ adapters.forEach(function (adapter) {
       });
     });
 
-    it('[4595] should reject xhr errors', function(done){
+    it('[4595] should reject xhr errors', function (done){
       var invalidUrl = 'http:///';
-      new PouchDB(dbs.name).replicate.to(invalidUrl, {}).catch(function() {
+      new PouchDB(dbs.name).replicate.to(invalidUrl, {}).catch(function () {
         done();
       });
 
     });
-    it('[4595] should emit error event on xhr error', function(done){
+    it('[4595] should emit error event on xhr error', function (done){
       var invalidUrl = 'http:///';
       new PouchDB(dbs.name).replicate.to(invalidUrl,{})
         .on('error', function () { done(); });
@@ -123,9 +123,9 @@ adapters.forEach(function (adapter) {
 
     it('Get invalid id', function () {
       var db = new PouchDB(dbs.name);
-      return db.get(1234).then(function() {
+      return db.get(1234).then(function () {
         throw 'show not be here';
-      }).catch(function(err) {
+      }).catch(function (err) {
         should.exist(err);
       });
     });
@@ -1039,7 +1039,7 @@ adapters.forEach(function (adapter) {
     it('2 invalid puts', function (done) {
       var db = new PouchDB(dbs.name);
       var called = 0;
-      var cb = function() {
+      var cb = function () {
         if (++called === 2) {
           done();
         }

--- a/tests/integration/test.bulk_docs.js
+++ b/tests/integration/test.bulk_docs.js
@@ -862,7 +862,7 @@ adapters.forEach(function (adapter) {
       });
     });
 
-    it('Bulk docs two different revisions to same document id', function(done) {
+    it('Bulk docs two different revisions to same document id', function (done) {
       var db = new PouchDB(dbs.name);
       var docid = "mydoc";
 
@@ -902,8 +902,8 @@ adapters.forEach(function (adapter) {
       // push the conflicted documents
       return db.bulkDocs([ a_doc, b_doc ], { new_edits: false })
 
-      .then(function() {
-        return db.get(docid, { open_revs: "all" }).then(function(resp) {
+      .then(function () {
+        return db.get(docid, { open_revs: "all" }).then(function (resp) {
           resp.length.should.equal(2, 'correct number of open revisions');
           resp[0].ok._id.should.equal(docid, 'rev 1, correct document id');
           resp[1].ok._id.should.equal(docid, 'rev 2, correct document id');
@@ -916,7 +916,7 @@ adapters.forEach(function (adapter) {
         });
       })
 
-      .then(function() { done(); }, done);
+      .then(function () { done(); }, done);
     });
 
     it('4204 respect revs_limit', function () {

--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -456,10 +456,10 @@ adapters.forEach(function (adapter) {
         }
       ];
       var db = new PouchDB(dbs.name);
-      db.bulkDocs(docs).then(function() {
+      db.bulkDocs(docs).then(function () {
         db.changes({filter: 'a/b/c'}).on('error', function () {
           done('should not be called');
-        }).on('complete', function() {
+        }).on('complete', function () {
           done();
         });
       });
@@ -474,8 +474,8 @@ adapters.forEach(function (adapter) {
             throw new Error(); // syntaxerrors can't be caught either.
           }.toString()
         }
-      }).then(function() {
-        db.changes({filter: 'test/test'}).then(function() {
+      }).then(function () {
+        db.changes({filter: 'test/test'}).then(function () {
           done('should have thrown');
         }).catch(function () {
           done();

--- a/tests/integration/test.http.js
+++ b/tests/integration/test.http.js
@@ -108,19 +108,19 @@ describe('test.http.js', function () {
     uri.host.should.equal('foo.com');
   });
 
-  it('Properly escape url params #4008', function() {
+  it('Properly escape url params #4008', function () {
     var ajax = PouchDB.utils.ajax;
-    PouchDB.utils.ajax = function(opts) {
+    PouchDB.utils.ajax = function (opts) {
       opts.url.should.not.contain('[');
       ajax.apply(this, arguments);
     };
     var db = new PouchDB(dbs.name);
-    return db.changes({doc_ids: ['1']}).then(function() {
+    return db.changes({doc_ids: ['1']}).then(function () {
       PouchDB.utils.ajax = ajax;
     });
   });
 
-  it('Allows the "ajax timeout" to extend "changes timeout"', function(done) {
+  it('Allows the "ajax timeout" to extend "changes timeout"', function (done) {
     var timeout = 120000;
     var db = new PouchDB(dbs.name, {
       skipSetup: true,
@@ -131,7 +131,7 @@ describe('test.http.js', function () {
 
     var ajax = PouchDB.utils.ajax;
     var ajaxOpts;
-    PouchDB.utils.ajax = function(opts) {
+    PouchDB.utils.ajax = function (opts) {
       if (/changes/.test(opts.url)) {
         ajaxOpts = opts;
         changes.cancel();
@@ -141,7 +141,7 @@ describe('test.http.js', function () {
 
     var changes = db.changes();
 
-    changes.on('complete', function() {
+    changes.on('complete', function () {
       should.exist(ajaxOpts);
       ajaxOpts.timeout.should.equal(timeout);
       PouchDB.utils.ajax = ajax;
@@ -187,20 +187,20 @@ describe('test.http.js', function () {
     });
   });
 
-  it('4358 db.info rejects when server is down', function() {
+  it('4358 db.info rejects when server is down', function () {
     var db = new PouchDB('http://example.com/foo');
     return db.info().then(function () {
       throw new Error('expected an error');
-    }).catch(function(err) {
+    }).catch(function (err) {
       should.exist(err);
     });
   });
 
-  it('4358 db.destroy rejects when server is down', function() {
+  it('4358 db.destroy rejects when server is down', function () {
     var db = new PouchDB('http://example.com/foo');
     return db.destroy().then(function () {
       throw new Error('expected an error');
-    }).catch(function(err) {
+    }).catch(function (err) {
       should.exist(err);
     });
   });

--- a/tests/integration/test.issue3179.js
+++ b/tests/integration/test.issue3179.js
@@ -146,7 +146,7 @@ adapters.forEach(function (adapters) {
             live: true,
             include_docs: true,
             conflicts: true
-          }).on('change', function(change) {
+          }).on('change', function (change) {
             if (!('_conflicts' in change.doc)) {
               changes.cancel();
             }
@@ -219,7 +219,7 @@ adapters.forEach(function (adapters) {
             live: true,
             include_docs: true,
             conflicts: true
-          }).on('change', function(change) {
+          }).on('change', function (change) {
             if (!('_conflicts' in change.doc)) {
               changes.cancel();
             }
@@ -302,7 +302,7 @@ adapters.forEach(function (adapters) {
         return local.get('1', {conflicts: true}).then(function (doc) {
           return local.remove(doc._id, doc._conflicts[0]);
         });
-      }).then(function() {
+      }).then(function () {
         return waitForConflictsResolved();
       }).then(function () {
         return local.get('1', {conflicts: true, revs: true});

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -64,7 +64,7 @@ adapters.forEach(function (adapters) {
       }
       // CSG will send a change event when just the ACL changed
       if (testUtils.isSyncGateway()) {
-        changes = changes.filter(function(change){
+        changes = changes.filter(function (change){
           return change.id !== "_user/";
         });
       }
@@ -307,7 +307,7 @@ adapters.forEach(function (adapters) {
         return db.allDocs({keys: ['foo']});
       }).then(function (res) {
         if (testUtils.isSyncGateway() && !res.rows[0].value) {
-          return remote.get('foo', {open_revs:'all'}).then(function(doc){
+          return remote.get('foo', {open_revs:'all'}).then(function (doc){
             return db.put({_id: 'foo', _rev: doc[0].ok._rev});
           });
         } else {
@@ -557,7 +557,7 @@ adapters.forEach(function (adapters) {
       }
 
       var finished = 0;
-      function isFinished () {
+      function isFinished() {
         if (++finished !== 2) {
           return;
         }
@@ -1759,7 +1759,7 @@ adapters.forEach(function (adapters) {
         return origId.apply(remote, arguments);
       };
 
-      return remote.post({}).then(function() {
+      return remote.post({}).then(function () {
         return new Promise(function (resolve, reject) {
           var rep = db.replicate.from(remote, {
             live: true
@@ -2441,9 +2441,9 @@ adapters.forEach(function (adapters) {
             return Promise.resolve({ results: getResults });
           };
           // Replicate and confirm failure, docs_written and target docs
-          db.replicate.from(remote).then(function() {
+          db.replicate.from(remote).then(function () {
             done(new Error('First replication should fail'));
-          }).catch(function(err) {
+          }).catch(function (err) {
             // We expect that first replication should fail
             should.exist(err);
 
@@ -2609,9 +2609,9 @@ adapters.forEach(function (adapters) {
       var doc = { _id: '3', count: 0 };
       var put;
 
-      return source.put({ _id: '4', count: 1 }, {}).then(function() {
+      return source.put({ _id: '4', count: 1 }, {}).then(function () {
         return source.put(doc, {});
-      }).then(function(_put) {
+      }).then(function (_put) {
         put = _put;
         // Do one replication, this replication
         // will fail writing one checkpoint
@@ -2627,14 +2627,14 @@ adapters.forEach(function (adapters) {
           target.get(checkpoint),
           source.get(checkpoint)
         ]);
-      }).then(function(res) {
+      }).then(function (res) {
         res[0].session_id.should.equal(res[1].session_id);
         res[0].last_seq.should.not.equal(res[1].last_seq);
 
         doc._rev = put.rev;
         doc.count++;
         return source.put(doc, {});
-      }).then(function() {
+      }).then(function () {
         // Trigger the mismatch on the 2nd replication
         mismatch = true;
         return source.replicate.to(dbs.name);
@@ -2800,7 +2800,7 @@ adapters.forEach(function (adapters) {
       });
     });
 
-    it('#3999-4 should "upgrade" an old checkpoint', function() {
+    it('#3999-4 should "upgrade" an old checkpoint', function () {
 
       var secondRound = false;
       var writeStrange = false;
@@ -2858,7 +2858,7 @@ adapters.forEach(function (adapters) {
        return source.put({ _id: '4', count: 1 }, {}).then(function () {
          writeStrange = true;
          return source.replicate.to(target);
-       }).then(function() {
+       }).then(function () {
          writeStrange = false;
          // Verify that we have old checkpoints:
          should.exist(checkpoint);
@@ -3405,7 +3405,7 @@ adapters.forEach(function (adapters) {
                 change.changes.should.have.length(1);
                 change.seq.should.equal(info.update_seq);
                 changes.cancel();
-              }).on('complete', function() {
+              }).on('complete', function () {
                 remote.info(function (err, info) {
                   var rchanges = remote.changes({
                     descending: true,
@@ -3856,7 +3856,7 @@ adapters.forEach(function (adapters) {
           return db.bulkDocs({docs: docs});
         }).then(function () {
           var replication = db.replicate.to(dbs.remote);
-          replication.on('denied', function(error) {
+          replication.on('denied', function (error) {
             deniedErrors.push(error);
           });
           return replication;
@@ -4053,17 +4053,17 @@ adapters.forEach(function (adapters) {
       });
     });
 
-    it('#3270 triggers "change" events with .docs property', function(done) {
+    it('#3270 triggers "change" events with .docs property', function (done) {
       var replicatedDocs = [];
       var db = new PouchDB(dbs.name);
-      db.bulkDocs({ docs: docs }, {}).then(function() {
+      db.bulkDocs({ docs: docs }, {}).then(function () {
         var replication = db.replicate.to(dbs.remote);
-        replication.on('change', function(change) {
+        replication.on('change', function (change) {
           replicatedDocs = replicatedDocs.concat(change.docs);
         });
         return replication;
       })
-      .then(function() {
+      .then(function () {
         replicatedDocs.sort(function (a, b) {
           return a._id > b._id ? 1 : -1;
         });
@@ -4101,7 +4101,7 @@ adapters.forEach(function (adapters) {
       });
     });
 
-    it("#3578 replication with a ddoc filter w/ _deleted=true", function() {
+    it("#3578 replication with a ddoc filter w/ _deleted=true", function () {
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
 
@@ -4118,13 +4118,13 @@ adapters.forEach(function (adapters) {
         {_id: 'c'}
       ]).then(function () {
         return remote.replicate.to(db, {filter: 'myddoc/myfilter'});
-      }).then(function() {
+      }).then(function () {
         return db.allDocs();
       }).then(function (res) {
         res.rows.should.have.length(2);
       }).then(function () {
         return remote.get('a');
-      }).then(function(doc) {
+      }).then(function (doc) {
         doc._deleted = true;
         return remote.put(doc);
       }).then(function () {
@@ -4136,7 +4136,7 @@ adapters.forEach(function (adapters) {
       });
     });
 
-    it("#3578 replication with a ddoc filter w/ remove()", function() {
+    it("#3578 replication with a ddoc filter w/ remove()", function () {
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
 
@@ -4153,13 +4153,13 @@ adapters.forEach(function (adapters) {
         {_id: 'c'}
       ]).then(function () {
         return remote.replicate.to(db, {filter: 'myddoc/myfilter'});
-      }).then(function() {
+      }).then(function () {
         return db.allDocs();
       }).then(function (res) {
         res.rows.should.have.length(2);
-      }).then(function(){
+      }).then(function (){
         return remote.get('a');
-      }).then(function(doc) {
+      }).then(function (doc) {
         return remote.remove(doc);
       }).then(function () {
         return remote.replicate.to(db, {filter: 'myddoc/myfilter'});
@@ -4170,16 +4170,16 @@ adapters.forEach(function (adapters) {
       });
     });
 
-    it("#2454 info() call breaks taskqueue", function(done) {
+    it("#2454 info() call breaks taskqueue", function (done) {
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
 
-      remote.bulkDocs(docs).then(function() {
+      remote.bulkDocs(docs).then(function () {
 
         var repl = db.replicate.from(remote, {live: true});
         repl.on('complete', done.bind(null, null));
 
-        remote.info().then(function() {
+        remote.info().then(function () {
           repl.cancel();
         }).catch(done);
       }).catch(done);
@@ -4247,7 +4247,7 @@ adapters.forEach(function (adapters) {
         // to fire (since there is nothing to wait deteministically for)
         // Without the setTimeout this will pass, just less likely to catch
         // the failing case
-        setTimeout(function() {
+        setTimeout(function () {
           push.cancel();
           pull.cancel();
         }, 100);
@@ -4284,16 +4284,16 @@ adapters.forEach(function (adapters) {
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
 
-      db.bulkDocs([{foo: 'bar'}]).then(function() {
+      db.bulkDocs([{foo: 'bar'}]).then(function () {
 
         var repl = db.replicate.to(remote, {live: true, retry: true});
 
-        repl.on('paused', function(err) {
+        repl.on('paused', function (err) {
           if (err) {
             repl.cancel();
           }
         });
-        repl.on('complete', function() {
+        repl.on('complete', function () {
           PouchDB.utils.ajax = ajax;
           done();
         });
@@ -4318,9 +4318,9 @@ adapters.forEach(function (adapters) {
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
 
-      return remote.bulkDocs([{foo: 'bar'}]).then(function() {
+      return remote.bulkDocs([{foo: 'bar'}]).then(function () {
         return db.replicate.from(remote, {heartbeat: 10});
-      }).then(function() {
+      }).then(function () {
         seenHeartBeat.should.equal(true);
         PouchDB.utils.ajax = ajax;
         done();
@@ -4346,9 +4346,9 @@ adapters.forEach(function (adapters) {
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
 
-      return remote.bulkDocs([{foo: 'bar'}]).then(function() {
+      return remote.bulkDocs([{foo: 'bar'}]).then(function () {
         return db.replicate.from(remote, {timeout: 20000});
-      }).then(function() {
+      }).then(function () {
         seenTimeout.should.equal(true);
         PouchDB.utils.ajax = ajax;
         done();

--- a/tests/integration/test.replication_events.js
+++ b/tests/integration/test.replication_events.js
@@ -35,16 +35,16 @@ adapters.forEach(function (adapters) {
       var repl = db.replicate.to(dbs.remote, {retry: true, live: true});
       var counter = 0;
 
-      repl.on('complete', function() { done(); });
+      repl.on('complete', function () { done(); });
 
-      repl.on('active', function() {
+      repl.on('active', function () {
         counter++;
         if (!(counter === 2 || counter === 4)) {
           done('active fired incorrectly');
         }
       });
 
-      repl.on('paused', function() {
+      repl.on('paused', function () {
         counter++;
         // We should receive a paused event when replication
         // starts because there is nothing to replicate
@@ -65,22 +65,22 @@ adapters.forEach(function (adapters) {
 
       var db = new PouchDB(dbs.name);
 
-      db.bulkDocs([{_id: 'a'}, {_id: 'b'}]).then(function() {
+      db.bulkDocs([{_id: 'a'}, {_id: 'b'}]).then(function () {
 
         var repl = db.replicate.to(dbs.remote, {retry: true, live: true});
 
         var counter = 0;
 
-        repl.on('complete', function() { done(); });
+        repl.on('complete', function () { done(); });
 
-        repl.on('active', function() {
+        repl.on('active', function () {
           counter++;
           if (!(counter === 1 || counter === 3 || counter === 5)) {
             done('active fired incorrectly:' + counter);
           }
         });
 
-        repl.on('paused', function() {
+        repl.on('paused', function () {
           counter++;
           // We should receive a paused event when replication
           // starts because there is nothing to replicate
@@ -116,7 +116,7 @@ adapters.forEach(function (adapters) {
         }
       };
 
-      db.bulkDocs([{_id: 'a'}, {_id: 'b'}]).then(function() {
+      db.bulkDocs([{_id: 'a'}, {_id: 'b'}]).then(function () {
 
         var repl = db.replicate.to(dbs.remote, {
           retry: true,
@@ -126,12 +126,12 @@ adapters.forEach(function (adapters) {
 
         var counter = 0;
 
-        repl.on('complete', function() {
+        repl.on('complete', function () {
           PouchDB.utils.ajax = ajax;
           done();
         });
 
-        repl.on('active', function() {
+        repl.on('active', function () {
           counter++;
           if (counter === 2) {
             // All good, wait for pause
@@ -146,7 +146,7 @@ adapters.forEach(function (adapters) {
           }
         });
 
-        repl.on('paused', function(err) {
+        repl.on('paused', function (err) {
           counter++;
           // Replication starts with a paused(err) because ajax is
           // failing

--- a/tests/integration/test.retry.js
+++ b/tests/integration/test.retry.js
@@ -131,7 +131,7 @@ adapters.forEach(function (adapters) {
         ++numChanges;
       });
 
-      rep.on('complete', function() {
+      rep.on('complete', function () {
         try {
           active.should.be.within(1, 2);
           paused.should.equal(2);
@@ -171,7 +171,7 @@ adapters.forEach(function (adapters) {
 
       var numDocsToWrite = 10;
 
-      return remote.post({}).then(function() {
+      return remote.post({}).then(function () {
         var originalNumListeners;
         var posted = 0;
 
@@ -243,7 +243,7 @@ adapters.forEach(function (adapters) {
 
       var numDocsToWrite = 10;
 
-      return remote.post({}).then(function() {
+      return remote.post({}).then(function () {
         var originalNumListeners;
         var posted = 0;
 
@@ -326,7 +326,7 @@ adapters.forEach(function (adapters) {
 
         var numDocsToWrite = 10;
 
-        return remote.post({}).then(function() {
+        return remote.post({}).then(function () {
           var originalNumListeners;
           var posted = 0;
 
@@ -399,7 +399,7 @@ adapters.forEach(function (adapters) {
 
       var numDocsToWrite = 10;
 
-      return remote.post({}).then(function() {
+      return remote.post({}).then(function () {
         var originalNumListeners;
         var posted = 0;
 
@@ -475,7 +475,7 @@ adapters.forEach(function (adapters) {
       var paused = 0;
       var numDocsToWrite = 50;
 
-      return remote.post({}).then(function() {
+      return remote.post({}).then(function () {
         var originalNumListeners;
         var posted = 0;
 
@@ -557,12 +557,12 @@ adapters.forEach(function (adapters) {
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
 
-      remote.post({a: 'doc'}).then(function() {
+      remote.post({a: 'doc'}).then(function () {
         startFailing = true;
         var rep = db.replicate.from(remote, {live: true, retry: true})
-          .on('change', function() { rep.cancel(); });
+          .on('change', function () { rep.cancel(); });
 
-        rep.on('complete', function() {
+        rep.on('complete', function () {
           PouchDB.utils.ajax = ajax;
           done();
         });

--- a/tests/integration/test.sync.js
+++ b/tests/integration/test.sync.js
@@ -363,7 +363,7 @@ adapters.forEach(function (adapters) {
       }).then(function () {
         // Replication isn't finished until onComplete has been called twice
         return db.allDocs().then(function (res1) {
-          return remote.allDocs().then(function(res2) {
+          return remote.allDocs().then(function (res2) {
             res1.total_rows.should.equal(res2.total_rows);
           });
         });
@@ -625,7 +625,7 @@ adapters.forEach(function (adapters) {
           return db.bulkDocs({docs: docs});
         }).then(function () {
           var sync = db.sync(dbs.remote);
-          sync.on('denied', function(error) {
+          sync.on('denied', function (error) {
             deniedErrors.push(error);
           });
           return sync;
@@ -671,7 +671,7 @@ adapters.forEach(function (adapters) {
             return db.bulkDocs({docs: docs});
           }).then(function () {
             var sync = remote.sync(db);
-            sync.on('denied', function(error) {
+            sync.on('denied', function (error) {
               deniedErrors.push(error);
             });
             return sync;
@@ -685,7 +685,7 @@ adapters.forEach(function (adapters) {
         });
       });
 
-    it('#3270 triggers "change" events with .docs property', function(done) {
+    it('#3270 triggers "change" events with .docs property', function (done) {
       var syncedDocs = [];
       var db = new PouchDB(dbs.name);
       var docs = [
@@ -694,14 +694,14 @@ adapters.forEach(function (adapters) {
         {_id: '3'}
       ];
 
-      db.bulkDocs({ docs: docs }, {}).then(function() {
+      db.bulkDocs({ docs: docs }, {}).then(function () {
         var sync = db.sync(dbs.remote);
-        sync.on('change', function(change) {
+        sync.on('change', function (change) {
           syncedDocs = syncedDocs.concat(change.change.docs);
         });
         return sync;
       })
-      .then(function() {
+      .then(function () {
         syncedDocs.sort(function (a, b) {
           return a._id > b._id ? 1 : -1;
         });
@@ -723,15 +723,15 @@ adapters.forEach(function (adapters) {
       var localDocs = [{_id: '0'}, {_id: '1'}];
       var remoteDocs = [{_id: 'a'}, {_id: 'b'}];
 
-      return remote.bulkDocs(remoteDocs).then(function() {
+      return remote.bulkDocs(remoteDocs).then(function () {
         return db.bulkDocs(localDocs);
-      }).then(function() {
+      }).then(function () {
         return db.sync(remote, {
           filter: function (doc) { return doc._id !== '0' && doc._id !== 'a'; }
         });
-      }).then(function() {
+      }).then(function () {
         return db.allDocs();
-      }).then(function(docs) {
+      }).then(function (docs) {
         docs.total_rows.should.equal(3);
         return remote.allDocs();
       }).then(function (docs) {
@@ -748,15 +748,15 @@ adapters.forEach(function (adapters) {
       var localDocs = [{_id: '0'}, {_id: '1'}];
       var remoteDocs = [{_id: 'a'}, {_id: 'b'}];
 
-      return remote.bulkDocs(remoteDocs).then(function() {
+      return remote.bulkDocs(remoteDocs).then(function () {
         return db.bulkDocs(localDocs);
-      }).then(function() {
+      }).then(function () {
         return new PouchDB.utils.Promise(function (resolve, reject) {
           var filter = function (doc) {
             return doc._id !== '0' && doc._id !== 'a';
           };
           var changes = 0;
-          var onChange = function(c) {
+          var onChange = function (c) {
             changes += c.change.docs.length;
             if (changes === 2) {
               sync.cancel();
@@ -767,9 +767,9 @@ adapters.forEach(function (adapters) {
             .on('change', onChange)
             .on('complete', resolve);
         });
-      }).then(function() {
+      }).then(function () {
         return db.allDocs();
-      }).then(function(docs) {
+      }).then(function (docs) {
         docs.total_rows.should.equal(3);
         return remote.allDocs();
       }).then(function (docs) {
@@ -785,16 +785,16 @@ adapters.forEach(function (adapters) {
       var localDocs = [{_id: '0'}, {_id: '1'}];
       var remoteDocs = [{_id: 'a'}, {_id: 'b'}];
 
-      return remote.bulkDocs(remoteDocs).then(function() {
+      return remote.bulkDocs(remoteDocs).then(function () {
         return db.bulkDocs(localDocs);
-      }).then(function() {
+      }).then(function () {
         return db.sync(remote, {
-          push: {filter: function(doc) { return doc._id === '0'; }},
-          pull: {filter: function(doc) { return doc._id === 'a'; }}
+          push: {filter: function (doc) { return doc._id === '0'; }},
+          pull: {filter: function (doc) { return doc._id === 'a'; }}
         });
-      }).then(function() {
+      }).then(function () {
         return db.allDocs();
-      }).then(function(docs) {
+      }).then(function (docs) {
         docs.total_rows.should.equal(3);
         return remote.allDocs();
       }).then(function (docs) {

--- a/tests/integration/test.sync_events.js
+++ b/tests/integration/test.sync_events.js
@@ -34,16 +34,16 @@ adapters.forEach(function (adapters) {
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
 
-      db.bulkDocs([{_id: 'a'}, {_id: 'b'}]).then(function() {
+      db.bulkDocs([{_id: 'a'}, {_id: 'b'}]).then(function () {
 
         var repl = db.sync(remote, {retry: true, live: true});
         var counter = 0;
 
-        repl.on('complete', function() {
+        repl.on('complete', function () {
           done();
         });
 
-        repl.on('active', function() {
+        repl.on('active', function () {
           counter++;
           if (counter === 1) {
             // We are good, initial replication
@@ -52,7 +52,7 @@ adapters.forEach(function (adapters) {
           }
         });
 
-        repl.on('paused', function() {
+        repl.on('paused', function () {
           counter++;
           if (counter === 1) {
             // Maybe a bug, if we have data should probably

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -162,13 +162,13 @@ testUtils.adapterUrl = function (adapter, name) {
 testUtils.cleanup = function (dbs, done) {
   dbs = uniq(dbs);
   var num = dbs.length;
-  var finished = function() {
+  var finished = function () {
     if (--num === 0) {
       done();
     }
   };
 
-  dbs.forEach(function(db) {
+  dbs.forEach(function (db) {
     new PouchDB(db).destroy(finished, finished);
   });
 };
@@ -288,7 +288,7 @@ testUtils.fin = function (promise, cb) {
 };
 
 testUtils.promisify = function (fun, context) {
-  return function() {
+  return function () {
     var args = [];
     for (var i = 0; i < arguments.length; i++) {
       args[i] = arguments[i];

--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -33,7 +33,7 @@ function asyncLoadScript(url, callback) {
   script.src = url;
 
   // Handle the case where an optional callback was passed in.
-  if ("function" === typeof(callback)) {
+  if ("function" === typeof (callback)) {
     script.onload = function () {
       callback();
 
@@ -81,10 +81,10 @@ function startTests() {
     // Capture logs for selenium output
     var logs = [];
 
-    (function(){
+    (function (){
 
       var oldLog = console.log;
-      console.log = function() {
+      console.log = function () {
         var args = Array.prototype.slice.call(arguments);
         args.unshift('log');
         logs.push(args);
@@ -92,7 +92,7 @@ function startTests() {
       };
 
       var oldError = console.error;
-      console.error = function() {
+      console.error = function () {
         var args = Array.prototype.slice.call(arguments);
         args.unshift('error');
         logs.push(args);

--- a/tests/mapreduce/test.mapreduce.js
+++ b/tests/mapreduce/test.mapreduce.js
@@ -1035,8 +1035,8 @@ function tests(suiteName, dbName, dbType, viewType) {
           map: function (doc) {
             emit(doc.foo);
           },
-          reduce: function(keys) {
-            return keys.map(function(keyId) {
+          reduce: function (keys) {
+            return keys.map(function (keyId) {
               var key = keyId[0];
               // var id = keyId[1];
               return key.join('');

--- a/tests/unit/test.ajax.js
+++ b/tests/unit/test.ajax.js
@@ -7,7 +7,7 @@ describe('test.ajax.js', function () {
   var cb;
   var ajax;
 
-  beforeEach(function() {
+  beforeEach(function () {
     mockery.enable({
       warnOnReplace: false,
       warnOnUnregistered: false,
@@ -22,7 +22,7 @@ describe('test.ajax.js', function () {
     ajax = require('../../lib/deps/ajax/ajaxCore');
   });
 
-  after(function() {
+  after(function () {
     mockery.disable();
   });
 
@@ -31,12 +31,12 @@ describe('test.ajax.js', function () {
     ajax.should.be.a('function');
   });
 
-  it('detects error on an interrupted binary file', function(done) {
+  it('detects error on an interrupted binary file', function (done) {
     ajax({
       method: 'GET',
       binary: true,
       url: 'http://test.db/dbname/docid/filename.jpg'
-    }, function(err, res) {
+    }, function (err, res) {
       // here's the test, we should get an 'err' response
       should.exist(err);
       should.not.exist(res);
@@ -44,7 +44,7 @@ describe('test.ajax.js', function () {
     });
 
     // Simulates an interrupted network request
-    setTimeout(function() {
+    setTimeout(function () {
       cb(null, {
         statusCode: 0
       },
@@ -52,18 +52,18 @@ describe('test.ajax.js', function () {
     }, 4);
   });
 
-  it('should work on a working binary file', function(done) {
+  it('should work on a working binary file', function (done) {
     ajax({
       method: 'GET',
       binary: true,
       url: 'http://test.db/dbname/docid/filename.jpg'
-    }, function(err, res) {
+    }, function (err, res) {
       should.not.exist(err);
       should.exist(res);
       done();
     });
 
-    setTimeout(function() {
+    setTimeout(function () {
       cb(null, {
         statusCode: 200,
         headers: {


### PR DESCRIPTION
A few changes here to better match our previous JSHint rules:

- `function () {}` not `function() {}`
- `if (condition) { ... }` (braces required)
- spaces after unary (e.g. `typeof(foo)` is wrong)

As it turned out, there were very few fixes to make, and eslint's
`--fix` feature did a great job here.