### PR TITLE
pouchdb-collections back in the monorepo

### DIFF
--- a/bin/external-deps.js
+++ b/bin/external-deps.js
@@ -8,7 +8,7 @@ module.exports = [
   // main deps
   'argsarray', 'debug', 'double-ended-queue', 'es3ify', 'es6-promise-pool',
   'fruitdown', 'inherits', 'js-extend', 'level-write-stream', 'levelup', 'lie',
-  'localstorage-down', 'memdown', 'pouchdb-collate', 'pouchdb-collections',
+  'localstorage-down', 'memdown', 'pouchdb-collate',
   'request', 'scope-eval', 'spark-md5', 'through2',
   'vuvuzela', 'leveldown', 'websql',
   // core node deps

--- a/docs/custom.md
+++ b/docs/custom.md
@@ -397,6 +397,16 @@ Tool to write a checkpoint, e.g. during replication.
 npm install --save-exact pouchdb-checkpointer
 ```
 
+### pouchdb-collections
+
+ES6 shims for Map and Set as used in PouchDB.
+
+#### Example usage
+
+```bash
+npm install --save-exact pouchdb-collections
+```
+
 ### pouchdb-errors
 
 Errors exposed by PouchDB.

--- a/packages/pouchdb-adapter-idb/package.json
+++ b/packages/pouchdb-adapter-idb/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "js-extend": "1.0.1",
     "pouchdb-binary-utils": "5.5.0-prerelease",
-    "pouchdb-collections": "1.0.1",
+    "pouchdb-collections": "5.5.0-prerelease",
     "pouchdb-adapter-utils": "5.5.0-prerelease",
     "pouchdb-errors": "5.5.0-prerelease",
     "pouchdb-json": "5.5.0-prerelease",

--- a/packages/pouchdb-adapter-leveldb-core/package.json
+++ b/packages/pouchdb-adapter-leveldb-core/package.json
@@ -18,7 +18,7 @@
     "level-write-stream": "1.0.0",
     "levelup": "1.3.2",
     "pouchdb-binary-utils": "5.5.0-prerelease",
-    "pouchdb-collections": "1.0.1",
+    "pouchdb-collections": "5.5.0-prerelease",
     "pouchdb-adapter-utils": "5.5.0-prerelease",
     "pouchdb-errors": "5.5.0-prerelease",
     "pouchdb-json": "5.5.0-prerelease",

--- a/packages/pouchdb-adapter-utils/package.json
+++ b/packages/pouchdb-adapter-utils/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "pouchdb-binary-utils": "5.5.0-prerelease",
-    "pouchdb-collections": "1.0.1",
+    "pouchdb-collections": "5.5.0-prerelease",
     "pouchdb-errors": "5.5.0-prerelease",
     "pouchdb-merge": "5.5.0-prerelease",
     "pouchdb-md5": "5.5.0-prerelease",

--- a/packages/pouchdb-adapter-websql-core/package.json
+++ b/packages/pouchdb-adapter-websql-core/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "js-extend": "1.0.1",
     "pouchdb-binary-utils": "5.5.0-prerelease",
-    "pouchdb-collections": "1.0.1",
+    "pouchdb-collections": "5.5.0-prerelease",
     "pouchdb-adapter-utils": "5.5.0-prerelease",
     "pouchdb-errors": "5.5.0-prerelease",
     "pouchdb-json": "5.5.0-prerelease",

--- a/packages/pouchdb-collections/LICENSE
+++ b/packages/pouchdb-collections/LICENSE
@@ -1,0 +1,202 @@
+
+                                Apache License
+                          Version 2.0, January 2004
+                       http://www.apache.org/licenses/
+
+  TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+  1. Definitions.
+
+     "License" shall mean the terms and conditions for use, reproduction,
+     and distribution as defined by Sections 1 through 9 of this document.
+
+     "Licensor" shall mean the copyright owner or entity authorized by
+     the copyright owner that is granting the License.
+
+     "Legal Entity" shall mean the union of the acting entity and all
+     other entities that control, are controlled by, or are under common
+     control with that entity. For the purposes of this definition,
+     "control" means (i) the power, direct or indirect, to cause the
+     direction or management of such entity, whether by contract or
+     otherwise, or (ii) ownership of fifty percent (50%) or more of the
+     outstanding shares, or (iii) beneficial ownership of such entity.
+
+     "You" (or "Your") shall mean an individual or Legal Entity
+     exercising permissions granted by this License.
+
+     "Source" form shall mean the preferred form for making modifications,
+     including but not limited to software source code, documentation
+     source, and configuration files.
+
+     "Object" form shall mean any form resulting from mechanical
+     transformation or translation of a Source form, including but
+     not limited to compiled object code, generated documentation,
+     and conversions to other media types.
+
+     "Work" shall mean the work of authorship, whether in Source or
+     Object form, made available under the License, as indicated by a
+     copyright notice that is included in or attached to the work
+     (an example is provided in the Appendix below).
+
+     "Derivative Works" shall mean any work, whether in Source or Object
+     form, that is based on (or derived from) the Work and for which the
+     editorial revisions, annotations, elaborations, or other modifications
+     represent, as a whole, an original work of authorship. For the purposes
+     of this License, Derivative Works shall not include works that remain
+     separable from, or merely link (or bind by name) to the interfaces of,
+     the Work and Derivative Works thereof.
+
+     "Contribution" shall mean any work of authorship, including
+     the original version of the Work and any modifications or additions
+     to that Work or Derivative Works thereof, that is intentionally
+     submitted to Licensor for inclusion in the Work by the copyright owner
+     or by an individual or Legal Entity authorized to submit on behalf of
+     the copyright owner. For the purposes of this definition, "submitted"
+     means any form of electronic, verbal, or written communication sent
+     to the Licensor or its representatives, including but not limited to
+     communication on electronic mailing lists, source code control systems,
+     and issue tracking systems that are managed by, or on behalf of, the
+     Licensor for the purpose of discussing and improving the Work, but
+     excluding communication that is conspicuously marked or otherwise
+     designated in writing by the copyright owner as "Not a Contribution."
+
+     "Contributor" shall mean Licensor and any individual or Legal Entity
+     on behalf of whom a Contribution has been received by Licensor and
+     subsequently incorporated within the Work.
+
+  2. Grant of Copyright License. Subject to the terms and conditions of
+     this License, each Contributor hereby grants to You a perpetual,
+     worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+     copyright license to reproduce, prepare Derivative Works of,
+     publicly display, publicly perform, sublicense, and distribute the
+     Work and such Derivative Works in Source or Object form.
+
+  3. Grant of Patent License. Subject to the terms and conditions of
+     this License, each Contributor hereby grants to You a perpetual,
+     worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+     (except as stated in this section) patent license to make, have made,
+     use, offer to sell, sell, import, and otherwise transfer the Work,
+     where such license applies only to those patent claims licensable
+     by such Contributor that are necessarily infringed by their
+     Contribution(s) alone or by combination of their Contribution(s)
+     with the Work to which such Contribution(s) was submitted. If You
+     institute patent litigation against any entity (including a
+     cross-claim or counterclaim in a lawsuit) alleging that the Work
+     or a Contribution incorporated within the Work constitutes direct
+     or contributory patent infringement, then any patent licenses
+     granted to You under this License for that Work shall terminate
+     as of the date such litigation is filed.
+
+  4. Redistribution. You may reproduce and distribute copies of the
+     Work or Derivative Works thereof in any medium, with or without
+     modifications, and in Source or Object form, provided that You
+     meet the following conditions:
+
+     (a) You must give any other recipients of the Work or
+         Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices
+         stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works
+         that You distribute, all copyright, patent, trademark, and
+         attribution notices from the Source form of the Work,
+         excluding those notices that do not pertain to any part of
+         the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its
+         distribution, then any Derivative Works that You distribute must
+         include a readable copy of the attribution notices contained
+         within such NOTICE file, excluding those notices that do not
+         pertain to any part of the Derivative Works, in at least one
+         of the following places: within a NOTICE text file distributed
+         as part of the Derivative Works; within the Source form or
+         documentation, if provided along with the Derivative Works; or,
+         within a display generated by the Derivative Works, if and
+         wherever such third-party notices normally appear. The contents
+         of the NOTICE file are for informational purposes only and
+         do not modify the License. You may add Your own attribution
+         notices within Derivative Works that You distribute, alongside
+         or as an addendum to the NOTICE text from the Work, provided
+         that such additional attribution notices cannot be construed
+         as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and
+     may provide additional or different license terms and conditions
+     for use, reproduction, or distribution of Your modifications, or
+     for any such Derivative Works as a whole, provided Your use,
+     reproduction, and distribution of the Work otherwise complies with
+     the conditions stated in this License.
+
+  5. Submission of Contributions. Unless You explicitly state otherwise,
+     any Contribution intentionally submitted for inclusion in the Work
+     by You to the Licensor shall be under the terms and conditions of
+     this License, without any additional terms or conditions.
+     Notwithstanding the above, nothing herein shall supersede or modify
+     the terms of any separate license agreement you may have executed
+     with Licensor regarding such Contributions.
+
+  6. Trademarks. This License does not grant permission to use the trade
+     names, trademarks, service marks, or product names of the Licensor,
+     except as required for reasonable and customary use in describing the
+     origin of the Work and reproducing the content of the NOTICE file.
+
+  7. Disclaimer of Warranty. Unless required by applicable law or
+     agreed to in writing, Licensor provides the Work (and each
+     Contributor provides its Contributions) on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+     implied, including, without limitation, any warranties or conditions
+     of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+     PARTICULAR PURPOSE. You are solely responsible for determining the
+     appropriateness of using or redistributing the Work and assume any
+     risks associated with Your exercise of permissions under this License.
+
+  8. Limitation of Liability. In no event and under no legal theory,
+     whether in tort (including negligence), contract, or otherwise,
+     unless required by applicable law (such as deliberate and grossly
+     negligent acts) or agreed to in writing, shall any Contributor be
+     liable to You for damages, including any direct, indirect, special,
+     incidental, or consequential damages of any character arising as a
+     result of this License or out of the use or inability to use the
+     Work (including but not limited to damages for loss of goodwill,
+     work stoppage, computer failure or malfunction, or any and all
+     other commercial damages or losses), even if such Contributor
+     has been advised of the possibility of such damages.
+
+  9. Accepting Warranty or Additional Liability. While redistributing
+     the Work or Derivative Works thereof, You may choose to offer,
+     and charge a fee for, acceptance of support, warranty, indemnity,
+     or other liability obligations and/or rights consistent with this
+     License. However, in accepting such obligations, You may act only
+     on Your own behalf and on Your sole responsibility, not on behalf
+     of any other Contributor, and only if You agree to indemnify,
+     defend, and hold each Contributor harmless for any liability
+     incurred by, or claims asserted against, such Contributor by reason
+     of your accepting any such warranty or additional liability.
+
+  END OF TERMS AND CONDITIONS
+
+  APPENDIX: How to apply the Apache License to your work.
+
+     To apply the Apache License to your work, attach the following
+     boilerplate notice, with the fields enclosed by brackets "[]"
+     replaced with your own identifying information. (Don't include
+     the brackets!)  The text should be enclosed in the appropriate
+     comment syntax for the file format. We also recommend that a
+     file or class name and description of purpose be included on the
+     same "printed page" as the copyright notice for easier
+     identification within third-party archives.
+
+  Copyright [yyyy] [name of copyright owner]
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.

--- a/packages/pouchdb-collections/README.md
+++ b/packages/pouchdb-collections/README.md
@@ -1,0 +1,26 @@
+pouchdb-collections ![semver non-compliant](https://img.shields.io/badge/semver-non--compliant-red.svg)
+======
+
+Super-minimal ES6 Map and Set shims for PouchDB.
+
+### Usage
+
+```bash
+npm install --save-exact pouchdb-collections
+```
+
+For full API documentation and guides on PouchDB, see [PouchDB.com](http://pouchdb.com/). For details on PouchDB sub-packages, see the [Custom Builds documentation](http://pouchdb.com/custom.html).
+
+
+### Warning: semver-free zone!
+
+This package is conceptually an internal API used by PouchDB or its plugins. It does not follow semantic versioning (semver), and rather its version is pegged to PouchDB's. Use exact versions when installing, e.g. with `--save-exact`.
+
+
+### Source
+
+PouchDB and its sub-packages are distributed as a [monorepo](https://github.com/babel/babel/blob/master/doc/design/monorepo.md).
+
+For a full list of packages, see [the GitHub source](https://github.com/pouchdb/pouchdb/tree/master/packages).
+
+

--- a/packages/pouchdb-collections/package.json
+++ b/packages/pouchdb-collections/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "pouchdb-collections",
+  "version": "5.5.0-prerelease",
+  "description": "Map and Set shims for PouchDB",
+  "main": "./lib/index.js",
+  "keywords": [
+    "map",
+    "set",
+    "collections"
+  ],
+  "author": "Dale Harvey <dale@arandomurl.com>",
+  "license": "Apache-2.0",
+  "repository": "https://github.com/pouchdb/pouchdb",
+  "jsnext:main": "./src/index.js",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "dependencies": {},
+  "contributors": [
+    {
+      "name": "Calvin Metcalf",
+      "email": "cmetcalf@appgeo.com"
+    }
+  ]
+}

--- a/packages/pouchdb-collections/src/index.js
+++ b/packages/pouchdb-collections/src/index.js
@@ -1,0 +1,60 @@
+// based on https://github.com/montagejs/collections
+function mangle(key) {
+  return '$' + key;
+}
+function unmangle(key) {
+  return key.substring(1);
+}
+function LazyMap() {
+  this.store = {};
+}
+LazyMap.prototype.get = function (key) {
+  var mangled = mangle(key);
+  return this.store[mangled];
+};
+LazyMap.prototype.set = function (key, value) {
+  var mangled = mangle(key);
+  this.store[mangled] = value;
+  return true;
+};
+LazyMap.prototype.has = function (key) {
+  var mangled = mangle(key);
+  return mangled in this.store;
+};
+LazyMap.prototype.delete = function (key) {
+  var mangled = mangle(key);
+  var res = mangled in this.store;
+  delete this.store[mangled];
+  return res;
+};
+LazyMap.prototype.forEach = function (cb) {
+  var keys = Object.keys(this.store);
+  for (var i = 0, len = keys.length; i < len; i++) {
+    var key = keys[i];
+    var value = this.store[key];
+    key = unmangle(key);
+    cb(value, key);
+  }
+};
+
+function LazySet(array) {
+  this.store = new LazyMap();
+
+  // init with an array
+  if (array && Array.isArray(array)) {
+    for (var i = 0, len = array.length; i < len; i++) {
+      this.add(array[i]);
+    }
+  }
+}
+LazySet.prototype.add = function (key) {
+  return this.store.set(key, true);
+};
+LazySet.prototype.has = function (key) {
+  return this.store.has(key);
+};
+
+export {
+  LazySet as Set,
+  LazyMap as Map
+};

--- a/packages/pouchdb-core/package.json
+++ b/packages/pouchdb-core/package.json
@@ -18,7 +18,7 @@
     "double-ended-queue": "2.0.0-0",
     "inherits": "2.0.1",
     "js-extend": "1.0.1",
-    "pouchdb-collections": "1.0.1",
+    "pouchdb-collections": "5.5.0-prerelease",
     "pouchdb-errors": "5.5.0-prerelease",
     "pouchdb-merge": "5.5.0-prerelease",
     "pouchdb-promise": "5.5.0-prerelease",

--- a/packages/pouchdb-for-coverage/package.json
+++ b/packages/pouchdb-for-coverage/package.json
@@ -30,7 +30,7 @@
     "pouchdb-browser": "5.5.0-prerelease",
     "pouchdb-checkpointer": "5.5.0-prerelease",
     "pouchdb-collate": "1.2.0",
-    "pouchdb-collections": "1.0.1",
+    "pouchdb-collections": "5.5.0-prerelease",
     "pouchdb-errors": "5.5.0-prerelease",
     "pouchdb-generate-replication-id": "5.5.0-prerelease",
     "pouchdb-mapreduce-utils": "5.5.0-prerelease",

--- a/packages/pouchdb-md5/package.json
+++ b/packages/pouchdb-md5/package.json
@@ -13,7 +13,7 @@
     "src"
   ],
   "dependencies": {
-    "pouchdb-collections": "1.0.1",
+    "pouchdb-collections": "5.5.0-prerelease",
     "pouchdb-errors": "5.5.0-prerelease",
     "pouchdb-binary-utils": "5.5.0-prerelease",
     "pouchdb-promise": "5.5.0-prerelease",

--- a/packages/pouchdb-utils/package.json
+++ b/packages/pouchdb-utils/package.json
@@ -16,7 +16,7 @@
     "argsarray": "0.0.1",
     "debug": "2.2.0",
     "inherits": "2.0.1",
-    "pouchdb-collections": "1.0.1",
+    "pouchdb-collections": "5.5.0-prerelease",
     "pouchdb-binary-utils": "5.5.0-prerelease",
     "pouchdb-errors": "5.5.0-prerelease",
     "pouchdb-md5": "5.5.0-prerelease",

--- a/packages/pouchdb/package.json
+++ b/packages/pouchdb/package.json
@@ -30,7 +30,6 @@
     "ltgt": "2.1.2",
     "memdown": "1.1.2",
     "pouchdb-collate": "1.2.0",
-    "pouchdb-collections": "1.0.1",
     "pull-stream": "2.21.0",
     "readable-stream": "1.0.33",
     "request": "2.72.0",


### PR DESCRIPTION
No reason not to do this. We own it, it's a core part of the library, and putting it in the monorepo means we get Rollup collapsing benefits.