### PR TITLE
(#5207) - build pouchdb-next.js as part of build process

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -59,6 +59,7 @@ or
 #### Other test options
 
 * `SKIP_MIGRATION=1` should be used to skip the migration tests.
+* `NEXT=1` will test pouchdb-next (PouchDB with v2 IndexedDB adapter).
 * `POUCHDB_SRC=../../dist/pouchdb.js` can be used to treat another file as the PouchDB source file.
 * `npm run test-webpack` will build with Webpack and then test that in a browser.
 

--- a/bin/build-pouchdb.js
+++ b/bin/build-pouchdb.js
@@ -239,6 +239,12 @@ function buildPluginsForBrowser() {
   }));
 }
 
+function buildPouchDBNext() {
+  return doBrowserify('src/next.js', {standalone: 'PouchDB'}).then(function (code) {
+    return writeFile('packages/pouchdb/dist/pouchdb-next.js', code);
+  });
+}
+
 var rimrafMkdirp = argsarray(function (args) {
   return all(args.map(function (otherPath) {
     return rimraf(addPath(otherPath));
@@ -265,14 +271,14 @@ function doBuildNode() {
 
 function doBuildDev() {
   return doAll(buildForNode, buildForBrowserify)()
-    .then(doAll(buildForBrowser, buildPluginsForBrowserify))
+    .then(doAll(buildForBrowser, buildPluginsForBrowserify, buildPouchDBNext))
     .then(buildPluginsForBrowser);
 }
 
 function doBuildAll() {
   return rimrafMkdirp('lib', 'dist', 'lib/extras')
     .then(doAll(buildForNode, buildForBrowserify))
-    .then(doAll(buildForBrowser, buildPluginsForBrowserify))
+    .then(doAll(buildForBrowser, buildPluginsForBrowserify, buildPouchDBNext))
     .then(doAll(buildPluginsForBrowser, buildNodeExtras, buildBrowserExtras));
 }
 

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -25,6 +25,10 @@ if (process.env.COUCH_HOST) {
   queryParams.couchHost = process.env.COUCH_HOST;
 }
 
+if (process.env.NEXT) {
+  queryParams.src = '../../packages/pouchdb/dist/pouchdb-next.js';
+}
+
 var rebuildPromise = Promise.resolve();
 
 function rebuildPouch() {

--- a/packages/pouchdb/package.json
+++ b/packages/pouchdb/package.json
@@ -44,15 +44,19 @@
   },
   "devDependencies": {
     "pouchdb-adapter-fruitdown": "5.5.0-prerelease",
+    "pouchdb-adapter-http": "5.5.0-prerelease",
+    "pouchdb-adapter-indexeddb": "5.5.0-prerelease",
     "pouchdb-adapter-localstorage": "5.5.0-prerelease",
     "pouchdb-adapter-memory": "5.5.0-prerelease",
     "pouchdb-adapter-node-websql": "5.5.0-prerelease",
     "pouchdb-ajax": "5.5.0-prerelease",
     "pouchdb-browser": "5.5.0-prerelease",
     "pouchdb-checkpointer": "5.5.0-prerelease",
+    "pouchdb-core": "5.5.0-prerelease",
     "pouchdb-generate-replication-id": "5.5.0-prerelease",
     "pouchdb-node": "5.5.0-prerelease",
     "pouchdb-promise": "5.5.0-prerelease",
+    "pouchdb-replication": "5.5.0-prerelease",
     "pouchdb-utils": "5.5.0-prerelease"
   },
   "browser": {

--- a/packages/pouchdb/src/next.js
+++ b/packages/pouchdb/src/next.js
@@ -1,0 +1,4 @@
+module.exports = require('pouchdb-core')
+  .plugin(require('pouchdb-adapter-indexeddb'))
+  .plugin(require('pouchdb-adapter-http'))
+  .plugin(require('pouchdb-replication'));


### PR DESCRIPTION
Prompted by https://github.com/pouchdb/pouchdb/issues/5207#issuecomment-230528015, you can now build `pouchdb-next.js` as part of the build process. To simplify the dev process, you can do:

    NEXT=1 npm run dev

and it will test the "next" adapter. This ought to also work for the automated tests, but I haven't checked yet.

Note that if/when we publish, we will also publish `pouchdb-next.js` to npm, but this is low-risk I think. Maybe it's even better to get a beta out there early.