### PR TITLE
Specifying custom ajax function

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -167,29 +167,17 @@ function HttpPouch(opts, callback) {
   api._ajax = ajaxCore;
   var ajaxFun = opts.ajaxFun;
 
-  /*function ajax(userOpts, options, callback) {
-    var reqAjax = userOpts.ajax || {};
-    var reqOpts = extend(clone(ajaxOpts), reqAjax, options);
-    log(reqOpts.method + ' ' + reqOpts.url);
-    return api._ajax(reqOpts, callback);
-  }*/
-
   function ajax(userOpts, options, callback) {
     var reqAjax = userOpts.ajax || {};
     var reqOpts = extend(clone(ajaxOpts), reqAjax, options);
     log(reqOpts.method + ' ' + reqOpts.url);
     if(typeof ajaxFun === 'function') {
-      return ajaxFun(reqOpts, function(finalReqOpts) {
-        return new Promise(function (resolve, reject) {
-          api._ajax(finalReqOpts, function (err, res) {
-            /* istanbul ignore if */
-            if (err) {
-              return reject(err);
-            }
-            resolve(res);
-          })
+      return ajaxFun(reqOpts, callback, function(finalReqOpts, userCb) {
+        return api._ajax(finalReqOpts, function(err, result, response) {
+          userCb(err, result, response);
+          callback(err, result, response);
         })
-      })
+      });
     }
     else {
       return api._ajax(reqOpts, callback)

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -165,12 +165,35 @@ function HttpPouch(opts, callback) {
   // Not strictly necessary, but we do this because numerous tests
   // rely on swapping ajax in and out.
   api._ajax = ajaxCore;
+  var ajaxFun = opts.ajaxFun;
+
+  /*function ajax(userOpts, options, callback) {
+    var reqAjax = userOpts.ajax || {};
+    var reqOpts = extend(clone(ajaxOpts), reqAjax, options);
+    log(reqOpts.method + ' ' + reqOpts.url);
+    return api._ajax(reqOpts, callback);
+  }*/
 
   function ajax(userOpts, options, callback) {
     var reqAjax = userOpts.ajax || {};
     var reqOpts = extend(clone(ajaxOpts), reqAjax, options);
     log(reqOpts.method + ' ' + reqOpts.url);
-    return api._ajax(reqOpts, callback);
+    if(typeof ajaxFun === 'function') {
+      return ajaxFun(reqOpts, function(finalReqOpts) {
+        return new Promise(function (resolve, reject) {
+          api._ajax(finalReqOpts, function (err, res) {
+            /* istanbul ignore if */
+            if (err) {
+              return reject(err);
+            }
+            resolve(res);
+          })
+        })
+      })
+    }
+    else {
+      return api._ajax(reqOpts, callback)
+    }
   }
 
   function ajaxPromise(userOpts, opts) {


### PR DESCRIPTION
This is a very rough attempt at #5322. This is probably not the prettiest way to do it so I'm open to any suggestions as to how to improve it. For me, the most important thing is that it lets me generate OAuth signatures for every outgoing request and seems to be working fine.

I'm having headaches trying to redirect my project to my fork, as the HTTP adapter is a sub-dependency. I would really appreciate it if we could merge this, or a better version of this, into the main repo.