### PR TITLE
(#5130) - Hard code maximum backoff timeout of 10 minutes

### DIFF
--- a/docs/_includes/api/replication.html
+++ b/docs/_includes/api/replication.html
@@ -13,7 +13,7 @@ Replication is an [event emitter][] like [changes()](#changes) and emits the `'c
 All options default to `false` unless otherwise specified.
 
 * `options.live`: If `true`, starts subscribing to future changes in the `source` database and continue replicating them.
-* `options.retry`: If `true` will attempt to retry replications in the case of failure (due to being offline), using a backoff algorithm that retries at longer and longer intervals until a connection is re-established. Only applicable if `options.live` is also `true`.
+* `options.retry`: If `true` will attempt to retry replications in the case of failure (due to being offline), using a backoff algorithm that retries at longer and longer intervals until a connection is re-established, with a maximum delay of 10 minutes. Only applicable if `options.live` is also `true`.
 
 **Filtering Options:**
 
@@ -29,7 +29,7 @@ All options default to `false` unless otherwise specified.
 * `options.timeout`: Request timeout (in milliseconds).
 * `options.batch_size`: Number of documents to process at a time. Defaults to 100. This affects the number of docs held in memory and the number sent at a time to the target server. You may need to adjust downward if targeting devices with low amounts of memory (e.g. phones) or if the documents are large in size. If your documents are small in size, then increasing this number will probably speed replication up.
 * `options.batches_limit`: Number of batches to process at a time. Defaults to 10. This (along wtih `batch_size`) controls how many docs are kept in memory at a time, so the maximum docs in memory at once would equal `batch_size` &times; `batches_limit`.
-* `options.back_off_function`: backoff function to be used in `retry` replication. This is a function that takes the current backoff as input (or 0 the first time) and returns a new backoff in milliseconds. You can use this to tweak when and how replication will try to reconnect to a remote database when the user goes offline. Defaults to a function that chooses a random backoff between 0 and 2 seconds and doubles every time it fails to connect. (See [Customizing retry replication](#customizing-retry-replication) below.)
+* `options.back_off_function`: backoff function to be used in `retry` replication. This is a function that takes the current backoff as input (or 0 the first time) and returns a new backoff in milliseconds. You can use this to tweak when and how replication will try to reconnect to a remote database when the user goes offline. Defaults to a function that chooses a random backoff between 0 and 2 seconds and doubles every time it fails to connect. The default delay will never exceed 10 minutes. (See [Customizing retry replication](#customizing-retry-replication) below.)
 
 #### Example Usage:
 

--- a/src/replicate/backoff.js
+++ b/src/replicate/backoff.js
@@ -1,12 +1,18 @@
 var STARTING_BACK_OFF = 0;
 
 function randomNumber(min, max) {
+  var maxTimeout = 600000; // Hard-coded default of 10 minutes
   min = parseInt(min, 10) || 0;
   max = parseInt(max, 10);
   if (max !== max || max <= min) {
     max = (min || 1) << 1; //doubling
   } else {
     max = max + 1;
+  }
+  // In order to not exceed maxTimeout, pick a random value between half of maxTimeout and maxTimeout
+  if(max > maxTimeout) {
+    min = maxTimeout >> 1; // divide by two
+    max = maxTimeout;
   }
   var ratio = Math.random();
   var range = max - min;
@@ -46,3 +52,4 @@ function backOff(opts, returnValue, error, callback) {
 }
 
 export default backOff;
+export { defaultBackOff }; // export for unit test

--- a/tests/unit/test.backoff.js
+++ b/tests/unit/test.backoff.js
@@ -1,0 +1,21 @@
+var should = require('chai').should();
+
+var defaultBackOff = require('../../lib/replicate/backoff').defaultBackOff;
+
+describe('test.backoff.js', function () {
+
+  it('defaultBackoff should start off at most 2 seconds and never exceed 10 minutes', function () {
+    should.exist(defaultBackOff);
+    var limit = 600000;
+    var delay = 0;
+    var values = [];
+    for(var i=0; i<100; i++) {
+      delay = defaultBackOff(delay);
+      values.push(delay);
+    }
+    var max = Math.max.apply(null, values);
+    values[0].should.be.at.most(2000);
+    max.should.be.at.most(limit);
+  });
+
+});


### PR DESCRIPTION
- Hard coded a maximum delay of 10 minutes into the default backoff function
- Added a unit test
- Updated the API documentation