### PR TITLE
(#5206) - fix Buffer being included in bundle

### DIFF
--- a/packages/pouchdb-binary-utils/package.json
+++ b/packages/pouchdb-binary-utils/package.json
@@ -22,6 +22,7 @@
     "./src/blob.js": "./src/blob-browser.js",
     "./src/binaryStringToBlobOrBuffer.js": "./src/binaryStringToBlobOrBuffer-browser.js",
     "./src/blobOrBufferToBase64.js": "./src/blobOrBufferToBase64-browser.js",
-    "./src/readAsArrayBuffer.js": "./src/readAsArrayBuffer-browser.js"
+    "./src/readAsArrayBuffer.js": "./src/readAsArrayBuffer-browser.js",
+    "./src/typedBuffer.js": "./src/typedBuffer-browser.js"
   }
 }

--- a/packages/pouchdb-binary-utils/src/typedBuffer-browser.js
+++ b/packages/pouchdb-binary-utils/src/typedBuffer-browser.js
@@ -1,0 +1,5 @@
+// this is not used in the browser
+function typedBuffer() {
+}
+
+export default typedBuffer;


### PR DESCRIPTION
This removes about 5kB from the bundle. It was a regression with the monorepo changes, now fixed.