### PR TITLE
(#5612) - remove stringify/parse hack

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
     "emit": true,
     "PouchDB": true,
     "should": true,
+    "assert": true,
     "testUtils": true,
     "importScripts": true
   },

--- a/packages/node_modules/pouchdb-mapreduce/src/evalFunctionInVm.js
+++ b/packages/node_modules/pouchdb-mapreduce/src/evalFunctionInVm.js
@@ -36,12 +36,7 @@ function evalFunctionInVm(func, emit) {
       JSON.stringify(arg1) + ',' +
       JSON.stringify(arg2) + ',' +
       JSON.stringify(arg3) + ');' +
-      'return {' +
-      '  result: (typeof __result__ !== "undefined" ? ' +
-      '    JSON.stringify(__result__) : ' +
-      '    void 0), ' +
-      '  emitteds: __emitteds__' +
-      '};' +
+      'return {result: __result__, emitteds: __emitteds__};' +
       '})()';
 
     var output = vm.runInNewContext(code);
@@ -49,12 +44,6 @@ function evalFunctionInVm(func, emit) {
     output.emitteds.forEach(function (emitted) {
       emit(emitted[0], emitted[1]);
     });
-    // Technically it's not required to stringify/parse the output from
-    // 'vm', but this makes the unit tests pass due to a bug in vm/should:
-    // http://stackoverflow.com/a/16273649/680742
-    if (typeof output.result !== 'undefined') {
-      output.result = JSON.parse(output.result);
-    }
     if (isBuiltInError(output.result)) {
       output.result = convertToTrueError(output.result);
     }

--- a/tests/fuzzy/index.html
+++ b/tests/fuzzy/index.html
@@ -12,6 +12,7 @@
     <script>
       mocha.setup({ui: 'bdd'});
       var should = chai.should();
+      var assert = chai.assert;
     </script>
     <script src="../integration/utils-bundle.js"></script>
     <script src="./seedrandom.min.js"></script>

--- a/tests/integration/index.html
+++ b/tests/integration/index.html
@@ -16,6 +16,7 @@
         ui: 'bdd'
       });
       var should = chai.should();
+      var assert = chai.assert;
     </script>
     <script src='deps/pouchdb-1.1.0-postfixed.js'></script>
     <script src='deps/pouchdb-2.0.0-postfixed.js'></script>

--- a/tests/integration/node.setup.js
+++ b/tests/integration/node.setup.js
@@ -22,4 +22,4 @@ global.testUtils = require('./utils.js');
 var chai = require('chai');
 chai.use(require('chai-as-promised'));
 global.should = chai.should();
-
+global.assert = chai.assert;

--- a/tests/mapreduce/index.html
+++ b/tests/mapreduce/index.html
@@ -16,6 +16,7 @@
     ui: 'bdd'
   });
   var should = chai.should();
+  var assert = chai.assert;
 </script>
 <script src='../integration/utils-bundle.js'></script>
 <script src="test.mapreduce.js"></script>

--- a/tests/mapreduce/test.mapreduce.js
+++ b/tests/mapreduce/test.mapreduce.js
@@ -1037,24 +1037,32 @@ function tests(suiteName, dbName, dbType, viewType) {
         }).then(function () {
           return db.query(queryFun, { reduce: true });
         }).then(function (res) {
-          res.rows.should.have.length(1, 'Correctly reduced returned rows');
-          should.not.exist(res.rows[0].key, 'Correct, non-existing key');
-          res.rows[0].value.should.have.length(5);
-          res.rows[0].value.should.include('foobarbaz');
-          res.rows[0].value.should.include('foobar'); // twice
-          res.rows[0].value.should.include('bazbar');
-          res.rows[0].value.should.include('baz');
+          // We're using `chai.assert` here because the usual `chai.should()`
+          // object extension magic won't work when executing functions in a
+          // sandbox using node's `vm` module.
+          // c.f. https://stackoverflow.com/a/16273649/680742
+          assert.lengthOf(res.rows, 1, 'Correctly reduced returned rows');
+          assert.isNull(res.rows[0].key, 'Correct, non-existing key');
+          assert.lengthOf(res.rows[0].value, 5);
+          assert.include(res.rows[0].value, 'foobarbaz');
+          assert.include(res.rows[0].value, 'foobar'); // twice
+          assert.include(res.rows[0].value, 'bazbar');
+          assert.include(res.rows[0].value, 'baz');
           return db.query(queryFun, { group_level: 1, reduce: true });
         }).then(function (res) {
-          res.rows.should.have.length(2, 'Correctly group reduced rows');
-          res.rows[0].key.should.deep.equal(['baz']);
-          res.rows[0].value.should.have.length(2);
-          res.rows[0].value.should.include('bazbar');
-          res.rows[0].value.should.include('baz');
-          res.rows[1].key.should.deep.equal(['foo']);
-          res.rows[1].value.should.have.length(3);
-          res.rows[1].value.should.include('foobarbaz');
-          res.rows[1].value.should.include('foobar'); // twice
+          // We're using `chai.assert` here because the usual `chai.should()`
+          // object extension magic won't work when executing functions in a
+          // sandbox using node's `vm` module.
+          // c.f. https://stackoverflow.com/a/16273649/680742
+          assert.lengthOf(res.rows, 2, 'Correctly group reduced rows');
+          assert.deepEqual(res.rows[0].key, ['baz']);
+          assert.lengthOf(res.rows[0].value, 2);
+          assert.include(res.rows[0].value, 'bazbar');
+          assert.include(res.rows[0].value, 'baz');
+          assert.deepEqual(res.rows[1].key, ['foo']);
+          assert.lengthOf(res.rows[1].value, 3);
+          assert.include(res.rows[1].value, 'foobarbaz');
+          assert.include(res.rows[1].value, 'foobar'); // twice
         });
       });
     });


### PR DESCRIPTION
When evaluating map/reduce functions in a sandbox by using node's `vm` module,
we returned a stringified result, which we then parsed outside the sandbox. We
did that in order to make chai's object extension magic with `chai.should()`
work, which doesn't work for objects that are returned from a `vm` sandbox
(https://stackoverflow.com/a/16273649/680742).

This removes the hack, and solves the issue by using chai's `assert` functions
in the particular test cases instead of the `should` property.