### PR TITLE
(#5219) - fix "unary operator expected"

### DIFF
--- a/bin/run-couchdb-on-travis.sh
+++ b/bin/run-couchdb-on-travis.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ $SERVER == 'couchdb-master' ]; then
+if [ "$SERVER" = "couchdb-master" ]; then
   # Install CouchDB Master
   docker run -d -p 3001:5984 klaemo/couchdb:2.0-dev --with-haproxy \
     --with-admin-party-please -n 1


### PR DESCRIPTION
Made a mistake in this bash script. I'm putting `[skip ci]` on this
because it was failing anyway due to the fact that this would only affect
the couchdb-master tests.