### PR TITLE
(#5832) - new feature: force update.

### DIFF
--- a/packages/node_modules/pouchdb-adapter-utils/src/processDocs.js
+++ b/packages/node_modules/pouchdb-adapter-utils/src/processDocs.js
@@ -93,7 +93,7 @@ function processDocs(revLimit, docInfos, api, fetchedDocs, tx, results,
 
       if (fetchedDocs.has(id)) {
         updateDoc(revLimit, fetchedDocs.get(id), currentDoc, results,
-          resultsIdx, docWritten, writeDoc, newEdits);
+          resultsIdx, docWritten, writeDoc, newEdits, opts.force);
       } else {
         // Ensure stemming applies to new writes as well
         var merged = merge([], currentDoc.metadata.rev_tree[0], revLimit);

--- a/packages/node_modules/pouchdb-adapter-utils/src/updateDoc.js
+++ b/packages/node_modules/pouchdb-adapter-utils/src/updateDoc.js
@@ -8,7 +8,7 @@ import {
 } from 'pouchdb-merge';
 
 function updateDoc(revLimit, prev, docInfo, results,
-                   i, cb, writeDoc, newEdits) {
+                   i, cb, writeDoc, newEdits, forceUpdate) {
 
   if (revExists(prev.rev_tree, docInfo.metadata.rev)) {
     results[i] = docInfo;
@@ -36,7 +36,7 @@ function updateDoc(revLimit, prev, docInfo, results,
     (!previouslyDeleted && merged.conflicts !== 'new_leaf') ||
     (previouslyDeleted && !deleted && merged.conflicts === 'new_branch')));
 
-  if (inConflict) {
+  if (inConflict && !forceUpdate) {
     var err = createError(REV_CONFLICT);
     results[i] = err;
     return cb();


### PR DESCRIPTION
add a `force` option to `put` operation to allow update based on
non-leaf revison and generate a new conflict revision, instead of
reporting update conflict error.

Couchdb doesn't support this option, so the test case will skip for http adapter.