### PR TITLE
(#5157) - avoid launching more requests than browser can perform

### DIFF
--- a/packages/pouchdb-utils/src/bulkGetShim.js
+++ b/packages/pouchdb-utils/src/bulkGetShim.js
@@ -1,5 +1,20 @@
 import pick from './pick';
 
+// Most browsers throttle concurrent requests at 6, so it's silly
+// to shim _bulk_get by trying to launch potentially hundreds of requests
+// and then letting the majority time out. We can handle this ourselves.
+var MAX_NUM_CONCURRENT_REQUESTS = 6;
+
+function identityFunction(x) {
+  return x;
+}
+
+function formatResultForOpenRevsGet(result) {
+  return [{
+    ok: result
+  }];
+}
+
 // shim for P/CouchDB adapters that don't directly implement _bulk_get
 function bulkGet(db, opts, callback) {
   var requests = Array.isArray(opts) ? opts : opts.docs;
@@ -18,7 +33,7 @@ function bulkGet(db, opts, callback) {
   var numDone = 0;
   var perDocResults = new Array(numDocs);
 
-  function collapseResults() {
+  function collapseResultsAndFinish() {
     var results = [];
     perDocResults.forEach(function (res) {
       res.docs.forEach(function (info) {
@@ -33,59 +48,83 @@ function bulkGet(db, opts, callback) {
 
   function checkDone() {
     if (++numDone === numDocs) {
-      collapseResults();
+      collapseResultsAndFinish();
     }
   }
 
-  function gotResult(i, id, docs) {
-    perDocResults[i] = {id: id, docs: docs};
+  function gotResult(docIndex, id, docs) {
+    perDocResults[docIndex] = {id: id, docs: docs};
     checkDone();
   }
 
-  Object.keys(requestsById).forEach(function (docId, i) {
+  var allRequests = Object.keys(requestsById);
 
-    var docRequests = requestsById[docId];
+  var i = 0;
 
-    // just use the first request as the "template"
-    // TODO: The _bulk_get API allows for more subtle use cases than this,
-    // but for now it is unlikely that there will be a mix of different
-    // "atts_since" or "attachments" in the same request, since it's just
-    // replicate.js that is using this for the moment.
-    // Also, atts_since is aspirational, since we don't support it yet.
-    var docOpts = pick(docRequests[0], ['atts_since', 'attachments']);
-    docOpts.open_revs = docRequests.map(function (request) {
-      // rev is optional, open_revs disallowed
-      return request.rev;
-    });
+  function nextBatch() {
 
-    // remove falsey / undefined revisions
-    docOpts.open_revs = docOpts.open_revs.filter(function (e) { return e; });
-
-    var formatResult = function (result) { return result; };
-
-    if (docOpts.open_revs.length === 0) {
-      delete docOpts.open_revs;
-
-      // when fetching only the "winning" leaf,
-      // transform the result so it looks like an open_revs
-      // request
-      formatResult = function (result) {
-        return [{
-          ok: result
-        }];
-      };
+    if (i >= allRequests.length) {
+      return;
     }
 
-    // globally-supplied options
-    ['revs', 'attachments', 'binary', 'ajax'].forEach(function (param) {
-      if (param in opts) {
-        docOpts[param] = opts[param];
+    var upTo = Math.min(i + MAX_NUM_CONCURRENT_REQUESTS, allRequests.length);
+    var batch = allRequests.slice(i, upTo);
+    processBatch(batch, i);
+    i += batch.length;
+  }
+
+  function processBatch(batch, offset) {
+    batch.forEach(function (docId, j) {
+      var docIdx = offset + j;
+      var docRequests = requestsById[docId];
+
+      // just use the first request as the "template"
+      // TODO: The _bulk_get API allows for more subtle use cases than this,
+      // but for now it is unlikely that there will be a mix of different
+      // "atts_since" or "attachments" in the same request, since it's just
+      // replicate.js that is using this for the moment.
+      // Also, atts_since is aspirational, since we don't support it yet.
+      var docOpts = pick(docRequests[0], ['atts_since', 'attachments']);
+      docOpts.open_revs = docRequests.map(function (request) {
+        // rev is optional, open_revs disallowed
+        return request.rev;
+      });
+
+      // remove falsey / undefined revisions
+      docOpts.open_revs = docOpts.open_revs.filter(identityFunction);
+
+      var formatResult = identityFunction;
+
+      if (docOpts.open_revs.length === 0) {
+        delete docOpts.open_revs;
+
+        // when fetching only the "winning" leaf,
+        // transform the result so it looks like an open_revs
+        // request
+        formatResult = formatResultForOpenRevsGet;
       }
+
+      // globally-supplied options
+      ['revs', 'attachments', 'binary', 'ajax'].forEach(function (param) {
+        if (param in opts) {
+          docOpts[param] = opts[param];
+        }
+      });
+      db.get(docId, docOpts, function (err, res) {
+        var result;
+        /* istanbul ignore if */
+        if (err) {
+          result = [{error: err}];
+        } else {
+          result = formatResult(res);
+        }
+        gotResult(docIdx, docId, result);
+        nextBatch();
+      });
     });
-    db.get(docId, docOpts, function (err, res) {
-      gotResult(i, docId, err ? [{error: err}] : formatResult(res));
-    });
-  });
+  }
+
+  nextBatch();
 }
 
 export default bulkGet;


### PR DESCRIPTION
The test succeeds before the fix and also succeeds after. This is a performance improvement, but one that I think it would be difficult to measure since you'd need a remote server that took a long time to respond and therefore caused the browser to cancel the request. In any case, it feels like a pretty obvious fix to throttle our open requests based on what the browser can actually handle. See https://github.com/pouchdb/pouchdb/pull/5157#issuecomment-220810820 for my reasoning behind this.