### PR TITLE
replaced extend from js-extend library with ES2015 builtin Object.assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,14 @@
     "argsarray": "0.0.1",
     "debug": "2.2.0",
     "double-ended-queue": "2.1.0-0",
+    "es6-object-assign": "^1.0.3",
     "es6-promise-pool": "2.4.4",
     "fruitdown": "1.0.2",
     "inherits": "2.0.3",
     "js-extend": "1.0.1",
     "level-codec": "6.2.0",
     "level-write-stream": "1.0.0",
+    "leveldown": "1.5.0",
     "levelup": "1.3.2",
     "lie": "3.1.0",
     "localstorage-down": "0.6.6",
@@ -53,7 +55,6 @@
     "spark-md5": "2.0.2",
     "through2": "2.0.1",
     "vuvuzela": "1.0.3",
-    "leveldown": "1.5.0",
     "websql": "0.4.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "localstorage-down": "0.6.6",
     "ltgt": "2.1.2",
     "memdown": "1.2.2",
+    "object.assign": "^4.0.4",
     "readable-stream": "1.0.33",
     "request": "2.74.0",
     "scope-eval": "0.0.3",

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -29,8 +29,8 @@ import {
 import PromisePool from 'es6-promise-pool';
 import { createError, BAD_ARG } from 'pouchdb-errors';
 import debug from 'debug';
-import objectAssign from 'es6-object-assign';
-objectAssign.polyfill();
+import objectAssign from 'object.assign';
+objectAssign.shim();
 
 var log = debug('pouchdb:http');
 

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -3,7 +3,6 @@ var MAX_SIMULTANEOUS_REVS = 50;
 
 var supportsBulkGetMap = {};
 
-import { extend } from 'js-extend';
 import Promise from 'pouchdb-promise';
 import ajaxCore from 'pouchdb-ajax';
 import getArguments from 'argsarray';
@@ -168,7 +167,7 @@ function HttpPouch(opts, callback) {
 
   function ajax(userOpts, options, callback) {
     var reqAjax = userOpts.ajax || {};
-    var reqOpts = extend(clone(ajaxOpts), reqAjax, options);
+    var reqOpts = Object.assign(clone(ajaxOpts), reqAjax, options);
     log(reqOpts.method + ' ' + reqOpts.url);
     return api._ajax(reqOpts, callback);
   }

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -29,6 +29,8 @@ import {
 import PromisePool from 'es6-promise-pool';
 import { createError, BAD_ARG } from 'pouchdb-errors';
 import debug from 'debug';
+import objectAssign from 'es6-object-assign';
+objectAssign.polyfill();
 
 var log = debug('pouchdb:http');
 

--- a/packages/node_modules/pouchdb-adapter-idb/src/utils.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/utils.js
@@ -14,8 +14,8 @@ import {
   blob as createBlob
 } from 'pouchdb-binary-utils';
 import { ATTACH_AND_SEQ_STORE, ATTACH_STORE, BY_SEQ_STORE } from './constants';
-import objectAssign from 'es6-object-assign';
-objectAssign.polyfill();
+import objectAssign from 'object.assign';
+objectAssign.shim();
 
 function tryCode(fun, that, args, PouchDB) {
   try {

--- a/packages/node_modules/pouchdb-adapter-idb/src/utils.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/utils.js
@@ -1,4 +1,3 @@
-import { extend } from 'js-extend';
 import Promise from 'pouchdb-promise';
 import { createError, IDB_ERROR } from 'pouchdb-errors';
 import {
@@ -173,7 +172,7 @@ function postProcessAttachments(results, asBlob) {
         var type = attObj.content_type;
         return new Promise(function (resolve) {
           readBlobData(body, type, asBlob, function (data) {
-            row.doc._attachments[att] = extend(
+            row.doc._attachments[att] = Object.assign(
               pick(attObj, ['digest', 'content_type']),
               {data: data}
             );

--- a/packages/node_modules/pouchdb-adapter-idb/src/utils.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/utils.js
@@ -14,6 +14,8 @@ import {
   blob as createBlob
 } from 'pouchdb-binary-utils';
 import { ATTACH_AND_SEQ_STORE, ATTACH_STORE, BY_SEQ_STORE } from './constants';
+import objectAssign from 'es6-object-assign';
+objectAssign.polyfill();
 
 function tryCode(fun, that, args, PouchDB) {
   try {

--- a/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
@@ -1,4 +1,3 @@
-import { extend } from 'js-extend';
 import {
   clone,
   pick,
@@ -76,7 +75,7 @@ function fetchAttachmentsIfNecessary(doc, opts, api, txn, cb) {
     var attObj = doc._attachments[att];
     var attOpts = {binary: opts.binary, ctx: txn};
     api._getAttachment(doc._id, att, attObj, attOpts, function (_, data) {
-      doc._attachments[att] = extend(
+      doc._attachments[att] = Object.assign(
         pick(attObj, ['digest', 'content_type']),
         { data: data }
       );
@@ -134,7 +133,7 @@ function WebSqlPouch(opts, callback) {
 
   // extend the options here, because sqlite plugin has a ton of options
   // and they are constantly changing, so it's more prudent to allow anything
-  var websqlOpts = extend({}, opts, {
+  var websqlOpts = Object.assign({}, opts, {
     version: POUCH_VERSION,
     description: opts.name,
     size: size
@@ -566,7 +565,7 @@ function WebSqlPouch(opts, callback) {
     var tx = opts.ctx;
     if (!tx) {
       return db.readTransaction(function (txn) {
-        api._get(id, extend({ctx: txn}, opts), callback);
+        api._get(id, Object.assign({ctx: txn}, opts), callback);
       });
     }
 

--- a/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
@@ -55,6 +55,8 @@ import {
 } from './utils';
 
 import openDB from './openDatabase';
+import objectAssign from 'es6-object-assign';
+objectAssign.polyfill();
 
 var websqlChanges = new Changes();
 

--- a/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
@@ -55,8 +55,8 @@ import {
 } from './utils';
 
 import openDB from './openDatabase';
-import objectAssign from 'es6-object-assign';
-objectAssign.polyfill();
+import objectAssign from 'object.assign';
+objectAssign.shim();
 
 var websqlChanges = new Changes();
 

--- a/packages/node_modules/pouchdb-adapter-websql/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-websql/src/index.js
@@ -1,5 +1,7 @@
 import WebSqlPouchCore from 'pouchdb-adapter-websql-core';
 import valid from './valid';
+import objectAssign from 'es6-object-assign';
+objectAssign.polyfill();
 
 function openDB(name, version, description, size) {
   // Traditional WebSQL API

--- a/packages/node_modules/pouchdb-adapter-websql/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-websql/src/index.js
@@ -1,5 +1,4 @@
 import WebSqlPouchCore from 'pouchdb-adapter-websql-core';
-import { extend } from 'js-extend';
 import valid from './valid';
 
 function openDB(name, version, description, size) {
@@ -8,7 +7,7 @@ function openDB(name, version, description, size) {
 }
 
 function WebSQLPouch(opts, callback) {
-  var _opts = extend({
+  var _opts = Object.assign({
     websql: openDB
   }, opts);
 

--- a/packages/node_modules/pouchdb-adapter-websql/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-websql/src/index.js
@@ -1,7 +1,7 @@
 import WebSqlPouchCore from 'pouchdb-adapter-websql-core';
 import valid from './valid';
-import objectAssign from 'es6-object-assign';
-objectAssign.polyfill();
+import objectAssign from 'object.assign';
+objectAssign.shim();
 
 function openDB(name, version, description, size) {
   // Traditional WebSQL API

--- a/packages/node_modules/pouchdb-ajax/src/ajaxCore.js
+++ b/packages/node_modules/pouchdb-ajax/src/ajaxCore.js
@@ -1,5 +1,4 @@
 import request from './request';
-import { extend } from 'js-extend';
 import { generateErrorFromResponse } from 'pouchdb-errors';
 import { clone } from 'pouchdb-utils';
 import applyTypeToBuffer from './applyTypeToBuffer';
@@ -18,7 +17,7 @@ function ajaxCore(options, callback) {
     cache: false
   };
 
-  options = extend(defaultOptions, options);
+  options = Object.assign(defaultOptions, options);
 
   function onSuccess(obj, resp, cb) {
     if (!options.binary && options.json && typeof obj === 'string') {

--- a/packages/node_modules/pouchdb-ajax/src/ajaxCore.js
+++ b/packages/node_modules/pouchdb-ajax/src/ajaxCore.js
@@ -3,8 +3,8 @@ import { generateErrorFromResponse } from 'pouchdb-errors';
 import { clone } from 'pouchdb-utils';
 import applyTypeToBuffer from './applyTypeToBuffer';
 import defaultBody from './defaultBody';
-import objectAssign from 'es6-object-assign';
-objectAssign.polyfill();
+import objectAssign from 'object.assign';
+objectAssign.shim();
 
 function ajaxCore(options, callback) {
 

--- a/packages/node_modules/pouchdb-ajax/src/ajaxCore.js
+++ b/packages/node_modules/pouchdb-ajax/src/ajaxCore.js
@@ -3,6 +3,8 @@ import { generateErrorFromResponse } from 'pouchdb-errors';
 import { clone } from 'pouchdb-utils';
 import applyTypeToBuffer from './applyTypeToBuffer';
 import defaultBody from './defaultBody';
+import objectAssign from 'es6-object-assign';
+objectAssign.polyfill();
 
 function ajaxCore(options, callback) {
 

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -30,8 +30,8 @@ import {
   INVALID_REV,
   createError
 } from 'pouchdb-errors';
-import objectAssign from 'es6-object-assign';
-objectAssign.polyfill();
+import objectAssign from 'object.assign';
+objectAssign.shim();
 
 /*
  * A generic pouch adapter

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -30,6 +30,8 @@ import {
   INVALID_REV,
   createError
 } from 'pouchdb-errors';
+import objectAssign from 'es6-object-assign';
+objectAssign.polyfill();
 
 /*
  * A generic pouch adapter

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -1,4 +1,3 @@
-import { extend } from 'js-extend';
 import Promise from 'pouchdb-promise';
 import { Map } from 'pouchdb-collections';
 import { EventEmitter } from 'events';
@@ -131,7 +130,7 @@ function allDocsKeysQuery(api, opts, callback) {
     offset: opts.skip
   };
   return Promise.all(keys.map(function (key) {
-    var subOpts = extend({key: key, deleted: 'ok'}, opts);
+    var subOpts = Object.assign({key: key, deleted: 'ok'}, opts);
     ['limit', 'skip', 'keys'].forEach(function (optKey) {
       delete subOpts[optKey];
     });

--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -1,5 +1,3 @@
-import { extend } from 'js-extend';
-
 import PouchDB from './constructor';
 import inherits from 'inherits';
 import { Map } from 'pouchdb-collections';
@@ -69,7 +67,7 @@ PouchDB.defaults = function (defaultOpts) {
       delete opts.name;
     }
 
-    opts = extend({}, defaultOpts, opts);
+    opts = Object.assign({}, defaultOpts, opts);
     PouchDB.call(this, name, opts);
   }
 

--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -2,6 +2,8 @@ import PouchDB from './constructor';
 import inherits from 'inherits';
 import { Map } from 'pouchdb-collections';
 import { EventEmitter as EE } from 'events';
+import objectAssign from 'es6-object-assign';
+objectAssign.polyfill();
 
 PouchDB.adapters = {};
 PouchDB.preferredAdapters = [];

--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -2,8 +2,8 @@ import PouchDB from './constructor';
 import inherits from 'inherits';
 import { Map } from 'pouchdb-collections';
 import { EventEmitter as EE } from 'events';
-import objectAssign from 'es6-object-assign';
-objectAssign.polyfill();
+import objectAssign from 'object.assign';
+objectAssign.shim();
 
 PouchDB.adapters = {};
 PouchDB.preferredAdapters = [];

--- a/packages/node_modules/pouchdb-replication/src/sync.js
+++ b/packages/node_modules/pouchdb-replication/src/sync.js
@@ -6,6 +6,8 @@ import {
 import inherits from 'inherits';
 import { EventEmitter as EE } from 'events';
 import { clone } from 'pouchdb-utils';
+import objectAssign from 'es6-object-assign';
+objectAssign.polyfill();
 
 inherits(Sync, EE);
 export default sync;

--- a/packages/node_modules/pouchdb-replication/src/sync.js
+++ b/packages/node_modules/pouchdb-replication/src/sync.js
@@ -6,8 +6,8 @@ import {
 import inherits from 'inherits';
 import { EventEmitter as EE } from 'events';
 import { clone } from 'pouchdb-utils';
-import objectAssign from 'es6-object-assign';
-objectAssign.polyfill();
+import objectAssign from 'object.assign';
+objectAssign.shim();
 
 inherits(Sync, EE);
 export default sync;

--- a/packages/node_modules/pouchdb-replication/src/sync.js
+++ b/packages/node_modules/pouchdb-replication/src/sync.js
@@ -1,4 +1,3 @@
-import { extend } from 'js-extend';
 import Promise from 'pouchdb-promise';
 import {
   replicate,
@@ -30,8 +29,8 @@ function Sync(src, target, opts, callback) {
   var self = this;
   this.canceled = false;
 
-  var optsPush = opts.push ? extend({}, opts, opts.push) : opts;
-  var optsPull = opts.pull ? extend({}, opts, opts.pull) : opts;
+  var optsPush = opts.push ? Object.assign({}, opts, opts.push) : opts;
+  var optsPull = opts.pull ? Object.assign({}, opts, opts.pull) : opts;
 
   this.push = replicate(src, target, optsPush);
   this.pull = replicate(target, src, optsPull);


### PR DESCRIPTION
I'm using PouchDB with ionic2 and was following https://github.com/driftyco/ionic/issues/8356

I could reduce a rollup problem by replacing extend from js-extend library with the ES2015 builtin function Object.assign.

Still need a custom rollup config (but no other manual change in node_modules folder). This repo https://github.com/ckaeslin/ionic2-RC0-pouchdb with replaced pouchdb-browser from this branch worked for me.
