### PR TITLE
(#5586) - updates to 6.0.0 blog post

### DIFF
--- a/docs/_posts/2016-09-05-pouchdb-6.0.0.md
+++ b/docs/_posts/2016-09-05-pouchdb-6.0.0.md
@@ -1,40 +1,113 @@
 ---
 layout: post
 
-title: PouchDB 6.0.0: Labour Day
+title: PouchDB 6.0.0&#58; Labour Day
 author: Dale Harvey
 
 ---
 
-To celebrate the USA and Canada's Labo(u)r Day we have decided to work extra hard to bring
-you PouchDB 6.0.0 which brings early retirement to those features that have done great
-work over the years but whose services are no longer necessary (don't worry, we will pay
+To celebrate the USA and Canada's Labo(u)r Day, we have decided to work extra hard to bring
+you PouchDB 6.0.0. This release brings early retirement to those features that have done great
+work over the years, but whose services are no longer necessary (don't worry, we will pay
 their pensions in full).
 
-Along with the removed features we have a large list of bugfixes, documentation
+Along with the removed features, we have a large list of bugfixes, documentation
 work and general improvements for you to enjoy with your BBQ.
 
 ### Removed Features
 
-PouchDB 5.4.0 introduces some deprecations. In 6.0 we have now removed these
+PouchDB 5.4.0 introduced some deprecations. In 6.0.0, we have now removed these
 features permanently:
 
-* ([#5154](https://github.com/pouchdb/pouchdb/issues/5154)) - Remove db.put(doc, id, rev)
+#### ([#5154](https://github.com/pouchdb/pouchdb/issues/5154)) - Remove `db.put(doc, id, rev)`
 
 Please use `db.put({_id: id, _rev: rev, data: 'foo'})` instead.
 
-* ([#5251](https://github.com/pouchdb/pouchdb/issues/5251)) - Remove `new PouchDB(dbName).then`
+#### ([#5251](https://github.com/pouchdb/pouchdb/issues/5251)) - Remove `new PouchDB(dbName).then`
 
-The constructor is now stateless. If you need to test whether setup can complete
+The constructor is now stateless. If you need to test whether setup can complete,
 then `new PouchDB(dbName).info()` can do that for you.
 
-* ([#5519](https://github.com/pouchdb/pouchdb/pull/5591)) - Remove extras API
-* ([#5591](https://github.com/pouchdb/pouchdb/pull/5519)) - Remove sqlite plugin support
+Note this also applies to the callback style, i.e. `new PouchDB(dbName, function (err) { /* ... */ }`.
 
-Please use the [pouchdb-adapter-cordova-sqlite](https://github.com/nolanlawson/pouchdb-adapter-cordova-sqlite/blob/master/README.md) plugin instead.
+#### ([#5591](https://github.com/pouchdb/pouchdb/pull/5519)) - Remove SQLite Plugin support
 
-* ([#5435](https://github.com/pouchdb/pouchdb/pull/5435)) - Remove getHost
+The WebSQL adapter no longer automatically detects the SQLite Plugin in Cordova environments.
+Please use the [pouchdb-adapter-cordova-sqlite](https://github.com/nolanlawson/pouchdb-adapter-cordova-sqlite) plugin instead.
 
+#### ([#5519](https://github.com/pouchdb/pouchdb/pull/5591)) - Remove `extras` API
+
+APIs like `require('pouchdb/extras/ajax')` are gone. Instead these have been extracted out into 
+separate packages:
+
+<div class="table-responsive">
+<table class="table">
+  <thead>
+  <tr>
+    <th>Removed</th>
+    <th>Use instead</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td><code>require('pouchdb/extras/ajax')</code></td>
+    <td><code>require('pouchdb-ajax')</code></td>
+  </tr>
+  <tr>
+    <td><code>require('pouchdb/extras/checkpointer')</code></td>
+    <td><code>require('pouchdb-checkpointer')</code></td>
+  </tr>
+  <tr>
+    <td><code>require('pouchdb/extras/generateReplicationId')</code></td>
+    <td><code>require('pouchdb-generate-replication-id')</code></td>
+  </tr>
+  <tr>
+    <td><code>require('pouchdb/extras/promise')</code></td>
+    <td><code>require('pouchdb-promise')</code></td>
+  </tr>
+  <tr>
+    <td><code>require('pouchdb/extras/fruitdown')</code></td>
+    <td><code>require('pouchdb-adapter-fruitdown')</code>*</td>
+  </tr>
+  <tr>
+    <td><code>require('pouchdb/extras/localstorage')</code></td>
+    <td><code>require('pouchdb-adapter-localstorage')</code>*</td>
+  </tr>
+  <tr>
+    <td><code>require('pouchdb/extras/memory')</code></td>
+    <td><code>require('pouchdb-adapter-memory')</code>*</td>
+  </tr>
+  <tr>
+    <td><code>require('pouchdb/extras/websql')</code></td>
+    <td><code>require('pouchdb-adapter-node-websql')</code>*</td>
+  </tr>
+  </tbody>
+</table>
+</div>
+
+{% include alert/start.html variant="info"%}
+{% markdown %}
+\* For the adapters, you'll also need to explicitly register them using `PouchDB.plugin()`, e.g. `PouchDB.plugin(require('pouchdb-adapter-memory'))`. Please see [Custom builds](/custom.html) for more info.
+{% endmarkdown %}
+{% include alert/end.html%}
+
+#### ([#5435](https://github.com/pouchdb/pouchdb/pull/5435)) - Remove `getUrl()`, `getHeaders()` from HTTP adapter
+
+Instead of the `getUrl()` API, you can use `db.name` to determine the URL for HTTP-based adapters. For `getHeaders()`
+no replacement is intended. Both APIs were previously undocumented.
+
+#### ([#5625](https://github.com/pouchdb/pouchdb/pull/5625), [#5590](https://github.com/pouchdb/pouchdb/pull/5590)) - Remove node-websql as dependency, remove `optionalDependencies`
+
+`leveldown` and `websql` are no longer optional dependencies. Instead, `websql` is removed entirely (use
+[pouchdb-adapter-node-websql](https://www.npmjs.com/package/pouchdb-adapter-node-websql) instead), and `leveldown` is
+now required.
+
+If you want to avoid installing `leveldown`, then you can use the [pouchdb-browser](https://www.npmjs.com/package/pouchdb-browser) preset if you don't need Node support, or you can use [pouchdb-memory](https://www.npmjs.com/package/pouchdb-memory) if you only need an in-memory database. For all other uses, see [Custom builds](/custom.html).
+
+#### ([#5612](https://github.com/pouchdb/pouchdb/pull/5612)) - Sandbox view and filter function execution
+
+View and filter functions now execute in `'use strict'` environments and within a sandbox in Node. If you were depending on
+non-strict mode or non-sandboxed behavior, then you will need to change your view/filter functions.
 
 ### Bugfixes
 

--- a/docs/api.html
+++ b/docs/api.html
@@ -31,7 +31,6 @@ edit: false
 {% include api/events.html %}
 {% include api/defaults.html %}
 {% include api/plugins.html %}
-{% include api/extras.html %}
 {% include api/debug_mode.html %}
 
 {% endmarkdown %}


### PR DESCRIPTION
Copyedits, added some deprecations we forgot to mention, added a table to help folks migrate from the `extras` API, fixed a lingering issue with the missing `extras.md` file.