### PR TITLE
(#4575) - assert correct error message in Couch master tests

### DIFF
--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -579,7 +579,7 @@ adapters.forEach(function (adapter) {
         test: 'somestuff'
       }, function (err) {
         should.exist(err);
-        err.name.should.equal('bad_request');
+        err.name.should.be.oneOf(['bad_request', 'illegal_docid']) ;
         done();
       });
     });


### PR DESCRIPTION
CouchDB 2.0 changed the error message text when an invalid document id is used. Update the tests to accept either the old or new errors.