### PR TITLE
Add safe npm dependency caching to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,3 +136,7 @@ matrix:
 branches:
   only:
   - master
+
+cache:
+  directories:
+  - $HOME/.npm


### PR DESCRIPTION
As discussed with @nolanlawson this PR adds dependency caching for Travis, but in a safe way.
It does not add the project's node_modules folder to the cache, but npm's global cache folder, that contains all the tarballs.
This isn't quite as fast as caching node_modules, but at least saves download time, while ensuring a consistent "fresh install" experience.

Time savings should be visible from the second build on.
