### PR TITLE
5782 - handle rev-1 conflict during sync

### DIFF
--- a/packages/node_modules/pouchdb-replication/src/getDocs.js
+++ b/packages/node_modules/pouchdb-replication/src/getDocs.js
@@ -125,19 +125,24 @@ function getDocs(src, target, diffs, state) {
     return doc._attachments && Object.keys(doc._attachments).length > 0;
   }
 
+  function hasConflicts(doc) {
+    return doc._conflicts && doc._conflicts.length > 0;
+  }
+
   function fetchRevisionOneDocs(ids) {
     // Optimization: fetch gen-1 docs and attachments in
     // a single request using _all_docs
     return src.allDocs({
       keys: ids,
-      include_docs: true
+      include_docs: true,
+      conflicts: true
     }).then(function (res) {
       if (state.cancelled) {
         throw new Error('cancelled');
       }
       res.rows.forEach(function (row) {
         if (row.deleted || !row.doc || !isGenOne(row.value.rev) ||
-            hasAttachments(row.doc)) {
+            hasAttachments(row.doc) || hasConflicts(row.doc)) {
           // if any of these conditions apply, we need to fetch using get()
           return;
         }

--- a/tests/integration/test.sync.js
+++ b/tests/integration/test.sync.js
@@ -878,7 +878,7 @@ adapters.forEach(function (adapters) {
       .then(function () { return remove(local, doc1._id); })
       .then(function () { return local.sync (remote); })
       .then(function () {
-        return Promise.all([
+        return testUtils.Promise.all([
           local.allDocs({include_docs: true}),
           remote.allDocs({include_docs: true})
         ]);

--- a/tests/integration/test.sync.js
+++ b/tests/integration/test.sync.js
@@ -833,5 +833,58 @@ adapters.forEach(function (adapters) {
       });
     });
 
+    it('5782 sync rev-1 conflicts', function () {
+      var local = new PouchDB(dbs.name);
+      var remote = new PouchDB(dbs.remote);
+
+      function update(a, id) {
+        return a.get(id).then(function (doc) {
+          doc.updated = Date.now();
+          return a.put(doc);
+        });
+      }
+
+      function remove(a, id) {
+        return a.get(id).then(function (doc) {
+          return a.remove(doc);
+        });
+      }
+
+      function conflict(docTemplate) {
+        return local.put(docTemplate).then(function () {
+          docTemplate.baz = 'fubar';
+          return remote.put(docTemplate);
+        });
+      }
+
+      var doc1 = {
+        _id: 'random-' + Date.now(),
+        foo: 'bar'
+      };
+
+      var doc2 = {
+        _id: 'random2-' + Date.now(),
+        foo: 'bar'
+      };
+
+      return conflict(doc2)
+      .then(function () { return local.replicate.to(remote); })
+      .then(function () { return update(local, doc2._id); })
+      .then(function () { return remove(local, doc2._id); })
+      .then(function () { return local.replicate.to(remote); })
+      .then(function () { return conflict(doc1); })
+      .then(function () { return update(remote, doc2._id); })
+      .then(function () { return local.replicate.to(remote); })
+      .then(function () { return remove(local, doc1._id); })
+      .then(function () { return local.sync (remote); })
+      .then(function () {
+        return Promise.all([
+          local.allDocs({include_docs: true}),
+          remote.allDocs({include_docs: true})
+        ]);
+      }).then(function (res) {
+        res[0].should.deep.equal(res[1]);
+      });
+    });
   });
 });


### PR DESCRIPTION
Adds a test to reproduce the fuzzy test failure detected in #5782.

A relatively simple workaround fixes this: if a conflict is detected in a rev-1 document, skip the bulk_docs optimisation for that id.