### PR TITLE
fix(memleak): correct `destroyed` event handler memory leak on `close()`

### DIFF
--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -728,6 +728,7 @@ AbstractPouchDB.prototype.changes = function (opts, callback) {
 
 AbstractPouchDB.prototype.close = adapterFun('close', function (callback) {
   this._closed = true;
+  this.emit('closed');
   return this._close(callback);
 });
 

--- a/packages/node_modules/pouchdb-core/src/constructor.js
+++ b/packages/node_modules/pouchdb-core/src/constructor.js
@@ -24,11 +24,24 @@ function prepareForDestruction(self) {
   }
 
   function onConstructorDestroyed() {
-    self.removeListener('destroyed', onDestroyed);
+    onClosed();
     self.emit('destroyed', self);
   }
 
+  function onClosed() {
+    self.removeListener('destroyed', onDestroyed);
+    if (destructionListeners.has(self.name)) {
+      var old_set = destructionListeners.get(self.name);
+      var old_set_index = old_set.indexOf(onConstructorDestroyed);
+      if(old_set_index >= 0) {
+        old_set.splice(old_set_index,1);
+        destructionListeners.set(self.name, []);
+      }
+    }
+  }
+
   self.once('destroyed', onDestroyed);
+  self.once('closed', onClosed);
 
   // in setup.js, the constructor is primed to listen for destroy events
   if (!destructionListeners.has(self.name)) {


### PR DESCRIPTION
Fixes #4868 
This extends `close()` so that the constructor can remove its `destroyed`-event-handling callbacks; both the local `destroyed()` callback (bound to a specific PouchDB instance) and the global `destroyed(name)` Pouch callback are removed.

This also modifies `.destroy()` in a similar fashion (I suspect `destroy` was leaking as well) ­— I'm more interested in fixing `.close()` though, so maintainers are welcome to revert that specific one-line change (Travis doesn't seem to like it too much).

The code could be prettier if the destruction-listeners were inside a more clever data store than a plain Array (a Set maybe?) — but this does the job I believe.