### PR TITLE
(#5902) - fix and test fetch() implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ env:
 
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome COMMAND=test
+  - FETCH=1 CLIENT=saucelabs:firefox:49 COMMAND=test
   - CLIENT=saucelabs:safari:6 COMMAND=test
   - CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
   - CLIENT="saucelabs:MicrosoftEdge" COMMAND=test

--- a/TESTING.md
+++ b/TESTING.md
@@ -110,6 +110,12 @@ To run the node-websql test in Node, run the tests with:
 
     ADAPTER=websql
 
+### Testing fetch vs XMLHttpRequest
+
+PouchDB falls back to either XHR or fetch, whichever is available. You can test fetch-only using:
+
+    FETCH=1 npm test
+
 ### Performance tests
 
 To run the performance test suite in node.js:

--- a/bin/build-module.js
+++ b/bin/build-module.js
@@ -73,7 +73,9 @@ function buildModule(filepath) {
           }),
           replace({
             // we have switches for coverage; don't ship this to consumers
-            'process.env.COVERAGE': JSON.stringify(!!process.env.COVERAGE)
+            'process.env.COVERAGE': JSON.stringify(!!process.env.COVERAGE),
+            // test for fetch vs xhr
+            'process.env.FETCH': JSON.stringify(!!process.env.FETCH)
           })
         ]
       }).then(function (bundle) {

--- a/bin/build-pouchdb.js
+++ b/bin/build-pouchdb.js
@@ -161,7 +161,9 @@ function doRollup(entry, browser, formatsToFiles) {
       }),
       replace({
         // we have switches for coverage; don't ship this to consumers
-        'process.env.COVERAGE': JSON.stringify(!!process.env.COVERAGE)
+        'process.env.COVERAGE': JSON.stringify(!!process.env.COVERAGE),
+        // test for fetch vs xhr
+        'process.env.FETCH': JSON.stringify(!!process.env.FETCH)
       })
     ]
   }).then(function (bundle) {

--- a/packages/node_modules/pouchdb-ajax/src/request-browser.js
+++ b/packages/node_modules/pouchdb-ajax/src/request-browser.js
@@ -47,13 +47,9 @@ function fetchRequest(options, callback) {
       'application/json');
   }
 
-  if (options.body && (options.body instanceof Blob)) {
-    readAsArrayBuffer(options.body, function (arrayBuffer) {
-      fetchOptions.body = arrayBuffer;
-    });
-  } else if (options.body &&
-             options.processData &&
-             typeof options.body !== 'string') {
+  if (options.body &&
+      options.processData &&
+      typeof options.body !== 'string') {
     fetchOptions.body = JSON.stringify(options.body);
   } else if ('body' in options) {
     fetchOptions.body = options.body;
@@ -94,10 +90,15 @@ function fetchRequest(options, callback) {
     if (response.statusCode >= 200 && response.statusCode < 300) {
       callback(null, response, result);
     } else {
-      callback(result, response);
+      result.status = response.statusCode;
+      callback(result);
     }
   }).catch(function (error) {
-    callback(error, response);
+    if (!error) {
+      // this happens when the listener is canceled
+      error = new Error('canceled');
+    }
+    callback(error);
   });
 
   return {abort: wrappedPromise.reject};
@@ -247,7 +248,7 @@ function testXhr() {
 var hasXhr = testXhr();
 
 function ajax(options, callback) {
-  if (hasXhr || options.xhr) {
+  if (!process.env.FETCH && (hasXhr || options.xhr)) {
     return xhRequest(options, callback);
   } else {
     return fetchRequest(options, callback);

--- a/tests/integration/test.ajax.js
+++ b/tests/integration/test.ajax.js
@@ -16,7 +16,11 @@ adapters.forEach(function (adapter) {
       }, function (err, res) {
         // here's the test, we should get an 'err' response
         should.exist(err);
-        err.code.should.match(/(ESOCKETTIMEDOUT|ETIMEDOUT|ENETUNREACH|EAGAIN|ECONNREFUSED)/);
+        if (err.code) { // xhr
+          err.code.should.match(/(ESOCKETTIMEDOUT|ETIMEDOUT|ENETUNREACH|EAGAIN|ECONNREFUSED)/);
+        } else { // fetch
+          err.status.should.equal(500);
+        }
         should.not.exist(res);
         done();
       });


### PR DESCRIPTION
This adds a new option to our test suite, `FETCH=1 npm test`, which allows you to test the `fetch()` implementation instead of XHR.

This also corrects various bugs in the implementation, and runs the test suite against SauceLabs' version of Firefox. I use SauceLabs because Travis' Firefox 32 will not cut the mustard.

Note that the `process.env.FETCH` code is not actually shipped to users because Rollup will trim it out.