### PR TITLE
(#5334) - fixing missing "inherits" in sublevel-pouchdb

### DIFF
--- a/packages/pouchdb-adapter-leveldb-core/package.json
+++ b/packages/pouchdb-adapter-leveldb-core/package.json
@@ -26,7 +26,7 @@
     "pouchdb-md5": "5.5.0-prerelease",
     "pouchdb-promise": "5.5.0-prerelease",
     "pouchdb-utils": "5.5.0-prerelease",
-    "sublevel-pouchdb": "1.0.0",
+    "sublevel-pouchdb": "1.0.1",
     "through2": "2.0.1"
   },
   "browser": {

--- a/packages/pouchdb-for-coverage/package.json
+++ b/packages/pouchdb-for-coverage/package.json
@@ -38,7 +38,7 @@
     "request": "2.72.0",
     "scope-eval": "0.0.3",
     "spark-md5": "2.0.2",
-    "sublevel-pouchdb": "1.0.0",
+    "sublevel-pouchdb": "1.0.1",
     "through2": "2.0.1",
     "vuvuzela": "1.0.3",
     "websql": "0.4.4"

--- a/packages/pouchdb/package.json
+++ b/packages/pouchdb/package.json
@@ -31,7 +31,7 @@
     "request": "2.72.0",
     "scope-eval": "0.0.3",
     "spark-md5": "2.0.2",
-    "sublevel-pouchdb": "1.0.0",
+    "sublevel-pouchdb": "1.0.1",
     "through2": "2.0.1",
     "vuvuzela": "1.0.3"
   },


### PR DESCRIPTION
See https://github.com/pouchdb/sublevel-pouchdb/issues/2 for background on this. Forgot to publish sublevel-pouchdb 1.0.1; now it's published and we're updating to it.