### PR TITLE
(#XXX) - Don't leak change listeners

### DIFF
--- a/packages/pouchdb-utils/src/changesHandler.js
+++ b/packages/pouchdb-utils/src/changesHandler.js
@@ -87,6 +87,7 @@ Changes.prototype.removeListener = function (dbName, id) {
   }
   EventEmitter.prototype.removeListener.call(this, dbName,
     this._listeners[id]);
+  delete this._listeners[id];
 };
 
 


### PR DESCRIPTION
When listener was removed, it still was kept in the internal array. I
don't think there is a sane way of testing this.