### PR TITLE
(#5417) - proper websql validation for cordova+ios

### DIFF
--- a/packages/pouchdb-adapter-websql/src/index.js
+++ b/packages/pouchdb-adapter-websql/src/index.js
@@ -1,6 +1,7 @@
 import WebSqlPouchCore from 'pouchdb-adapter-websql-core';
 import { extend } from 'js-extend';
-import valid from './valid';
+import { guardedConsole } from 'pouchdb-utils';
+import { valid, validWithoutCheckingCordova } from './validation';
 
 function createOpenDBFunction(opts) {
   return function (name, version, description, size) {
@@ -29,6 +30,15 @@ function WebSQLPouch(opts, callback) {
   var _opts = extend({
     websql: websql
   }, opts);
+
+  if (typeof cordova !== 'undefined' && !validWithoutCheckingCordova()) {
+    guardedConsole('error',
+      'PouchDB error: you must install a SQLite plugin ' +
+      'in order for PouchDB to work on this platform. Options:' +
+      '\n - https://github.com/nolanlawson/cordova-plugin-sqlite-2' +
+      '\n - https://github.com/litehelpers/Cordova-sqlite-storage' +
+      '\n - https://github.com/Microsoft/cordova-plugin-websql');
+  }
 
   WebSqlPouchCore.call(this, _opts, callback);
 }

--- a/packages/pouchdb-adapter-websql/src/validation.js
+++ b/packages/pouchdb-adapter-websql/src/validation.js
@@ -49,17 +49,32 @@ function isValidWebSQL() {
   return openedTestDB;
 }
 
-function valid() {
-  // SQLitePlugin leaks this global object, which we can use
-  // to detect if it's installed or not. The benefit is that it's
-  // declared immediately, before the 'deviceready' event has fired.
-  if (typeof SQLitePlugin !== 'undefined') {
-    return true;
-  }
+function validWithoutCheckingCordova() {
   if (typeof openDatabase === 'undefined') {
     return false;
+  }
+  if (typeof sqlitePlugin !== 'undefined') {
+    // Both sqlite-storage and SQLite Plugin 2 create this global object,
+    // which we can check for to determine validity. It should be defined
+    // after the 'deviceready' event.
+    return true;
   }
   return isValidWebSQL();
 }
 
-export default valid;
+function valid() {
+  // The Cordova SQLite Plugin and SQLite Plugin 2 can be used in cordova apps,
+  // and we can't know whether or not the plugin was loaded until after the
+  // 'deviceready' event. Since it's impractical for us to wait for that event
+  // before returning true/false for valid(), we just return true here
+  // and notify the user that they may need a plugin.
+  if (typeof cordova !== 'undefined') {
+    return true;
+  }
+  return validWithoutCheckingCordova();
+}
+
+export {
+  valid,
+  validWithoutCheckingCordova
+};


### PR DESCRIPTION
My proposed fix for #5417:
- if `typeof cordova !== 'undefined'`, return `true` from `valid()`
- once `new PouchDB()` is called, do a second `valid()` check if we're in a Cordova app. if so, and if `!valid()`, then show a warning to the user that they need to install a SQLite plugin:

![screenshot 2016-07-01 08 34 51](https://cloud.githubusercontent.com/assets/283842/16526623/ee9c5aaa-3f66-11e6-88cd-1f9f7f9dae26.png)

I've tested manually to confirm it works; no real way I can see to add it to our test harness currently.
