### PR TITLE
(#5581) - update firefox in travis to 48.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo:
   false
 
 addons:
-  firefox: "41.0.1"
+  firefox: "48.0"
 
 before_install:
   # Because Saucelabs doesnt proxy 5984 on OSX
@@ -52,24 +52,24 @@ env:
 
   # Test against pouchdb-server
   - CLIENT=node SERVER=pouchdb-server COMMAND=test
-  - CLIENT=selenium:firefox:41.0.1 SERVER=pouchdb-server COMMAND=test
+  - CLIENT=selenium:firefox:48.0 SERVER=pouchdb-server COMMAND=test
   - SERVER_ADAPTER=memdown LEVEL_ADAPTER=memdown SERVER=pouchdb-server COMMAND=test
 
   # Test against pouchdb-express-router
   - CLIENT=node SERVER=pouchdb-express-router COMMAND=test
 
   # Test in firefox/phantomjs running on travis
-  - CLIENT=selenium:firefox:41.0.1 COMMAND=test
+  - CLIENT=selenium:firefox:48.0 COMMAND=test
   - CLIENT=selenium:phantomjs COMMAND=test
 
   # Test auto-compaction in Node, Phantom, and Firefox
   - AUTO_COMPACTION=true CLIENT=node COMMAND=test
-  - AUTO_COMPACTION=true CLIENT=selenium:firefox:41.0.1 COMMAND=test
+  - AUTO_COMPACTION=true CLIENT=selenium:firefox:48.0 COMMAND=test
   - AUTO_COMPACTION=true CLIENT=selenium:phantomjs COMMAND=test
 
   # Test map/reduce
   - TYPE=mapreduce CLIENT=node COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:firefox:41.0.1 COMMAND=test
+  - TYPE=mapreduce CLIENT=selenium:firefox:48.0 COMMAND=test
   - TYPE=mapreduce CLIENT=selenium:phantomjs COMMAND=test
 
   # Testing in saucelabs
@@ -83,28 +83,28 @@ env:
   # split up the android+iphone tests as it goes over time
   - SKIP_MIGRATION=true CLIENT="saucelabs:iphone:8.1:OS X 10.10" COMMAND=test
   - CLIENT="saucelabs:Android:5.1:Linux" COMMAND=test
-  - CLIENT=selenium:firefox:41.0.1 ADAPTERS=memory COMMAND=test
-  - CLIENT=selenium:firefox:41.0.1 ADAPTERS=localstorage COMMAND=test
+  - CLIENT=selenium:firefox:48.0 ADAPTERS=memory COMMAND=test
+  - CLIENT=selenium:firefox:48.0 ADAPTERS=localstorage COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:41.0.1 COMMAND=test-webpack
+  - CLIENT=selenium:firefox:48.0 COMMAND=test-webpack
 
   # Test CouchDB master (aka bigcouch branch)
   - COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:41.0.1 SERVER=couchdb-master COMMAND=test
+  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:48.0 SERVER=couchdb-master COMMAND=test
 
   # Test Couchbase Sync Gateway
   - GREP=test.replication.js CLIENT=node SERVER=sync-gateway BAIL=0 COMMAND=test
 
   # Test Cloudant
-  - CLIENT=selenium:firefox:41.0.1 SERVER=couchdb-master COUCH_HOST=https://$CLOUDANT_USERNAME:$CLOUDANT_PASSWORD@pouch.cloudant.com COMMAND=test
+  - CLIENT=selenium:firefox:48.0 SERVER=couchdb-master COUCH_HOST=https://$CLOUDANT_USERNAME:$CLOUDANT_PASSWORD@pouch.cloudant.com COMMAND=test
 
   # Performance tests
-  - CLIENT=selenium:firefox:41.0.1 PERF=1 COMMAND=test
+  - CLIENT=selenium:firefox:48.0 PERF=1 COMMAND=test
   - PERF=1 COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:41.0.1 NEXT=1 COMMAND=test
+  - CLIENT=selenium:firefox:48.0 NEXT=1 COMMAND=test
 
   - COMMAND=test-extras
   - COMMAND=test-unit
@@ -121,15 +121,15 @@ matrix:
 
   # Allowed failures
   - env: COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:41.0.1 SERVER=couchdb-master COMMAND=test
+  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:48.0 SERVER=couchdb-master COMMAND=test
   - env: CLIENT=node SERVER=pouchdb-express-router COMMAND=test
   - env: CLIENT=node SERVER=pouchdb-server COMMAND=test
-  - env: CLIENT=selenium:firefox:41.0.1 SERVER=pouchdb-server COMMAND=test
+  - env: CLIENT=selenium:firefox:48.0 SERVER=pouchdb-server COMMAND=test
   - env: SERVER_ADAPTER=memdown LEVEL_ADAPTER=memdown SERVER=pouchdb-server COMMAND=test
-  - env: CLIENT=selenium:firefox:41.0.1 SERVER=couchdb-master COUCH_HOST=https://$CLOUDANT_USERNAME:$CLOUDANT_PASSWORD@pouch.cloudant.com COMMAND=test
+  - env: CLIENT=selenium:firefox:48.0 SERVER=couchdb-master COUCH_HOST=https://$CLOUDANT_USERNAME:$CLOUDANT_PASSWORD@pouch.cloudant.com COMMAND=test
   - env: CLIENT="saucelabs:MicrosoftEdge" COMMAND=test
-  - env: CLIENT=selenium:firefox:41.0.1 PERF=1 COMMAND=test
-  - env: CLIENT=selenium:firefox:41.0.1 NEXT=1 COMMAND=test
+  - env: CLIENT=selenium:firefox:48.0 PERF=1 COMMAND=test
+  - env: CLIENT=selenium:firefox:48.0 NEXT=1 COMMAND=test
 
   fast_finish: true
 

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -16,7 +16,7 @@ var testTimeout = 30 * 60 * 1000;
 var username = process.env.SAUCE_USERNAME;
 var accessKey = process.env.SAUCE_ACCESS_KEY;
 
-var SELENIUM_VERSION = process.env.SELENIUM_VERSION || '2.45.0';
+var SELENIUM_VERSION = process.env.SELENIUM_VERSION || '2.53.1';
 
 // BAIL=0 to disable bailing
 var bail = process.env.BAIL !== '0';


### PR DESCRIPTION
Last I checked, we were stuck with 41.0.1 because of problems with WebDriver, but I believe the latest version of Selenium should work with 48.0 using the new geckodriver. Fingers crossed this passes.