### PR TITLE
Use rouge for documentation syntax highlighting

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -5,5 +5,5 @@ gem 'jekyll'
 group :jekyll_plugins do
   gem 'jekyll-paginate'
   gem 'redcarpet'
-  gem 'pygments.rb'
+  gem 'rouge'
 end

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -23,10 +23,6 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
     mercenary (0.3.6)
-    posix-spawn (0.3.11)
-    pygments.rb (0.6.3)
-      posix-spawn (~> 0.3.6)
-      yajl-ruby (~> 1.2.0)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
@@ -34,7 +30,6 @@ GEM
     rouge (1.10.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
-    yajl-ruby (1.2.1)
 
 PLATFORMS
   ruby
@@ -42,8 +37,8 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   jekyll-paginate
-  pygments.rb
   redcarpet
+  rouge
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 name: PouchDB
 description: PouchDB, the JavaScript Database that Syncs!
 url: http://pouchdb.com
-highlighter: pygments
+highlighter: rouge
 markdown: redcarpet
 baseurl:
 version: 5.3.2


### PR DESCRIPTION
Right now syntax highlighting uses pygments.  This means you need to have python installed and `pip install pygments` before the syntax highlighting will work.

This PR replaces pygments with [rouge](https://github.com/jneen/rouge) which is pure ruby and the default for Jekyll 3.  Rouge uses the same stylesheets as pygments so there shouldn't be any change in appearance and the `highlight.less` stylesheet will continue to work.

Note that testing this won't work until #5092 is merged, unless you manually `cd docs && bundle install`.

![highlight-diff](https://cloud.githubusercontent.com/assets/9440455/14770318/ac143036-0a3c-11e6-825b-2e5702554d0f.png)