### PR TITLE
(#5590) - remove optionalDependencies (BREAKING CHANGE)

### DIFF
--- a/packages/node_modules/pouchdb/package.json
+++ b/packages/node_modules/pouchdb/package.json
@@ -24,6 +24,7 @@
     "js-extend": "*",
     "level-codec": "*",
     "level-write-stream": "*",
+    "leveldown": "*",
     "levelup": "*",
     "lie": "*",
     "localstorage-down": "*",
@@ -35,10 +36,7 @@
     "scope-eval": "*",
     "spark-md5": "*",
     "through2": "*",
-    "vuvuzela": "*"
-  },
-  "optionalDependencies": {
-    "leveldown": "*",
+    "vuvuzela": "*",
     "websql": "*"
   },
   "browser": {


### PR DESCRIPTION
These are no longer required because users have the option to use custom builds instead. This is intended for 6.0.0.