### PR TITLE
(#5303) - Add json as a gem dep to prevent build failures

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -7,3 +7,5 @@ group :jekyll_plugins do
   gem 'redcarpet'
   gem 'pygments.rb'
 end
+
+gem 'json'

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
       sass (~> 3.4)
     jekyll-watch (1.3.1)
       listen (~> 3.0)
+    json (1.8.3)
     kramdown (1.10.0)
     liquid (3.0.6)
     listen (3.0.6)
@@ -42,8 +43,9 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   jekyll-paginate
+  json
   pygments.rb
   redcarpet
 
 BUNDLED WITH
-   1.10.6
+   1.12.5


### PR DESCRIPTION
I was getting

```
bundler: failed to load command: jekyll (/home/nick/bin/jekyll)
LoadError: cannot load such file -- json
```

Adding json as a dependency then running bundle install let me execute `npm run build-site` with no issues.