### PR TITLE
Use 'hasOwnProperty' instead of 'in' operator

### DIFF
--- a/packages/node_modules/pouchdb-utils/src/bulkGetShim.js
+++ b/packages/node_modules/pouchdb-utils/src/bulkGetShim.js
@@ -22,7 +22,7 @@ function bulkGet(db, opts, callback) {
   // consolidate into one request per doc if possible
   var requestsById = {};
   requests.forEach(function (request) {
-    if (request.id in requestsById) {
+    if (requestsById.hasOwnProperty(request.id)) {
       requestsById[request.id].push(request);
     } else {
       requestsById[request.id] = [request];


### PR DESCRIPTION
If the request id has the same name as one of the property of the prototype of Object, it will tries to push the request to the prototype property.