### PR TITLE
5793 - fixes for sync against Couchbase Sync Gateway

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/allDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/allDocs.js
@@ -98,7 +98,10 @@ function idbAllDocs(opts, api, idb, callback) {
       docIdRevIndex.get(key).onsuccess =  function onGetDoc(e) {
         row.doc = decodeDoc(e.target.result);
         if (opts.conflicts) {
-          row.doc._conflicts = collectConflicts(metadata);
+          var conflicts = collectConflicts(metadata);
+          if (conflicts.length) {
+            row.doc._conflicts = conflicts;
+          }
         }
         fetchAttachmentsIfNecessary(row.doc, opts, txn);
       };

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/allDocs.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/allDocs.js
@@ -108,7 +108,10 @@ export default function (idb, metadata, opts, callback) {
       row.doc._rev = doc.rev;
 
       if (opts.conflicts) {
-        row.doc._conflicts = collectConflicts(doc);
+        var conflicts = collectConflicts(doc);
+        if (conflicts.length) {
+          row.doc._conflicts = conflicts;
+        }
       }
 
       if (opts.attachments && doc.data._attachments) {

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -913,7 +913,10 @@ function LevelPouch(opts, callback) {
             doc.doc = data;
             doc.doc._rev = doc.value.rev;
             if (opts.conflicts) {
-              doc.doc._conflicts = collectConflicts(metadata);
+              var conflicts = collectConflicts(metadata);
+              if (conflicts.length) {
+                doc.doc._conflicts = conflicts;
+              }
             }
             for (var att in doc.doc._attachments) {
               if (doc.doc._attachments.hasOwnProperty(att)) {

--- a/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
@@ -704,7 +704,10 @@ function WebSqlPouch(opts, callback) {
               doc.doc = data;
               doc.doc._rev = winningRev;
               if (opts.conflicts) {
-                doc.doc._conflicts = collectConflicts(metadata);
+                var conflicts = collectConflicts(metadata);
+                if (conflicts.length) {
+                  doc.doc._conflicts = conflicts;
+                }
               }
               fetchAttachmentsIfNecessary(doc.doc, opts, api, tx);
             }

--- a/packages/node_modules/pouchdb-replication/src/getDocs.js
+++ b/packages/node_modules/pouchdb-replication/src/getDocs.js
@@ -147,6 +147,12 @@ function getDocs(src, target, diffs, state) {
           return;
         }
 
+        // strip _conflicts array to appease CSG (#5793)
+        /* istanbul ignore if */
+        if (row.doc._conflicts) {
+          delete row.doc._conflicts;
+        }
+
         // the doc we got back from allDocs() is sufficient
         resultDocs.push(row.doc);
         delete diffs[row.id];

--- a/tests/integration/test.all_docs.js
+++ b/tests/integration/test.all_docs.js
@@ -690,5 +690,19 @@ adapters.forEach(function (adapter) {
         });
       });
     }
+
+    it('5793 _conflicts should not exist if no conflicts', function () {
+      var db = new PouchDB(dbs.name);
+      return db.put({
+        _id: '0', a: 1
+      }).then(function () {
+        return db.allDocs({
+          include_docs: true,
+          conflicts: true
+        });
+      }).then(function (result) {
+        should.not.exist(result.rows[0].doc._conflicts);
+      });
+    });
   });
 });

--- a/tests/integration/test.bulk_docs.js
+++ b/tests/integration/test.bulk_docs.js
@@ -1039,5 +1039,22 @@ adapters.forEach(function (adapter) {
         results[0].should.have.property('status', 409);
       });
     });
+
+    it('5793 bulk docs accepts _conflicts when new_edits=false', function () {
+      var db = new PouchDB(dbs.name);
+      var newdoc = {
+        '_id': 'foobar',
+        '_rev': '1-123',
+        '_conflicts': []
+      };
+
+      return db.bulkDocs({ docs: [newdoc] },
+        { new_edits: false }
+      ).then(function () {
+        return db.allDocs();
+      }).then(function (result) {
+        result.rows.length.should.equal(1);
+      });
+    });
   });
 });


### PR DESCRIPTION
This adds a couple of tests around handling of `conflicts` in `allDocs` and `bulkDocs`, the latter of which I expect to fail against Couchbase Sync Gateway. It also tweaks the workaround added in #5767 to strip the `_conflicts` array from the `allDocs` response to prevent POSTing it to the server unnecessarily.
