### PR TITLE
fix(package): avoid extra slashes in base url

### DIFF
--- a/src/adapters/http/index.js
+++ b/src/adapters/http/index.js
@@ -108,6 +108,10 @@ function genUrl(opts, path) {
   // Otherwise, the path delimiter is the empty string
   var pathDel = !opts.path ? '' : '/';
 
+  if (!opts.path && path === '/') {
+      path = '';
+  }
+
   // If the host already has a path, then we need to have a path delimiter
   // Otherwise, the path delimiter is the empty string
   return opts.protocol + '://' + opts.host +


### PR DESCRIPTION
This patch is an attempt to avoid erroneous `//` at end of the base path

Before it could generate a url such as `http://localhost:1234//` where couchdb would return this server error
   ```
   {"error":"illegal_database_name","reason":"Name: '_session'. Only lowercase characters (a-z), digits (0-9), and any of the characters _, $, (, ), +, -, and / are allowed. Must begin with a letter."}
   ```
This should fix https://github.com/nolanlawson/pouchdb-authentication/issues/39 and https://github.com/nolanlawson/pouchdb-authentication/pull/74 (but it doesn't) because...

⚠️ ⚠️ This is a breaking change. If this fix is accepted, the regex.replace on this line https://github.com/nolanlawson/pouchdb-authentication/blob/master/lib/utils.js#L6 will break something fierce... So I think some discussion should be had as to where to fix it...

If this project (pouchdb) determines not to make the change - I think we can use https://github.com/jfromaniello/url-join in https://github.com/nolanlawson/pouchdb-authentication to turn `http://localhost:5984///_session` in to `http://localhost:5984/_session`

Thoughts?