### PR TITLE
Remove info block that is destroying formatting

### DIFF
--- a/docs/_guides/queries.md
+++ b/docs/_guides/queries.md
@@ -35,11 +35,9 @@ db.query(function (doc, emit) {
 
 In the above example, the `result` object will contain stubs of documents where the `name` attribute is equal to `'foo'`. To include the document in each row of results, use the `include_docs` option.
 
-{% include alert/start.html variant="info" %}
 
 The <code>emit</code> pattern is part of the standard <a href='http://couchdb.readthedocs.org/en/latest/couchapp/views/intro.html'>CouchDB map/reduce API</a>.  What the function basically says is, "for each document, emit <code>doc.name</code> as a key."
 
-{% include alert/end.html %}
 
 ### Persistent queries
 


### PR DESCRIPTION
The formatting is messed up on this page https://pouchdb.com/guides/queries.html

I'm guessing there is something about that info block that is doing it. Sorry I don't have the tools installed to check right now.