### PR TITLE
(#5625) - remove websql as dependency of pouchdb

### DIFF
--- a/packages/node_modules/pouchdb/package.json
+++ b/packages/node_modules/pouchdb/package.json
@@ -36,8 +36,7 @@
     "scope-eval": "*",
     "spark-md5": "*",
     "through2": "*",
-    "vuvuzela": "*",
-    "websql": "*"
+    "vuvuzela": "*"
   },
   "browser": {
     "./lib/index.js": "./lib/index-browser.js",


### PR DESCRIPTION
Not sure how I missed this, but there's no reason to have this dependency anymore, because the functionality has been moved into a separate package. This should vastly speed up `npm install pouchdb` and make it less error-prone.