### PR TITLE
(#5356) - leveldb-core should use index-browser.js

### DIFF
--- a/packages/pouchdb-adapter-leveldb-core/package.json
+++ b/packages/pouchdb-adapter-leveldb-core/package.json
@@ -30,6 +30,7 @@
     "through2": "2.0.1"
   },
   "browser": {
+    "./lib/index.js": "./lib/index-browser.js",
     "./src/createEmptyBlobOrBuffer.js": "./src/createEmptyBlobOrBuffer-browser.js",
     "./src/migrate.js": "./src/migrate-browser.js",
     "./src/prepareAttachmentForStorage.js": "./src/prepareAttachmentForStorage-browser.js",


### PR DESCRIPTION
Forgot to add this line to `package.json` to tell `pouchdb-adapter-leveldb-core` to use `index-browser.js` when browserified. The impact is that you see this when you try to browserify it:

```
Error: Cannot find module 'leveldown' from '/Users/nolan/workspace/pouchdb-all-dbs/node_modules/pouchdb-adapter-leveldb-core/lib'
    at /Users/nolan/workspace/pouchdb-all-dbs/node_modules/resolve/lib/async.js:46:17
    at process (/Users/nolan/workspace/pouchdb-all-dbs/node_modules/resolve/lib/async.js:173:43)
    at ondir (/Users/nolan/workspace/pouchdb-all-dbs/node_modules/resolve/lib/async.js:188:17)
    at load (/Users/nolan/workspace/pouchdb-all-dbs/node_modules/resolve/lib/async.js:69:43)
    at onex (/Users/nolan/workspace/pouchdb-all-dbs/node_modules/resolve/lib/async.js:92:31)
    at /Users/nolan/workspace/pouchdb-all-dbs/node_modules/resolve/lib/async.js:22:47
    at FSReqWrap.oncomplete (fs.js:82:15)
```

Unfortunately this will necessitate a 5.4.4 release. Otherwise projects like `pouchdb-memory` and anything that uses the non-leveldown adapters in a browser-based project will fail.