### PR TITLE
(#5626) - aggressively bundle pouchdb-browser/pouchdb-node

### DIFF
--- a/bin/build-modules.js
+++ b/bin/build-modules.js
@@ -31,15 +31,9 @@ function buildPackage(pkg) {
 }
 
 readDir('packages/node_modules').then(function (packages) {
-  // `pouchdb-for-coverage` has to be built last because it depends on
-  // `pouchdb`, which has a particular index.es.js file as its jsnext:main
-  return Promise.all(packages.filter(function (pkg) {
-    return pkg !== 'pouchdb-for-coverage';
-  }).map(buildPackage)).then(function () {
-    return buildPackage('pouchdb-for-coverage');
+  return Promise.all(packages.map(buildPackage)).catch(function (err) {
+    console.error('build error');
+    console.error(err.stack);
+    process.exit(1);
   });
-}).catch(function (err) {
-  console.error('build error');
-  console.error(err.stack);
-  process.exit(1);
 });

--- a/bin/verify-dependencies.js
+++ b/bin/verify-dependencies.js
@@ -30,9 +30,15 @@ getReqs('pouchdb/lib/index-browser.js').should.not.contain('pouchdb');
 getReqs('pouchdb/lib/index-browser.js').should.not.contain('leveldown');
 getReqs('pouchdb/lib/index-browser.js').should.not.contain('pouchdb-core');
 
-// sub-dependencies are not so aggressively bundled (for now, anyway)
-getReqs('pouchdb-node/lib/index.js').should.contain('pouchdb-core');
-getReqs('pouchdb-browser/lib/index.js').should.contain('pouchdb-core');
+// pouchdb-node and pouchdb-browser are also aggressively bundled
+getReqs('pouchdb-node/lib/index.js').should.not.contain('pouchdb-core');
+getReqs('pouchdb-node/lib/index.js').should.not.contain('pouchdb-promise');
+getReqs('pouchdb-node/lib/index.js').should.contain('leveldown');
+getReqs('pouchdb-browser/lib/index.js').should.not.contain('pouchdb-core');
+getReqs('pouchdb-browser/lib/index.js').should.not.contain('pouchdb-promise');
+getReqs('pouchdb-browser/lib/index.js').should.contain('lie');
+
+// other sub-dependencies are not so aggressively bundled (for now, anyway)
 getReqs('pouchdb-mapreduce/lib/index.js').should.contain('pouchdb-promise');
 getReqs('pouchdb-mapreduce/lib/index-browser.js')
   .should.contain('pouchdb-promise');

--- a/packages/node_modules/pouchdb-browser/package.json
+++ b/packages/node_modules/pouchdb-browser/package.json
@@ -3,7 +3,7 @@
   "version": "6.1.0-prerelease",
   "description": "PouchDB, the browser-only edition.",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.es.js",
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",

--- a/packages/node_modules/pouchdb-for-coverage/package.json
+++ b/packages/node_modules/pouchdb-for-coverage/package.json
@@ -3,7 +3,12 @@
   "version": "6.1.0-prerelease",
   "main": "./lib/index.js",
   "private": true,
+  "//": [
+    "Below, the node version is used for coverage tests.",
+    "The browser version is actually used for tests/integration/utils.js."
+  ],
   "browser": {
-    "./lib/index.js": "./lib/index-browser.js"
+    "./lib/index.js": "./lib/index-browser.js",
+    "./src/pouchdb.js": "./src/pouchdb-browser.js"
   }
 }

--- a/packages/node_modules/pouchdb-for-coverage/src/index.js
+++ b/packages/node_modules/pouchdb-for-coverage/src/index.js
@@ -1,6 +1,4 @@
-// import directly from src rather than jsnext:main because in ths case
-// the jsnext:main is actually built
-import PouchDB from 'pouchdb/src/index';
+import PouchDB from './pouchdb';
 import ajax from 'pouchdb-ajax';
 import utils from './utils';
 import errors from './errors';

--- a/packages/node_modules/pouchdb-for-coverage/src/pouchdb-browser.js
+++ b/packages/node_modules/pouchdb-for-coverage/src/pouchdb-browser.js
@@ -1,0 +1,4 @@
+// import directly from src rather than jsnext:main because in ths case
+// the jsnext:main is actually built (lib/index*.es.js)
+import PouchDB from 'pouchdb-browser/src/index';
+export default PouchDB;

--- a/packages/node_modules/pouchdb-for-coverage/src/pouchdb.js
+++ b/packages/node_modules/pouchdb-for-coverage/src/pouchdb.js
@@ -1,0 +1,4 @@
+// import directly from src rather than jsnext:main because in ths case
+// the jsnext:main is actually built (lib/index*.es.js)
+import PouchDB from 'pouchdb-node/src/index';
+export default PouchDB;

--- a/packages/node_modules/pouchdb-node/package.json
+++ b/packages/node_modules/pouchdb-node/package.json
@@ -3,7 +3,7 @@
   "version": "6.1.0-prerelease",
   "description": "PouchDB, the Node-only edition.",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.es.js",
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",

--- a/packages/node_modules/pouchdb/package.json
+++ b/packages/node_modules/pouchdb/package.json
@@ -17,7 +17,7 @@
   "browser": {
     "./lib/index.js": "./lib/index-browser.js",
     "./lib/index.es.js": "./lib/index-browser.es.js",
-    "pouchdb-node": "pouchdb-browser"
+    "./src/pouchdb.js": "./src/pouchdb-browser.js"
   },
   "jspm": {
     "main": "dist/pouchdb.js"

--- a/packages/node_modules/pouchdb/src/index.js
+++ b/packages/node_modules/pouchdb/src/index.js
@@ -1,2 +1,2 @@
-import PouchDB from 'pouchdb-node';
+import PouchDB from './pouchdb';
 export default PouchDB;

--- a/packages/node_modules/pouchdb/src/pouchdb-browser.js
+++ b/packages/node_modules/pouchdb/src/pouchdb-browser.js
@@ -1,0 +1,5 @@
+// Pull from src because pouchdb-node/pouchdb-browser themselves
+// are aggressively optimized and jsnext:main would normally give us this
+// aggressive bundle.
+import PouchDB from 'pouchdb-browser/src/index';
+export default PouchDB;

--- a/packages/node_modules/pouchdb/src/pouchdb.js
+++ b/packages/node_modules/pouchdb/src/pouchdb.js
@@ -1,0 +1,5 @@
+// Pull from src because pouchdb-node/pouchdb-browser themselves
+// are aggressively optimized and jsnext:main would normally give us this
+// aggressive bundle.
+import PouchDB from 'pouchdb-node/src/index';
+export default PouchDB;


### PR DESCRIPTION
With this change, `pouchdb-browser` and `pouchdb-node` really give you exactly the same thing (respectively) as `pouchdb`. You no longer pay the bundler tax by switching from `pouchdb` to `pouchdb-browser`.

I also had to go in and update our `jsnext:main` for `pouchdb-browser`/`pouchdb-node`, in the odd case that someone is actually using ES6 modules and wants the ES6 version. `verify-dependencies.sh` was also updated to ensure it tests for the proper dependencies.