### PR TITLE
(#5315) - fix non-leveldown migration for `opts.db`

### DIFF
--- a/packages/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/pouchdb-adapter-leveldb-core/src/index.js
@@ -183,11 +183,11 @@ function LevelPouch(opts, callback) {
       db = dbStore.get(name);
       db._docCount  = -1;
       db._queue = new Deque();
-      /* istanbul ignore if */
-      if (opts.noMigrate || (opts.db && !opts.migrate)) {
-        afterDBCreated();
-      } else {
+      /* istanbul ignore else */
+      if (opts.migrate) { // migration for leveldown
         migrate.toSublevel(name, db, afterDBCreated);
+      } else {
+        afterDBCreated();
       }
     })));
   }

--- a/packages/pouchdb-adapter-leveldb/src/index.js
+++ b/packages/pouchdb-adapter-leveldb/src/index.js
@@ -20,7 +20,7 @@ function LevelDownPouch(opts, callback) {
 
   var _opts = extend({
     db: leveldown,
-    migrate: true
+    migrate: !opts.db
   }, opts);
 
   CoreLevelPouch.call(this, _opts, callback);


### PR DESCRIPTION
I tested manually and confirmed that this works. Unfortunately nowhere in our tests do we confirm that manually setting `opts.db` avoids running the migration tests. OTOH our futureproof solution (the custom builds) will indeed fail the tests if anything is broken there (i.e. if it tries to run in the browser, it'll definitely fail).

This will probably require a 5.4.3 release.