### PR TITLE
(#5692) - fix unnecessary deps in pouchdb package

### DIFF
--- a/bin/build-pouchdb.js
+++ b/bin/build-pouchdb.js
@@ -225,7 +225,9 @@ function buildPluginsForBrowser() {
         doUglify(code, comments[plugin], 'dist/pouchdb.' + plugin + '.min.js')
       ]);
     });
-  }));
+  })).then(function () {
+    return rimraf(addPath('lib/plugins')); // no need for this after building dist/
+  });
 }
 
 function buildPouchDBNext() {
@@ -253,7 +255,7 @@ var doAll = argsarray(function (args) {
 });
 
 function doBuildNode() {
-  return mkdirp('lib/plugins')
+  return mkdirp(addPath('lib/plugins'))
     .then(buildForNode);
 }
 


### PR DESCRIPTION
The `pouchdb` package currently contains three unnecessary deps:

- `memdown`
- `localstorage-down`
- `fruitdown`

The reason these were included was because, in the process of building `dist/pouchdb.fruitdown.js` et al, we accidentally left around some `lib/plugins/` files, which were being picked up by the `update-dependencies.js` script in order to populate the dependencies in `package.json`. Since those `lib/plugins` files are only used to build the `dist/` bundles (since the `extras/` API is gone), we can just remove them during the build process, which fixes the problem.