### PR TITLE
(#5305) - fix pouchdb-adapter-node-websql

### DIFF
--- a/packages/pouchdb-adapter-node-websql/package.json
+++ b/packages/pouchdb-adapter-node-websql/package.json
@@ -15,6 +15,6 @@
   "dependencies": {
     "js-extend": "1.0.1",
     "websql": "0.4.4",
-    "pouchdb-adapter-websql": "5.5.0-prerelease"
+    "pouchdb-adapter-websql-core": "5.5.0-prerelease"
   }
 }

--- a/packages/pouchdb-adapter-node-websql/src/index.js
+++ b/packages/pouchdb-adapter-node-websql/src/index.js
@@ -1,4 +1,4 @@
-import WebSqlPouch from 'pouchdb-adapter-websql';
+import WebSqlPouchCore from 'pouchdb-adapter-websql-core';
 import { extend } from 'js-extend';
 import websql from 'websql';
 
@@ -7,7 +7,7 @@ function NodeWebSqlPouch(opts, callback) {
     websql: websql // pass node-websql in as our "openDatabase" function
   }, opts);
 
-  WebSqlPouch.call(this, _opts, callback);
+  WebSqlPouchCore.call(this, _opts, callback);
 }
 
 // overrides for normal WebSQL behavior in the browser

--- a/tests/integration/test.defaults.js
+++ b/tests/integration/test.defaults.js
@@ -1,6 +1,8 @@
 'use strict';
 if (!process.env.LEVEL_ADAPTER &&
-    !process.env.LEVEL_PREFIX && !process.env.AUTO_COMPACTION) {
+    !process.env.LEVEL_PREFIX &&
+    !process.env.AUTO_COMPACTION &&
+    !process.env.ADAPTER) {
   // these tests don't make sense for anything other than default leveldown
   var path = require('path');
   var mkdirp = require('mkdirp');

--- a/tests/integration/test.node-websql.js
+++ b/tests/integration/test.node-websql.js
@@ -1,0 +1,11 @@
+'use strict';
+
+if (process.env.ADAPTER === 'websql') {
+  describe('test.node-websql.js', function () {
+    it('should run websql when we are actually testing websql', function () {
+      var db = new PouchDB('testdb');
+      db.adapter.should.equal('websql');
+      return db.destroy();
+    });
+  });
+}

--- a/tests/integration/test.prefix.js
+++ b/tests/integration/test.prefix.js
@@ -36,7 +36,9 @@ describe('test.prefix.js', function () {
 // This is also tested in test.defaults.js, however I wanted to cover
 // the different use cases of prefix in here
 if (typeof process !== 'undefined' &&
-    !process.env.LEVEL_ADAPTER && !process.env.LEVEL_PREFIX ) {
+    !process.env.LEVEL_ADAPTER &&
+    !process.env.LEVEL_PREFIX &&
+    !process.env.ADAPTER) {
 
   var mkdirp = require('mkdirp');
   var rimraf = require('rimraf');

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -354,8 +354,10 @@ if (typeof process !== 'undefined' && !process.browser) {
     // (the two strings are just to fool Browserify because sqlite3 fails
     // in Node 0.11-0.12)
     require('../../packages/' + 'pouchdb/extras/websql');
-    global.PouchDB = global.PouchDB.defaults({prefix: './tmp/_pouch_'});
-    global.PouchDB.preferredAdapters = ['websql'];
+    global.PouchDB = global.PouchDB.defaults({
+      prefix: './tmp/_pouch_'
+    });
+    delete global.PouchDB.adapters.leveldb;
   } else {
     // test regular leveldown in node
     global.PouchDB = global.PouchDB.defaults({prefix: './tmp/_pouch_'});


### PR DESCRIPTION
Unfortunately `pouchdb-adapter-node-websql` is broken due to a typo, and it wasn't caught in CI because it turns out we _teeeeechnically_ only test `pouchdb/extras/websql`, which is slightly different from `pouchdb-adapter-node-websql`. Since I think it's silly to run an extra test for a slightly different usage, I've just fixed it manually and gonna call that good.