### PR TITLE
(#5612) - add vm to ignored deps

### DIFF
--- a/bin/external-deps.js
+++ b/bin/external-deps.js
@@ -10,7 +10,7 @@ module.exports = [
   'fruitdown', 'inherits', 'js-extend', 'level-write-stream', 'levelup', 'lie',
   'localstorage-down', 'memdown',
   'request', 'scope-eval', 'spark-md5', 'through2',
-  'vuvuzela', 'leveldown', 'websql',
+  'vuvuzela', 'leveldown', 'websql', 'vm',
   // core node deps
   'fs', 'crypto', 'events', 'path',
   // sublevel-pouchdb


### PR DESCRIPTION
Rollup ignores this anyway, but it's nice to be explicit so that we don't get an additional warning message during the build.