### PR TITLE
(#5898) - process.nextTick() -> setTimeout() for browser code

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -5,7 +5,8 @@ import {
   toPromise,
   hasLocalStorage,
   changesHandler as Changes,
-  uuid
+  uuid,
+  nextTick
 } from 'pouchdb-utils';
 import {
   isDeleted,
@@ -821,7 +822,7 @@ function init(api, opts, callback) {
   if (cached) {
     idb = cached.idb;
     api._meta = cached.global;
-    process.nextTick(function () {
+    nextTick(function () {
       callback(null, api);
     });
     return;

--- a/packages/node_modules/pouchdb-adapter-idb/src/utils.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/utils.js
@@ -2,7 +2,8 @@ import { jsExtend as extend } from 'pouchdb-utils';
 import Promise from 'pouchdb-promise';
 import { createError, IDB_ERROR } from 'pouchdb-errors';
 import {
-  pick
+  pick,
+  nextTick
 } from 'pouchdb-utils';
 import {
   safeJsonParse,
@@ -41,7 +42,7 @@ function applyNext(PouchDB) {
   item.action(function (err, res) {
     tryCode(item.callback, this, [err, res], PouchDB);
     taskQueue.running = false;
-    process.nextTick(function () {
+    nextTick(function () {
       applyNext(PouchDB);
     });
   });

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -10,7 +10,8 @@ import {
   changesHandler as Changes,
   filterChange,
   functionName,
-  uuid
+  uuid,
+  nextTick
 } from 'pouchdb-utils';
 import {
   isDeleted,
@@ -217,7 +218,7 @@ function LevelPouch(opts, callback) {
         stores.metaStore.get(UUID_KEY, function (err, value) {
           instanceId = !err ? value : uuid();
           stores.metaStore.put(UUID_KEY, instanceId, function () {
-            process.nextTick(function () {
+            nextTick(function () {
               callback(null, api);
             });
           });
@@ -248,7 +249,7 @@ function LevelPouch(opts, callback) {
       update_seq: db._updateSeq,
       backend_adapter: functionName(leveldown)
     };
-    return process.nextTick(function () {
+    return nextTick(function () {
       callback(null, res);
     });
   };
@@ -291,7 +292,7 @@ function LevelPouch(opts, callback) {
       args[args.length - 1] = getArguments(function (cbArgs) {
         callback.apply(null, cbArgs);
         if (++numDone === readTasks.length) {
-          process.nextTick(function () {
+          nextTick(function () {
             // all read tasks have finished
             readTasks.forEach(function () {
               db._queue.shift();
@@ -311,7 +312,7 @@ function LevelPouch(opts, callback) {
     var callback = args[args.length - 1];
     args[args.length - 1] = getArguments(function (cbArgs) {
       callback.apply(null, cbArgs);
-      process.nextTick(function () {
+      nextTick(function () {
         db._queue.shift();
         if (db._queue.length) {
           executeNext();
@@ -334,7 +335,7 @@ function LevelPouch(opts, callback) {
       });
 
       if (db._queue.length === 1) {
-        process.nextTick(executeNext);
+        nextTick(executeNext);
       }
     });
   }
@@ -349,7 +350,7 @@ function LevelPouch(opts, callback) {
       });
 
       if (db._queue.length === 1) {
-        process.nextTick(executeNext);
+        nextTick(executeNext);
       }
     });
   }
@@ -787,7 +788,7 @@ function LevelPouch(opts, callback) {
     function complete(err) {
       /* istanbul ignore if */
       if (err) {
-        return process.nextTick(function () {
+        return nextTick(function () {
           callback(err);
         });
       }
@@ -813,7 +814,7 @@ function LevelPouch(opts, callback) {
         db._docCount += docCountDelta;
         db._updateSeq = newUpdateSeq;
         levelChanges.notify(name);
-        process.nextTick(function () {
+        nextTick(function () {
           callback(null, results);
         });
       });

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/transaction.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/transaction.js
@@ -4,6 +4,7 @@
 // when you're done
 
 import { Map, Set } from 'pouchdb-collections';
+import { nextTick } from 'pouchdb-utils';
 
 function getCacheFor(transaction, store) {
   var prefix = store.prefix()[0];
@@ -25,12 +26,12 @@ LevelTransaction.prototype.get = function (store, key, callback) {
   var cache = getCacheFor(this, store);
   var exists = cache.get(key);
   if (exists) {
-    return process.nextTick(function () {
+    return nextTick(function () {
       callback(null, exists);
     });
   } else if (exists === null) { // deleted marker
     /* istanbul ignore next */
-    return process.nextTick(function () {
+    return nextTick(function () {
       callback({name: 'NotFoundError'});
     });
   }

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -12,7 +12,8 @@ import {
   adapterFun,
   upsert,
   bulkGetShim,
-  invalidIdError
+  invalidIdError,
+  nextTick
 } from 'pouchdb-utils';
 import {
   traverseRevTree,
@@ -164,7 +165,7 @@ function doNextCompaction(self) {
       } else {
         callback(null, res);
       }
-      process.nextTick(function () {
+      nextTick(function () {
         self._compactionQueue.shift();
         if (self._compactionQueue.length) {
           doNextCompaction(self);

--- a/packages/node_modules/pouchdb-mapreduce-utils/src/index.js
+++ b/packages/node_modules/pouchdb-mapreduce-utils/src/index.js
@@ -1,13 +1,14 @@
 import argsarray from 'argsarray';
+import { nextTick } from 'pouchdb-utils';
 
 var promisedCallback = function (promise, callback) {
   if (callback) {
     promise.then(function (res) {
-      process.nextTick(function () {
+      nextTick(function () {
         callback(null, res);
       });
     }, function (reason) {
-      process.nextTick(function () {
+      nextTick(function () {
         callback(reason);
       });
     });

--- a/packages/node_modules/pouchdb-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-mapreduce/src/index.js
@@ -1,6 +1,7 @@
 import {
   flatten,
-  guardedConsole
+  guardedConsole,
+  nextTick
 } from 'pouchdb-utils';
 
 import {
@@ -879,7 +880,7 @@ function queryPromised(db, fun, opts) {
       return createView(createViewOpts).then(function (view) {
         if (opts.stale === 'ok' || opts.stale === 'update_after') {
           if (opts.stale === 'update_after') {
-            process.nextTick(function () {
+            nextTick(function () {
               updateView(view);
             });
           }

--- a/packages/node_modules/pouchdb-utils/package.json
+++ b/packages/node_modules/pouchdb-utils/package.json
@@ -18,6 +18,7 @@
     "./src/env/hasLocalStorage.js": "./src/env/hasLocalStorage-browser.js",
     "./src/env/isChromeApp.js": "./src/env/isChromeApp-browser.js",
     "./src/explainError.js": "./src/explainError-browser.js",
-    "./src/isBinaryObject.js": "./src/isBinaryObject-browser.js"
+    "./src/isBinaryObject.js": "./src/isBinaryObject-browser.js",
+    "./src/nextTick.js": "./src/nextTick-browser.js"
   }
 }

--- a/packages/node_modules/pouchdb-utils/src/index.js
+++ b/packages/node_modules/pouchdb-utils/src/index.js
@@ -15,6 +15,7 @@ import invalidIdError from './invalidIdError';
 import isChromeApp from './env/isChromeApp';
 import isCordova from './isCordova';
 import listenerCount from './listenerCount';
+import nextTick from './nextTick';
 import normalizeDdocFunctionName from './normalizeDdocFunctionName';
 import once from './once';
 import parseDdocFunctionName from './parseDdocFunctionName';
@@ -42,6 +43,7 @@ export {
   isChromeApp,
   isCordova,
   listenerCount,
+  nextTick,
   normalizeDdocFunctionName,
   once,
   parseDdocFunctionName,

--- a/packages/node_modules/pouchdb-utils/src/nextTick-browser.js
+++ b/packages/node_modules/pouchdb-utils/src/nextTick-browser.js
@@ -1,0 +1,5 @@
+// lightweight process.nextTick, avoids pulling in huge process polyfill
+function nextTick(fn) {
+  setTimeout(fn, 0);
+}
+export default nextTick;

--- a/packages/node_modules/pouchdb-utils/src/nextTick.js
+++ b/packages/node_modules/pouchdb-utils/src/nextTick.js
@@ -1,0 +1,5 @@
+function nextTick(fn) {
+  process.nextTick(fn);
+}
+
+export default nextTick;

--- a/packages/node_modules/pouchdb-utils/src/toPromise.js
+++ b/packages/node_modules/pouchdb-utils/src/toPromise.js
@@ -2,6 +2,7 @@ import Promise from 'pouchdb-promise';
 import getArguments from 'argsarray';
 import clone from './clone';
 import once from './once';
+import nextTick from './nextTick';
 
 function toPromise(func) {
   //create the function we will be returning
@@ -17,7 +18,7 @@ function toPromise(func) {
       // if it was a callback, create a new callback which calls it,
       // but do so async so we don't trap any errors
       usedCB = function (err, resp) {
-        process.nextTick(function () {
+        nextTick(function () {
           tempCB(err, resp);
         });
       };


### PR DESCRIPTION
A small change to improve our bundle size. Old `pouchdb.min.js` size: 141835. New size: 140201. (1.6kB reduction, 1.15% total size reduced.)

There is no need to use `process.nextTick()` in browser code. This ends up being quite a large polyfill, whereas since we're just trying to avoid releasing Zalgo, a `setTimeout()` is perfectly fine.