### PR TITLE
(#5782) - always use string representation of seed

### DIFF
--- a/tests/fuzzy/test.fuzzy.js
+++ b/tests/fuzzy/test.fuzzy.js
@@ -15,10 +15,6 @@
 // generate an arbitrary one. With any given seed the 'random' generations
 // are deteministic so if we find a seed that fails the test we can provide
 // that seed again to rerun the same actions and generate the same failure
-var seed = testUtils.params().seed || Date.now();
-if (Math.seedrandom) {
-  Math.seedrandom(seed);
-}
 
 // This is the amount of random actions we do
 var actionCount = 100;

--- a/tests/integration/node.setup.js
+++ b/tests/integration/node.setup.js
@@ -4,7 +4,7 @@
 require('throw-max-listeners-error');
 
 var seedrandom = require('seedrandom');
-var seed = process.env.SEED || Date.now();
+var seed = (process.env.SEED || Date.now()) + "";
 console.log('Seeded with: ' + seed);
 seedrandom(seed, { global: true });
 


### PR DESCRIPTION
I noticed that tests appeared to be deterministic when I specified
a seed value but the order of operations was different to that
reported by a specific test run.

This is because the initial seed generates an number (timestamp)
whereas an environment variable passed in is a string. Casting
all seed values to a string normalises these, allowing failing test
runs to be reproduced.