### PR TITLE
(#5118) - allow perf testing for node-websql

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -172,9 +172,17 @@ Or the automated browser runner:
 
     PERF=1 CLIENT=selenium:firefox npm test
 
-You can also use `GREP` to run certain tests, or `LEVEL_ADAPTER` to use a certain *down adapter:
+You can also use `GREP` to run certain tests:
 
-    PERF=1 GREP=basic-inserts LEVEL_ADAPTER=memdown npm test
+    PERF=1 GREP=basic-inserts npm test
+
+You can also use `LEVEL_ADAPTER` to use a certain "DOWN" adapter:
+
+    PERF=1 LEVEL_ADAPTER=memdown npm test
+
+You can also test against node-websql:
+
+    PERF=1 ADAPTER=websql npm test
 
 ### Performance tests in the browser
 

--- a/tests/performance/index.js
+++ b/tests/performance/index.js
@@ -3,8 +3,13 @@
 
 var opts = {};
 
-var levelAdapter = typeof process !== 'undefined' && process.env &&
-    process.env.LEVEL_ADAPTER;
+var levelAdapter;
+if (typeof process !== 'undefined' && process.env) {
+  levelAdapter = process.env.LEVEL_ADAPTER;
+  if (process.env.ADAPTER) {
+    opts.adapter = process.env.ADAPTER;
+  }
+}
 
 function runTestSuites(PouchDB) {
   var reporter = require('./perf.reporter');
@@ -46,6 +51,9 @@ if (global.window && global.window.location && global.window.location.search) {
   }
 }
 if (startNow) {
-  var PouchDB = process.browser ? window.PouchDB : require('../..');
+  var PouchDB = process.browser ? window.PouchDB : require('../../lib/index.js');
+  if (!process.browser) {
+    require('../../extras/websql');
+  }
   runTestSuites(PouchDB);
 }


### PR DESCRIPTION
Before this commit, the instructions in `TESTING.md`
for testing node-websql would work for the integration
tests, but not the perf tests. Now they work for the perf
tests as well.