### PR TITLE
(#5430) - fix js-extend version

### DIFF
--- a/packages/pouchdb/package.json
+++ b/packages/pouchdb/package.json
@@ -21,7 +21,7 @@
     "es6-promise-pool": "2.4.2",
     "fruitdown": "1.0.2",
     "inherits": "2.0.1",
-    "js-extend": "0.0.1",
+    "js-extend": "1.0.1",
     "level-codec": "6.1.0",
     "level-write-stream": "1.0.0",
     "levelup": "1.3.2",


### PR DESCRIPTION
This is the kind of error that's unfortunately hard to catch due to the new bundling setup. My bad, sorry for that.