### PR TITLE
(#4922) - Do not call 'destroyed' twice for http instances

### DIFF
--- a/packages/pouchdb-adapter-http/src/index.js
+++ b/packages/pouchdb-adapter-http/src/index.js
@@ -967,8 +967,6 @@ function HttpPouch(opts, callback) {
       if (err && err.status && err.status !== 404) {
         return callback(err);
       }
-      api.emit('destroyed');
-      api.constructor.emit('destroyed', opts.name);
       callback(null, resp);
     });
   };

--- a/tests/integration/test.events.js
+++ b/tests/integration/test.events.js
@@ -109,5 +109,21 @@ adapters.forEach(function (adapter) {
       }
     });
 
+    it('4922 Destroyed is not called twice', function (done) {
+      var count = 0;
+      function destroyed() {
+        count++;
+        if (count === 1) {
+          setTimeout(function () {
+            count.should.equal(1);
+            PouchDB.removeListener('destroyed', destroyed);
+            done();
+          }, 50);
+        }
+      }
+      PouchDB.on('destroyed', destroyed);
+      new PouchDB(dbs.name).destroy();
+    });
+
   });
 });


### PR DESCRIPTION
At some point (probably prior to mapreduce / dependentDb's) the http adapter was wholly responsible for its own `destroy` so it emitted its own `destroyed` events, then we switched it to use adapters.js's `destroy` which also fires the events and didnt remove the old versions