### PR TITLE
Newline after Plugins (h2)

### DIFF
--- a/docs/external.md
+++ b/docs/external.md
@@ -6,7 +6,7 @@ sidebar: nav.html
 
 Below is a list of known plugins, tools and projects can be used with PouchDB.
 
-{% include anchor.html title="Plugins" hash="plugins" %}
+## {% include anchor.html title="Plugins" hash="plugins" %}
 
 #### [PouchDB allDbs()](https://github.com/nolanlawson/pouchdb-all-dbs)
 


### PR DESCRIPTION
Not sure what's the best way to skip to the next line after the "Plugins" (h2) title. It's a tad convoluted :-)