### PR TITLE
(#5203) - fix rebuild before `npm t`

### DIFF
--- a/bin/build-node.sh
+++ b/bin/build-node.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 # don't bother doing this in travis because it's already been built
-if [ ! -z $TRAVIS ]; then
+if [ -z $TRAVIS ]; then
   BUILD_NODE=1 npm run build-modules
 fi


### PR DESCRIPTION
Dumb mistake, I did `! -z` when I meant to do `-z`. This should also speed up our Travis builds, since it skips an unnecessary extra build.