### PR TITLE
(#5192) - improve test coverage

### DIFF
--- a/packages/pouchdb-adapter-fruitdown/package.json
+++ b/packages/pouchdb-adapter-fruitdown/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "js-extend": "1.0.1",
     "fruitdown": "1.0.2",
-    "pouchdb-adapter-leveldb-core": "5.4.0-prerelease",
-    "pouchdb-utils": "5.4.0-prerelease"
+    "pouchdb-adapter-leveldb-core": "5.4.0-prerelease"
   }
 }

--- a/packages/pouchdb-adapter-fruitdown/src/index.js
+++ b/packages/pouchdb-adapter-fruitdown/src/index.js
@@ -1,5 +1,4 @@
 import CoreLevelPouch from 'pouchdb-adapter-leveldb-core';
-import { toPromise } from 'pouchdb-utils';
 import { extend } from 'js-extend';
 
 import fruitdown from 'fruitdown';
@@ -18,17 +17,6 @@ FruitDownPouch.valid = function () {
 };
 FruitDownPouch.use_prefix = true;
 
-FruitDownPouch.destroy = toPromise(function (name, opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-  var _opts = extend({
-    db: fruitdown
-  }, opts);
-
-  return fruitdown.destroy(name, _opts, callback);
-});
 export default function (PouchDB) {
   PouchDB.adapter('fruitdown', FruitDownPouch, true);
 }

--- a/packages/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/pouchdb-adapter-leveldb-core/src/index.js
@@ -150,6 +150,8 @@ function LevelPouch(opts, callback) {
   var revLimit = opts.revs_limit;
   var db;
   var name = opts.name;
+  // TODO: this is undocumented and unused probably
+  /* istanbul ignore else */
   if (typeof opts.createIfMissing === 'undefined') {
     opts.createIfMissing = true;
   }
@@ -177,6 +179,7 @@ function LevelPouch(opts, callback) {
       db = dbStore.get(name);
       db._docCount  = -1;
       db._queue = new Deque();
+      /* istanbul ignore if */
       if (opts.noMigrate || (opts.db && !opts.migrate)) {
         afterDBCreated();
       } else {
@@ -1456,20 +1459,8 @@ function LevelPouch(opts, callback) {
     }
   };
   function callDestroy(name, cb) {
-    /* istanbul ignore else */
-    if (typeof leveldown.destroy === 'function') {
-      leveldown.destroy(name, cb);
-    } else {
-      process.nextTick(cb);
-    }
+    leveldown.destroy(name, cb);
   }
 }
-
-LevelPouch.valid = function () {
-  // this gets overriden by the *down-based browser adapters
-  return true;
-};
-
-LevelPouch.use_prefix = false;
 
 export default LevelPouch;

--- a/packages/pouchdb-adapter-leveldb/package.json
+++ b/packages/pouchdb-adapter-leveldb/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "js-extend": "1.0.1",
     "leveldown": "1.4.6",
-    "pouchdb-adapter-leveldb-core": "5.4.0-prerelease",
-    "pouchdb-utils": "5.4.0-prerelease"
+    "pouchdb-adapter-leveldb-core": "5.4.0-prerelease"
   }
 }

--- a/packages/pouchdb-adapter-leveldb/src/index.js
+++ b/packages/pouchdb-adapter-leveldb/src/index.js
@@ -1,5 +1,4 @@
 import CoreLevelPouch from 'pouchdb-adapter-leveldb-core';
-import { toPromise } from 'pouchdb-utils';
 import { extend } from 'js-extend';
 import requireLeveldown from './requireLeveldown';
 
@@ -26,17 +25,6 @@ LevelDownPouch.valid = function () {
 };
 LevelDownPouch.use_prefix = false;
 
-LevelDownPouch.destroy = toPromise(function (name, opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-  var _opts = extend({
-    db: leveldown
-  }, opts);
-
-  return leveldown.destroy(name, _opts, callback);
-});
 export default function (PouchDB) {
   PouchDB.adapter('leveldb', LevelDownPouch, true);
 }

--- a/packages/pouchdb-adapter-localstorage/package.json
+++ b/packages/pouchdb-adapter-localstorage/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "js-extend": "1.0.1",
     "localstorage-down": "0.6.6",
-    "pouchdb-adapter-leveldb-core": "5.4.0-prerelease",
-    "pouchdb-utils": "5.4.0-prerelease"
+    "pouchdb-adapter-leveldb-core": "5.4.0-prerelease"
   }
 }

