### PR TITLE
(#5406) - fix unnecessary sublevel dep

### DIFF
--- a/packages/pouchdb-for-coverage/package.json
+++ b/packages/pouchdb-for-coverage/package.json
@@ -43,7 +43,6 @@
     "request": "2.72.0",
     "scope-eval": "0.0.3",
     "spark-md5": "2.0.2",
-    "sublevel-pouchdb": "1.0.1",
     "through2": "2.0.1",
     "vuvuzela": "1.0.3",
     "websql": "0.4.4"


### PR DESCRIPTION
This is a dependency I forgot to clean up when I moved `sublevel-pouchdb` into the monorepo. Having this dependency here does nothing.