### PR TITLE
(#5728) - Fix extra newline on band headings

### DIFF
--- a/docs/static/less/pouchdb/type.less
+++ b/docs/static/less/pouchdb/type.less
@@ -15,6 +15,10 @@ h1, h2, h3 {
   display: block;
 }
 
+.band h1 {
+  display: inline-block;
+}
+
 p, ul, ol, pre {
   margin-bottom: @spacing-base;
 }


### PR DESCRIPTION
Not the cleanest CSS fix, but better working than clean, if anyone wants to fix it a nicer way feel free