### PR TITLE
(#5832) - return correct revision after doc update

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
@@ -243,7 +243,7 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, idbChanges, callback) {
 
       metadata.seq = e.target.result;
       // Current _rev is calculated from _rev_tree on read
-      delete metadata.rev;
+      // delete metadata.rev;
       var metadataToStore = encodeMetadata(metadata, winningRev,
         winningRevIsDeleted);
       var metaDataReq = docStore.put(metadataToStore);
@@ -266,7 +266,7 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, idbChanges, callback) {
       results[resultsIdx] = {
         ok: true,
         id: metadata.id,
-        rev: winningRev
+        rev: metadata.rev
       };
       fetchedDocs.set(docInfo.metadata.id, docInfo.metadata);
       insertAttachmentMappings(docInfo, metadata.seq, callback);

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -685,7 +685,7 @@ function LevelPouch(opts, callback) {
         results[resultsIdx] = {
           ok: true,
           id: docInfo.metadata.id,
-          rev: winningRev
+          rev: docInfo.metadata.rev
         };
         fetchedDocs.set(docInfo.metadata.id, docInfo.metadata);
         callback2();

--- a/packages/node_modules/pouchdb-adapter-websql-core/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-websql-core/src/bulkDocs.js
@@ -239,6 +239,7 @@ function websqlBulkDocs(dbOpts, req, opts, api, db, websqlChanges, callback) {
       }
 
       docInfo.metadata.seq = seq;
+      var rev = docInfo.metadata.rev;
       delete docInfo.metadata.rev;
 
       var sql = isUpdate ?
@@ -256,7 +257,7 @@ function websqlBulkDocs(dbOpts, req, opts, api, db, websqlChanges, callback) {
         results[resultsIdx] = {
           ok: true,
           id: docInfo.metadata.id,
-          rev: winningRev
+          rev: rev
         };
         fetchedDocs.set(id, docInfo.metadata);
         callback();

--- a/tests/integration/test.conflicts.js
+++ b/tests/integration/test.conflicts.js
@@ -529,5 +529,36 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('5832 - update losing leaf returns correct rev', function () {
+      // given
+      var docs = [
+        {
+          _id: 'fubar',
+          _rev: '1-a1',
+          _revisions: { start: 1, ids: [ 'a1' ] }
+        }, {
+          _id: 'fubar',
+          _rev: '2-a2',
+          _revisions: { start: 2, ids: [ 'a2', 'a1' ] }
+        }, {
+          _id: 'fubar',
+          _rev: '2-b2',
+          _revisions: { start: 2, ids: [ 'b2', 'a1' ] }
+        }
+      ];
+      var db = new PouchDB(dbs.name);
+      return db.bulkDocs({
+        docs: docs, new_edits: false
+      }).then(function () {
+        return db.get('fubar', { conflicts: true });
+      })
+      .then(function (doc) {
+        return db.remove(doc);
+      })
+      .then(function (result) {
+        result.rev[0].should.equal('3');
+      });
+    });
+
   });
 });


### PR DESCRIPTION
For some adapters, document updates were returning
the winning rev in the document update metadata
rather than the revision just written. This adds
a test for the behaviour and fixes it.