### PR TITLE
Prevent from throwing in firefox private mode

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -970,6 +970,8 @@ function init(api, opts, callback) {
     var msg = 'Failed to open indexedDB, are you in private browsing mode?';
     guardedConsole('error', msg);
     callback(createError(IDB_ERROR, msg));
+    
+    return true; // It's preventing `InvalidStateError` and `UnknownError` exceptions.
   };
 }
 


### PR DESCRIPTION
This is a continution of #4010.
I'm seeing a lot of `InvalidStateError` error from users accessing my app in the private mode of Firefox.
I don't think that throwing an error here have much value.

I'm using https://github.com/localForage/localForage/issues/195#issuecomment-185135074 as inspiration.

- [ ] We need to upgrade the pouchdb docs error section if we move forward.