### PR TITLE
Fix the install jekyll script

### DIFF
--- a/bin/install-jekyll.sh
+++ b/bin/install-jekyll.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if ! gem list bundler -i > /dev/null 2>&1; then
+if ! command -v bundler >/dev/null 2>&1; then
     echo "bundler is not installed.  You need to do: gem install bundler"
     exit 1
 fi


### PR DESCRIPTION
I just looked back at my changes from #5089 and realized the install jekyll script is wrong.

I was checking if the dependencies are satisfied when I should have been checking if bundler is in the PATH.

I tested the bundler check by doing:

```bash
PATH='' ./bin/install-jekyll.sh 
```