### PR TITLE
(#5102) - specify md5 data encoding

### DIFF
--- a/src/deps/md5.js
+++ b/src/deps/md5.js
@@ -2,7 +2,7 @@ import toPromise from './toPromise';
 import crypto from 'crypto';
 
 var res = toPromise(function (data, callback) {
-  var base64 = crypto.createHash('md5').update(data).digest('base64');
+  var base64 = crypto.createHash('md5').update(data, 'binary').digest('base64');
   callback(null, base64);
 });
 

--- a/src/mapreduce/md5.js
+++ b/src/mapreduce/md5.js
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 
 function MD5(string) {
-  return crypto.createHash('md5').update(string).digest('hex');
+  return crypto.createHash('md5').update(string, 'binary').digest('hex');
 }
 
 export default MD5;


### PR DESCRIPTION
The default encoding was switched to utf8 in nodejs/node#5522