### PR TITLE
remove dead link to extras source code

### DIFF
--- a/docs/_includes/api/extras.html
+++ b/docs/_includes/api/extras.html
@@ -126,6 +126,6 @@ The ES6 `Promise` shim as used by PouchDB. Expect this to be `lie` where a globa
 
 #### Caveats
 
-These APIs are not rigorously documented and may change frequently. Refer to the [source code](https://github.com/pouchdb/pouchdb/tree/master/extras) for the details of the APIs.
+These APIs are not rigorously documented and may change frequently. Refer to the [Ajax](https://github.com/pouchdb/pouchdb/tree/master/packages/pouchdb-ajax), [Checkpointer](https://github.com/pouchdb/pouchdb/tree/master/packages/pouchdb-checkpointer) & [Promise](https://github.com/pouchdb/pouchdb/tree/master/packages/pouchdb-promise) source code for the details of the APIs.
 
 If your plugin depends on a particular version of PouchDB, please notify your users. Unless you like to live dangerously, you should also nail down the version of PouchDB you are using in your `package.json`. And if you need any other internal modules, please submit a pull request!


### PR DESCRIPTION
Replaced with links to the Ajax, Checkpointer & Promise source code, respectively.