### PR TITLE
Support options.timeout in replication bulkDocs(); closes #5584

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -620,6 +620,7 @@ function HttpPouch(opts, callback) {
       ajax(opts, {
         method: 'POST',
         url: genDBUrl(host, '_bulk_docs'),
+        timeout: opts.timeout,
         body: req
       }, function (err, results) {
         if (err) {

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -57,7 +57,8 @@ function replicate(src, target, opts, returnValue, result) {
       return;
     }
     var docs = currentBatch.docs;
-    return target.bulkDocs({docs: docs, new_edits: false}).then(function (res) {
+    var bulkOpts = {timeout: opts.timeout};
+    return target.bulkDocs({docs: docs, new_edits: false}, bulkOpts).then(function (res) {
       /* istanbul ignore if */
       if (returnValue.cancelled) {
         completeReplication();


### PR DESCRIPTION
This is the simplest possible PR to close #5584. Basically pouchdb-replication passes that timeout value to bulkDocs, and the HTTP adapter passes it to request.

This is a very small change, but please let me know if you would like for me to add a unit test.