### PR TITLE
(#5905) - remove es6-promise-pool, use smaller custom impl

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "argsarray": "0.0.1",
     "debug": "2.3.2",
     "double-ended-queue": "2.1.0-0",
-    "es6-promise-pool": "2.4.4",
     "fruitdown": "1.0.2",
     "inherits": "2.0.3",
     "level-codec": "6.2.0",

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -27,7 +27,7 @@ import {
   blobOrBufferToBase64 as blufferToBase64
 } from 'pouchdb-binary-utils';
 
-import PromisePool from 'es6-promise-pool';
+import pool from './promise-pool';
 import { createError, BAD_ARG } from 'pouchdb-errors';
 import debug from 'debug';
 
@@ -438,13 +438,7 @@ function HttpPouch(opts, callback) {
       // Sync Gateway would normally send it back as multipart/mixed,
       // which we cannot parse. Also, this is more efficient than
       // receiving attachments as base64-encoded strings.
-      function fetch() {
-
-        if (!filenames.length) {
-          return null;
-        }
-
-        var filename = filenames.pop();
+      function fetch(filename) {
         var att = atts[filename];
         var path = encodeDocId(doc._id) + '/' + encodeAttachmentId(filename) +
           '?rev=' + doc._rev;
@@ -466,9 +460,15 @@ function HttpPouch(opts, callback) {
         });
       }
 
+      var promiseFactories = filenames.map(function (filename) {
+        return function () {
+          return fetch(filename);
+        };
+      });
+
       // This limits the number of parallel xhr requests to 5 any time
       // to avoid issues with maximum browser request limits
-      return new PromisePool(fetch, 5, {promise: Promise}).start();
+      return pool(promiseFactories, 5);
     }
 
     function fetchAllAttachments(docOrDocs) {

--- a/packages/node_modules/pouchdb-adapter-http/src/promise-pool.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/promise-pool.js
@@ -1,0 +1,54 @@
+// dead simple promise pool, inspired by https://github.com/timdp/es6-promise-pool
+// but much smaller in code size. limits the number of concurrent promises that are executed
+
+import Promise from 'pouchdb-promise';
+
+function pool(promiseFactories, limit) {
+  return new Promise(function (resolve, reject) {
+    var running = 0;
+    var current = 0;
+    var done = 0;
+    var len = promiseFactories.length;
+    var err;
+
+    function runNext() {
+      running++;
+      promiseFactories[current++]().then(onSuccess, onError);
+    }
+
+    function doNext() {
+      if (++done === len) {
+        /* istanbul ignore if */
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      } else {
+        runNextBatch();
+      }
+    }
+
+    function onSuccess() {
+      running--;
+      doNext();
+    }
+
+    /* istanbul ignore next */
+    function onError(thisErr) {
+      running--;
+      err = err || thisErr;
+      doNext();
+    }
+
+    function runNextBatch() {
+      while (running < limit && current < len) {
+        runNext();
+      }
+    }
+
+    runNextBatch();
+  });
+}
+
+export default pool;


### PR DESCRIPTION
| | Size before | Size after |
| --- | --- | ---- |
| min | 140K | 136K |
| min+gz | 45506 | 44779 |

This shaves off 4KB from the min size and ~1KB from the min+gz size, by replacing `es6-promise-pool` with a smaller custom implementation that does the same thing.