### PR TITLE
(#4575) use unique database names in tests

### DIFF
--- a/tests/fuzzy/test.fuzzy.js
+++ b/tests/fuzzy/test.fuzzy.js
@@ -112,7 +112,7 @@ describe('chaos-monkey', function () {
   beforeEach(function (done) {
     Promise = testUtils.Promise;
     var aname = testUtils.adapterUrl('local', 'testdb');
-    var bname = testUtils.adapterUrl('http', 'test_repl_remote');
+    var bname = testUtils.adapterUrl('http', 'test_repl_remote' + (new Date()).getTime());
     testUtils.cleanup([aname, bname], function () {
       a = new PouchDB(aname);
       b = new PouchDB(bname);

--- a/tests/integration/browser.info.js
+++ b/tests/integration/browser.info.js
@@ -8,7 +8,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime());
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/integration/browser.worker.js
+++ b/tests/integration/browser.worker.js
@@ -45,8 +45,8 @@ function runTests() {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl('local', 'testdb');
-      dbs.remote = testUtils.adapterUrl('http', 'test_repl_remote');
+      dbs.name = testUtils.adapterUrl('local', 'testdb' + (new Date()).getTime());
+      dbs.remote = testUtils.adapterUrl('http', 'test_repl_remote' + (new Date()).getTime());
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });
 

--- a/tests/integration/test.all_docs.js
+++ b/tests/integration/test.all_docs.js
@@ -7,7 +7,7 @@ adapters.forEach(function (adapter) {
 
     var dbs = {};
     beforeEach(function (done) {
-      dbs = {name: testUtils.adapterUrl(adapter, 'testdb')};
+      dbs = {name: testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime())};
       testUtils.cleanup([dbs.name], done);
     });
 
@@ -28,7 +28,7 @@ adapters.forEach(function (adapter) {
       testUtils.writeDocs(db, JSON.parse(JSON.stringify(origDocs)),
         function () {
         db.allDocs(function (err, result) {
-          should.not.exist(err);
+          should.not.exist(err, err);
           var rows = result.rows;
           result.total_rows.should.equal(4, 'correct number of results');
           for (var i = 0; i < rows.length; i++) {

--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -33,7 +33,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime());
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -7,9 +7,10 @@ adapters.forEach(function (adapter) {
   describe('test.basics.js-' + adapter, function () {
 
     var dbs = {};
+    var db_name = 'testdb' + (new Date()).getTime();
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
+      dbs.name = testUtils.adapterUrl(adapter, db_name);
       testUtils.cleanup([dbs.name], done);
     });
 
@@ -845,7 +846,7 @@ adapters.forEach(function (adapter) {
     it('db.info should give correct name', function (done) {
       var db = new PouchDB(dbs.name);
       db.info().then(function (info) {
-        info.db_name.should.equal('testdb');
+        info.db_name.should.equal(db_name);
         done();
       });
     });

--- a/tests/integration/test.bulk_docs.js
+++ b/tests/integration/test.bulk_docs.js
@@ -26,7 +26,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime());
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/integration/test.bulk_get.js
+++ b/tests/integration/test.bulk_get.js
@@ -7,7 +7,7 @@ adapters.forEach(function (adapter) {
 
     var dbs = {};
     beforeEach(function (done) {
-      dbs = {name: testUtils.adapterUrl(adapter, 'testdb')};
+      dbs = {name: testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime())};
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -24,8 +24,8 @@ adapters.forEach(function (adapter) {
     }
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
-      dbs.remote = testUtils.adapterUrl(adapter, 'test_repl_remote');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime());
+      dbs.remote = testUtils.adapterUrl(adapter, 'test_repl_remote' + (new Date()).getTime());
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });
 

--- a/tests/integration/test.compaction.js
+++ b/tests/integration/test.compaction.js
@@ -12,7 +12,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime());
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/integration/test.conflicts.js
+++ b/tests/integration/test.conflicts.js
@@ -8,7 +8,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime());
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/integration/test.design_docs.js
+++ b/tests/integration/test.design_docs.js
@@ -8,7 +8,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime());
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/integration/test.events.js
+++ b/tests/integration/test.events.js
@@ -7,7 +7,7 @@ adapters.forEach(function (adapter) {
 
     var dbs = {};
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime());
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/integration/test.get.js
+++ b/tests/integration/test.get.js
@@ -8,7 +8,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime());
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/integration/test.issue221.js
+++ b/tests/integration/test.issue221.js
@@ -13,8 +13,8 @@ adapters.forEach(function (adapters) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
-      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote');
+      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb' + (new Date()).getTime());
+      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote' + (new Date()).getTime());
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });
 

--- a/tests/integration/test.issue2674.js
+++ b/tests/integration/test.issue2674.js
@@ -14,8 +14,8 @@ adapterPairs.forEach(function (adapters) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
-      dbs.secondDB = testUtils.adapterUrl(adapters[0], 'test_repl_remote');
+      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb' + (new Date()).getTime());
+      dbs.secondDB = testUtils.adapterUrl(adapters[0], 'test_repl_remote' + (new Date()).getTime());
       //
       // "test_slash_ids" is just a convenient name, b/c we re-use db
       // names to avoid the Safari popup bug in long-running tests.

--- a/tests/integration/test.issue3179.js
+++ b/tests/integration/test.issue3179.js
@@ -17,8 +17,8 @@ adapters.forEach(function (adapters) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
-      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote');
+      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb' + (new Date()).getTime());
+      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote' + (new Date()).getTime());
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });
 

--- a/tests/integration/test.issue3646.js
+++ b/tests/integration/test.issue3646.js
@@ -8,7 +8,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime());
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/integration/test.local_docs.js
+++ b/tests/integration/test.local_docs.js
@@ -8,7 +8,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime());
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -20,8 +20,8 @@ adapters.forEach(function (adapters) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
-      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote');
+      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb' + (new Date()).getTime());
+      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote'+ (new Date()).getTime());
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });
 

--- a/tests/integration/test.replication_events.js
+++ b/tests/integration/test.replication_events.js
@@ -19,8 +19,8 @@ adapters.forEach(function (adapters) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
-      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote');
+      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb' + (new Date()).getTime());
+      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote' + (new Date()).getTime());
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });
 

--- a/tests/integration/test.reserved.js
+++ b/tests/integration/test.reserved.js
@@ -13,8 +13,8 @@ adapters.forEach(function (adapters) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
-      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote');
+      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb' + (new Date()).getTime());
+      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote' + (new Date()).getTime());
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });
 

--- a/tests/integration/test.retry.js
+++ b/tests/integration/test.retry.js
@@ -18,8 +18,8 @@ adapters.forEach(function (adapters) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
-      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote');
+      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb' + (new Date()).getTime());
+      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote' + (new Date()).getTime());
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });
 

--- a/tests/integration/test.revs_diff.js
+++ b/tests/integration/test.revs_diff.js
@@ -8,7 +8,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime());
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/integration/test.slash_id.js
+++ b/tests/integration/test.slash_id.js
@@ -14,7 +14,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime());
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/integration/test.sync.js
+++ b/tests/integration/test.sync.js
@@ -17,8 +17,8 @@ adapters.forEach(function (adapters) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
-      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote');
+      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb' + (new Date()).getTime());
+      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote' + (new Date()).getTime());
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });
 

--- a/tests/integration/test.sync_events.js
+++ b/tests/integration/test.sync_events.js
@@ -19,8 +19,8 @@ adapters.forEach(function (adapters) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
-      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote');
+      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb' + (new Date()).getTime());
+      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote' + (new Date()).getTime());
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });
 

--- a/tests/integration/test.taskqueue.js
+++ b/tests/integration/test.taskqueue.js
@@ -8,7 +8,7 @@ adapters.forEach(function (adapter) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapter, 'testdb');
+      dbs.name = testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime());
       testUtils.cleanup([dbs.name], done);
     });
 

