### PR TITLE
(#5619) - fix set-version script

### DIFF
--- a/bin/set-version.js
+++ b/bin/set-version.js
@@ -23,22 +23,6 @@ var jsonFiles = packages.map(function (pkg) {
 jsonFiles.forEach(function (jsonFile) {
   var json = JSON.parse(fs.readFileSync(jsonFile), 'utf-8');
   json.version = version;
-  // update version of all inner dependencies
-  var depsList = [
-    json.dependencies,
-    json.devDependencies,
-    json.peerDependencies
-  ];
-  depsList.forEach(function (deps) {
-    if (!deps) {
-      return;
-    }
-    Object.keys(deps).forEach(function (key) {
-      if (packages.indexOf(key) !== -1) {
-        deps[key] = version;
-      }
-    });
-  });
   fs.writeFileSync(jsonFile, JSON.stringify(json, null, '  ') + '\n', 'utf-8');
 });
 


### PR DESCRIPTION
The `set-version` script doesn't need to update the dependency versions inside of the individual `package.json`s; we set these to `*` and then they're set by the `release.sh` script.