### PR TITLE
(#5645) - prefer immediate to process.nextTick() for better perf

### DIFF
--- a/bin/external-deps.js
+++ b/bin/external-deps.js
@@ -8,7 +8,7 @@ module.exports = [
   // main deps
   'argsarray', 'debug', 'double-ended-queue', 'es3ify', 'es6-promise-pool',
   'fruitdown', 'inherits', 'js-extend', 'level-write-stream', 'levelup', 'lie',
-  'localstorage-down', 'memdown',
+  'localstorage-down', 'memdown', 'immediate',
   'request', 'scope-eval', 'spark-md5', 'through2',
   'vuvuzela', 'leveldown', 'websql',
   // core node deps

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "double-ended-queue": "2.1.0-0",
     "es6-promise-pool": "2.4.4",
     "fruitdown": "1.0.2",
+    "immediate": "3.0.6",
     "inherits": "2.0.1",
     "js-extend": "1.0.1",
     "level-codec": "6.2.0",

--- a/packages/node_modules/pouchdb-adapter-idb/package.json
+++ b/packages/node_modules/pouchdb-adapter-idb/package.json
@@ -13,6 +13,7 @@
     "src"
   ],
   "dependencies": {
+    "immediate": "*",
     "js-extend": "*",
     "pouchdb-binary-utils": "*",
     "pouchdb-collections": "*",

--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -14,6 +14,7 @@ import {
   winningRev as calculateWinningRev
 } from 'pouchdb-merge';
 
+import immediate from 'immediate';
 import { Map, Set } from 'pouchdb-collections';
 import idbBulkDocs from './bulkDocs';
 import idbAllDocs from './allDocs';
@@ -821,7 +822,7 @@ function init(api, opts, callback) {
   if (cached) {
     idb = cached.idb;
     api._meta = cached.global;
-    process.nextTick(function () {
+    immediate(function () {
       callback(null, api);
     });
     return;

--- a/packages/node_modules/pouchdb-adapter-idb/src/utils.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/utils.js
@@ -1,3 +1,4 @@
+import immediate from 'immediate';
 import { extend } from 'js-extend';
 import Promise from 'pouchdb-promise';
 import { createError, IDB_ERROR } from 'pouchdb-errors';
@@ -41,7 +42,7 @@ function applyNext(PouchDB) {
   item.action(function (err, res) {
     tryCode(item.callback, this, [err, res], PouchDB);
     taskQueue.running = false;
-    process.nextTick(function () {
+    immediate(function () {
       applyNext(PouchDB);
     });
   });

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/package.json
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "argsarray": "*",
     "double-ended-queue": "*",
+    "immediate": "*",
     "level-write-stream": "*",
     "levelup": "*",
     "pouchdb-binary-utils": "*",

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -1,3 +1,4 @@
+import immediate from 'immediate';
 import levelup from 'levelup';
 import sublevel from 'sublevel-pouchdb';
 import { obj as through } from 'through2';
@@ -210,7 +211,7 @@ function LevelPouch(opts, callback) {
           stores.metaStore.get(UUID_KEY, function (err, value) {
             instanceId = !err ? value : uuid();
             stores.metaStore.put(UUID_KEY, instanceId, function () {
-              process.nextTick(function () {
+              immediate(function () {
                 callback(null, api);
               });
             });
@@ -242,7 +243,7 @@ function LevelPouch(opts, callback) {
       update_seq: db._updateSeq,
       backend_adapter: functionName(leveldown)
     };
-    return process.nextTick(function () {
+    return immediate(function () {
       callback(null, res);
     });
   };
@@ -285,7 +286,7 @@ function LevelPouch(opts, callback) {
       args[args.length - 1] = getArguments(function (cbArgs) {
         callback.apply(null, cbArgs);
         if (++numDone === readTasks.length) {
-          process.nextTick(function () {
+          immediate(function () {
             // all read tasks have finished
             readTasks.forEach(function () {
               db._queue.shift();
@@ -305,7 +306,7 @@ function LevelPouch(opts, callback) {
     var callback = args[args.length - 1];
     args[args.length - 1] = getArguments(function (cbArgs) {
       callback.apply(null, cbArgs);
-      process.nextTick(function () {
+      immediate(function () {
         db._queue.shift();
         if (db._queue.length) {
           executeNext();
@@ -328,7 +329,7 @@ function LevelPouch(opts, callback) {
       });
 
       if (db._queue.length === 1) {
-        process.nextTick(executeNext);
+        immediate(executeNext);
       }
     });
   }
@@ -343,7 +344,7 @@ function LevelPouch(opts, callback) {
       });
 
       if (db._queue.length === 1) {
-        process.nextTick(executeNext);
+        immediate(executeNext);
       }
     });
   }
@@ -781,7 +782,7 @@ function LevelPouch(opts, callback) {
     function complete(err) {
       /* istanbul ignore if */
       if (err) {
-        return process.nextTick(function () {
+        return immediate(function () {
           callback(err);
         });
       }
@@ -807,7 +808,7 @@ function LevelPouch(opts, callback) {
         db._docCount += docCountDelta;
         db._updateSeq = newUpdateSeq;
         levelChanges.notify(name);
-        process.nextTick(function () {
+        immediate(function () {
           callback(null, results);
         });
       });

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/migrate-browser.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/migrate-browser.js
@@ -1,13 +1,14 @@
+import immediate from 'immediate';
 // in the browser, LevelAlt doesn't need the
 // pre-2.2.0 LevelDB-specific migrations
 var toSublevel = function (name, db, callback) {
-  process.nextTick(function () {
+  immediate(function () {
     callback();
   });
 };
 
 var localAndMetaStores = function (db, stores, callback) {
-  process.nextTick(function () {
+  immediate(function () {
     callback();
   });
 };

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/transaction.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/transaction.js
@@ -3,6 +3,7 @@
 // things in-memory and then does a big batch() operation
 // when you're done
 
+import immediate from 'immediate';
 import { Map, Set } from 'pouchdb-collections';
 
 function getCacheFor(transaction, store) {
@@ -25,12 +26,12 @@ LevelTransaction.prototype.get = function (store, key, callback) {
   var cache = getCacheFor(this, store);
   var exists = cache.get(key);
   if (exists) {
-    return process.nextTick(function () {
+    return immediate(function () {
       callback(null, exists);
     });
   } else if (exists === null) { // deleted marker
     /* istanbul ignore next */
-    return process.nextTick(function () {
+    return immediate(function () {
       callback({name: 'NotFoundError'});
     });
   }

--- a/packages/node_modules/pouchdb-core/package.json
+++ b/packages/node_modules/pouchdb-core/package.json
@@ -16,6 +16,7 @@
     "argsarray": "*",
     "debug": "*",
     "double-ended-queue": "*",
+    "immediate": "*",
     "inherits": "*",
     "js-extend": "*",
     "pouchdb-collections": "*",

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -1,3 +1,4 @@
+import immediate from 'immediate';
 import { extend } from 'js-extend';
 import Promise from 'pouchdb-promise';
 import { Map } from 'pouchdb-collections';
@@ -170,7 +171,7 @@ function doNextCompaction(self) {
       } else {
         callback(null, res);
       }
-      process.nextTick(function () {
+      immediate(function () {
         self._compactionQueue.shift();
         if (self._compactionQueue.length) {
           doNextCompaction(self);

--- a/packages/node_modules/pouchdb-mapreduce-utils/src/index.js
+++ b/packages/node_modules/pouchdb-mapreduce-utils/src/index.js
@@ -3,13 +3,9 @@ import argsarray from 'argsarray';
 var promisedCallback = function (promise, callback) {
   if (callback) {
     promise.then(function (res) {
-      process.nextTick(function () {
-        callback(null, res);
-      });
+      callback(null, res);
     }, function (reason) {
-      process.nextTick(function () {
-        callback(reason);
-      });
+      callback(reason);
     });
   }
   return promise;

--- a/packages/node_modules/pouchdb-mapreduce/package.json
+++ b/packages/node_modules/pouchdb-mapreduce/package.json
@@ -13,6 +13,7 @@
     "src"
   ],
   "dependencies": {
+    "immediate": "*",
     "inherits": "*",
     "pouchdb-binary-utils": "*",
     "pouchdb-collate": "*",

--- a/packages/node_modules/pouchdb-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-mapreduce/src/index.js
@@ -1,3 +1,4 @@
+import immediate from 'immediate';
 import {
   flatten,
   guardedConsole
@@ -915,7 +916,7 @@ function queryPromised(db, fun, opts) {
       return createView(createViewOpts).then(function (view) {
         if (opts.stale === 'ok' || opts.stale === 'update_after') {
           if (opts.stale === 'update_after') {
-            process.nextTick(function () {
+            immediate(function () {
               updateView(view);
             });
           }

--- a/packages/node_modules/pouchdb-md5/src/binaryMd5-browser.js
+++ b/packages/node_modules/pouchdb-md5/src/binaryMd5-browser.js
@@ -45,6 +45,7 @@ function binaryMd5(data, callback) {
   var append = inputIsString ? appendString : appendBlob;
 
   function next() {
+    // avoid starving the DOM by breaking this up into setImmediates/setTimeouts
     setImmediateShim(loadNextChunk);
   }
 

--- a/packages/node_modules/pouchdb-utils/package.json
+++ b/packages/node_modules/pouchdb-utils/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "argsarray": "*",
     "debug": "*",
+    "immediate": "*",
     "inherits": "*",
     "pouchdb-collections": "*",
     "pouchdb-binary-utils": "*",

--- a/packages/node_modules/pouchdb-utils/src/toPromise.js
+++ b/packages/node_modules/pouchdb-utils/src/toPromise.js
@@ -1,3 +1,4 @@
+import immediate from 'immediate';
 import Promise from 'pouchdb-promise';
 import getArguments from 'argsarray';
 import clone from './clone';
@@ -17,7 +18,7 @@ function toPromise(func) {
       // if it was a callback, create a new callback which calls it,
       // but do so async so we don't trap any errors
       usedCB = function (err, resp) {
-        process.nextTick(function () {
+        immediate(function () {
           tempCB(err, resp);
         });
       };


### PR DESCRIPTION
Based on my understanding of `process.nextTick()` vs `setTimeout()` vs microtasks, I see no reason why we wouldn't want to prefer `immediate` (which uses MutationObsevers under the hood to create microtasks) to `process.nextTick()`.

Looking at PouchDB in a JS profiler (e.g. Chrome flamegraphs), I see a lot of time being spent idle, just waiting for `drainQueue()` (i.e. the `process.nextTick()` shim). That time could be better spent executing microtasks, so that PouchDB can execute more quickly.

The only downside of microtasks is the potential to starve the DOM, but in those cases people should just be putting PouchDB into a web worker anyway. The only exception I found in our codebase where it made sense not to use `immediate` was in the batched md5 summing, because in that case if we used `immediate` then there would be no point in breaking up things into batches, because the DOM would never have a chance to breathe. Hence I kept @calvinmetcalf's original choice of `global.setImmediate || global.setTimeout`, since `setImmediate` also gives the DOM a chance to breathe but without waiting a tick.

I'm waiting to see if this passes in Travis; if so, I'll do some perf tests to see the improvement. Also note that I'm using a slightly older version of `immediate`, because it's a smaller version of `immediate` that matches our current version of `lie` and thus doesn't increase the bundle size.