### PR TITLE
(#5506) - update pouchdb-collate docs

### DIFF
--- a/docs/custom.md
+++ b/docs/custom.md
@@ -397,6 +397,16 @@ Tool to write a checkpoint, e.g. during replication.
 npm install --save-exact pouchdb-checkpointer
 ```
 
+### pouchdb-collate
+
+Collation functions for PouchDB map/reduce.
+
+#### Example usage
+
+```bash
+npm install --save-exact pouchdb-collate
+```
+
 ### pouchdb-collections
 
 ES6 shims for Map and Set as used in PouchDB.

--- a/packages/pouchdb-collate/README.md
+++ b/packages/pouchdb-collate/README.md
@@ -1,4 +1,4 @@
-PouchDB Collate
+PouchDB Collate ![semver non-compliant](https://img.shields.io/badge/semver-non--compliant-red.svg)
 ===
 
 Collation functions for PouchDB map/reduce. Used by PouchDB map/reduce to maintain consistent [CouchDB collation ordering](https://wiki.apache.org/couchdb/View_collation).
@@ -8,25 +8,26 @@ The PouchDB Collate API is not exposed by PouchDB itself, but if you'd like to u
 Usage
 -----
 
-In Node:
-
-```
-$ npm install pouchdb-collate
+```bash
+npm install pouchdb-collate
 ```
 
-```
+```js
 var pouchCollate = require('pouchdb-collate');
 ```
 
-In the browser you can install with Bower:
+Warning: semver-free zone!
+----
 
-```
-$ bower install pouchdb-collate
-```
+This package is conceptually an internal API used by PouchDB or its plugins. It does not follow semantic versioning (semver), and rather its version is pegged to PouchDB's. Use exact versions when installing, e.g. with `--save-exact`.
 
-Or just download from the [releases page](https://github.com/pouchdb/collate/releases).
 
-Then it will be available as `window.pouchCollate`.
+Source
+----
+
+PouchDB and its sub-packages are distributed as a [monorepo](https://github.com/babel/babel/blob/master/doc/design/monorepo.md).
+
+For a full list of packages, see [the GitHub source](https://github.com/pouchdb/pouchdb/tree/master/packages).
 
 API
 ----

--- a/packages/pouchdb-collate/package.json
+++ b/packages/pouchdb-collate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pouchdb-collate",
   "version": "5.5.0-prerelease",
-  "description": "",
+  "description": "Collation functions for PouchDB map/reduce",
   "main": "lib/index.js",
   "keywords": [
     "pouchdb",


### PR DESCRIPTION
Adding language to match the other semver-non-compliant packages and a `description`.