### PR TITLE
(#5886) - fix bulkGet with reserved _id

### DIFF
--- a/packages/node_modules/pouchdb-collections/src/index.js
+++ b/packages/node_modules/pouchdb-collections/src/index.js
@@ -6,39 +6,44 @@ function unmangle(key) {
   return key.substring(1);
 }
 function LazyMap() {
-  this.store = {};
+  this._store = {};
 }
 LazyMap.prototype.get = function (key) {
   var mangled = mangle(key);
-  return this.store[mangled];
+  return this._store[mangled];
 };
 LazyMap.prototype.set = function (key, value) {
   var mangled = mangle(key);
-  this.store[mangled] = value;
+  this._store[mangled] = value;
   return true;
 };
 LazyMap.prototype.has = function (key) {
   var mangled = mangle(key);
-  return mangled in this.store;
+  return mangled in this._store;
 };
 LazyMap.prototype.delete = function (key) {
   var mangled = mangle(key);
-  var res = mangled in this.store;
-  delete this.store[mangled];
+  var res = mangled in this._store;
+  delete this._store[mangled];
   return res;
 };
 LazyMap.prototype.forEach = function (cb) {
-  var keys = Object.keys(this.store);
+  var keys = Object.keys(this._store);
   for (var i = 0, len = keys.length; i < len; i++) {
     var key = keys[i];
-    var value = this.store[key];
+    var value = this._store[key];
     key = unmangle(key);
     cb(value, key);
   }
 };
+Object.defineProperty(LazyMap.prototype, 'size', {
+  get: function () {
+    return Object.keys(this._store).length;
+  }
+});
 
 function LazySet(array) {
-  this.store = new LazyMap();
+  this._store = new LazyMap();
 
   // init with an array
   if (array && Array.isArray(array)) {
@@ -48,10 +53,10 @@ function LazySet(array) {
   }
 }
 LazySet.prototype.add = function (key) {
-  return this.store.set(key, true);
+  return this._store.set(key, true);
 };
 LazySet.prototype.has = function (key) {
-  return this.store.has(key);
+  return this._store.has(key);
 };
 
 export {

--- a/packages/node_modules/pouchdb-utils/src/bulkGetShim.js
+++ b/packages/node_modules/pouchdb-utils/src/bulkGetShim.js
@@ -1,4 +1,5 @@
 import pick from './pick';
+import { Map } from 'pouchdb-collections';
 
 // Most browsers throttle concurrent requests at 6, so it's silly
 // to shim _bulk_get by trying to launch potentially hundreds of requests
@@ -20,16 +21,16 @@ function bulkGet(db, opts, callback) {
   var requests = opts.docs;
 
   // consolidate into one request per doc if possible
-  var requestsById = {};
+  var requestsById = new Map();
   requests.forEach(function (request) {
-    if (request.id in requestsById) {
-      requestsById[request.id].push(request);
+    if (requestsById.has(request.id)) {
+      requestsById.get(request.id).push(request);
     } else {
-      requestsById[request.id] = [request];
+      requestsById.set(request.id, [request]);
     }
   });
 
-  var numDocs = Object.keys(requestsById).length;
+  var numDocs = requestsById.size;
   var numDone = 0;
   var perDocResults = new Array(numDocs);
 
@@ -57,7 +58,10 @@ function bulkGet(db, opts, callback) {
     checkDone();
   }
 
-  var allRequests = Object.keys(requestsById);
+  var allRequests = [];
+  requestsById.forEach(function (value, key) {
+    allRequests.push(key);
+  });
 
   var i = 0;
 
@@ -76,7 +80,7 @@ function bulkGet(db, opts, callback) {
   function processBatch(batch, offset) {
     batch.forEach(function (docId, j) {
       var docIdx = offset + j;
-      var docRequests = requestsById[docId];
+      var docRequests = requestsById.get(docId);
 
       // just use the first request as the "template"
       // TODO: The _bulk_get API allows for more subtle use cases than this,

--- a/tests/integration/test.bulk_get.js
+++ b/tests/integration/test.bulk_get.js
@@ -65,6 +65,23 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('#5886 bulkGet with reserved id', function (done) {
+      var db = new PouchDB(dbs.name);
+      db.put({_id: 'constructor', val: 1}).then(function (response) {
+        var rev = response.rev;
+        db.bulkGet({
+          docs: [
+            {id: 'constructor', rev: rev}
+          ]
+        }).then(function (response) {
+          var result = response.results[0];
+          result.docs[0].ok._id.should.equal('constructor');
+          should.not.exist(result.docs[0].ok._revisions);
+          done();
+        });
+      });
+    });
+
     it('_revisions is returned when specified', function (done) {
       var db = new PouchDB(dbs.name);
       db.put({_id: 'foo', val: 1}).then(function (response) {


### PR DESCRIPTION
Follow-up to #5886. Instead of using `hasOwnProperty` I opted for `pouchdb-collections`'s `Map` since this is the typical pattern we use elsewhere.

I also added a `size` property on the Map per the [Map spec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/size) and renamed `obj.store` to `obj._store` to indicate that it's private.

I also added a new test that fails before the fix but succeeds after.