### PR TITLE
(#5848) Fix constructor modifying options object

### DIFF
--- a/packages/node_modules/pouchdb-core/src/constructor.js
+++ b/packages/node_modules/pouchdb-core/src/constructor.js
@@ -2,7 +2,7 @@ import debug from 'debug';
 import inherits from 'inherits';
 import Adapter from './adapter';
 import TaskQueue from './taskqueue';
-import { clone } from 'pouchdb-utils';
+import { clone, jsExtend as extend  } from 'pouchdb-utils';
 import parseAdapter from './parseAdapter';
 
 // OK, so here's the deal. Consider this code:
@@ -46,18 +46,20 @@ function prepareForDestruction(self) {
 }
 
 inherits(PouchDB, Adapter);
-function PouchDB(name, opts) {
+function PouchDB(originalName, originalOpts) {
   // In Node our test suite only tests this for PouchAlt unfortunately
   /* istanbul ignore if */
   if (!(this instanceof PouchDB)) {
-    return new PouchDB(name, opts);
+    return new PouchDB(originalName, originalOpts);
   }
 
   var self = this;
-  opts = opts || {};
+
+  var opts = extend({}, originalOpts);
+  var name = originalName;
 
   if (name && typeof name === 'object') {
-    opts = name;
+    opts = extend({}, originalName);
     name = opts.name;
     delete opts.name;
   }

--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -56,15 +56,16 @@ PouchDB.plugin = function (obj) {
 };
 
 PouchDB.defaults = function (defaultOpts) {
-  function PouchAlt(name, opts) {
+  function PouchAlt(virginName, virginOpts) {
     if (!(this instanceof PouchAlt)) {
-      return new PouchAlt(name, opts);
+      return new PouchAlt(virginName, virginOpts);
     }
 
-    opts = opts || {};
+    var opts = extend({}, virginOpts);
+    var name = virginName;
 
     if (name && typeof name === 'object') {
-      opts = name;
+      opts = extend({}, virginName);
       name = opts.name;
       delete opts.name;
     }

--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -56,16 +56,16 @@ PouchDB.plugin = function (obj) {
 };
 
 PouchDB.defaults = function (defaultOpts) {
-  function PouchAlt(virginName, virginOpts) {
+  function PouchAlt(originalName, originalOpts) {
     if (!(this instanceof PouchAlt)) {
-      return new PouchAlt(virginName, virginOpts);
+      return new PouchAlt(originalName, originalOpts);
     }
 
-    var opts = extend({}, virginOpts);
-    var name = virginName;
+    var opts = extend({}, originalOpts);
+    var name = originalName;
 
     if (name && typeof name === 'object') {
-      opts = extend({}, virginName);
+      opts = extend({}, originalName);
       name = opts.name;
       delete opts.name;
     }

--- a/tests/integration/test.constructor.js
+++ b/tests/integration/test.constructor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('constructor errors', function () {
+describe('test.constructor.js', function () {
 
   it('should error on an undefined name', function (done) {
     try {
@@ -32,6 +32,17 @@ describe('constructor errors', function () {
     } catch (err) {
       should.equal(err instanceof Error, true, 'should be an error');
       done();
+    }
+  });
+
+  it('should not modify original options', function (done) {
+    try {
+      const opts = { name: 'test' };
+      new PouchDB(opts);
+      new PouchDB(opts);
+      done();
+    } catch (e) {
+      done('Should not have thrown.');
     }
   });
 


### PR DESCRIPTION
Using the same options object more than once was modifying the original
object. The options object was being cloned after the modification
rather than before. This fixes that and adds a test to make sure you can
use the same object again.