### PR TITLE
(#5128) - monorepo blog post

### DIFF
--- a/docs/_posts/2016-05-17-introducing-pouchdb-custom-builds.md
+++ b/docs/_posts/2016-05-17-introducing-pouchdb-custom-builds.md
@@ -1,0 +1,241 @@
+---
+layout: post
+
+title: Introducing PouchDB custom builds
+author: Nolan Lawson
+
+---
+
+{% include alert/start.html variant="info" %}
+
+{% markdown %}
+
+**TL;DR:** PouchDB 5.4.0 has a new [monorepo architecture](https://lernajs.io/) with multiple npm packages that you can install and build separately. Check out [Custom Builds](/custom.html) to get started.
+
+{% endmarkdown %}
+{% include alert/end.html %}
+
+> "Hold the pickles, hold the lettuce; special orders don't upset us."
+>
+> _– Burger King jingle_
+
+When you're building a large open-source project, the challenge often becomes less about "how do we add new features?" and more about "how do we let people opt-out of the features they don't want?".
+
+This is especially important in JavaScript projects, where the code is often shipped to users' browsers, meaning every byte counts. Furthermore, with modern build systems based on npm, it's painful to sit and wait for a large dependency to be `npm install`ed, especially if you're only using a small part of it.
+
+Large dependencies can mean a loading spinner in your user's browser, as well as an npm spinner in your own console.
+
+### PouchDB – not so pocket-sized anymore
+
+PouchDB is an ambitious project, and as such it's grown a lot over the years. It started out as a simple way to sync CouchDB to IndexedDB (originally [only supporting Firefox Nightly](https://github.com/pouchdb/pouchdb/blob/e46433351bbda4adfbea8849e38c44edd9260a98/README)!), whereas now it's used in a variety of contexts:
+
+- In Node.js using [LevelDB][LevelDOWN]
+- In hybrid apps using [native SQLite][SQLitePlugin2]
+- As its own [server][pouchdb-server]
+- As an AJAX interface to CouchDB
+- As a layer over WebSQL, LocalStorage, or even in-memory
+
+With each addition, the codebase has steadily swollen to support each new use case. And while we've been pretty good at keeping the core size down (45kB min+gz is hefty for a JavaScript library, but not enormous), users often ask us these sorts of questions:
+
+- What if I don't want map/reduce?
+- What if I'm only using the IndexedDB adapter?
+- What if I'm only using PouchDB to talk to CouchDB?
+
+If you're not using any of the dependencies, it's a shame to include them in the bundle that gets shipped to your users. We feel ya.
+
+Also, because PouchDB has some large native dependencies (such as LevelDB), the first `npm install` can take a very long time, and it can even fail on certain operating systems (Windows, looking at you). This is especially bothersome when you consider that those dependencies are only required if you're using PouchDB in Node.js. (And even then, you could just use the in-memory adapter instead.)
+
+So unfortunately, folks who are only using PouchDB in the browser still have to pay the extra cost of installing LevelDB. And ditto for SQLite, even though it's only used in the optional `node-websql` adapter! This is a less-than-ideal scenario.
+
+### Breaking up is hard to do
+
+With PouchDB 5.4.0, though, we've made a huge architectural change to support users who want a slimmer or more customized PouchDB experience. Starting with this release, many of the core
+modules that were previously internal to PouchDB can now be `npm install`ed and configured separately.
+
+By adopting this pattern, PouchDB is joining the likes of [Babel][], [Lodash][], [Ember][], and other projects that have been unbundled for quite some time. However, even though many JavaScripters now take this kind of unbundling for granted, it's still [very difficult for library authors to implement](https://medium.com/@jonathanewerner/thoughts-about-package-modularization-d9631f7a41f1). npm itself does not come with built-in tools to manage multi-package projects, and even [npm link](https://docs.npmjs.com/cli/link) can quickly break down if you're trying to run a large test suite with multiple projects across multiple repos.
+
+Luckily, the Babel authors have risen to the occasion and created [Lerna](http://lernajs.com/), which is the tool they use to manage [Babel's numerous sub-packages](https://github.com/babel/babel/tree/f7c6afe594202104b6047ec67b3cbe2987b04aa8/packages). Lerna allows JavaScript library authors to define multiple packages for a single repo, and then link and test them all as one. In other words, it's a tool to manage [monorepos](https://github.com/babel/babel/blob/f7c6afe594202104b6047ec67b3cbe2987b04aa8/doc/design/monorepo.md).
+
+As it turns out, this monorepo strategy is perfect for PouchDB. Logically, we have many small interdependent components (such as the replication module, the map/reduce module, or the IndexedDB adapter), but we prefer to test them all in one large test suite, because often a change in one module can have cascading effects in another module. Breaking everything up into many tiny repos, which would be tested, versioned, and developed independently, is just not practical for us.
+
+Using Lerna, though, we can keep all of PouchDB's codebase in one repo, and still release it as separate packages. There are still some tricky bits – such as how to manage source code versus bundled code, and how to measure code coverage – but in those cases [Rollup](http://rollupjs.org/) remains a great tool to allow us to de-bundle and re-bundle at will. In particular, Rollup allows us to build a "debug" version of PouchDB with many more endpoints exposed, which we then test as a single `index.js` for measuring code coverage. Then, we are still free to ship a "production" version of PouchDB with those endpoints disabled.
+
+With this release, we are also committing to the `jsnext:main` standard [as promoted by Rollup](https://github.com/rollup/rollup/wiki/jsnext:main), meaning that all of our packages (including `pouchdb` itself) now ship with both ES modules and CommonJS, and you are free to use whichever one you want. In general, the ES modules will tend to give you smaller bundle sizes (assuming you are using Rollup, SystemJS, or Webpack 2 as your bundler), whereas the CommonJS bundle is more appropriate for backwards compatibility. (Neither release makes use of ES6 features aside from ES modules, so you do not need a transpiler like Babel or [Bublé](http://buble.surge.sh/)).
+
+### Cool, how does it work?
+
+PouchDB now ships with a few presets, which are a good demonstration of how the new plugin feature works. Here's `pouchdb-browser` (as CommonJS), which is the "browser" version of PouchDB:
+
+```js
+var PouchDB = require('pouchdb-core');
+
+PouchDB.plugin(require('pouchdb-adapter-idb'))
+  .plugin(require('pouchdb-adapter-websql'))
+  .plugin(require('pouchdb-adapter-http'))
+  .plugin(require('pouchdb-mapreduce'))
+  .plugin(require('pouchdb-replication'));
+
+module.exports = PouchDB;
+```
+
+As you can see, `pouchdb-browser` is just an extension of `pouchdb-core`, with some key modules added in: the IndexedDB adapter, the WebSQL adapter, the HTTP adapter, map/reduce, and replication. If you're not using any of these features, you can just delete that plugin and enjoy the file savings.
+
+Additionally, you'll notice that `pouchdb-browser` does not depend on LevelDB at all. Instead, that lives in `pouchdb-node`, a.k.a. the "Node" version of PouchDB:
+
+```js
+var PouchDB = require('pouchdb-core');
+
+PouchDB.plugin(require('pouchdb-adapter-leveldb'))
+  .plugin(require('pouchdb-adapter-http'))
+  .plugin(require('pouchdb-mapreduce'))
+  .plugin(require('pouchdb-replication'));
+
+module.exports = PouchDB;
+```
+
+The only difference here is that `pouchdb-browser` uses IndexedDB and WebSQL, whereas `pouchdb-node` uses LevelDB. Hence, LevelDB is not installed if you do `npm install pouchdb-browser`.
+
+Also, if you'd like to use a custom adapter, those are now shipped separately. So if you want to use PouchDB in a purely in-memory mode, you can do:
+
+```js
+var PouchDB = require('pouchdb-core')
+  .plugin(require('pouchdb-adapter-memory'));
+```
+
+Or if you're only using PouchDB to talk to CouchDB:
+
+```js
+var PouchDB = require('pouchdb-core')
+  .plugin(require('pouchdb-adapter-http'));
+```
+
+This applies to all of the plugins we previously shipped in the ["extras" API](http://pouchdb.com/api.html#extras). Any of these can now be mixed and matched as desired:
+
+* `pouchdb-adapter-fruitdown`
+* `pouchdb-adapter-localstorage`
+* `pouchdb-adapter-memory`
+* `pouchdb-adapter-node-websql`
+
+Note that the plugin order of the non-HTTP adapters matters. So for instance, if you wanted to fall back from IndexedDB to WebSQL to LocalStorage to in-memory, you would do:
+
+```js
+var PouchDB = require('pouchdb-core')
+  .plugin(require('pouchdb-adapter-idb'))
+  .plugin(require('pouchdb-adapter-websql'))
+  .plugin(require('pouchdb-adapter-localstorage'))
+  .plugin(require('pouchdb-adapter-memory'));
+```
+
+This also opens up the possibility of more easily including custom third-party adapters, such
+as [worker-pouch](https://github.com/nolanlawson/worker-pouch) and [socket-pouch](https://github.com/nolanlawson/socket-pouch).
+
+### How many bytes can it save?
+
+Here is a breakdown of the bundle size of various possible PouchDB configurations, using Browserify, [bundle-collapser](https://github.com/substack/bundle-collapser), and Uglify.
+
+<div class="table-responsive">
+<table class="table"><thead>
+<tr>
+<th>Preset</th>
+<th>Browserify + Uglify</th>
+<th>Browserify + Uglify + Gzip</th>
+</tr>
+</thead><tbody>
+<tr>
+<td><code>pouchdb</code></td>
+<td>140.06 kB</td>
+<td>45.15 kB</td>
+</tr>
+<tr>
+<td><code>pouchdb-browser</code></td>
+<td>148.3 kB</td>
+<td>47.54 kB</td>
+</tr>
+<tr>
+<td><code>pouchdb-http</code></td>
+<td>64.29 kB</td>
+<td>21.54 kB</td>
+</tr>
+<tr>
+<td>PouchDB, IndexedDB only</td>
+<td>83.47 kB</td>
+<td>27.79 kB</td>
+</tr>
+<tr>
+<td>PouchDB, WebSQL only</td>
+<td>85.15 kB</td>
+<td>28.16 kB</td>
+</tr>
+<tr>
+<td>PouchDB, replication only</td>
+<td>76.28 kB</td>
+<td>25.26 kB</td>
+</tr>
+<tr>
+<td>PouchDB, in-memory only</td>
+<td>350.74 kB</td>
+<td>100.81 kB</td>
+</tr>
+</tbody></table></div>
+
+Note that `pouchdb-browser` is slightly bigger than `pouchdb`, because `pouchdb`
+is heavily optimized with Rollup before publishing, whereas `pouchdb-browser` is
+not. Also, some optional plugins (like `pouchdb-adapter-memory`) are still quite large. In the future, we may consider using Rollup more aggressively, or trying to reduce the size of `pouchdb-core`. Or we might just wait
+for the ecosystem to switch to tools that do automatic tree-shaking for ES modules,
+such as Rollup or Webpack 2. (If you use such a tool, and it supports `jsnext:main`, then you should already be able to get smaller bundle sizes.)
+
+In the meantime, though, a major benefit of PouchDB unbundling is still in reduced `npm install` times, as well as avoiding compatibility issues with native dependencies like `leveldown` and `sqlite3`.
+
+### Backwards compatibility?
+
+Yes indeed, as suggested by the 5.4.0 release version, this is a fully _backwards-compatible change_. The `pouchdb` module will still act exactly as it did before, including the `dist/` and `extras/` APIs. Essentially, a `npm install pouchdb` will install the kitchen sink. We believe this is the best approach, because it provides a batteries-included experience for beginners, without having to burden them with understanding a vast plugin API.
+
+However, the `extras/` API is deprecated, and will be removed in a later version. Furthermore, the `PouchDB.utils`, `PouchDB.ajax`, and `PouchDB.Errors` APIs, which have been undocumented and unrecommended for years, are now removed. Plugin authors should update their code to use the new sub-packages.
+
+That said, there is an important note about the new sub-packages: all of them are pegged to PouchDB's version number, meaning that when PouchDB cuts a new release, each of the sub-packages will also be released with the same version number. Furthermore, not all of these sub-packages follow [semantic versioning](http://semver.org/), because conceptually they are internal modules, which are only exposed on npm as an implementation detail. The APIs for these packages may change at any time, so you should use exact versioning if you decide to use them directly. These packages will be clearly marked as non-semver in their READMEs.
+
+In the new system, the packages that serve as "plugins" (as well as `pouchdb` itself) are considered user-facing and semver-compliant. In particular, these packages follow semver:
+
+* `pouchdb`
+* `pouchdb-adapter-fruitdown`
+* `pouchdb-adapter-http`
+* `pouchdb-adapter-idb`
+* `pouchdb-adapter-leveldb`
+* `pouchdb-adapter-localstorage`
+* `pouchdb-adapter-memory`
+* `pouchdb-adapter-node-websql`
+* `pouchdb-adapter-websql`
+* `pouchdb-browser`
+* `pouchdb-http`
+* `pouchdb-mapreduce`
+* `pouchdb-node`
+* `pouchdb-replication`
+
+Other modules, such as `pouchdb-ajax`, `pouchdb-checkpointer`, and `pouchdb-promise`, may be freely used, but they make no guarantees as to semver. As we did with the `extras/` API, all of these are used at your own risk.
+
+### Scoped packages?
+
+We considered using [scoped packages](https://www.npmjs.com/private-modules) (e.g. `@pouchdb/foo`) as opposed to prefixed packages (e.g. `pouchdb-foo`) for the new monorepo architecture. In fact, we even asked the community to [vote on the issue](https://github.com/pouchdb/pouchdb/pull/5137), and after one day the vote came down to 25 for scopes and 20 for prefixes.
+
+However, the core PouchDB team ultimately decided that it's too early to hop onto the scoping bandwagon. There are still plenty of thorny issues with scopes, such as the fact that you can't search for them on [npmjs.com](http://npmjs.com), they break some third-party tools like [Sinopia](https://github.com/rlidwka/sinopia/issues/399) and [local-npm](https://github.com/nolanlawson/local-npm/issues/116), and npm organizations are not free for open-source yet. We look forward to these issues being resolved as scoping matures, at which point we may consider moving over to scoped packages.
+
+For the foreseeable future, though, PouchDB's sub-packages will sport names like `pouchdb-browser`, `pouchdb-ajax`, and `pouchdb-replication`. Even if it's a bit old-fashioned, we hope that PouchDB's users will experience fewer surprises and confusion with this more traditional naming convention. And considering the popularity of `ember-*`, `babel-*`, and `react-*` packages, it's safe to say PouchDB is in good company.
+
+### Build-a-bear, build-a-pouch
+
+Since there are dozens of combinations for building your own PouchDB, we encourage the community to mix-and-match, and to publish any presets that they find useful. As of 5.4.0, there are three presets that PouchDB will officially support as first-party packages:
+
+* `pouchdb-browser` – the "browser" version of PouchDB
+* `pouchdb-node` – the "Node" version of PouchDB
+* `pouchdb-http` – PouchDB as an HTTP interface to CouchDB (sans map/reduce)
+
+In the future, we also plan to move some packages that have previously existed in third-party repos (including `pouchdb-server`, `pouchdb-express-router`, and `pouchdb-find`) into the main PouchDB repository, so that they can be tested, versioned, and released at the same time as PouchDB.
+
+So please, try out the new customizable PouchDB, and let us know what you think! And if there are any bugs, there's only one repo you need to worry about, so please direct your bugs to [the PouchDB issues page](http://github.com/pouchdb/pouchdb/issues/). Happy unbundling!
+
+[LevelDOWN]: https://github.com/Level/leveldown
+[SQLitePlugin2]: https://github.com/nolanlawson/cordova-plugin-sqlite-2
+[pouchdb-server]: https://github.com/pouchdb/pouchdb-server/
+[Lodash]: http://lodash.com/
+[Babel]: http://babeljs.io/
+[Ember]: http://emberjs.com/

--- a/docs/custom.md
+++ b/docs/custom.md
@@ -8,11 +8,11 @@ PouchDB supports custom builds, meaning you can pick and choose the features of
 PouchDB that you want to use, potentially resulting in smaller bundle sizes
 and faster build times.
 
-PouchDB exposes its custom builds via separate packages available on `npm`. All of
-these packages follow the format `pouchdb-*` and can be installed using `npm install`.
+PouchDB exposes its custom builds via separate packages available on npm. All of
+these packages follow the format `pouchdb-<name>` and can be installed using `npm install`.
 
-Some packages come included by default in the main `pouchdb` package, whereas 
-others are supported at a first-party level, but must be installed separately in order to be used.
+Some packages are included by default in the main `pouchdb` package, whereas 
+others (including third-party packages) must be installed separately.
 
 {% include alert/start.html variant="warning"%}
 {% markdown %}
@@ -32,22 +32,26 @@ like [Browserify][], [Webpack][], [SystemJS][], [Rollup][], or [JSPM][]. Tools l
 {% endmarkdown %}
 {% include alert/end.html%}
 
-PouchDB packages come in three basic flavors: *presets*, *plugins*, and
+PouchDB packages come in three flavors: *presets*, *plugins*, and
 *utilities*.
 
-Presets constitute a collection of plugins, and they expose a `PouchDB` object that is ready to be used. Plugins are features that can be added using the `PouchDB.plugin()`
-API. Utilities are grab-bags of features, and are only recommended for advanced use cases.
+**Presets** are a collection of plugins, which expose a `PouchDB` object that is ready to be used.
+
+**Plugins** are features that can be added to a `PouchDB` instance using the `PouchDB.plugin()`
+API.
+
+**Utilities** are grab-bags of helper functions, and are only recommended for advanced use cases.
 
 #### Quick links
 
-* [**Presets**](#presets)
-* [**Plugins**](#plugins)
-* [**Utilities**](#utilities)
+* [Presets](#presets)
+* [Plugins](#plugins)
+* [Utilities](#utilities)
 
 {% include anchor.html class="h2" title="Presets" hash="presets" %}
 
 Presets export a `PouchDB` object and contain a built-in set of PouchDB
-plugins.
+plugins. You are free to create your own presets, but PouchDB provides a few first-party presets to address common use cases.
 
 ### pouchdb-browser
 
@@ -154,13 +158,11 @@ PouchDB.plugin(/* attach plugins to make me more interesting! */);
 
 {% include anchor.html class="h2" title="Plugins" hash="plugins" %}
 
-There are two major types of plugins: _adapter plugins_ and _regular plugins_.
+Plugins contain functionality that can be added to a `PouchDB` instance using `PouchDB.plugin()`. There are many [third-party plugins](/external.html), but the ones described below are first-party plugins, which are given the same level of support as PouchDB itself. Some first-party plugins are included in the default `pouchdb` build, whereas others aren't.
 
-Adapter plugins (such as IndexedDB, WebSQL, LevelDB, and HTTP) constitute a
-special class of PouchDB plugins, since they determine the storage format that
+There is also a special type of plugin called an _adapter plugin_.  Adapter plugins (such as IndexedDB, WebSQL, LevelDB, and HTTP) determine the storage format that
 PouchDB uses. For the non-HTTP adapters, the plugin order matters, i.e. if you
-want IndexedDB to be preferred to WebSQL, then you should load it first. (Notice that
-`pouchdb-browser` does exactly this.)
+want IndexedDB to be preferred to WebSQL, then you should load it first. (Notice that `pouchdb-browser` does exactly this.)
 
 ### pouchdb-adapter-idb
 
@@ -176,6 +178,7 @@ npm install pouchdb-adapter-idb
 ```js
 PouchDB.plugin(require('pouchdb-adapter-idb'));
 var db = new PouchDB('mydb', {adapter: 'idb'});
+console.log(db.adapter); // 'idb'
 ```
 
 ### pouchdb-adapter-websql
@@ -192,6 +195,7 @@ npm install pouchdb-adapter-websql
 ```js
 PouchDB.plugin(require('pouchdb-adapter-websql'));
 var db = new PouchDB('mydb', {adapter: 'websql'});
+console.log(db.adapter); // 'websql'
 ```
 
 ### pouchdb-adapter-leveldb
@@ -208,6 +212,7 @@ npm install pouchdb-adapter-leveldb
 ```js
 PouchDB.plugin(require('pouchdb-adapter-leveldb'));
 var db = new PouchDB('mydb', {adapter: 'leveldb'});
+console.log(db.adapter); // 'leveldb'
 ```
 
 ### pouchdb-adapter-http
@@ -228,6 +233,7 @@ npm install pouchdb-adapter-http
 ```js
 PouchDB.plugin(require('pouchdb-adapter-http'));
 var db = new PouchDB('http://127.0.0.1:5984/mydb');
+console.log(db.adapter); // 'http'
 ```
 
 ### pouchdb-adapter-memory
@@ -244,6 +250,7 @@ npm install pouchdb-adapter-memory
 ```js
 PouchDB.plugin(require('pouchdb-adapter-memory'));
 var db = new PouchDB('mydb', {adapter: 'memory'});
+console.log(db.adapter); // 'memory'
 ```
 
 ### pouchdb-adapter-localstorage
@@ -260,6 +267,7 @@ npm install pouchdb-adapter-localstorage
 ```js
 PouchDB.plugin(require('pouchdb-adapter-localstorage'));
 var db = new PouchDB('mydb', {adapter: 'localstorage'});
+console.log(db.adapter); // 'localstorage'
 ```
 
 ### pouchdb-adapter-fruitdown
@@ -276,6 +284,7 @@ npm install pouchdb-adapter-fruitdown
 ```js
 PouchDB.plugin(require('pouchdb-adapter-fruitdown'));
 var db = new PouchDB('mydb', {adapter: 'fruitdown'});
+console.log(db.adapter); // 'fruitdown'
 ```
 
 ### pouchdb-adapter-node-websql
@@ -292,6 +301,7 @@ npm install pouchdb-adapter-node-websql
 ```js
 PouchDB.plugin(require('pouchdb-adapter-node-websql'));
 var db = new PouchDB('mydb', {adapter: 'websql'});
+console.log(db.adapter); // 'websql'
 ```
 
 ### pouchdb-mapreduce
@@ -329,20 +339,20 @@ db.replicate(/* see replicate/sync API docs for full info */);
 {% include anchor.html class="h2" title="Utilities" hash="utilities" %}
 
 These utilities are intended only for advanced users of PouchDB, such as
-third-party plugin authors. Formerly many of them were exposed via the `extras/` API, which
+third-party plugin authors. Formerly, many of them were exposed via the `extras/` API, which
 is now deprecated.
 
-Most of these are internal, and the APIs are not throoughly documented. You will
+Most of these are internal, and the APIs are not thoroughly documented. You will
 most likely need to read the source code to understand how they work.
 
 {% include alert/start.html variant="warning"%}
 {% markdown %}
 
-**Warning: you are entering a semver-free zone.**
+**Warning:** you are entering a semver-free zone.
 
 In contrast to the presets and plugins listed above, **none of the following packages
 follow semver**. Their versions are pinned to PouchDB's, and may change at any time
-without warning. You are strongly recommended to use exact versions when installing these packages.
+without warning. You are strongly recommended to **use exact versions** when installing these packages.
 
 {% endmarkdown %}
 {% include alert/end.html%}


### PR DESCRIPTION
First draft of the blog post describing the new monorepo architecture. I figured it was a big enough change that it deserved its own blog post. The rest of the release notes can still be a separate post.

This also takes a stance on some architectural decisions (prefixes vs scopes, semver, etc.), so this is an opportunity for us to consider these choices and make sure we're going down the right path. I hope I explained my reasoning well enough, but please let me know if you disagree with anything I say.

Also I'm sorry to speak on behalf of the "core PouchDB team;" if anybody feels that their view isn't being properly represented, let me know.

**Edit:** here's a [built version of the page](https://nolanlawson.s3.amazonaws.com/pouchdb/www/20160517/unbundling.htm) so that it's easier on your eyes. 😃 