### PR TITLE
(#5379) - do not update checkpoint if last_seq has not changed

### DIFF
--- a/packages/pouchdb-checkpointer/src/index.js
+++ b/packages/pouchdb-checkpointer/src/index.js
@@ -35,6 +35,12 @@ function updateCheckpoint(db, id, checkpoint, session, returnValue) {
     if (returnValue.cancelled) {
       return;
     }
+
+    // if the checkpoint has not changed, do not update
+    if(doc.last_seq === checkpoint) {
+      return;
+    }
+
     // Filter out current entry for this replication
     doc.history = (doc.history || []).filter(function (item) {
       return item.session_id !== session;


### PR DESCRIPTION
Avoid updating the checkpoint when there is no change to the sequence
number. This prevents unnecessary updates to the checkpoint document,
generating traffic and compaction bloat.

This approach doesn't help if the source database is CouchDB 2.0 or
Cloudant because sequence values may change even if the underlying
database doesn't. I can't think of a way around this, but it's also an
edge case - it just means that a PouchDB database might grow if
compaction isn't run.