### PR TITLE
(#5427) - fix browser perf tests

### DIFF
--- a/tests/performance/index.html
+++ b/tests/performance/index.html
@@ -5,10 +5,10 @@
   </head>
   <body>
     <pre style="width: 100%; height: 100%;" id="output"></pre>
-    <script src="/dist/pouchdb.js"></script>
-    <script src="/dist/pouchdb.localstorage.js"></script>
-    <script src="/dist/pouchdb.idb-alt.js"></script>
-    <script src="/dist/pouchdb.memory.js"></script>
+    <script src="/packages/pouchdb/dist/pouchdb.js"></script>
+    <script src="/packages/pouchdb/dist/pouchdb.localstorage.js"></script>
+    <script src="/packages/pouchdb/dist/pouchdb.fruitdown.js"></script>
+    <script src="/packages/pouchdb/dist/pouchdb.memory.js"></script>
     <script src="../performance-bundle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
These are not tested in CI, so I added `[skip ci]'. The URLs were not updated after the monorepo changes.