### PR TITLE
Use encodeDocId for PUT url.

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -644,7 +644,7 @@ function HttpPouch(opts, callback) {
       // Update/create the document
       ajax(opts, {
         method: 'PUT',
-        url: genDBUrl(host, encodeURIComponent(doc._id)),
+        url: genDBUrl(host, encodeDocId(doc._id)),
         body: doc
       }, function (err, result) {
         if (err) {


### PR DESCRIPTION
Fixes reverse proxy usage with pouch 6.0.

https://github.com/pouchdb/pouchdb/issues/5644