### PR TITLE
(#5883) - Retrieves the appropriate _revisions when there are duplicate rev-hash

### DIFF
--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -40,15 +40,6 @@ function compare(left, right) {
   return left < right ? -1 : left > right ? 1 : 0;
 }
 
-// returns first element of arr satisfying callback predicate
-function arrayFirst(arr, callback) {
-  for (var i = 0; i < arr.length; i++) {
-    if (callback(arr[i], i) === true) {
-      return arr[i];
-    }
-  }
-}
-
 // Wrapper for functions that call the bulkdocs api with a single doc,
 // if the first result is an error, return an error
 function yankError(callback) {
@@ -588,10 +579,18 @@ AbstractPouchDB.prototype.get = adapterFun('get', function (id, opts, cb) {
 
     if (opts.revs || opts.revs_info) {
       var paths = rootToLeaf(metadata.rev_tree);
-      var path = arrayFirst(paths, function (arr) {
-        return arr.ids.map(function (x) { return x.id; })
-          .indexOf(doc._rev.split('-')[1]) !== -1;
-      });
+      var path = paths.reduce(function selectRevPath(result, arr) {
+        var splittedRev = doc._rev.split('-');
+        var revNo       = parseInt(splittedRev[0]);
+        var revHash     = splittedRev[1];
+        var hashIndex   = arr.ids.map(function (x) { return x.id; })
+          .indexOf(revHash);
+        var hashFoundAtRevPos = hashIndex === (revNo - 1);
+
+        return (hashFoundAtRevPos || (!result && hashIndex !== -1))
+          ? arr
+          : result;
+      }, null);
 
       var indexOfRev = path.ids.map(function (x) {return x.id; })
         .indexOf(doc._rev.split('-')[1]) + 1;

--- a/tests/integration/test.get.js
+++ b/tests/integration/test.get.js
@@ -732,5 +732,36 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('#5883 Testing with duplicate rev hash', function (done) {
+      var db = new PouchDB(dbs.name);
+      db.bulkDocs([
+          {
+            "_id": "foo",
+            "_rev": "3-deleted",
+            "_deleted": true,
+            "_revisions": {
+                "start": 3,
+                "ids": ["deleted", "0a21b4bd4399b51e144a06b126031edc", "created"]
+            }
+          },
+          {
+            "_id": "foo",
+            "_rev": "3-0a21b4bd4399b51e144a06b126031edc",
+            "_revisions": {
+                "start": 3,
+                "ids": ["0a21b4bd4399b51e144a06b126031edc", "updated", "created"]
+            }
+          }
+        ], { new_edits: false
+      }).then(function () {
+        return db.get('foo', { revs: true });
+      }).then(function (doc) {
+        doc._revisions.start.should.equal(3);
+        doc._revisions.ids.should.eql(["0a21b4bd4399b51e144a06b126031edc", "updated", "created"]);
+        done();
+      }).catch(done);
+    });
+
+
   });
 });


### PR DESCRIPTION
See #5883 for details.

Instead of always taking the first in the paths array, I modified it so it takes the one for the revision being retrieved if it exists and keep the first in the other cases.