### PR TITLE
Regression in replicateTo method.

### DIFF
--- a/src/replicate/replicate.js
+++ b/src/replicate/replicate.js
@@ -279,7 +279,7 @@ function replicate(src, target, opts, returnValue, result) {
     }
     pendingBatch.seq = change.seq;
     pendingBatch.changes.push(change);
-    processPendingBatch(changesOpts.live);
+    processPendingBatch(batches.length === 0);
   }
 
 


### PR DESCRIPTION
I have remote CouchDB with 30_000 docs. I replicateFrom all docs. But(!) replicateTo 'paused' events not trigger. And I see than pouchdb every seconds send _bulk_docs, _local and _revs_diff to CouchDB and I see in CouchDB 

```json
{
   "_id":"_local/VfNqh5fhbhdOCfRFn8pEmA==",
   "_rev":"0-675",
   "session_id":"4241BF48-47C3-5446-B3FE-F329644B5F2E",
   "history":[
      {
         "last_seq":675,
         "session_id":"4241BF48-47C3-5446-B3FE-F329644B5F2E"
      }
   ],
   "replicator":"pouchdb",
   "version":1,
   "last_seq":675
}
```

where last_seq increments by one. After last_seq = 30_000 'paused' events in replicateTo is triggered.  But when revert batches.length === 0 'paused' events trigger immediately as expected.

But, I have question number 2: why pouchdb send every second _bulk_docs, _local and _revs_diff to CouchDB?? And i See in CouchDB log: 

```json
{
   "_id":"_local/VfNqh5fhbhdOCfRFn8pEmA==",
   "_rev":"0-675",
   "session_id":"4241BF48-47C3-5446-B3FE-F329644B5F2E",
   "history":[
      {
         "last_seq":675,
         "session_id":"4241BF48-47C3-5446-B3FE-F329644B5F2E"
      }
   ],
   "replicator":"pouchdb",
   "version":1,
   "last_seq":675
}
```

where last_seq increments by one ??? I'm not create any docs locally in pouch. All docs was replicated from remote CouchDB. Oh... my head... Thanks!