### PR TITLE
(#4199) - add a download specific page

### DIFF
--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -1,4 +1,5 @@
-{% include nav_item.html path="/learn.html" text="About PouchDB" %}
+{% include nav_item.html path="/learn.html" text="About" %}
+{% include nav_item.html path="/download.html" text="Download" %}
 {% include nav_item.html path="/users.html" text="Who's using PouchDB?" %}
 {% include nav_item.html path="/getting-started.html" text="Get Started Guide" %}
 {% include nav_item.html path="/api.html" text="API" %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -53,12 +53,7 @@
             <a class='btn btn-link btn-lg' href="{{ site.baseurl }}/learn.html">Learn</a>
           </li>
           <li>
-            <a
-                class='btn btn-primary btn-lg'
-                href="https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb-{{ site.version }}.min.js"
-            >
-                Download <strong>v{{ site.version }}</strong>
-            </a>
+            <a class='btn btn-primary btn-lg' href="{{ site.baseurl }}/download.html">Download <strong>v{{ site.version }}</strong></a>
           </li>
         </ul>
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -1,0 +1,60 @@
+---
+layout: 2ColLeft
+title: Download
+sidebar: nav.html
+---
+
+{% include anchor.html class="h3" title="File Download" hash="file" %}
+
+The PouchDB file should come before any files that use it.
+
+For use in a HTML file:
+
+{% highlight html %}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pouchdb/{{ site.version }}/pouchdb.min.js"></script>
+<script>
+  var db = new PouchDB('my_database');
+</script>
+{% endhighlight %}
+
+PouchDB is supplied as a compressed and uncompressed download:
+
+* [Download pouchdb-{{ site.version }}.min.js][latest-min] (compressed for production)
+* [Download pouchdb-{{ site.version }}.js][latest] (uncompressed for debugging)
+
+PouchDB is also hosted on Content Delivery Networks:
+
+* [PouchDB on jsdelivr](http://www.jsdelivr.com/#!pouchdb)
+* [PouchDB on cdnjs](https://cdnjs.com/libraries/pouchdb).
+
+{% include anchor.html class="h3" title="npm" hash="npm" %}
+
+PouchDB can also be installed through [npm](http://npmjs.com) for Node.js. This can be used on the server and/or browser.
+
+**A bundler such as [browserify](http://browserify.org/) or [webpack](https://webpack.github.io/) is needed for browser usage.**
+
+{% highlight bash %}npm install --save pouchdb{% endhighlight %}
+
+After installing, you can require and use:
+
+{% highlight javascript %}
+var PouchDB = require('pouchdb');
+var db = new PouchDB('my_database');
+{% endhighlight %}
+
+{% include anchor.html class="h3" title="Bower" hash="bower" %}
+
+PouchDB can be installed through [bower](http://bower.io).
+
+{% highlight bash %}bower install --save pouchdb{% endhighlight %}
+
+{% include anchor.html class="h3" title="Past releases" hash="past-releases" %}
+
+For past releases and changelog, check out the [Github releases page](https://github.com/pouchdb/pouchdb/releases).
+
+{% include anchor.html class="h3" title="Plugins" hash="plugins" %}
+
+For plugins, see the [plugins page](/external.html).
+
+[latest]: https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb-{{ site.version }}.js
+[latest-min]: https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb-{{ site.version }}.min.js

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -10,47 +10,6 @@ PouchDB also runs in **Node.js** and can be used as a direct interface to **Couc
 
 PouchDB is a free open-source project, written in JavaScript and driven by our [wonderful  community](https://github.com/pouchdb/pouchdb/graphs/contributors). If you want to get involved, then check out the [contributing guide](https://github.com/pouchdb/pouchdb/blob/master/CONTRIBUTING.md).
 
-{% include anchor.html class="h3" title="Installing" hash="installing" %}
-
-To start using PouchDB in your website, simply [download][latest-min] it and include it in your page:
-
-{% highlight html %}
-<script src="pouchdb-{{ site.version }}.min.js"></script>
-{% endhighlight %}
-
-Or install it with Bower:
-
-{% highlight bash %}$ bower install --save pouchdb{% endhighlight %}
-
-Or install it as a Node.js module:
-
-{% highlight bash %}$ npm install --save pouchdb{% endhighlight %}
-
-{% include anchor.html class="h3" title="Using PouchDB" hash="using_pouchdb" %}
-
-In the browser, getting started is as simple as:
-
-{% highlight javascript %}
-var db = new PouchDB('my_database');
-{% endhighlight %}
-
-In Node.js, you'll need to `require()` it first:
-
-{% highlight javascript %}
-var PouchDB = require('pouchdb');
-var db = new PouchDB('my_database');
-{% endhighlight %}
-
-Or, to use PouchDB as a direct client to CouchDB, simply pass in a URL:
-
-{% highlight javascript %}
-var db = new PouchDB('http://localhost:5984/my_database');
-{% endhighlight %}
-
-All of these `db`s share the same API, regardless of where they're storing data!
-
-To learn more about how to use PouchDB, check out our [Getting Started Tutorial](getting-started.html), [Guides](/guides/) and the [API Documentation](api.html).
-
 {% include anchor.html class="h3" title="Browser Support" hash="browser_support" %}
 
 PouchDB supports all modern browsers, using [IndexedDB][] under the hood and falling back to [WebSQL][] where IndexedDB isn't supported. It is [fully tested](https://travis-ci.org/pouchdb/pouchdb/) and supported in:
@@ -74,21 +33,6 @@ In Node.js, PouchDB uses [LevelDB][] under the hood, and also supports [many oth
 
 PouchDB can also run as its own CouchDB-compatible web server, using [PouchDB Server](https://github.com/pouchdb/pouchdb-server).
 
-{% include anchor.html class="h3" title="Downloads" hash="downloads" %}
-
-Latest and greatest:
-
-* [pouchdb-{{ site.version }}.min.js][latest-min] (compressed for production)
-* [pouchdb-{{ site.version }}.js][latest] (uncompressed for debugging)
-
-PouchDB is also hosted on [jsdelivr](http://www.jsdelivr.com/#!pouchdb) and [cdnjs](https://cdnjs.com/libraries/pouchdb).
-
-For past releases and changelog, check out the [Github releases page](https://github.com/pouchdb/pouchdb/releases).
-
-For plugins, see the [plugins page](/external.html).
-
 [IndexedDB]: http://caniuse.com/#feat=indexeddb
 [WebSQL]: http://caniuse.com/#feat=sql-storage
 [LevelDB]: http://leveldb.org/
-[latest]: https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb-{{ site.version }}.js
-[latest-min]: https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb-{{ site.version }}.min.js


### PR DESCRIPTION
This is for #4199

Rather than the download button downloading the file straight away you're taken to a page describing different download and install options.

This also moves installation instructions from the about section which was hidden away.

Trying to make this a simple as possible, which is hard so feedback is welcome!

Here's some screens:
![Download page screenshot 1](https://cloud.githubusercontent.com/assets/2591901/14753910/3218eece-08d0-11e6-9510-1c91f30d0bb5.png)

![Download page screenshot 2](https://cloud.githubusercontent.com/assets/2591901/14753911/321b778e-08d0-11e6-81fa-713a4a987d12.png)