### PR TITLE
(#5429) - WIP - leveldb: simplify stored metadata json

### DIFF
--- a/packages/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/pouchdb-adapter-leveldb-core/src/index.js
@@ -54,6 +54,11 @@ import {
   createError
 } from 'pouchdb-errors';
 
+import {
+  inflateMetadata,
+  deflateMetadata
+} from './metadataCompression';
+
 var DOC_STORE = 'document-store';
 var BY_SEQ_STORE = 'by-sequence';
 var ATTACHMENT_STORE = 'attach-store';
@@ -365,6 +370,8 @@ function LevelPouch(opts, callback) {
         return callback(createError(MISSING_DOC, 'missing'));
       }
 
+      metadata = inflateMetadata(metadata);
+
       var rev = getWinningRev(metadata);
       var deleted = getIsDeleted(metadata, rev);
       if (deleted && !opts.rev) {
@@ -516,14 +523,15 @@ function LevelPouch(opts, callback) {
           // skip local docs
           return checkDone();
         }
-        txn.get(stores.docStore, doc._id, function (err, info) {
+        txn.get(stores.docStore, doc._id, function (err, metadata) {
           if (err) {
             /* istanbul ignore if */
             if (err.name !== 'NotFoundError') {
               overallErr = err;
             }
           } else {
-            fetchedDocs.set(doc._id, info);
+            metadata = inflateMetadata(metadata);
+            fetchedDocs.set(doc._id, metadata);
           }
           checkDone();
         });
@@ -664,6 +672,7 @@ function LevelPouch(opts, callback) {
         docInfo.metadata.rev_map[docInfo.metadata.rev] =
           docInfo.metadata.seq = seq;
         var seqKey = formatSeq(seq);
+        var metadataToStore = deflateMetadata(docInfo.metadata);
         var batch = [{
           key: seqKey,
           value: docInfo.data,
@@ -671,7 +680,7 @@ function LevelPouch(opts, callback) {
           type: 'put'
         }, {
           key: docInfo.metadata.id,
-          value: docInfo.metadata,
+          value: metadataToStore,
           prefix: stores.docStore,
           type: 'put'
         }];
@@ -876,7 +885,7 @@ function LevelPouch(opts, callback) {
       var docstream = stores.docStore.readStream(readstreamOpts);
 
       var throughStream = through(function (entry, _, next) {
-        var metadata = entry.value;
+        var metadata = inflateMetadata(entry.value);
         // winningRev and deleted are performance-killers, but
         // in newer versions of PouchDB, they are cached on the metadata
         var winningRev = getWinningRev(metadata);
@@ -1112,6 +1121,7 @@ function LevelPouch(opts, callback) {
           isLocalId(metadata.id)) {
           return next();
         }
+        metadata = inflateMetadata(metadata);
         docIdsToMetadata.set(doc._id, metadata);
         onGetMetadata(metadata);
       });
@@ -1161,6 +1171,7 @@ function LevelPouch(opts, callback) {
       if (err) {
         callback(createError(MISSING_DOC));
       } else {
+        metadata = inflateMetadata(metadata);
         callback(null, metadata.rev_tree);
       }
     });

--- a/packages/pouchdb-adapter-leveldb-core/src/metadataCompression.js
+++ b/packages/pouchdb-adapter-leveldb-core/src/metadataCompression.js
@@ -1,0 +1,90 @@
+// Functions for inflating/deflating document metadata before/after storage.
+//
+// When storing document metadata, the most common type of object is a document
+// with a single revision. This is heavily used, e.g. in the case of
+// persistent map/reduce. These two functions serve to trim down the metadata
+// object before storage, both to reduce size on disk and to improve performance
+// by avoiding serializing and deserializing unnecessarily large JSON objects.
+//
+// Here's how it works. Consider this JSON object:
+//
+//  {
+//    "id": "foo",
+//    "rev_tree": [
+//    {
+//      "pos": 1,
+//      "ids": [
+//        "xxx",
+//        {
+//          "status": "available"
+//        },
+//        []
+//      ]
+//    }
+//  ],
+//    "rev": "1-xxx",
+//    "rev_map": {
+//    "1-xxx": 1
+//  },
+//    "winningRev": "1-xxx",
+//    "deleted": false,
+//    "seq": 1
+//  }
+//
+// Almost everything here is pure waste. This can be simplified as:
+//
+//  {
+//    "id": "foo",
+//    "rev": "1-81fbf8fbee50fd8da15be4d38750f396",
+//    "seq": 1185
+//  }
+//
+// And the rest can be inferred
+
+function inflateMetadata(metadata) {
+  if (!metadata.rev_tree) {
+    // first generation, exactly one revision in tree
+    var revMap = {};
+    revMap[metadata.rev] = metadata.seq;
+    return {
+      id: metadata.id,
+      rev_tree: [
+        {
+          pos: 1,
+          ids: [
+            metadata.rev.replace(/^\d+-/, ''),
+            { status: 'available'},
+            []
+          ]
+        }
+      ],
+      rev: metadata.rev,
+      rev_map: revMap,
+      winningRev: metadata.rev,
+      deleted: !!metadata.deleted,
+      seq: metadata.seq
+    };
+  }
+  return metadata;
+}
+
+function deflateMetadata(metadata) {
+  if (/^1-/.test(metadata.rev) && Object.keys(metadata.rev_map).length === 1) {
+    // first generation, exactly one revision in tree
+    var deflatedMetadata = {
+      id: metadata.id,
+      rev: metadata.rev,
+      seq: metadata.seq
+    };
+    if (metadata.deleted) {
+      deflatedMetadata.deleted = true;
+    }
+    return deflatedMetadata;
+  }
+  return metadata;
+}
+
+export {
+  inflateMetadata,
+  deflateMetadata
+};


### PR DESCRIPTION
This is a perf improvement designed to reduce the amount of space metadata documents take up on disk, for the `leveldb-core` adapter.

It also has a speed benefit due to less time spent serializing/deserializing JSON. To prove it, I ran the temp-views test with 50 iterations 3 times (`PERF=1 GREP=temp-view npm t`), and came up with these numbers:

| Run | before | after | improvement |
| ---- | --- | ---- | ---- |
| 1 | 107868ms | 104111ms | 3.48% |
| 2 | 112161ms | 109656ms | 2.23% |
| 3 | 113830ms | 109341ms | 3.94% |

The basic idea is that for the most common class of documents &ndash; those with one non-deleted first-generation revision &ndash; we can simplify the structure on-disk and just store the id and rev. For more details, see the comments in  `metadataCompression.js`.

I would like to port this improvement to the idb/websql adapters as well, but for starters I'm just doing leveldb.