### PR TITLE
(#5452) - Removing unnecessary err

### DIFF
--- a/packages/pouchdb-replication/src/replicate.js
+++ b/packages/pouchdb-replication/src/replicate.js
@@ -418,7 +418,6 @@ function replicate(src, target, opts, returnValue, result) {
   function onCheckpointError(err) {
     writingCheckpoint = false;
     abortReplication('writeCheckpoint completed with error', err);
-    throw err;
   }
 
   /* istanbul ignore if */

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -4449,6 +4449,24 @@ adapters.forEach(function (adapters) {
       });
     });
 
+    it('#5452 Cleanly fail with no unhandled promises on a bad connection', function (done) {
+
+      if (!/http/.test(dbs.remote)) {
+        return done();
+      }
+
+      var db = new PouchDB(dbs.name);
+      var remote = new PouchDB('http://localhost:9382/does_not_exist', {skip_setup: true});
+
+      return remote.replicate.to(db, {
+          live: true,
+          since: 0,
+          timeout: 20000
+      }).catch(function () {
+          done();
+      });
+    });
+
     it('#2426 doc_ids dont prevent replication', function () {
 
       var db = new PouchDB(dbs.name);


### PR DESCRIPTION
#5452 

The test will trigger an onCheckpointError that will cause an unhandled
promise exception if the throw is included and works just fine if it is
removed.