### PR TITLE
pass options to ajax call of http's api.bulkGet

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -296,7 +296,7 @@ function HttpPouch(opts, callback) {
         /* istanbul ignore next */
         params.attachments = true;
       }
-      ajax({}, {
+      ajax(opts, {
         url: genDBUrl(host, '_bulk_get' + paramsToStr(params)),
         method: 'POST',
         body: { docs: opts.docs}


### PR DESCRIPTION
all api calls except bulkGet pass the options of the api command to the ajax call. This is great for allowing plugins to modify a call, so I added it to bulkGet, too (I suppose it's a mistake that all api calls except bulkGet do this)