### PR TITLE
(#5322) - update pouchdb-ajax to exec preRequest and preResponse funct…

### DIFF
--- a/packages/node_modules/pouchdb-ajax/src/ajaxCore.js
+++ b/packages/node_modules/pouchdb-ajax/src/ajaxCore.js
@@ -62,25 +62,49 @@ function ajaxCore(options, callback) {
     options.json = false;
   }
 
-  return request(options, function (err, response, body) {
+  if ((options.preRequest) && (typeof options.preRequest == 'function')) {
+    return options.preRequest(options)
+      .then(function (opts) {
+        return returnRequest(opts);
+      }).catch(function (err) {
+        return callback(generateErrorFromResponse(err));
+      });
+  }
+
+  function returnRequest(options) {
+    return request(options, function (err, response, body) {
+      var content_type = response && response.headers && response.headers['content-type'];
+      var data = body || defaultBody();
+
+      // CouchDB doesn't always return the right content-type for JSON data, so
+      // we check for ^{ and }$ (ignoring leading/trailing whitespace)
+      if (!options.binary && (options.json || !options.processData) &&
+          typeof data !== 'object' &&
+          (/json/.test(content_type) ||
+           (/^[\s]*\{/.test(data) && /\}[\s]*$/.test(data)))) {
+        try {
+          data = JSON.parse(data.toString());
+        } catch (e) {}
+      }
+
+      if (options.preResponse && (typeof options.preResponse == 'function')) {
+        return options.preResponse(err, response, data)
+          .then(function (args) {
+            return handleResponse(args.err, args.response, args.data);
+          }).catch(function (err) {     
+            return callback(generateErrorFromResponse(err));
+          });
+      } 
+
+      return handleResponse(err, response, data);
+    });
+  }
+
+  function handleResponse(err, response, data) {
+    var error;
 
     if (err) {
       return callback(generateErrorFromResponse(err));
-    }
-
-    var error;
-    var content_type = response.headers && response.headers['content-type'];
-    var data = body || defaultBody();
-
-    // CouchDB doesn't always return the right content-type for JSON data, so
-    // we check for ^{ and }$ (ignoring leading/trailing whitespace)
-    if (!options.binary && (options.json || !options.processData) &&
-        typeof data !== 'object' &&
-        (/json/.test(content_type) ||
-         (/^[\s]*\{/.test(data) && /\}[\s]*$/.test(data)))) {
-      try {
-        data = JSON.parse(data.toString());
-      } catch (e) {}
     }
 
     if (response.statusCode >= 200 && response.statusCode < 300) {
@@ -90,7 +114,9 @@ function ajaxCore(options, callback) {
       error.status = response.statusCode;
       callback(error);
     }
-  });
+  }
+  
+  return returnRequest(options);
 }
 
 export default ajaxCore;


### PR DESCRIPTION
This allow execute `preRequest` and `preResponse` functions defined in replication `options.ajax`.

```
var replication = PouchDB.replicate(source, targer, {
  live: true,
  ...
  ajax: {
    preRequest: function(options) {
      return new Promise(function(resolve, reject) {
        ...
        //options are passed to request
        resolve(options)
      })
    },
    preResponse: function(err, response, data) {
      return new Promise(function(resolve, reject) {
        ....
        //err, response, data - are from request() callback and passed to next callback
        resolve({'err': err, 'response': response, 'data': data})
      }
    }
  }
})