--- a/packages/pouchdb-adapter-localstorage/src/index.js
+++ b/packages/pouchdb-adapter-localstorage/src/index.js
@@ -1,5 +1,4 @@
 import CoreLevelPouch from 'pouchdb-adapter-leveldb-core';
-import { toPromise } from 'pouchdb-utils';
 import { extend } from 'js-extend';
 
 import localstoragedown from 'localstorage-down';
@@ -18,17 +17,6 @@ LocalStoragePouch.valid = function () {
 };
 LocalStoragePouch.use_prefix = true;
 
-LocalStoragePouch.destroy = toPromise(function (name, opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-  var _opts = extend({
-    db: localstoragedown
-  }, opts);
-
-  return localstoragedown.destroy(name, _opts, callback);
-});
 export default function (PouchDB) {
   PouchDB.adapter('localstorage', LocalStoragePouch, true);
 }

--- a/packages/pouchdb-adapter-memory/package.json
+++ b/packages/pouchdb-adapter-memory/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "js-extend": "1.0.1",
     "memdown": "1.1.2",
-    "pouchdb-adapter-leveldb-core": "5.4.0-prerelease",
-    "pouchdb-utils": "5.4.0-prerelease"
+    "pouchdb-adapter-leveldb-core": "5.4.0-prerelease"
   }
 }

--- a/packages/pouchdb-adapter-memory/src/index.js
+++ b/packages/pouchdb-adapter-memory/src/index.js
@@ -1,5 +1,4 @@
 import CoreLevelPouch from 'pouchdb-adapter-leveldb-core';
-import { toPromise } from 'pouchdb-utils';
 import { extend } from 'js-extend';
 
 import memdown from 'memdown';
@@ -18,17 +17,6 @@ MemDownPouch.valid = function () {
 };
 MemDownPouch.use_prefix = false;
 
-MemDownPouch.destroy = toPromise(function (name, opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-  var _opts = extend({
-    db: memdown
-  }, opts);
-
-  return memdown.destroy(name, _opts, callback);
-});
 export default function (PouchDB) {
   PouchDB.adapter('memory', MemDownPouch, true);
 }

--- a/packages/pouchdb-ajax/src/ajaxCore.js
+++ b/packages/pouchdb-ajax/src/ajaxCore.js
@@ -51,6 +51,7 @@ function ajaxCore(options, callback) {
       err2.status = err.status;
       return cb(err2);
     }
+    /* istanbul ignore if */
     if (err.message && err.message === 'ETIMEDOUT') {
       return cb(err);
     }

--- a/packages/pouchdb-binary-utils/package.json
+++ b/packages/pouchdb-binary-utils/package.json
@@ -19,6 +19,7 @@
     "./src/arrayBufferToBinaryString.js": "./src/arrayBufferToBinaryString-browser.js",
     "./src/base64.js": "./src/base64-browser.js",
     "./src/base64StringToBlobOrBuffer.js": "./src/base64StringToBlobOrBuffer-browser.js",
+    "./src/blob.js": "./src/blob-browser.js",
     "./src/binaryStringToBlobOrBuffer.js": "./src/binaryStringToBlobOrBuffer-browser.js",
     "./src/blobOrBufferToBase64.js": "./src/blobOrBufferToBase64-browser.js",
     "./src/readAsArrayBuffer.js": "./src/readAsArrayBuffer-browser.js"

--- a/packages/pouchdb-binary-utils/src/blob-browser.js
+++ b/packages/pouchdb-binary-utils/src/blob-browser.js
@@ -1,0 +1,27 @@
+// Abstracts constructing a Blob object, so it also works in older
+// browsers that don't support the native Blob constructor (e.g.
+// old QtWebKit versions, Android < 4.4).
+function createBlob(parts, properties) {
+  /* global BlobBuilder,MSBlobBuilder,MozBlobBuilder,WebKitBlobBuilder */
+  parts = parts || [];
+  properties = properties || {};
+  try {
+    return new Blob(parts, properties);
+  } catch (e) {
+    if (e.name !== "TypeError") {
+      throw e;
+    }
+    var Builder = typeof BlobBuilder !== 'undefined' ? BlobBuilder :
+                  typeof MSBlobBuilder !== 'undefined' ? MSBlobBuilder :
+                  typeof MozBlobBuilder !== 'undefined' ? MozBlobBuilder :
+                  WebKitBlobBuilder;
+    var builder = new Builder();
+    for (var i = 0; i < parts.length; i += 1) {
+      builder.append(parts[i]);
+    }
+    return builder.getBlob(properties.type);
+  }
+}
+
+export default createBlob;
+

