### PR TITLE
(#5504) - update lie to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "js-extend": "1.0.1",
     "lerna": "nolanlawson/lerna#pouchdb-monorepo",
     "less": "2.7.1",
-    "lie": "3.0.4",
+    "lie": "3.1.0",
     "lodash.debounce": "4.0.7",
     "memdown": "1.2.0",
     "mkdirp": "0.5.1",

--- a/packages/pouchdb-errors/package.json
+++ b/packages/pouchdb-errors/package.json
@@ -13,7 +13,6 @@
     "src"
   ],
   "dependencies": {
-    "inherits": "2.0.1",
-    "lie": "3.0.4"
+    "inherits": "2.0.1"
   }
 }

--- a/packages/pouchdb-for-coverage/package.json
+++ b/packages/pouchdb-for-coverage/package.json
@@ -15,7 +15,7 @@
     "level-write-stream": "1.0.0",
     "leveldown": "1.4.6",
     "levelup": "1.3.2",
-    "lie": "3.0.4",
+    "lie": "3.1.0",
     "localstorage-down": "0.6.6",
     "ltgt": "2.1.2",
     "memdown": "1.1.2",

--- a/packages/pouchdb-promise/package.json
+++ b/packages/pouchdb-promise/package.json
@@ -13,6 +13,6 @@
     "src"
   ],
   "dependencies": {
-    "lie": "3.0.4"
+    "lie": "3.1.0"
   }
 }

--- a/packages/pouchdb/package.json
+++ b/packages/pouchdb/package.json
@@ -25,7 +25,7 @@
     "level-codec": "6.1.0",
     "level-write-stream": "1.0.0",
     "levelup": "1.3.2",
-    "lie": "3.0.4",
+    "lie": "3.1.0",
     "localstorage-down": "0.6.6",
     "ltgt": "2.1.2",
     "memdown": "1.1.2",


### PR DESCRIPTION
This release is pretty helpful, because it reduces the time it takes to `npm install` lie and how much space it takes up on disk by a lot: https://github.com/calvinmetcalf/lie/pull/34

Also I removed one instance where we had an unnecessary `lie` in `package.json`.

Closed https://github.com/pouchdb/pouchdb/pull/5503 in favor of this PR.