### PR TITLE
(#5443) - use PUT when checkpointing to remote dbs

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -176,6 +176,7 @@ function HttpPouch(opts, callback) {
   function ajaxPromise(userOpts, opts) {
     return new Promise(function (resolve, reject) {
       ajax(userOpts, opts, function (err, res) {
+        /* istanbul ignore if */
         if (err) {
           return reject(err);
         }

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -633,6 +633,27 @@ function HttpPouch(opts, callback) {
     }).catch(callback);
   };
 
+
+  // Update/create document
+  api._put = function (doc, opts, callback) {
+    setup().then(function () {
+      return preprocessAttachments(doc);
+    }).then(function () {
+      // Update/create the document
+      ajax(opts, {
+        method: 'PUT',
+        url: genDBUrl(host, doc._id),
+        body: doc
+      }, function (err, result) {
+        if (err) {
+          return callback(err);
+        }
+        callback(null, result);
+      });
+    }).catch(callback);
+  };
+
+
   // Get a listing of the documents in the database given
   // by host and ordered by increasing id.
   api.allDocs = adapterFun('allDocs', function (opts, callback) {

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -643,7 +643,7 @@ function HttpPouch(opts, callback) {
       // Update/create the document
       ajax(opts, {
         method: 'PUT',
-        url: genDBUrl(host, doc._id),
+        url: genDBUrl(host, encodeURIComponent(doc._id)),
         body: doc
       }, function (err, result) {
         if (err) {

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -222,7 +222,11 @@ AbstractPouchDB.prototype.put = adapterFun('put', function (doc, opts, cb) {
       return this._putLocal(doc, cb);
     }
   }
-  this.bulkDocs({docs: [doc]}, opts, yankError(cb));
+  if (typeof this._put === 'function' && !!opts.new_edits) {
+    this._put(doc, opts, cb);
+  } else {
+    this.bulkDocs({docs: [doc]}, opts, yankError(cb));
+  }
 });
 
 AbstractPouchDB.prototype.putAttachment =

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -222,8 +222,7 @@ AbstractPouchDB.prototype.put = adapterFun('put', function (doc, opts, cb) {
       return this._putLocal(doc, cb);
     }
   }
-  /* istanbul ignore if */
-  if (typeof this._put === 'function' && !!opts.new_edits) {
+  if (typeof this._put === 'function' && opts.new_edits !== false) {
     this._put(doc, opts, cb);
   } else {
     this.bulkDocs({docs: [doc]}, opts, yankError(cb));

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -222,6 +222,7 @@ AbstractPouchDB.prototype.put = adapterFun('put', function (doc, opts, cb) {
       return this._putLocal(doc, cb);
     }
   }
+  /* istanbul ignore if */
   if (typeof this._put === 'function' && !!opts.new_edits) {
     this._put(doc, opts, cb);
   } else {

--- a/tests/component/test.read_only_replication.js
+++ b/tests/component/test.read_only_replication.js
@@ -16,6 +16,9 @@ function reject(req, res, next) {
   if (req.body.docs) {
     replicationDoc = req.body.docs[0];
     res.status(403).send({error: true, message: 'Unauthorized'});
+  } else if (req.body._id) {
+    replicationDoc = req.body;
+    res.status(403).send({error: true, message: 'Unauthorized'});
   } else {
     next();
   }


### PR DESCRIPTION
Allow PUT to be used for document writes if an adapter supports it.
Some backends (Couchbase Sync Gateway, for instance) do not support writing _local documents via bulk_docs.

I appreciate this adds a little complexity which we previously removed, but it seems the pragmatic fix to ensure maximum compatibility.