### PR TITLE
(#5145) - Update checkpoint even when no changes

### DIFF
--- a/src/replicate/replicate.js
+++ b/src/replicate/replicate.js
@@ -293,7 +293,7 @@ function replicate(src, target, opts, returnValue, result) {
       processPendingBatch(true);
     } else {
 
-      var complete = function() {
+      var complete = function () {
         if (continuous) {
           changesOpts.live = true;
           getChanges();

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -1548,8 +1548,7 @@ adapters.forEach(function (adapters) {
       });
     });
 
-    it('Empty replication updates checkpoint (#5145)',
-       function (done) {
+    it('Empty replication updates checkpoint (#5145)', function () {
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
       var changes = remote.changes;
@@ -1592,10 +1591,9 @@ adapters.forEach(function (adapters) {
       }).then(function () {
         // Restore remote.changes to original
         remote.changes = changes;
-        done();
       }).catch(function (err) {
         remote.changes = changes;
-        done(err);
+        throw err;
       });
     });
 

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -1548,6 +1548,35 @@ adapters.forEach(function (adapters) {
       });
     });
 
+    it('Empty replication updates checkpoint (#5145)',
+       function (done) {
+      var db = new PouchDB(dbs.name);
+      var remote = new PouchDB(dbs.remote);
+      var docs1 = [ {_id: '0', integer: 0} ];
+      remote.bulkDocs({ docs: docs1 }, function () {
+        var filter = function () {
+          return false;
+        };
+        db.replicate.from(remote, {
+          filter: filter
+        }, function (err, result) {
+          result.ok.should.equal(true);
+          result.docs_written.should.equal(0);
+          result.docs_read.should.equal(0);
+          result.last_seq.should.equal(1);
+          db.replicate.from(remote, {
+            filter: filter
+          }, function (err, result) {
+            result.ok.should.equal(true);
+            result.docs_written.should.equal(0);
+            result.docs_read.should.equal(0);
+            result.last_seq.should.equal(1);
+            done();
+          });
+        });
+      });
+    });
+
     it('Replication with deleted doc', function (done) {
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);


### PR DESCRIPTION
Explicitly write a checkpoint when there are no current batches and no changes returned so future replications can start from the latest seq.