--- a/packages/pouchdb-binary-utils/src/blob.js
+++ b/packages/pouchdb-binary-utils/src/blob.js
@@ -1,27 +1,6 @@
-// Abstracts constructing a Blob object, so it also works in older
-// browsers that don't support the native Blob constructor (e.g.
-// old QtWebKit versions, Android < 4.4).
-function createBlob(parts, properties) {
-  /* global BlobBuilder,MSBlobBuilder,MozBlobBuilder,WebKitBlobBuilder */
-  parts = parts || [];
-  properties = properties || {};
-  try {
-    return new Blob(parts, properties);
-  } catch (e) {
-    if (e.name !== "TypeError") {
-      throw e;
-    }
-    var Builder = typeof BlobBuilder !== 'undefined' ? BlobBuilder :
-                  typeof MSBlobBuilder !== 'undefined' ? MSBlobBuilder :
-                  typeof MozBlobBuilder !== 'undefined' ? MozBlobBuilder :
-                  WebKitBlobBuilder;
-    var builder = new Builder();
-    for (var i = 0; i < parts.length; i += 1) {
-      builder.append(parts[i]);
-    }
-    return builder.getBlob(properties.type);
-  }
+// This function is unused in Node
+/* istanbul ignore next */
+function createBlob() {
 }
 
 export default createBlob;
-

--- a/packages/pouchdb-checkpointer/src/index.js
+++ b/packages/pouchdb-checkpointer/src/index.js
@@ -177,13 +177,11 @@ function compareReplicationLogs(srcDoc, tgtDoc) {
   if (srcDoc.session_id === tgtDoc.session_id) {
     return {
       last_seq: srcDoc.last_seq,
-      history: srcDoc.history || []
+      history: srcDoc.history
     };
   }
 
-  var sourceHistory = srcDoc.history || [];
-  var targetHistory = tgtDoc.history || [];
-  return compareReplicationHistory(sourceHistory, targetHistory);
+  return compareReplicationHistory(srcDoc.history, tgtDoc.history);
 }
 
 function compareReplicationHistory(sourceHistory, targetHistory) {

--- a/packages/pouchdb-replication/src/getDocs.js
+++ b/packages/pouchdb-replication/src/getDocs.js
@@ -35,6 +35,7 @@ function getDocAttachmentsFromTargetOrSource(target, src, doc) {
       return target.getAttachment(localDoc._id, filename);
     }));
   }).catch(function (error) {
+    /* istanbul ignore if */
     if (error.status !== 404) {
       throw error;
     }

--- a/packages/pouchdb-utils/src/bulkGetShim.js
+++ b/packages/pouchdb-utils/src/bulkGetShim.js
@@ -2,7 +2,7 @@ import pick from './pick';
 
 // shim for P/CouchDB adapters that don't directly implement _bulk_get
 function bulkGet(db, opts, callback) {
-  var requests = Array.isArray(opts) ? opts : opts.docs;
+  var requests = opts.docs;
 
   // consolidate into one request per doc if possible
   var requestsById = {};
@@ -83,7 +83,14 @@ function bulkGet(db, opts, callback) {
       }
     });
     db.get(docId, docOpts, function (err, res) {
-      gotResult(i, docId, err ? [{error: err}] : formatResult(res));
+      var result;
+      /* istanbul ignore if */
+      if (err) {
+        result = [{error: err}];
+      } else {
+        result = formatResult(res);
+      }
+      gotResult(i, docId, result);
     });
   });
 }

--- a/tests/integration/test.sync.js
+++ b/tests/integration/test.sync.js
@@ -332,11 +332,11 @@ adapters.forEach(function (adapters) {
       replications.cancel();
     });
 
-    it.skip('Test sync cancel called twice', function (done) {
+    it('Test sync cancel called twice', function (done) {
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
       var replications = db.sync(remote).on('complete', function () {
-        setTimeout(done); // let cancel() get called twice before finishing
+        done();
       });
       should.exist(replications);
       replications.cancel();


### PR DESCRIPTION
We regressed a bit on coverage (99.5%) with the monorepo stuff, mostly due to
me mistakenly including some non-Node stuff in with the Node build. This fixes
that, and also adds some `istanbul ignore`s where it makes sense.