### PR TITLE
(#5842) - Show build errors

### DIFF
--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -34,7 +34,7 @@ var rebuildPromise = Promise.resolve();
 function rebuildPouch() {
   rebuildPromise = rebuildPromise.then(buildPouchDB).then(function () {
     console.log('Rebuilt packages/node_modules/pouchdb');
-  });
+  }).catch(console.error);
 }
 
 function browserifyPromise(src, dest) {
@@ -51,7 +51,7 @@ function rebuildTestUtils() {
       'tests/integration/utils-bundle.js');
   }).then(function () {
     console.log('Rebuilt tests/integration/utils-bundle.js');
-  });
+  }).catch(console.error);
 }
 
 function rebuildPerf() {
@@ -60,7 +60,7 @@ function rebuildPerf() {
       'tests/performance-bundle.js');
   }).then(function () {
     console.log('Rebuilt tests/performance-bundle.js');
-  });
+  }).catch(console.error);
 }
 
 function watchAll() {


### PR DESCRIPTION
Not sure what was going on with my build, I kept seeing 

```
    took 493 ms to rollup src/plugins/localstorage.js
{ Error: ENOENT: no such file or directory, open '/Users/daleharvey/src/pouchdb/packages/node_modules/pouchdb/lib/plugins/memory.js.tmp'
    at Error (native)
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/Users/daleharvey/src/pouchdb/packages/node_modules/pouchdb/lib/plugins/memory.js.tmp' }
```

But it went away, it helps to see the errors