### PR TITLE
(#5215) - move parseHex to websql, code cleanup

### DIFF
--- a/packages/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/pouchdb-adapter-leveldb-core/src/index.js
@@ -4,7 +4,7 @@ import { obj as through } from 'through2';
 import getArguments from 'argsarray';
 import { Map, Set } from 'pouchdb-collections';
 import migrate from './migrate';
-import Deque from "double-ended-queue";
+import Deque from 'double-ended-queue';
 import Promise from 'pouchdb-promise';
 import {
   clone,

--- a/packages/pouchdb-adapter-leveldb-core/src/migrate.js
+++ b/packages/pouchdb-adapter-leveldb-core/src/migrate.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { isLocalId, winningRev } from 'pouchdb-utils';
 import levelup from 'levelup';
 import { obj as through } from 'through2';
-import LevelWriteStream from "level-write-stream";
+import LevelWriteStream from 'level-write-stream';
 
 var stores = [
   'document-store',

--- a/packages/pouchdb-adapter-websql-core/src/index.js
+++ b/packages/pouchdb-adapter-websql-core/src/index.js
@@ -6,7 +6,6 @@ import {
   filterChange,
   isDeleted,
   isLocalId,
-  parseHexString,
   hasLocalStorage,
   collectConflicts,
   traverseRevTree,
@@ -22,6 +21,7 @@ import {
   btoa
 } from 'pouchdb-binary-utils';
 
+import parseHexString from './parseHex';
 import websqlBulkDocs from './bulkDocs';
 
 import {

--- a/packages/pouchdb-adapter-websql-core/src/parseHex.js
+++ b/packages/pouchdb-adapter-websql-core/src/parseHex.js
@@ -10,7 +10,7 @@
 //
 
 function decodeUtf8(str) {
-  return decodeURIComponent(window.escape(str));
+  return decodeURIComponent(escape(str));
 }
 
 function hexToInt(charCode) {

--- a/packages/pouchdb-core/src/setup.js
+++ b/packages/pouchdb-core/src/setup.js
@@ -1,6 +1,6 @@
 import { extend } from 'js-extend';
 
-import PouchDB from "./constructor";
+import PouchDB from './constructor';
 import inherits from 'inherits';
 import { Map } from 'pouchdb-collections';
 import { EventEmitter as EE } from 'events';

--- a/packages/pouchdb-json/src/index.js
+++ b/packages/pouchdb-json/src/index.js
@@ -1,5 +1,5 @@
-import safeJsonParse from './safeJsonParse.js';
-import safeJsonStringify from './safeJsonStringify.js';
+import safeJsonParse from './safeJsonParse';
+import safeJsonStringify from './safeJsonStringify';
 
 export {
   safeJsonParse,

--- a/packages/pouchdb-utils/src/index.js
+++ b/packages/pouchdb-utils/src/index.js
@@ -1,37 +1,36 @@
-import adapterFun from './adapterFun.js';
-import bulkGetShim from './bulkGetShim.js';
-import clone from './clone.js';
+import adapterFun from './adapterFun';
+import bulkGetShim from './bulkGetShim';
+import clone from './clone';
 import explainError from './explainError';
-import isDeleted from './docs/isDeleted.js';
-import isLocalId from './docs/isLocalId.js';
-import normalizeDdocFunctionName from './docs/normalizeDdocFunctionName.js';
-import parseDdocFunctionName from './docs/parseDdocFunctionName.js';
-import { parseDoc, invalidIdError} from './docs/parseDoc.js';
-import preprocessAttachments from './docs/preprocessAttachments.js';
-import processDocs from './docs/processDocs.js';
-import updateDoc from './docs/updateDoc.js';
-import hasLocalStorage from './env/hasLocalStorage.js';
-import isChromeApp from './env/isChromeApp.js';
-import extend from './extend.js';
-import filterChange from './filterChange.js';
-import flatten from './flatten.js';
-import functionName from './functionName.js';
-import isCordova from './isCordova.js';
-import collectConflicts from './merge/collectConflicts.js';
-import collectLeaves from './merge/collectLeaves.js';
-import compactTree from './merge/compactTree.js';
-import merge from './merge/index.js';
-import revExists from './merge/revExists.js';
-import rootToLeaf from './merge/rootToLeaf.js';
-import traverseRevTree from './merge/traverseRevTree.js';
-import winningRev from './merge/winningRev.js';
-import once from './once.js';
-import parseHexString from './parseHex.js';
-import parseUri from './parseUri.js';
-import pick from './pick.js';
-import toPromise from './toPromise.js';
-import upsert from './upsert.js';
-import uuid from './uuid.js';
+import isDeleted from './docs/isDeleted';
+import isLocalId from './docs/isLocalId';
+import normalizeDdocFunctionName from './docs/normalizeDdocFunctionName';
+import parseDdocFunctionName from './docs/parseDdocFunctionName';
+import { parseDoc, invalidIdError} from './docs/parseDoc';
+import preprocessAttachments from './docs/preprocessAttachments';
+import processDocs from './docs/processDocs';
+import updateDoc from './docs/updateDoc';
+import hasLocalStorage from './env/hasLocalStorage';
+import isChromeApp from './env/isChromeApp';
+import extend from './extend';
+import filterChange from './filterChange';
+import flatten from './flatten';
+import functionName from './functionName';
+import isCordova from './isCordova';
+import collectConflicts from './merge/collectConflicts';
+import collectLeaves from './merge/collectLeaves';
+import compactTree from './merge/compactTree';
+import merge from './merge/index';
+import revExists from './merge/revExists';
+import rootToLeaf from './merge/rootToLeaf';
+import traverseRevTree from './merge/traverseRevTree';
+import winningRev from './merge/winningRev';
+import once from './once';
+import parseUri from './parseUri';
+import pick from './pick';
+import toPromise from './toPromise';
+import upsert from './upsert';
+import uuid from './uuid';
 import changesHandler from './changesHandler';
 import defaultBackOff from './defaultBackOff';
 
@@ -60,7 +59,6 @@ export {
   once,
   parseDdocFunctionName,
   parseDoc,
-  parseHexString,
   parseUri,
   pick,
   preprocessAttachments,


### PR DESCRIPTION
Really minor change - `parseHex()` is only used by websql, so no need
to have it in `pouchdb-utils` where it'll be just one more unused variable
in CJS-based builds using `pouchdb-utils` but not `pouchdb-adapter-websql`.

I also went ahead and removed `.js` from every import, since it's unnecessary, and made sure all imports are using single quotes and not double quotes.