### PR TITLE
(#5207) - Add info to internal _getAttachment API

### DIFF
--- a/packages/pouchdb-adapter-indexeddb/src/index.js
+++ b/packages/pouchdb-adapter-indexeddb/src/index.js
@@ -357,7 +357,7 @@ function init(api, opts, callback) {
     };
   };
 
-  api._getAttachment = function (attachment, opts, callback) {
+  api._getAttachment = function (docId, attachId, attachment, opts, callback) {
     var txn;
     if (opts.ctx) {
       txn = opts.ctx;

--- a/packages/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/pouchdb-adapter-leveldb-core/src/index.js
@@ -395,7 +395,7 @@ function LevelPouch(opts, callback) {
 
   // not technically part of the spec, but if putAttachment has its own
   // method...
-  api._getAttachment = function (attachment, opts, callback) {
+  api._getAttachment = function (docId, attachId, attachment, opts, callback) {
     var digest = attachment.digest;
     var type = attachment.content_type;
 

--- a/packages/pouchdb-adapter-websql-core/src/index.js
+++ b/packages/pouchdb-adapter-websql-core/src/index.js
@@ -71,7 +71,7 @@ function fetchAttachmentsIfNecessary(doc, opts, api, txn, cb) {
   function fetchAttachment(doc, att) {
     var attObj = doc._attachments[att];
     var attOpts = {binary: opts.binary, ctx: txn};
-    api._getAttachment(attObj, attOpts, function (_, data) {
+    api._getAttachment(doc._id, att, attObj, attOpts, function (_, data) {
       doc._attachments[att] = extend(
         pick(attObj, ['digest', 'content_type']),
         { data: data }
@@ -850,7 +850,7 @@ function WebSqlPouch(opts, callback) {
     callback();
   };
 
-  api._getAttachment = function (attachment, opts, callback) {
+  api._getAttachment = function (docId, attachId, attachment, opts, callback) {
     var res;
     var tx = opts.ctx;
     var digest = attachment.digest;


### PR DESCRIPTION
The current _getAttachment` API doesnt provide enough information to get the attachment unless you have attachments keyed by digest alone, idb-next needs the revisions and document id data to be able to pick them up, this shouldnt impact anything as its internal only