### PR TITLE
(#5140) - remove use of buffer.toArrayBuffer()

### DIFF
--- a/src/adapters/leveldb/readAsBlobOrBuffer-browser.js
+++ b/src/adapters/leveldb/readAsBlobOrBuffer-browser.js
@@ -2,8 +2,10 @@ import createBlob from '../../deps/binary/blob';
 
 function readAsBlobOrBuffer(storedObject, type) {
   // In the browser, we've stored a binary string. This now comes back as a
-  // browserified Node-style Buffer, but we want a Blob instead.
-  return createBlob([storedObject.toArrayBuffer()], {type: type});
+  // browserified Node-style Buffer (implemented as a typed array),
+  // but we want a Blob instead.
+  var byteArray = new Uint8Array(storedObject);
+  return createBlob([byteArray], {type: type});
 }
 
 export default readAsBlobOrBuffer;


### PR DESCRIPTION
buffer [dropped support for toArrayBuffer](https://github.com/feross/buffer/issues/90). However, all the
browsers we support have[ typed array support](http://caniuse.com/#feat=typedarrays) so we can use storedObject directly, I think.