### PR TITLE
(#5260) Catches unhandled rejections in tests

### DIFF
--- a/tests/integration/index.html
+++ b/tests/integration/index.html
@@ -24,6 +24,7 @@
     <script src='deps/pouchdb-3.2.0-postfixed.js'></script>
     <script src='deps/pouchdb-3.6.0-postfixed.js'></script>
     <script src='utils-bundle.js'></script>
+    <script src='test.setup_global_hooks.js'></script>
     <script src='test.ajax.js'></script>
     <script src='test.aa.setup.js'></script>
     <script src='test.basics.js'></script>

--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -466,10 +466,6 @@ adapters.forEach(function (adapter) {
     });
 
     it('3356 throw inside a filter', function (done) {
-      var testFor5238 = function (err) {
-        done('There was an unhandledRejection ' + err);
-      };
-      testUtils.addUnhandledRejectionListener(testFor5238);
       var db = new PouchDB(dbs.name);
       db.put({
         _id: "_design/test",
@@ -484,10 +480,6 @@ adapters.forEach(function (adapter) {
         done();
       }).catch(function (err) {
         done('We had an error - ' + err);
-      }).then(function () {
-        setTimeout(function () {
-          testUtils.removeUnhandledRejectionListener(testFor5238);
-        }, 1);
       });
     });
 

--- a/tests/integration/test.setup_global_hooks.js
+++ b/tests/integration/test.setup_global_hooks.js
@@ -1,0 +1,18 @@
+"use strict";
+
+var currentListener = null;
+var currentError = null;
+
+beforeEach(function (done) {
+  currentError = null;
+  currentListener = function (error) {
+    currentError = error;
+  };
+  testUtils.addUnhandledRejectionListener(currentListener);
+  done();
+});
+
+afterEach(function (done) {
+  testUtils.removeUnhandledRejectionListener(currentListener);
+  done(currentError);
+});


### PR DESCRIPTION
#5260 - Adds a new 'test' called test.setup_global_hooks which uses Mocha's
beforeEach and afterEach hooks to set up a listener, both in node and in
browsers like Chrome that support unhandledrejection, to catch any
unhandled Promise rejections and cause the test run to fail.