### PR TITLE
(#5398) - move replicate/sync entirely to plugin

### DIFF
--- a/packages/pouchdb-core/src/constructor.js
+++ b/packages/pouchdb-core/src/constructor.js
@@ -84,23 +84,6 @@ function PouchDB(name, opts) {
 
   self.adapter = opts.adapter;
 
-  // needs access to PouchDB;
-  self.replicate = {};
-
-  self.replicate.from = function (url, opts, callback) {
-    return self.constructor.replicate(url, self, opts, callback);
-  };
-
-  self.replicate.to = function (url, opts, callback) {
-    return self.constructor.replicate(self, url, opts, callback);
-  };
-
-  self.sync = function (dbName, opts, callback) {
-    return self.constructor.sync(self, dbName, opts, callback);
-  };
-
-  self.replicate.sync = self.sync;
-
   PouchDB.adapters[opts.adapter].call(self, opts, function (err) {
     /* istanbul ignore if */
     if (err) {

--- a/packages/pouchdb-replication/src/index.js
+++ b/packages/pouchdb-replication/src/index.js
@@ -4,6 +4,24 @@ import sync from './sync';
 function replication(PouchDB) {
   PouchDB.replicate = replicate;
   PouchDB.sync = sync;
+
+  Object.defineProperty(PouchDB.prototype, 'replicate', {
+    get: function () {
+      var self = this;
+      return {
+        from: function (other, opts, callback) {
+          return self.constructor.replicate(other, self, opts, callback);
+        },
+        to: function (other, opts, callback) {
+          return self.constructor.replicate(self, other, opts, callback);
+        }
+      };
+    }
+  });
+
+  PouchDB.prototype.sync = function (dbName, opts, callback) {
+    return this.constructor.sync(this, dbName, opts, callback);
+  };
 }
 
 export default replication;

--- a/tests/integration/test.sync.js
+++ b/tests/integration/test.sync.js
@@ -358,7 +358,7 @@ adapters.forEach(function (adapters) {
         return remote.put(doc2);
       }).then(function () {
         return new testUtils.Promise(function (resolve, reject) {
-          db.replicate.sync(remote).on('complete', resolve).on('error', reject);
+          db.sync(remote).on('complete', resolve).on('error', reject);
         });
       }).then(function () {
         // Replication isn't finished until onComplete has been called twice


### PR DESCRIPTION
This isn't a breaking change; it's just something that I didn't bother to do when I made the monorepo.

OTOH I did notice this weird thing - `db.replicate.sync` - which was never documented and ~~wasn't in our tests~~ _(correction: it was in a single test)_. So I removed it.