### PR TITLE
Add check for file:// URLs

### DIFF
--- a/packages/pouchdb-core/src/constructor.js
+++ b/packages/pouchdb-core/src/constructor.js
@@ -64,6 +64,11 @@ function PouchDB(name, opts) {
     throw new Error('Missing/invalid DB name');
   }
 
+  if (typeof window !== 'undefined' && window.location && window.location.href && window.location.href.match(/^file:/)) {
+    console.warn("Warning: PouchDB will not work correctly on file:// URLs, because the underlying" +
+      "storage (IndexedDB or WebSQL) will not. Please serve PouchDB-using pages from a web server.");
+  }
+  
   var prefixedName = (opts.prefix || '') + name;
   var backend = parseAdapter(prefixedName, opts);
 


### PR DESCRIPTION
Display a warning if one attempts to use PouchDB in a browser on a file URL, because it won't work right.

Appreciate that there isn't a test for this, but the whole test suite is designed to spin up a server and then test against it; spinning up saucelabs/selenium to run the suite of browser tests against a file: URL just to see if this warning is emitted (and then have all the tests fail because Pouch doesn't work on file: URLs) seemed rather overkill.