### PR TITLE
(#5118) - Revert #4867 to fix performance regression

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -185,67 +185,6 @@ function attachmentNameError(name) {
   return false;
 }
 
-function cacheUpdateRequired(api, cache, designDocName, callback) {
-  cache.seq = cache.seq || 0;
-  var changesOpts = {
-    doc_ids: [ '_design/' + designDocName ],
-    limit: 1,
-    since: cache.seq
-  };
-  api.changes(changesOpts).then(function (res) {
-    var latestSeq = res.results && res.results.length && res.results[0].seq;
-    if (latestSeq && latestSeq > cache.seq) {
-      // invalidate the cache
-      cache.seq = latestSeq;
-      delete cache.promise;
-    }
-    callback();
-  }).catch(callback);
-}
-
-function getDesignDocCache(api, designDocName, callback) {
-  api._ddocCache = api._ddocCache || {};
-  api._ddocCache[designDocName] = api._ddocCache[designDocName] || {};
-  var cache = api._ddocCache[designDocName];
-  cacheUpdateRequired(api, cache, designDocName, function (err) {
-    if (err) {
-      return callback(err);
-    }
-    if (!cache.promise) {
-      cache.promise = new Promise(function (resolve, reject) {
-        api._get('_design/' + designDocName, {}, function (err, res) {
-          if (err) {
-            return reject(err);
-          }
-          var cache = {};
-          ['views', 'filters'].forEach(function (propertyName) {
-            cache[propertyName] = res.doc[propertyName];
-          });
-          resolve(cache);
-        });
-      });
-    }
-    cache.promise.then(function (cache) {
-      callback(null, cache);
-    }).catch(callback);
-  });
-}
-
-function getDesignDocProperty(api, designDocName, propertyName,
-                              propertyElement, callback) {
-  getDesignDocCache(api, designDocName, function (err, designDoc) {
-    if (err) {
-      return callback(err);
-    }
-    var element = designDoc[propertyName] &&
-                  designDoc[propertyName][propertyElement];
-    if (!element) {
-      return callback(createError(MISSING_DOC));
-    }
-    callback(null, element);
-  });
-}
-
 inherits(AbstractPouchDB, EventEmitter);
 
 function AbstractPouchDB() {
@@ -727,16 +666,6 @@ AbstractPouchDB.prototype.get =
       callback(null, doc);
     }
   });
-});
-
-AbstractPouchDB.prototype.getView =
-  adapterFun('getView', function (designDocName, viewName, callback) {
-  getDesignDocProperty(this, designDocName, 'views', viewName, callback);
-});
-
-AbstractPouchDB.prototype.getFilter =
-  adapterFun('getFilter', function (designDocName, filterName, callback) {
-  getDesignDocProperty(this, designDocName, 'filters', filterName, callback);
 });
 
 AbstractPouchDB.prototype.getAttachment =

--- a/src/changes.js
+++ b/src/changes.js
@@ -202,7 +202,7 @@ Changes.prototype.filterChanges = function (opts) {
     }
     // fetch a view from a design doc, make it behave like a filter
     var viewName = parseDdocFunctionName(opts.view);
-    this.db.getView(viewName[0], viewName[1], function (err, view) {
+    this.db.get('_design/' + viewName[0], function (err, ddoc) {
       /* istanbul ignore if */
       if (self.isCancelled) {
         return callback(null, {status: 'cancelled'});
@@ -211,10 +211,14 @@ Changes.prototype.filterChanges = function (opts) {
       if (err) {
         return callback(generateErrorFromResponse(err));
       }
-      if (!view.map) {
-        return callback(createError(MISSING_DOC));
+      var mapFun = ddoc && ddoc.views && ddoc.views[viewName[1]] &&
+        ddoc.views[viewName[1]].map;
+      if (!mapFun) {
+        return callback(createError(MISSING_DOC,
+          (ddoc.views ? 'missing json key: ' + viewName[1] :
+            'missing json key: views')));
       }
-      opts.filter = evalView(view.map);
+      opts.filter = evalView(mapFun);
       self.doChanges(opts);
     });
   } else {
@@ -223,7 +227,7 @@ Changes.prototype.filterChanges = function (opts) {
     if (!filterName) {
       return self.doChanges(opts);
     }
-    this.db.getFilter(filterName[0], filterName[1], function (err, filterFun) {
+    this.db.get('_design/' + filterName[0], function (err, ddoc) {
       /* istanbul ignore if */
       if (self.isCancelled) {
         return callback(null, {status: 'cancelled'});
@@ -231,6 +235,12 @@ Changes.prototype.filterChanges = function (opts) {
       /* istanbul ignore next */
       if (err) {
         return callback(generateErrorFromResponse(err));
+      }
+      var filterFun = ddoc && ddoc.filters && ddoc.filters[filterName[1]];
+      if (!filterFun) {
+        return callback(createError(MISSING_DOC,
+          ((ddoc && ddoc.filters) ? 'missing json key: ' + filterName[1]
+            : 'missing json key: filters')));
       }
       opts.filter = evalFilter(filterFun);
       self.doChanges(opts);

--- a/tests/mapreduce/test.persisted.js
+++ b/tests/mapreduce/test.persisted.js
@@ -406,13 +406,13 @@ function tests(suiteName, dbName, dbType) {
       }
       return new PouchDB(dbName).then(function (db) {
         return db.bulkDocs({docs : docs}).then(function (responses) {
-          var promise = Promise.resolve();
+          var tasks = [];
           for (var i = 0; i < docs.length; i++) {
             /* jshint loopfunc:true */
             docs[i]._rev = responses[i].rev;
-            promise = promise.then(db.query('view' + i + '/view'));
+            tasks.push(db.query('view' + i + '/view'));
           }
-          return promise;
+          return Promise.all(tasks);
         }).then(function () {
           docs.forEach(function (doc) {
             doc._deleted = true;


### PR DESCRIPTION
This reverts commit 0ddeae6b6c44fa12b83c5348df6947e3ce28c28c.

I tested the performance before and after reverting this commit. Using the `persisted-views` test with the iterations bumped up to 5000 and using the memdown adapter, I did 5 separate runs each and got the following numbers (median is highlighted in bold):

**Before reverting**:

23228ms / 29725ms / **25060ms** / 25461ms / 26044ms

**After reverting**:

20072ms / 22256ms / 19847ms / **21406ms** / 22568ms

By this measure, 0ddeae6b6c44fa12b83c5348df6947e3ce28c28c represents a **17.0%** performance regression.

It's worth acknowledging that @garethbowen intended #4867 as a fix for the case of a 9MB ddoc, and it does seem like 0ddeae6b6c44fa12b83c5348df6947e3ce28c28c would be a big performance increase in that case, because you wouldn't have to parse that huge ddoc for every query. In contrast, `persisted-views` tests a much smaller ddoc and measures the performance of repeatedly `query()`ing it.

However, I think it's safe to say that 9MB ddocs are the exception rather than the rule, and especially given the increased code weight and other criticisms I brought up in https://github.com/pouchdb/pouchdb/issues/4867#issuecomment-216418677, I would be in favor of reverting.

I'm opening this PR to allow others to weigh in, though.