### PR TITLE
Differentiate between validation and non-validation errors

### DIFF
--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -4327,42 +4327,6 @@ adapters.forEach(function (adapters) {
       db.post({a: 'doc'});
     });
 
-    it('#4276 Triggers paused error', function (done) {
-
-      if (!(/http/.test(dbs.remote) && !/http/.test(dbs.name))) {
-        return done();
-      }
-
-      var err = {
-        "message": "_writer access is required for this request",
-        "name": "unauthorized",
-        "status": 401
-      };
-
-      var db = new PouchDB(dbs.name);
-      var remote = new PouchDB(dbs.remote);
-
-      var ajax = remote._ajax;
-      remote._ajax = function (opts, cb) {
-        cb(err);
-      };
-
-      db.bulkDocs([{foo: 'bar'}]).then(function () {
-
-        var repl = db.replicate.to(remote, {live: true, retry: true});
-
-        repl.on('paused', function (err) {
-          if (err) {
-            repl.cancel();
-          }
-        });
-        repl.on('complete', function () {
-          remote._ajax = ajax;
-          done();
-        });
-      });
-    });
-
     it('Heartbeat gets passed', function (done) {
 
       if (!(/http/.test(dbs.remote) && !/http/.test(dbs.name))) {

--- a/tests/integration/test.replication_events.js
+++ b/tests/integration/test.replication_events.js
@@ -254,5 +254,107 @@ adapters.forEach(function (adapters) {
         });
       }).catch(done);
     });
+
+    describe('#5172 triggering error when replicating', function () {
+      var securedDbs = [], source, dest, previousAjax;
+      beforeEach(function () {
+        var err = {
+          'status': 401,
+          'name': 'unauthorized',
+          'message': 'You are not authorized to access this db.'
+        };
+
+        source = new PouchDB(dbs.name);
+        dest = new PouchDB(dbs.remote);
+
+        if (adapters[0] === 'http') {
+          previousAjax = source._ajax;
+          source._ajax = function (opts, cb) { cb(err); };
+          securedDbs.push(source);
+        }
+
+        if (adapters[1] === 'http') {
+          previousAjax = dest._ajax;
+          dest._ajax = function (opts, cb) { cb(err); };
+          securedDbs.push(dest);
+        }
+      });
+
+      afterEach(function () {
+        securedDbs.forEach(function (db) {
+          db._ajax = previousAjax;
+        });
+      });
+
+      function attachHandlers(replication) {
+        var invokedHandlers = [];
+        ['change', 'complete', 'paused', 'active', 'denied', 'error'].forEach(function (type) {
+          replication.on(type, function () {
+            invokedHandlers.push(type);
+          });
+        });
+        return invokedHandlers;
+      }
+
+      it('from or to a secured database, using live replication', function () {
+        if (adapters[0] === 'local' && adapters[1] === 'local') {
+          return;
+        }
+
+        var replication = source.replicate.to(dest, {live: true});
+        var invokedHandlers = attachHandlers(replication);
+
+        return replication.then(function () {
+          throw new Error('Resulting promise should be rejected');
+        }, function () {
+          invokedHandlers.should.be.eql(['error'], 'incorrect handler was invoked');
+        });
+      });
+
+      it('from or to a secured database, using live replication with checkpoint', function () {
+        if (adapters[0] === 'local' && adapters[1] === 'local') {
+          return;
+        }
+
+        var replication = source.replicate.to(dest, {live: true, since: 1234});
+        var invokedHandlers = attachHandlers(replication);
+
+        return replication.then(function () {
+          throw new Error('Resulting promise should be rejected');
+        }, function () {
+          invokedHandlers.should.be.eql(['error'], 'incorrect handler was invoked');
+        });
+      });
+
+      it('from or to a secured database, using live replication with retrying', function () {
+        if (adapters[0] === 'local' && adapters[1] === 'local') {
+          return;
+        }
+
+        var replication = source.replicate.to(dest, {live: true, retry: true});
+        var invokedHandlers = attachHandlers(replication);
+
+        return replication.then(function () {
+          throw new Error('Resulting promise should be rejected');
+        }, function () {
+          invokedHandlers.should.be.eql(['error'], 'incorrect handler was invoked');
+        });
+      });
+
+      it('from or to a secured database, using one-shot replication', function () {
+        if (adapters[0] === 'local' && adapters[1] === 'local') {
+          return;
+        }
+
+        var replication = source.replicate.to(dest);
+        var invokedHandlers = attachHandlers(replication);
+
+        return replication.then(function () {
+          throw new Error('Resulting promise should be rejected');
+        }, function () {
+          invokedHandlers.should.be.eql(['error'], 'incorrect handler was invoked');
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Up to now, all 401 and 403 error were treated the same, i.e. it was
assumed that it may be connected to a result of a validation function on
the destination database or to error saving a design as non-admin user
(there is also a case of saving checkpoint on a read-only source
database, but it is dealt with by the Checkpointer).

This change introduces storing the validation errors separately, to
handle 401s on fetching remote databases properly. I decided to signal
these as errors, keeping `denied` only for validation errors (following
the separation between the two).