### PR TITLE
Fixes inline appearance of some headers

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -64,12 +64,14 @@
 
         <div class="container">
 
-          <h1 class="margin-bottom-none">{{ page.title }}</h1>
-          {% if page.edit != false %}
-            <span class="h1 margin-bottom-none">
-              {% include edit_button.html %}
-            </span>
-          {% endif %}
+          <h1 class="margin-bottom-none">
+            {{ page.title }}
+            {% if page.edit != false %}
+              <span class="margin-bottom-none">
+                {% include edit_button.html %}
+              </span>
+            {% endif %}
+          </h1>
           {% if page.sub_title %}
             <h4>{{ page.sub_title}}</h4>
           {% endif %}

--- a/docs/static/less/pouchdb/type.less
+++ b/docs/static/less/pouchdb/type.less
@@ -2,7 +2,7 @@
 
 h1, h2, h3, h4, h5, h6,
 .h1, .h2, .h3, .h4, .h5, .h6 {
-  display: inline-block;
+  display: block;
   margin-top: 0;
   margin-bottom: .5em;
   .highlight + &,


### PR DESCRIPTION
I noticed that some headers were aligned incorrectly, such as:
"Using db.put()" https://pouchdb.com/api.html#create_document
"PouchDB allDbs()" https://pouchdb.com/external.html#plugins
and others in similar locations.

As far as I could tell, this doesn't change the appearance of anything else on the site, but let me know if you find otherwise.