### PR TITLE
use node implementation for react-native (FileReaderSync)

### DIFF
--- a/packages/node_modules/pouchdb-binary-utils/package.json
+++ b/packages/node_modules/pouchdb-binary-utils/package.json
@@ -21,5 +21,15 @@
     "./src/blobOrBufferToBase64.js": "./src/blobOrBufferToBase64-browser.js",
     "./src/blobOrBufferToBinaryString.js": "./src/blobOrBufferToBinaryString-browser.js",
     "./src/typedBuffer.js": "./src/typedBuffer-browser.js"
+  },
+  "react-native": {
+    "./lib/index.js": "./lib/index.js",
+    "./src/base64.js": "./src/base64-browser.js",
+    "./src/base64StringToBlobOrBuffer.js": "./src/base64StringToBlobOrBuffer.js",
+    "./src/blob.js": "./src/blob.js",
+    "./src/binaryStringToBlobOrBuffer.js": "./src/binaryStringToBlobOrBuffer.js",
+    "./src/blobOrBufferToBase64.js": "./src/blobOrBufferToBase64.js",
+    "./src/blobOrBufferToBinaryString.js": "./src/blobOrBufferToBinaryString.js",
+    "./src/typedBuffer.js": "./src/typedBuffer.js"
   }
 }


### PR DESCRIPTION
in react-native there is no FileReaderSync, but the Node Implementation with Buffer works fine.
This would help me, and all other PouchDb react native users.

Thanks Christoph