### PR TITLE
(#5527) - Check if ArrayBuffer is defined before binary check

### DIFF
--- a/packages/pouchdb-utils/src/isBinaryObject-browser.js
+++ b/packages/pouchdb-utils/src/isBinaryObject-browser.js
@@ -1,5 +1,5 @@
 function isBinaryObject(object) {
-  return object instanceof ArrayBuffer ||
+  return (typeof ArrayBuffer !== 'undefined' && object instanceof ArrayBuffer) ||
     (typeof Blob !== 'undefined' && object instanceof Blob);
 }
 


### PR DESCRIPTION
Fixes #5527. I've unfortunately been unable to run the tests on the browser (tried Mac, Windows & BashOnWindows), but I believe the change is pretty straightforward.