### PR TITLE
(#5696) - retry each browser test once in Travis

### DIFF
--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -80,7 +80,17 @@ elif [ "$CLIENT" == "node" ]; then
 elif [ "$CLIENT" == "dev" ]; then
     npm run launch-dev-server
 else
-    npm run test-browser
+    if [ -z $TRAVIS ]; then
+        npm run test-browser
+    else
+        # Saucelabs is extremely faily. If a test fails, try it again
+        # once, so we aren't manually restarting Travis jobs all the time.
+        npm run test-browser
+        if [[ $? != 0 ]]; then
+          echo 'Retrying the browser test'
+          npm run test-browser
+        fi
+    fi
 fi
 
 EXIT_STATUS=$?


### PR DESCRIPTION
I spend an ungodly amount of time just restarting tests in Travis. The failed tests are almost always due to Saucelabs/Selenium/webdriver/gremlins/whatever. I think it's reasonable to run the tests once again if they fail. It's better than restarting the whole test, which runs `npm install` and `npm run build` and all that all over again.