### PR TITLE
(#5788) - test: fix ajax timeout test

### DIFF
--- a/tests/integration/test.ajax.js
+++ b/tests/integration/test.ajax.js
@@ -16,7 +16,7 @@ adapters.forEach(function (adapter) {
       }, function (err, res) {
         // here's the test, we should get an 'err' response
         should.exist(err);
-        err.code.should.match(/(ETIMEDOUT|ENETUNREACH|EAGAIN|ECONNREFUSED)/);
+        err.code.should.match(/(ESOCKETTIMEDOUT|ETIMEDOUT|ENETUNREACH|EAGAIN|ECONNREFUSED)/);
         should.not.exist(res);
         done();
       });


### PR DESCRIPTION
This adds the error code `ESOCKETTIMEDOUT` to the ajax test assertion
match pattern in order to make the test pass when testing with Node.js
v6 against PouchDB >= v6.0.7.