### PR TITLE
release memory faster in ajax requests

### DIFF
--- a/packages/pouchdb-ajax/src/request-browser.js
+++ b/packages/pouchdb-ajax/src/request-browser.js
@@ -133,11 +133,16 @@ function xhRequest(options, callback) {
     }
   };
 
-  var cleanUp= function () {
+  var cleanUp = function () {
     doClearTimeout();
     ret.abort = function () {};
+    xhr.onprogress = undefined;
+    if (xhr.upload) {
+      xhr.upload.onprogress = undefined;
+    }
+    xhr.onreadystatechange = undefined;
     xhr = undefined;
-  }
+  };
 
   if (options.xhr) {
     xhr = new options.xhr();


### PR DESCRIPTION
The main issue was that postponed (by setTimeout) 'timeoutReq' function was very often (half of requests) not released immediately after the request was completed but after 10 or 30 seconds (default timeout). On iPhone 6 it caused big memory consumption and very often crashes during sync with db with many inline attachments. This fix makes the sync process uses less memory and releases it faster. Exemplary project to observe the issue https://github.com/olexme/pouchdb-cordova.