### PR TITLE
Add back the pagination gem

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,6 +3,7 @@ description: PouchDB, the JavaScript Database that Syncs!
 url: http://pouchdb.com
 highlighter: pygments
 markdown: redcarpet
+gems: [jekyll-paginate]
 baseurl:
 version: 5.3.2
 paginate: 5


### PR DESCRIPTION
I can't find the official source but Jekyll 3 removed the jekyll-paginate gem from the default install.  If the plugin isn't included than `{% for post in paginator.posts %}` doesn't do anything and the blog posts don't show up.

~~Ideally we should use the github pages gem and bundler to install plugins, but I thought it would be better to fix one thing at a time.~~  Since the site doesn't need to be built by github pages, the site can use any gems it wants.  Using bundler would make it easier to install the correct gems, so I will open a separate PR for that.

Closes #5084