### PR TITLE
(#5379) do not update checkpoint if last_seq has not changed

### DIFF
--- a/packages/pouchdb-replication/src/replicate.js
+++ b/packages/pouchdb-replication/src/replicate.js
@@ -308,7 +308,8 @@ function replicate(src, target, opts, returnValue, result) {
       };
 
       // update the checkpoint so we start from the right seq next time
-      if (!currentBatch && changes.results.length === 0) {
+      if (!currentBatch && changes.results.length === 0 &&
+        changes.last_seq !== changesOpts.since) {
         writingCheckpoint = true;
         checkpointer.writeCheckpoint(changes.last_seq,
             session).then(function () {


### PR DESCRIPTION
Now that we checkpoint on every batch of changes (rather than when replication is complete), avoid updating the checkpoint when the source database has not changed. As a first pass, we determine
this based on whether _changes/last_seq progresses, though this won't work if the source database is CouchDB 2.0 or Cloudant where sequence values may change even if the underlying data doesn't. I can't think of a way around this, but it's also an edge case - it just means that a PouchDB database might grow if compaction isn't run.