### PR TITLE
(#5736) - Warn about attachments without content_type

### DIFF
--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -1,4 +1,7 @@
-import { jsExtend as extend } from 'pouchdb-utils';
+import {
+    jsExtend as extend,
+    guardedConsole
+} from 'pouchdb-utils';
 import Promise from 'pouchdb-promise';
 import { Map } from 'pouchdb-collections';
 import { EventEmitter } from 'events';
@@ -244,6 +247,9 @@ AbstractPouchDB.prototype.putAttachment =
     type = blob;
     blob = rev;
     rev = null;
+  }
+  if (!type) {
+    guardedConsole('warn', 'Attachment', attachmentId, 'on document', docId, 'is missing content_type');
   }
 
   function createAttachment(doc) {
@@ -785,6 +791,9 @@ AbstractPouchDB.prototype.bulkDocs =
     if (doc._attachments) {
       Object.keys(doc._attachments).forEach(function (name) {
         attachmentError = attachmentError || attachmentNameError(name);
+        if (!doc._attachments[name].content_type) {
+          guardedConsole('warn', 'Attachment', name, 'on document', doc._id, 'is missing content_type');
+        }
       });
     }
   });

--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -100,6 +100,23 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('5736 warning for putAttachment without content_type', function () {
+      var db = new PouchDB(dbs.name);
+      return db.putAttachment('bar', 'baz.txt', testUtils.btoa('text'), '');
+    });
+
+    it('5736 warning for bulkDocs attachments without content_type', function () {
+      var db = new PouchDB(dbs.name);
+      var doc = {
+        _attachments: {
+          'att.txt': {
+            data: testUtils.btoa('well')
+          }
+        }
+      };
+      return db.bulkDocs([doc]);
+    });
+
     it('fetch atts with open_revs and missing', function () {
       var db = new PouchDB(dbs.name);
       var doc = {


### PR DESCRIPTION
Handles #5736. Emit a warning when an attachment is inserted without a content_type,
which is almost always a bug (e.g. see #5726). This is not treated as an
error in PouchDB since users may be replicating from a CouchDB they have
no control over.

A few people mentioned wanting to help with this one in the issue, but some time has passed without any activity. I'm not intending to step on any toes, apologies if I am!