### PR TITLE
(#5238) - Fix unhandled rejection in changes

### DIFF
--- a/packages/pouchdb-core/src/changes.js
+++ b/packages/pouchdb-core/src/changes.js
@@ -2,6 +2,7 @@ import Promise from 'pouchdb-promise';
 import getArguments from 'argsarray';
 import {
   clone,
+  listenerCount,
   once,
   parseDdocFunctionName,
   normalizeDdocFunctionName
@@ -32,7 +33,9 @@ function Changes(db, opts, callback) {
   opts = opts ? clone(opts) : {};
   var complete = opts.complete = once(function (err, resp) {
     if (err) {
-      self.emit('error', err);
+      if (listenerCount(self, 'error') > 0) {
+        self.emit('error', err);
+      }
     } else {
       self.emit('complete', resp);
     }

--- a/packages/pouchdb-utils/src/index.js
+++ b/packages/pouchdb-utils/src/index.js
@@ -12,6 +12,7 @@ import hasLocalStorage from './env/hasLocalStorage';
 import invalidIdError from './invalidIdError';
 import isChromeApp from './env/isChromeApp';
 import isCordova from './isCordova';
+import listenerCount from './listenerCount';
 import normalizeDdocFunctionName from './normalizeDdocFunctionName';
 import once from './once';
 import parseDdocFunctionName from './parseDdocFunctionName';
@@ -36,6 +37,7 @@ export {
   invalidIdError,
   isChromeApp,
   isCordova,
+  listenerCount,
   normalizeDdocFunctionName,
   once,
   parseDdocFunctionName,

--- a/packages/pouchdb-utils/src/listenerCount.js
+++ b/packages/pouchdb-utils/src/listenerCount.js
@@ -1,0 +1,8 @@
+import { EventEmitter as EE } from 'events';
+
+function listenerCount(ee, type) {
+  return 'listenerCount' in ee ? ee.listenerCount(type) :
+                                 EE.listenerCount(ee, type);
+}
+
+export default listenerCount;

--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -465,7 +465,16 @@ adapters.forEach(function (adapter) {
       });
     });
 
-    it('3356 throw inside a filter', function (done) {
+    it.only('3356 throw inside a filter', function (done) {
+      var testFor5238 = function (err) {
+        done('There was an unhandledRejection ' + err);
+      };
+      testUtils.addGlobalEventListener(
+        testUtils.getUnHandledRejectionEventName(), testFor5238);
+      after(function () {
+        testUtils.removeGlobalEventListener(
+          testUtils.getUnHandledRejectionEventName(), testFor5238);
+      });
       var db = new PouchDB(dbs.name);
       db.put({
         _id: "_design/test",

--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -465,16 +465,11 @@ adapters.forEach(function (adapter) {
       });
     });
 
-    it.only('3356 throw inside a filter', function (done) {
+    it('3356 throw inside a filter', function (done) {
       var testFor5238 = function (err) {
         done('There was an unhandledRejection ' + err);
       };
-      testUtils.addGlobalEventListener(
-        testUtils.getUnHandledRejectionEventName(), testFor5238);
-      after(function () {
-        testUtils.removeGlobalEventListener(
-          testUtils.getUnHandledRejectionEventName(), testFor5238);
-      });
+      testUtils.addUnhandledRejectionListener(testFor5238);
       var db = new PouchDB(dbs.name);
       db.put({
         _id: "_design/test",
@@ -483,12 +478,16 @@ adapters.forEach(function (adapter) {
             throw new Error(); // syntaxerrors can't be caught either.
           }.toString()
         }
+      }).should.eventually.be.fulfilled.then(function () {
+        return db.changes({filter: 'test/test'}).should.eventually.be.rejected;
       }).then(function () {
-        db.changes({filter: 'test/test'}).then(function () {
-          done('should have thrown');
-        }).catch(function () {
-          done();
-        });
+        done();
+      }).catch(function (err) {
+        done('We had an error - ' + err);
+      }).then(function () {
+        setTimeout(function () {
+          testUtils.removeUnhandledRejectionListener(testFor5238);
+        }, 1);
       });
     });
 

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -284,7 +284,7 @@ testUtils.makeBlob = function (data, type) {
 testUtils.getUnHandledRejectionEventName = function () {
   return typeof window !== 'undefined' ? 'unhandledrejection' :
     'unhandledRejection';
-}
+};
 
 testUtils.addGlobalEventListener = function (eventName, listener) {
   // The window test has to go first because the process test will pass
@@ -300,6 +300,11 @@ testUtils.addGlobalEventListener = function (eventName, listener) {
   return null;
 };
 
+testUtils.addUnhandledRejectionListener = function (listener) {
+  return testUtils.addGlobalEventListener(
+    testUtils.getUnHandledRejectionEventName(), listener);
+};
+
 testUtils.removeGlobalEventListener = function (eventName, listener) {
   if (typeof process !== 'undefined') {
     return process.removeListener(eventName, listener);
@@ -310,6 +315,11 @@ testUtils.removeGlobalEventListener = function (eventName, listener) {
   }
 
   return null;
+};
+
+testUtils.removeUnhandledRejectionListener = function (listener) {
+  return testUtils.removeGlobalEventListener(
+    testUtils.getUnHandledRejectionEventName(), listener);
 };
 
 if (typeof process !== 'undefined' && !process.browser) {

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -281,6 +281,37 @@ testUtils.makeBlob = function (data, type) {
   }
 };
 
+testUtils.getUnHandledRejectionEventName = function () {
+  return typeof window !== 'undefined' ? 'unhandledrejection' :
+    'unhandledRejection';
+}
+
+testUtils.addGlobalEventListener = function (eventName, listener) {
+  // The window test has to go first because the process test will pass
+  // in the browser's test environment
+  if (typeof window !== 'undefined' && window.addEventListener) {
+    return window.addEventListener(eventName, listener);
+  }
+
+  if (typeof process !== 'undefined') {
+    return process.on(eventName, listener);
+  }
+
+  return null;
+};
+
+testUtils.removeGlobalEventListener = function (eventName, listener) {
+  if (typeof process !== 'undefined') {
+    return process.removeListener(eventName, listener);
+  }
+
+  if (typeof window !== 'undefined' && window.removeEventListener) {
+    return window.removeEventListener(eventName, listener);
+  }
+
+  return null;
+};
+
 if (typeof process !== 'undefined' && !process.browser) {
   if (process.env.COVERAGE) {
     global.PouchDB = require('../../packages/pouchdb-for-coverage');


### PR DESCRIPTION
changes - Checks to make sure someone is listening for the error event
before emitting it. See #5238 for details.

index - Registering listenerCount

listenerCount - Supports both the modern and legacy versions of
  listenerCount

test.changes.js - This test will fail if there is an unhandled rejection
so we use it to test that the fix worked.

utils - Enables adding/removing events on the either the process or
windows object depending on environment. And dealing with the fact
that the unhandledRejection event is spelled differently in node vs
the browser. Note that this is a NOOP in Firefox but works in Chrome. This
just means if there is a bug in Firefox it won't be caught.