### PR TITLE
(#5190) - selectively install CouchDB on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,33 +16,15 @@ addons:
   firefox: "41.0.1"
 
 before_install:
-
-  # Install CouchDB Stable
-  - docker run -d -p 3000:5984 klaemo/couchdb:1.6.1
-
-  # Install CouchDB Master
-  - docker run -d -p 3001:5984 klaemo/couchdb:2.0-dev --with-haproxy --with-admin-party-please -n 1
-
   # Because Saucelabs doesnt proxy 5984 on OSX
   - "if [ -z \"$COUCH_HOST\" ]; then export COUCH_HOST=http://127.0.0.1:3000; fi"
 
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-
     # Fail early so we dont run hours of saucelabs if we know there
     # is a lint failure
   - npm run eslint
-
-    # set up CORS
-  - "./node_modules/.bin/add-cors-to-couchdb http://127.0.0.1:3000"
-
-    # Configure CORS against master
-  - curl -X PUT http://127.0.0.1:3001/_node/node1@127.0.0.1/_config/httpd/enable_cors -d '"true"'
-  - curl -X PUT http://127.0.0.1:3001/_node/node1@127.0.0.1/_config/cors/origins -d '"*"'
-  - curl -X PUT http://127.0.0.1:3001/_node/node1@127.0.0.1/_config/cors/credentials -d '"true"'
-  - curl -X PUT http://127.0.0.1:3001/_node/node1@127.0.0.1/_config/cors/methods -d '"GET, PUT, POST, HEAD, DELETE"'
-  - curl -X PUT http://127.0.0.1:3001/_node/node1@127.0.0.1/_config/cors/headers -d '"accept, authorization, content-type, origin, referer, x-csrf-token"'
 
 script: npm run $COMMAND
 

--- a/bin/run-couchdb-on-travis.sh
+++ b/bin/run-couchdb-on-travis.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+if [ $SERVER == 'couchdb-master' ]; then
+  # Install CouchDB Master
+  docker run -d -p 3001:5984 klaemo/couchdb:2.0-dev --with-haproxy \
+    --with-admin-party-please -n 1
+  COUCH_PORT=3001
+else
+  # Install CouchDB Stable
+  docker run -d -p 3000:5984 klaemo/couchdb:1.6.1
+  COUCH_PORT=3000
+fi
+
+# wait for couchdb to start, add cors
+npm install add-cors-to-couchdb
+while [ '200' != $(curl -s -o /dev/null -w %{http_code} http://127.0.0.1:${COUCH_PORT}) ]; do
+  echo waiting for couch to load... ;
+  sleep 1;
+done
+./node_modules/.bin/add-cors-to-couchdb http://127.0.0.1:${COUCH_PORT}

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -52,6 +52,10 @@ if [[ ! -z $SERVER ]]; then
   fi
 fi
 
+if [ ! -z $TRAVIS ]; then
+  source ./bin/run-couchdb-on-travis.sh
+fi
+
 if [ "$CLIENT" == "selenium:phantomjs" ]; then
   npm install phantomjs@2.1.2 # do this on-demand to avoid slow installs
 fi

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "test-webpack": "bash bin/test-webpack.sh"
   },
   "dependencies": {
-    "add-cors-to-couchdb": "0.0.4",
     "argsarray": "0.0.1",
     "body-parser": "1.15.1",
     "browserify": "12.0.2",


### PR DESCRIPTION
Trying to speed up our Travis builds. There's no reason to install _both_ CouchDB 1.6 and CouchDB master; we should selectively install them based on the build settings.