### PR TITLE
(#5612) - change view & filter function execution

### DIFF
--- a/packages/node_modules/pouchdb-core/package.json
+++ b/packages/node_modules/pouchdb-core/package.json
@@ -26,6 +26,8 @@
     "scope-eval": "*"
   },
   "browser": {
-    "./lib/index.js": "./lib/index-browser.js"
+    "./lib/index.js": "./lib/index-browser.js",
+    "./src/evalFilter.js": "./src/evalFilter-browser.js",
+    "./src/evalView.js": "./src/evalView-browser.js"
   }
 }

--- a/packages/node_modules/pouchdb-core/src/evalFilter-browser.js
+++ b/packages/node_modules/pouchdb-core/src/evalFilter-browser.js
@@ -1,0 +1,7 @@
+import scopedEval from 'scope-eval';
+
+function evalFilter(input) {
+  return scopedEval('"use strict";\nreturn ' + input + ';', {});
+}
+
+export default evalFilter;

--- a/packages/node_modules/pouchdb-core/src/evalFilter.js
+++ b/packages/node_modules/pouchdb-core/src/evalFilter.js
@@ -1,7 +1,9 @@
-import scopedEval from 'scope-eval';
+import vm from 'vm';
 
 function evalFilter(input) {
-  return scopedEval('return ' + input + ';', {});
+  var code = '(function() {\n"use strict";\nreturn ' + input + '\n})()';
+
+  return vm.runInNewContext(code);
 }
 
 export default evalFilter;

--- a/packages/node_modules/pouchdb-core/src/evalView-browser.js
+++ b/packages/node_modules/pouchdb-core/src/evalView-browser.js
@@ -1,0 +1,22 @@
+import scopedEval from 'scope-eval';
+
+function evalView(input) {
+  var code = [
+    'return function(doc) {',
+    '  "use strict";',
+    '  var emitted = false;',
+    '  var emit = function (a, b) {',
+    '    emitted = true;',
+    '  };',
+    '  var view = ' + input + ';',
+    '  view(doc);',
+    '  if (emitted) {',
+    '    return true;',
+    '  }',
+    '};'
+  ].join('\n');
+
+  return scopedEval(code, {});
+}
+
+export default evalView;

--- a/packages/node_modules/pouchdb-core/src/evalView.js
+++ b/packages/node_modules/pouchdb-core/src/evalView.js
@@ -1,6 +1,8 @@
+import vm from 'vm';
+
 function evalView(input) {
-  /* jshint evil:true */
-  return new Function('doc', [
+  var code = [
+    '"use strict";',
     'var emitted = false;',
     'var emit = function (a, b) {',
     '  emitted = true;',
@@ -10,7 +12,9 @@ function evalView(input) {
     'if (emitted) {',
     '  return true;',
     '}'
-  ].join('\n'));
+  ].join('\n');
+
+  return vm.runInNewContext('(function(doc) {\n' + code + '\n})');
 }
 
 export default evalView;


### PR DESCRIPTION
This changes both `evalView` and `evalFilter` in pouchdb-core to enforce
strict mode. When running Node.js, we're furthermore executing the
respective function in a sandbox now. We're using the `vm` module
provided by Node.js for that.

BREAKING CHANGE: this may break view or filter functions, as we're now
generally enforcing strict mode for view and filter functions.