### PR TITLE
(#5884) - add rollup-plugin-node-globals for browser builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "replace": "0.3.0",
     "rimraf": "2.5.4",
     "rollup": "0.34.13",
+    "rollup-plugin-node-globals": "^1.1.0",
     "rollup-plugin-node-resolve": "2.0.0",
     "rollup-plugin-replace": "1.1.1",
     "sauce-connect-launcher": "0.17.0",


### PR DESCRIPTION
Since not all build systems automatically shim process and globals
and other such globals like browserify does this adds those into
the build when not building for node.