### PR TITLE
Address website layout bugs #5495 and #5709

### DIFF
--- a/docs/_includes/anchor.html
+++ b/docs/_includes/anchor.html
@@ -3,12 +3,4 @@
 {% else %}
   {% assign class = 'h2' %}
 {% endif %}
-<div>
-  <div class='{{ class }}'>
-    <div class='anchor-id' id='{{ include.hash }}'></div>
-    <a class='anchor' href='#{{ include.hash }}' name='{{ include.hash }}'>{{ include.title | markdownify | remove: '<p>' | remove: '</p>' }}</a>
-    {% if include.edit %}
-      <a data-toggle="tooltip" data-placement="top" title="Edit this on Github" class="icon-edit" href="{{ site.github.repository_url }}/edit/master/docs/_includes/api/{{ include.hash }}.html" target="_blank"></a>
-    {% endif %}
-  </div>
-</div>
+<div class='{{ class }}'><div class='anchor-id' id='{{ include.hash }}'></div><a class='anchor' href='#{{ include.hash }}' name='{{ include.hash }}'>{{ include.title }}</a>{% if include.edit %}<a data-toggle="tooltip" data-placement="top" title="Edit this on Github" class="icon-edit" href="{{ site.github.repository_url }}/edit/master/docs/_includes/api/{{ include.hash }}.html" target="_blank"></a>{% endif %}</div>

--- a/docs/static/less/pouchdb/type.less
+++ b/docs/static/less/pouchdb/type.less
@@ -11,6 +11,10 @@ h1, h2, h3, h4, h5, h6,
   }
 }
 
+h1, h2, h3 {
+  display: block;
+}
+
 p, ul, ol, pre {
   margin-bottom: @spacing-base;
 }


### PR DESCRIPTION
Reverts the previous change which added `<div>`s around anchors (which fixes #5709) and attempting to fix #5495 with CSS only.