### PR TITLE
(#5486) - Handle empty xhr response

### DIFF
--- a/packages/pouchdb-ajax/src/request-browser.js
+++ b/packages/pouchdb-ajax/src/request-browser.js
@@ -213,7 +213,7 @@ function xhRequest(options, callback) {
       if (timedout) {
         err = new Error('ETIMEDOUT');
         err.code = 'ETIMEDOUT';
-      } else {
+      } else if (typeof xhr.response === 'string') {
         try {
           err = JSON.parse(xhr.response);
         } catch(e) {}


### PR DESCRIPTION
This can occur in Chrome on desktop, and probably other browsers too