### PR TITLE
(#5855) - fix JSON.parse overflows

### DIFF
--- a/packages/node_modules/pouchdb-json/src/safeJsonParse.js
+++ b/packages/node_modules/pouchdb-json/src/safeJsonParse.js
@@ -1,28 +1,15 @@
 import vuvuzela from 'vuvuzela';
 
-function slowJsonParse(str) {
+function safeJsonParse(str) {
+  // This try/catch guards against stack overflow errors.
+  // JSON.parse() is faster than vuvuzela.parse() but vuvuzela
+  // cannot overflow.
   try {
     return JSON.parse(str);
   } catch (e) {
     /* istanbul ignore next */
     return vuvuzela.parse(str);
   }
-}
-
-function safeJsonParse(str) {
-  // try/catch is deoptimized in V8, leading to slower
-  // times than we'd like to have. Most documents are _not_
-  // huge, and do not require a slower code path just to parse them.
-  // We can be pretty sure that a document under 50000 characters
-  // will not be so deeply nested as to throw a stack overflow error
-  // (depends on the engine and available memory, though, so this is
-  // just a hunch). 50000 was chosen based on the average length
-  // of this string in our test suite, to try to find a number that covers
-  // most of our test cases (26 over this size, 26378 under it).
-  if (str.length < 50000) {
-    return JSON.parse(str);
-  }
-  return slowJsonParse(str);
 }
 
 export default safeJsonParse;


### PR DESCRIPTION
See #5855 for discussion. Apparently V8 doesn't deopt try/catches anymore.