### PR TITLE
(#5682) - find requires(), ignore imports

### DIFF
--- a/bin/update-dependencies.js
+++ b/bin/update-dependencies.js
@@ -33,7 +33,12 @@ modules.forEach(function (mod) {
   // for the dependencies, find all require() calls
   var srcFiles = glob.sync(path.join(pkgDir, 'lib/**/*.js'));
   var uniqDeps = uniq(flatten(srcFiles.map(function (srcFile) {
-    return findRequires(fs.readFileSync(srcFile, 'utf8'));
+    var code = fs.readFileSync(srcFile, 'utf8');
+    try {
+      return findRequires(code);
+    } catch (e) {
+      return []; // happens if this is an es6 module, parsing fails
+    }
   }))).filter(function (dep) {
     // some modules require() themselves, e.g. for plugins
     return dep !== pkg.name &&


### PR DESCRIPTION
I noticed that `node bin/update-dependencies.js` was failing due to new ES6 module code in `lib/`. The parser used by `find-requires` will throw if it encounters an `import` keyword. This fixes it so that such errors are ignored. (We don't need to look at `import`s because there's always an equivalent `require()` in the CJS code.)

I added `[skip ci]` because this script never runs during build/test, only during publish.