--- a/tests/mapreduce/test.mapreduce.js
+++ b/tests/mapreduce/test.mapreduce.js
@@ -8,7 +8,7 @@ adapters.forEach(function (adapter) {
   var viewTypes = ['persisted', 'temp'];
   viewTypes.forEach(function (viewType) {
     var suiteName = 'test.mapreduce.js-' + adapter + '-' + viewType;
-    var dbName = testUtils.adapterUrl(adapter, 'testdb');
+    var dbName = testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime());
 
     tests(suiteName, dbName, adapter, viewType);
   });

--- a/tests/mapreduce/test.persisted.js
+++ b/tests/mapreduce/test.persisted.js
@@ -5,7 +5,7 @@ var adapters = ['local', 'http'];
 adapters.forEach(function (adapter) {
 
   var suiteName = 'test.persisted.js-' + adapter;
-  var dbName = testUtils.adapterUrl(adapter, 'testdb');
+  var dbName = testUtils.adapterUrl(adapter, 'testdb' + (new Date()).getTime());
 
   tests(suiteName, dbName, adapter);
 });

--- a/tests/mapreduce/test.views.js
+++ b/tests/mapreduce/test.views.js
@@ -11,8 +11,8 @@ adapters.forEach(function (adapters) {
     var dbs = {};
 
     beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
-      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote');
+      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb' + (new Date()).getTime());
+      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote' + (new Date()).getTime());
       testUtils.cleanup([dbs.name, dbs.remote], done);
     });
 


### PR DESCRIPTION
CouchDB 2.x appears to get into a funk when databases with the same name are rapidly created/deleted.

To work around this, use unique database names in each test. This code be cleaned up / de-duplicated - as a first cut this is just to get the tests passing.