### PR TITLE
docs update: #5154 deprecated params of put

### DIFF
--- a/docs/_includes/api/create_document.html
+++ b/docs/_includes/api/create_document.html
@@ -2,7 +2,7 @@
 
 ### Using db.put()
 {% highlight js %}
-db.put(doc, [docId], [docRev], [options], [callback])
+db.put(doc, [options], [callback])
 {% endhighlight %}
 
 Create a new document or update an existing document. If the document already exists, you must specify its revision `_rev`, otherwise a conflict will occur.


### PR DESCRIPTION
I also noticed that the title `using db.put (h3)` is on the same line like the title `create/update a document (h2)` removing the css `display: inline-block` would help, but maybe introduces other unwanted changes..