### PR TITLE
(#5400) - set peerDependencies on pouchdb-core

### DIFF
--- a/bin/set-version.js
+++ b/bin/set-version.js
@@ -23,8 +23,15 @@ jsonFiles.forEach(function (jsonFile) {
   var json = JSON.parse(fs.readFileSync(jsonFile), 'utf-8');
   json.version = version;
   // update version of all inner dependencies
-  var depsList = [json.dependencies || {}, json.devDependencies || {}];
+  var depsList = [
+    json.dependencies,
+    json.devDependencies,
+    json.peerDependencies
+  ];
   depsList.forEach(function (deps) {
+    if (!deps) {
+      return;
+    }
     Object.keys(deps).forEach(function (key) {
       if (packages.indexOf(key) !== -1) {
         deps[key] = version;

--- a/packages/pouchdb-adapter-fruitdown/package.json
+++ b/packages/pouchdb-adapter-fruitdown/package.json
@@ -16,5 +16,8 @@
     "js-extend": "1.0.1",
     "fruitdown": "1.0.2",
     "pouchdb-adapter-leveldb-core": "5.5.0-prerelease"
+  },
+  "peerDependencies": {
+    "pouchdb-core": "5.5.0-prerelease"
   }
 }

--- a/packages/pouchdb-adapter-http/package.json
+++ b/packages/pouchdb-adapter-http/package.json
@@ -23,5 +23,8 @@
     "pouchdb-md5": "5.5.0-prerelease",
     "pouchdb-promise": "5.5.0-prerelease",
     "pouchdb-utils": "5.5.0-prerelease"
+  },
+  "peerDependencies": {
+    "pouchdb-core": "5.5.0-prerelease"
   }
 }

--- a/packages/pouchdb-adapter-idb/package.json
+++ b/packages/pouchdb-adapter-idb/package.json
@@ -22,5 +22,8 @@
     "pouchdb-merge": "5.5.0-prerelease",
     "pouchdb-promise": "5.5.0-prerelease",
     "pouchdb-utils": "5.5.0-prerelease"
+  },
+  "peerDependencies": {
+    "pouchdb-core": "5.5.0-prerelease"
   }
 }

--- a/packages/pouchdb-adapter-indexeddb/package.json
+++ b/packages/pouchdb-adapter-indexeddb/package.json
@@ -20,5 +20,8 @@
     "pouchdb-binary-utils": "5.5.0-prerelease",
     "pouchdb-utils": "5.5.0-prerelease"
   },
+  "peerDependencies": {
+    "pouchdb-core": "5.5.0-prerelease"
+  },
   "private": true
 }

--- a/packages/pouchdb-adapter-leveldb/package.json
+++ b/packages/pouchdb-adapter-leveldb/package.json
@@ -16,5 +16,8 @@
     "js-extend": "1.0.1",
     "leveldown": "1.4.6",
     "pouchdb-adapter-leveldb-core": "5.5.0-prerelease"
+  },
+  "peerDependencies": {
+    "pouchdb-core": "5.5.0-prerelease"
   }
 }

--- a/packages/pouchdb-adapter-localstorage/package.json
+++ b/packages/pouchdb-adapter-localstorage/package.json
@@ -16,5 +16,8 @@
     "js-extend": "1.0.1",
     "localstorage-down": "0.6.6",
     "pouchdb-adapter-leveldb-core": "5.5.0-prerelease"
+  },
+  "peerDependencies": {
+    "pouchdb-core": "5.5.0-prerelease"
   }
 }

--- a/packages/pouchdb-adapter-memory/package.json
+++ b/packages/pouchdb-adapter-memory/package.json
@@ -16,5 +16,8 @@
     "js-extend": "1.0.1",
     "memdown": "1.1.2",
     "pouchdb-adapter-leveldb-core": "5.5.0-prerelease"
+  },
+  "peerDependencies": {
+    "pouchdb-core": "5.5.0-prerelease"
   }
 }

--- a/packages/pouchdb-adapter-node-websql/package.json
+++ b/packages/pouchdb-adapter-node-websql/package.json
@@ -16,5 +16,8 @@
     "js-extend": "1.0.1",
     "websql": "0.4.4",
     "pouchdb-adapter-websql-core": "5.5.0-prerelease"
+  },
+  "peerDependencies": {
+    "pouchdb-core": "5.5.0-prerelease"
   }
 }

--- a/packages/pouchdb-adapter-websql/package.json
+++ b/packages/pouchdb-adapter-websql/package.json
@@ -16,5 +16,8 @@
     "js-extend": "1.0.1",
     "pouchdb-adapter-websql-core": "5.5.0-prerelease",
     "pouchdb-utils": "5.5.0-prerelease"
+  },
+  "peerDependencies": {
+    "pouchdb-core": "5.5.0-prerelease"
   }
 }

--- a/packages/pouchdb-mapreduce/package.json
+++ b/packages/pouchdb-mapreduce/package.json
@@ -26,5 +26,8 @@
   },
   "browser": {
     "./lib/index.js": "./lib/index-browser.js"
+  },
+  "peerDependencies": {
+    "pouchdb-core": "5.5.0-prerelease"
   }
 }

--- a/packages/pouchdb-replication/package.json
+++ b/packages/pouchdb-replication/package.json
@@ -21,5 +21,8 @@
     "pouchdb-generate-replication-id": "5.5.0-prerelease",
     "pouchdb-promise": "5.5.0-prerelease",
     "pouchdb-utils": "5.5.0-prerelease"
+  },
+  "peerDependencies": {
+    "pouchdb-core": "5.5.0-prerelease"
   }
 }


### PR DESCRIPTION
I think the simplest system is to just set a `peerDependency` on all semvered plugins (e.g. `pouchdb-adapter-http` but not `pouchdb-ajax`) to warn the user if they're using any version of `pouchdb-core` other than the exact same one as the plugin. Trying to do ranges here would be too complicated in my opinion; let's just advise users to update all the versions at the same time.