### PR TITLE
(#5663) - remove unnecessary NotFoundError allocation

### DIFF
--- a/packages/node_modules/sublevel-pouchdb/src/NotFoundError.js
+++ b/packages/node_modules/sublevel-pouchdb/src/NotFoundError.js
@@ -1,7 +1,7 @@
 import inherits from 'inherits';
 
-function NotFoundError(reason) {
-  Error.call(this, reason);
+function NotFoundError() {
+  Error.call(this);
 }
 
 inherits(NotFoundError, Error);

--- a/packages/node_modules/sublevel-pouchdb/src/shell.js
+++ b/packages/node_modules/sublevel-pouchdb/src/shell.js
@@ -4,6 +4,8 @@ import NotFoundError from './NotFoundError';
 var EventEmitter = events.EventEmitter;
 var version = "6.5.4";
 
+var NOT_FOUND_ERROR = new NotFoundError();
+
 var sublevel = function (nut, prefix, createStream, options) {
   var emitter = new EventEmitter();
   emitter.sublevels = {};
@@ -92,7 +94,7 @@ var sublevel = function (nut, prefix, createStream, options) {
     }
     nut.get(key, prefix, mergeOpts(opts), function (err, value) {
       if (err) {
-        cb(new NotFoundError(err));
+        cb(NOT_FOUND_ERROR);
       } else {
         cb(null, value);
       }


### PR DESCRIPTION
Did some profiling for the in-memory adapter, found that these allocations eat up a lot of time. After this fix, they don't. There's no need to wrap the error BTW because the leveldown spec only requires that the error name be `'NotFound'`.