### PR TITLE
(#5904) - more helpful error message for invalid plugin

### DIFF
--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -46,7 +46,7 @@ PouchDB.plugin = function (obj) {
   if (typeof obj === 'function') { // function style for plugins
     obj(PouchDB);
   } else if (typeof obj !== 'object' || Object.keys(obj).length === 0){
-    throw new Error('Invalid plugin: object passed in is empty or not an object');
+    throw new Error('Invalid plugin: got \"' + obj + '\", expected an object or a function');
   } else {
     Object.keys(obj).forEach(function (id) { // object style for plugins
       PouchDB.prototype[id] = obj[id];


### PR DESCRIPTION
https://github.com/pouchdb/upsert/issues/29 indicates that the current error message is still not very helpful, since folks are still confused about what to do.