### PR TITLE
(#5572) - add Safari 10 support for IDB (WIP)

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -978,17 +978,19 @@ function init(api, opts, callback) {
 }
 
 IdbPouch.valid = function () {
-  // Issue #2533, we finally gave up on doing bug
-  // detection instead of browser sniffing. Safari brought us
-  // to our knees.
-  var isSafari = typeof openDatabase !== 'undefined' &&
+  // Issue #2533, we finally gave up on doing feature
+  // detection instead of browser sniffing. Safari <10 has IDB
+  // bugs and they're too tricky to use feature detection for
+  var isOldSafari = typeof openDatabase !== 'undefined' &&
     /(Safari|iPhone|iPad|iPod)/.test(navigator.userAgent) &&
     !/Chrome/.test(navigator.userAgent) &&
-    !/BlackBerry/.test(navigator.platform);
-
+    !/BlackBerry/.test(navigator.platform) &&
+    // Issue #5572, Safari 10 fixes most major IDB bugs
+    /Version\/(\d+)/.test(navigator.userAgent) &&
+    parseInt(navigator.userAgent.match(/Version\/(\d+)/)[1], 10) < 10;
   // some outdated implementations of IDB that appear on Samsung
   // and HTC Android devices <4.4 are missing IDBKeyRange
-  return !isSafari && typeof indexedDB !== 'undefined' &&
+  return !isOldSafari && typeof indexedDB !== 'undefined' &&
     typeof IDBKeyRange !== 'undefined';
 };
 

--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -978,20 +978,20 @@ function init(api, opts, callback) {
 }
 
 IdbPouch.valid = function () {
-  // Issue #2533, we finally gave up on doing feature
-  // detection instead of browser sniffing. Safari <10 has IDB
-  // bugs and they're too tricky to use feature detection for
-  var isOldSafari = typeof openDatabase !== 'undefined' &&
-    /(Safari|iPhone|iPad|iPod)/.test(navigator.userAgent) &&
-    !/Chrome/.test(navigator.userAgent) &&
-    !/BlackBerry/.test(navigator.platform) &&
-    // Issue #5572, Safari 10 fixes most major IDB bugs
-    /Version\/(\d+)/.test(navigator.userAgent) &&
-    parseInt(navigator.userAgent.match(/Version\/(\d+)/)[1], 10) < 10;
-  // some outdated implementations of IDB that appear on Samsung
-  // and HTC Android devices <4.4 are missing IDBKeyRange
-  return !isOldSafari && typeof indexedDB !== 'undefined' &&
-    typeof IDBKeyRange !== 'undefined';
+  /* global Intl,msIndexedDB */
+  // IDBKeyRange sniffs out some old Samsung/HTC Android devices with pre-v1
+  // IndexedDB implementations.
+  // Intl sniffs out pre-v10 Safari and similar WebKit-based engines which
+  // had buggy IDB implementations. Its debut in Android coincides with that of
+  // IDB (v4.4) but for IE it was released in v11, so to allow for IE10 we check
+  // for msIndexedDB. We avoid checking for webkitIndexedDB because Chrome warns
+  // in the console which would probably annoy developers.
+  return typeof indexedDB !== 'undefined' &&
+    typeof IDBKeyRange !== 'undefined' &&
+    (
+      typeof msIndexedDB !== 'undefined' ||
+      (typeof Intl === 'object' && /\[native code\]/.test(Intl.constructor.toString()))
+    );
 };
 
 function tryStorageOption(dbName, storage) {


### PR DESCRIPTION
This PR is just to start the conversation about supporting Safari 10 IndexedDB. As described in #5572 there are still some issues to resolve:
- [ ] Benchmark to determine if Safari IDB is too slow compared to Safari WebSQL
- [ ] Confirm that the Dexie-reported issues don't affect us
- [ ] Confirm that the UA parsing logic I've added works across all Safari-like browsers, e.g. UIWebView, WKWebView, Chrome iOS, Firefox iOS
- [ ] Add a SauceLabs test for Safari >=10, ensure it passes 100%

It's been a long time coming, but I think it's about time we start putting WebSQL out to pasture.
