### PR TITLE
(#5746) - move js-extend into source

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "es6-promise-pool": "2.4.4",
     "fruitdown": "1.0.2",
     "inherits": "2.0.3",
-    "js-extend": "1.0.1",
     "level-codec": "6.2.0",
     "level-write-stream": "1.0.0",
     "levelup": "1.3.2",

--- a/packages/node_modules/pouchdb-adapter-fruitdown/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-fruitdown/src/index.js
@@ -1,5 +1,5 @@
 import CoreLevelPouch from 'pouchdb-adapter-leveldb-core';
-import { extend } from 'js-extend';
+import { jsExtend as extend } from 'pouchdb-utils';
 
 import fruitdown from 'fruitdown';
 

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -3,7 +3,7 @@ var MAX_SIMULTANEOUS_REVS = 50;
 
 var supportsBulkGetMap = {};
 
-import { extend } from 'js-extend';
+import { jsExtend as extend } from 'pouchdb-utils';
 import Promise from 'pouchdb-promise';
 import ajaxCore from 'pouchdb-ajax';
 import getArguments from 'argsarray';

--- a/packages/node_modules/pouchdb-adapter-idb/src/utils.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/utils.js
@@ -1,4 +1,4 @@
-import { extend } from 'js-extend';
+import { jsExtend as extend } from 'pouchdb-utils';
 import Promise from 'pouchdb-promise';
 import { createError, IDB_ERROR } from 'pouchdb-errors';
 import {

--- a/packages/node_modules/pouchdb-adapter-leveldb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb/src/index.js
@@ -1,5 +1,5 @@
 import CoreLevelPouch from 'pouchdb-adapter-leveldb-core';
-import { extend } from 'js-extend';
+import { jsExtend as extend } from 'pouchdb-utils';
 import requireLeveldown from './requireLeveldown';
 import migrate from './migrate';
 

--- a/packages/node_modules/pouchdb-adapter-localstorage/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-localstorage/src/index.js
@@ -1,5 +1,5 @@
 import CoreLevelPouch from 'pouchdb-adapter-leveldb-core';
-import { extend } from 'js-extend';
+import { jsExtend as extend } from 'pouchdb-utils';
 
 import localstoragedown from 'localstorage-down';
 

--- a/packages/node_modules/pouchdb-adapter-memory/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-memory/src/index.js
@@ -1,5 +1,5 @@
 import CoreLevelPouch from 'pouchdb-adapter-leveldb-core';
-import { extend } from 'js-extend';
+import { jsExtend as extend } from 'pouchdb-utils';
 
 import memdown from 'memdown';
 

--- a/packages/node_modules/pouchdb-adapter-node-websql/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-node-websql/src/index.js
@@ -1,5 +1,5 @@
 import WebSqlPouchCore from 'pouchdb-adapter-websql-core';
-import { extend } from 'js-extend';
+import { jsExtend as extend } from 'pouchdb-utils';
 import websql from 'websql';
 
 function NodeWebSqlPouch(opts, callback) {

--- a/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
@@ -1,4 +1,4 @@
-import { extend } from 'js-extend';
+import { jsExtend as extend } from 'pouchdb-utils';
 import {
   clone,
   pick,

--- a/packages/node_modules/pouchdb-adapter-websql/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-websql/src/index.js
@@ -1,5 +1,5 @@
 import WebSqlPouchCore from 'pouchdb-adapter-websql-core';
-import { extend } from 'js-extend';
+import { jsExtend as extend } from 'pouchdb-utils';
 import valid from './valid';
 
 function openDB(name, version, description, size) {

--- a/packages/node_modules/pouchdb-ajax/src/ajaxCore.js
+++ b/packages/node_modules/pouchdb-ajax/src/ajaxCore.js
@@ -1,5 +1,5 @@
 import request from './request';
-import { extend } from 'js-extend';
+import { jsExtend as extend } from 'pouchdb-utils';
 import { generateErrorFromResponse } from 'pouchdb-errors';
 import { clone } from 'pouchdb-utils';
 import applyTypeToBuffer from './applyTypeToBuffer';

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -1,4 +1,4 @@
-import { extend } from 'js-extend';
+import { jsExtend as extend } from 'pouchdb-utils';
 import Promise from 'pouchdb-promise';
 import { Map } from 'pouchdb-collections';
 import { EventEmitter } from 'events';

--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -1,4 +1,4 @@
-import { extend } from 'js-extend';
+import { jsExtend as extend } from 'pouchdb-utils';
 
 import PouchDB from './constructor';
 import inherits from 'inherits';

--- a/packages/node_modules/pouchdb-for-coverage/src/utils.js
+++ b/packages/node_modules/pouchdb-for-coverage/src/utils.js
@@ -16,7 +16,8 @@ import {
   once,
   upsert,
   toPromise,
-  defaultBackOff
+  defaultBackOff,
+  jsExtend
 } from 'pouchdb-utils';
 
 import {
@@ -46,7 +47,7 @@ import {
   generateErrorFromResponse
 } from 'pouchdb-errors';
 
-import { extend } from 'js-extend';
+import { jsExtend as extend } from 'pouchdb-utils';
 
 import generateReplicationId from 'pouchdb-generate-replication-id';
 import checkpointer from 'pouchdb-checkpointer';
@@ -74,6 +75,7 @@ export default {
   toPromise: toPromise,
   checkpointer: checkpointer,
   defaultBackOff: defaultBackOff,
+  jsExtend: jsExtend,
   mapReduceUtils: {
     uniq: uniq,
     sequentialize: sequentialize,

--- a/packages/node_modules/pouchdb-replication/src/sync.js
+++ b/packages/node_modules/pouchdb-replication/src/sync.js
@@ -1,4 +1,4 @@
-import { extend } from 'js-extend';
+import { jsExtend as extend } from 'pouchdb-utils';
 import Promise from 'pouchdb-promise';
 import {
   replicate,

--- a/packages/node_modules/pouchdb-utils/src/index.js
+++ b/packages/node_modules/pouchdb-utils/src/index.js
@@ -6,6 +6,7 @@ import guardedConsole from './guardedConsole';
 import defaultBackOff from './defaultBackOff';
 import explainError from './explainError';
 import extend from './extend';
+import jsExtend from './jsExtend';
 import filterChange from './filterChange';
 import flatten from './flatten';
 import functionName from './functionName';
@@ -31,6 +32,7 @@ export {
   defaultBackOff,
   explainError,
   extend,
+  jsExtend,
   filterChange,
   flatten,
   functionName,

--- a/packages/node_modules/pouchdb-utils/src/jsExtend.js
+++ b/packages/node_modules/pouchdb-utils/src/jsExtend.js
@@ -1,0 +1,30 @@
+// forked from
+// https://github.com/vmattos/js-extend/blob/7023fd69a9e9552688086b8b8006b1fcf916a306/extend.js
+// TODO: I don't know why we have two different extend() functions in PouchDB
+
+var slice = Array.prototype.slice;
+var each = Array.prototype.forEach;
+
+function extend(obj) {
+  if (typeof obj !== 'object') {
+    throw obj + ' is not an object' ;
+  }
+
+  var sources = slice.call(arguments, 1);
+
+  each.call(sources, function (source) {
+    if (source) {
+      for (var prop in source) {
+        if (typeof source[prop] === 'object' && obj[prop]) {
+          extend.call(obj, obj[prop], source[prop]);
+        } else {
+          obj[prop] = source[prop];
+        }
+      }
+    }
+  });
+
+  return obj;
+}
+
+export default extend;

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -270,7 +270,7 @@ testUtils.ajax = PouchForCoverage.ajax;
 testUtils.uuid = pouchUtils.uuid;
 testUtils.parseUri = pouchUtils.parseUri;
 testUtils.errors = PouchForCoverage.Errors;
-testUtils.extend = require('js-extend').extend;
+testUtils.extend = pouchUtils.jsExtend;
 
 testUtils.makeBlob = function (data, type) {
   if (typeof process !== 'undefined' && !process.browser) {


### PR DESCRIPTION
Stopgap solution to fix Ionic 2 breakages. See #5746 for details.

Long story short: I don't know if Ionic will fix this themselves before they release Ionic 2. Ultimately the problem is that js-extend is too clever in its module format, and it breaks Rollup. There doesn't seem to be a Rollup plugin that can handle it correctly. It's also like 15 lines of code, so we can just put it in source.

I noticed we now have two different extend functions for some reason. We should evaluate merging that and see if there are perf/compat problems, but for 15 lines of code it's probably not even worth it.