### PR TITLE
(#5122) - remove unnecessary code from leveldb/index.js

### DIFF
--- a/src/adapters/leveldb/index.js
+++ b/src/adapters/leveldb/index.js
@@ -674,7 +674,7 @@ function LevelPouch(opts, callback) {
         if (seq) {
           // check that there aren't any existing revisions with the same
           // revision id, else we shouldn't do anything
-          return callback2(null, docInfo.revsStemmed);
+          return callback2();
         }
         seq = ++newUpdateSeq;
         docInfo.metadata.rev_map[docInfo.metadata.rev] =
@@ -698,7 +698,7 @@ function LevelPouch(opts, callback) {
           rev: winningRev
         };
         fetchedDocs.set(docInfo.metadata.id, docInfo.metadata);
-        callback2(null, docInfo.revsStemmed);
+        callback2();
       }
 
       if (!attachments.length) {


### PR DESCRIPTION
Noticed that `revsStemmed` is never set. Not sure what
this code was trying to do, but it doesn't seem to
make any difference.