### PR TITLE
(#5364) - verify index-browser is referenced in browser builds

### DIFF
--- a/bin/build-module.js
+++ b/bin/build-module.js
@@ -44,6 +44,11 @@ function buildModule(filepath) {
     }));
   }
 
+  if (pkg.browser && pkg.browser['./lib/index.js'] !== './lib/index-browser.js') {
+    return Promise.reject(new Error(pkg.name +
+      ' is missing a "lib/index.js" entry in the browser field'));
+  }
+
   // browser & node vs one single vanilla version
   var versions = pkg.browser ? [false, true] : [false];
 


### PR DESCRIPTION
Adds a check during builds to catch errors in pkg.browser entries, such
as the one fixed by #5356