### PR TITLE
(#5070) - stop testing node 0.10 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,9 +141,6 @@ matrix:
   fast_finish: true
 
   include:
-    - node_js: "0.10"
-      services: docker
-      env: CLIENT=node COMMAND=test
     - node_js: "0.11"
       services: docker
       env: CLIENT=node COMMAND=test


### PR DESCRIPTION
We should probably start a discussion about whether to keep
Node 0.10 support or not, but I'd be in favor of just
removing it because it's constantly failing in Travis, and it's
annoying to have to deal with.

We _could_ add it to allowed failures, but I figure why eat
up Travis CPU when we don't need to.