### PR TITLE
Use bundler to install jekyll dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,9 +97,10 @@ Workflows can vary, but here is a very simple workflow for contributing a bug fi
 Building PouchDB Documentation
 --------------------------------------
 
-The source for the website http://pouchdb.com is stored inside the `docs` directory of the PouchDB repository, you can make changes and submit pull requests as with any other patch. To build and view the website locally you will need to install [jekyll](http://jekyllrb.com/) and a few other gems:
+The source for the website http://pouchdb.com is stored inside the `docs` directory of the PouchDB repository, you can make changes and submit pull requests as with any other patch. To build and view the website locally you will need to install [jekyll](http://jekyllrb.com/) and a few other gems.  Jekyll is installed using [bundler](http://bundler.io/) so you need to install that first.
 
-    $ gem install jekyll redcarpet pygments.rb
+    $ gem install bundler
+    $ npm run install-jekyll
 
 If you haven't already done so, you'll also need to run `npm install` to pull in packages for the dev server:
 

--- a/bin/build-site.js
+++ b/bin/build-site.js
@@ -16,10 +16,8 @@ var POUCHDB_LESS = __dirname + '/../docs/static/less/pouchdb/pouchdb.less';
 process.chdir('docs');
 
 function checkJekyll() {
-  return exec('gem list jekyll -i').then(function (result) {
-    if (!/true/.test(result.stdout)) {
-      throw new Error('You need to do: gem install jekyll');
-    }
+  return exec('bundle check').catch(function (err) {
+    throw new Error('Jekyll is not installed.  You need to do: npm run install-jekyll');
   });
 }
 
@@ -37,7 +35,7 @@ function buildJekyll(path) {
   if (path && /^_site/.test(path.relative)) {
     return;
   }
-  return exec('jekyll build').then(function () {
+  return exec('bundle exec jekyll build').then(function () {
     console.log('=> Rebuilt jekyll');
     return highlightEs6();
   }).then(function () {

--- a/bin/install-jekyll.sh
+++ b/bin/install-jekyll.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if ! gem list bundler -i > /dev/null 2>&1; then
+    echo "bundler is not installed.  You need to do: gem install bundler"
+    exit 1
+fi
+
+cd docs && bundle install

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gem 'jekyll'
+
+group :jekyll_plugins do
+  gem 'jekyll-paginate'
+  gem 'redcarpet'
+  gem 'pygments.rb'
+end

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,0 +1,49 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    colorator (0.1)
+    ffi (1.9.10)
+    jekyll (3.1.3)
+      colorator (~> 0.1)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 3.0)
+      mercenary (~> 0.3.3)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-paginate (1.1.0)
+    jekyll-sass-converter (1.4.0)
+      sass (~> 3.4)
+    jekyll-watch (1.3.1)
+      listen (~> 3.0)
+    kramdown (1.10.0)
+    liquid (3.0.6)
+    listen (3.0.6)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9.7)
+    mercenary (0.3.6)
+    posix-spawn (0.3.11)
+    pygments.rb (0.6.3)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.2.0)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.7)
+      ffi (>= 0.5.0)
+    redcarpet (3.3.4)
+    rouge (1.10.1)
+    safe_yaml (1.0.4)
+    sass (3.4.22)
+    yajl-ruby (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll
+  jekyll-paginate
+  pygments.rb
+  redcarpet
+
+BUNDLED WITH
+   1.10.6

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "posttest": "npm run eslint",
     "prepublish": "npm run build",
     "release": "sh bin/release.sh",
+    "install-jekyll": "sh bin/install-jekyll.sh",
     "publish-site": "sh bin/publish-site.sh",
     "build-site": "node ./bin/build-site.js",
     "report-coverage": "npm run build-as-modular-es5 && COVERAGE=1 npm test && istanbul-coveralls --no-rm",


### PR DESCRIPTION
This PR uses bundler to install jekyll and all jekyll plugins.  It's like a package.json but for Ruby.

Right now you have to global install all the plugins like `sudo gem install jekyll jekyll-paginate pygments.rb redcarpet`.  If you already have one installed but it's a different version the site won't build correctly.

By using bundler, you just need to type `bundle install` and it installs the version specified in the Gemfile.lock.

The command to build jekyll is changed to `bundle exec jekyll build` which  makes sure it's built with the correct version of jekyll.  Another nice change is that the `checkJekyll` function will check for all dependencies specified in the Gemfile, including plugins.

Now that there is a Gemfile, you can run `bundle update` to update the dependency versions.  After doing that you would commit the updated `Gemfile.lock`.