### PR TITLE
(#5908) - remove non-essential Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo:
   false
 
 addons:
-  firefox: "48.0"
+  firefox: "41.0.1"
 
 before_install:
   # Because Saucelabs doesnt proxy 5984 on OSX
@@ -39,66 +39,47 @@ env:
 
   matrix:
   - CLIENT=node COMMAND=test
-  - CLIENT=node LEVEL_PREFIX=foo_ COMMAND=test
 
   # Test WebSQL in Node (using node-websql)
   - CLIENT=node ADAPTER=websql COMMAND=test
-
-  # Test against pouchdb-server
-  - CLIENT=node SERVER=pouchdb-server COMMAND=test
-  - CLIENT=selenium:firefox:48.0 SERVER=pouchdb-server COMMAND=test
-  - SERVER_ADAPTER=memdown LEVEL_ADAPTER=memdown SERVER=pouchdb-server COMMAND=test
-
-  # Test against pouchdb-express-router
-  - CLIENT=node SERVER=pouchdb-express-router COMMAND=test
+  # Test in-memory using Node
+  - CLIENT=node ADAPTER=memory COMMAND=test
 
   # Test in firefox/phantomjs running on travis
-  - CLIENT=selenium:firefox:48.0 COMMAND=test
+  - CLIENT=selenium:firefox:41.0.1 COMMAND=test
   - CLIENT=selenium:phantomjs COMMAND=test
 
   # Test auto-compaction in Node, Phantom, and Firefox
   - AUTO_COMPACTION=true CLIENT=node COMMAND=test
-  - AUTO_COMPACTION=true CLIENT=selenium:firefox:48.0 COMMAND=test
+  - AUTO_COMPACTION=true CLIENT=selenium:firefox:41.0.1 COMMAND=test
   - AUTO_COMPACTION=true CLIENT=selenium:phantomjs COMMAND=test
 
   # Test map/reduce
   - TYPE=mapreduce CLIENT=node COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:firefox:48.0 COMMAND=test
+  - TYPE=mapreduce CLIENT=selenium:firefox:41.0.1 COMMAND=test
   - TYPE=mapreduce CLIENT=selenium:phantomjs COMMAND=test
 
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome COMMAND=test
   - CLIENT=saucelabs:safari:6 COMMAND=test
   - CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
-  - CLIENT="saucelabs:MicrosoftEdge" COMMAND=test
-  - CLIENT="saucelabs:internet explorer:10:Windows 8" ADAPTERS=memory COMMAND=test
   - CLIENT="saucelabs:iphone:8.4:OS X 10.11" ADAPTERS=fruitdown COMMAND=test
 
   # split up the android+iphone tests as it goes over time
   - SKIP_MIGRATION=true CLIENT="saucelabs:iphone:8.1:OS X 10.10" COMMAND=test
   - CLIENT="saucelabs:Android:5.1:Linux" COMMAND=test
-  - CLIENT=selenium:firefox:48.0 ADAPTERS=memory COMMAND=test
-  - CLIENT=selenium:firefox:48.0 ADAPTERS=localstorage COMMAND=test
+  - CLIENT=selenium:firefox:41.0.1 ADAPTERS=memory COMMAND=test
+  - CLIENT=selenium:firefox:41.0.1 ADAPTERS=localstorage COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:48.0 COMMAND=test-webpack
+  - CLIENT=selenium:firefox:41.0.1 COMMAND=test-webpack
 
   # Test CouchDB master (aka bigcouch branch)
   - COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:48.0 SERVER=couchdb-master COMMAND=test
+  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:41.0.1 SERVER=couchdb-master COMMAND=test
 
-  # Test Couchbase Sync Gateway
-  - GREP=test.replication.js CLIENT=node SERVER=sync-gateway BAIL=0 COMMAND=test
-
-  # Test Cloudant
-  - CLIENT=selenium:firefox:48.0 SERVER=couchdb-master COUCH_HOST=https://$CLOUDANT_USERNAME:$CLOUDANT_PASSWORD@pouch.cloudant.com COMMAND=test
-
-  # Performance tests
-  - CLIENT=selenium:firefox:48.0 PERF=1 COMMAND=test
-  - PERF=1 COMMAND=test
-
-  # Test Webpack bundle
-  - CLIENT=selenium:firefox:48.0 NEXT=1 COMMAND=test
+  # Test PouchDB Next
+  - CLIENT=selenium:firefox:41.0.1 NEXT=1 COMMAND=test
 
   - COMMAND=test-unit
   - COMMAND=test-component
@@ -114,24 +95,10 @@ matrix:
     - node_js: "4"
       services: docker
       env: CLIENT=node COMMAND=test
-    - node_js: "stable"
-      services: docker
-      env: CLIENT=node COMMAND=test
   allow_failures:
-  - env: GREP=test.replication.js CLIENT=node SERVER=sync-gateway BAIL=0 COMMAND=test
   - env: COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:48.0 SERVER=couchdb-master COMMAND=test
-  - env: CLIENT=node SERVER=pouchdb-express-router COMMAND=test
-  - env: CLIENT=node SERVER=pouchdb-server COMMAND=test
-  - env: CLIENT=selenium:firefox:48.0 SERVER=pouchdb-server COMMAND=test
-  - env: SERVER_ADAPTER=memdown LEVEL_ADAPTER=memdown SERVER=pouchdb-server COMMAND=test
-  - env: CLIENT=selenium:firefox:48.0 SERVER=couchdb-master COUCH_HOST=https://$CLOUDANT_USERNAME:$CLOUDANT_PASSWORD@pouch.cloudant.com COMMAND=test
-  - env: CLIENT="saucelabs:MicrosoftEdge" COMMAND=test
-  - env: CLIENT=selenium:firefox:48.0 PERF=1 COMMAND=test
-  - env: CLIENT=selenium:firefox:48.0 NEXT=1 COMMAND=test
-  - node_js: "stable"
-    services: docker
-    env: CLIENT=node COMMAND=test
+  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:41.0.1 SERVER=couchdb-master COMMAND=test
+  - env: CLIENT=selenium:firefox:41.0.1 NEXT=1 COMMAND=test
 
 branches:
   only:

--- a/TESTING.md
+++ b/TESTING.md
@@ -90,21 +90,11 @@ Then in the PouchDB project, run:
 
 This works because `npm run dev` does not start up the pouchdb-server itself (only `npm test` does).
 
-### Testing the in-memory adapter
+### Testing different Node adapters
 
-`pouchdb-server` uses the `--in-memory` flag to use MemDOWN.  To enable this, set
+Use this option to test the in-memory adapter:
 
-    SERVER_ADAPTER=memory
-
-Whereas on the client this is configured using `PouchDB.defaults()`, so you can enable it like so:
-
-    LEVEL_ADAPTER=memdown
-
-The value is a comma-separated list of key values, where the key-values are separated by colons.
-
-Some Level adapters also require a standard database name prefix (e.g. `riak://` or `mysql://`), which you can specify like so:
-
-    LEVEL_PREFIX=riak://localhost:8087/
+    ADAPTER=memory
 
 To run the node-websql test in Node, run the tests with:
 

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -14,12 +14,6 @@ if [[ ! -z $SERVER ]]; then
     TESTDIR=./tests/pouchdb_server
     rm -rf $TESTDIR && mkdir -p $TESTDIR
     FLAGS="--dir $TESTDIR"
-    if [[ ! -z $SERVER_ADAPTER ]]; then
-      FLAGS="$FLAGS --level-backend $SERVER_ADAPTER"
-    fi
-    if [[ ! -z $SERVER_PREFIX ]]; then
-      FLAGS="$FLAGS --level-prefix $SERVER_PREFIX"
-    fi
     echo -e "Starting up pouchdb-server with flags: $FLAGS \n"
     ./node_modules/.bin/pouchdb-server -n -p 6984 $FLAGS &
     export SERVER_PID=$!

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -337,21 +337,7 @@ if (typeof process !== 'undefined' && !process.browser) {
     global.PouchDB = require('../../packages/node_modules/pouchdb');
   }
 
-  if (process.env.LEVEL_ADAPTER || process.env.LEVEL_PREFIX) {
-    // test a special *down adapter and/or prefix
-    var defaults = {};
-
-    if (process.env.LEVEL_ADAPTER) {
-      defaults.db = require(process.env.LEVEL_ADAPTER);
-      console.log('Using client-side leveldown adapter: ' +
-        process.env.LEVEL_ADAPTER);
-    }
-    if (process.env.LEVEL_PREFIX) {
-      defaults.prefix = process.env.LEVEL_PREFIX;
-      console.log('Using client-side leveldown prefix: ' + defaults.prefix);
-    }
-    global.PouchDB = global.PouchDB.defaults(defaults);
-  } else if (process.env.AUTO_COMPACTION) {
+  if (process.env.AUTO_COMPACTION) {
     // test autocompaction
     global.PouchDB = global.PouchDB.defaults({
       auto_compaction: true,
@@ -361,12 +347,16 @@ if (typeof process !== 'undefined' && !process.browser) {
     // test WebSQL in Node
     // (the two strings are just to fool Browserify because sqlite3 fails
     // in Node 0.11-0.12)
-    global.PouchDB.plugin(require('../../packages/node_modules/' +
+   global.PouchDB.plugin(require('../../packages/node_modules/' +
       'pouchdb-adapter-node-websql'));
     global.PouchDB.preferredAdapters = ['websql', 'leveldb'];
     global.PouchDB = global.PouchDB.defaults({
       prefix: path.resolve('./tmp/_pouch_')
     });
+  } else if (process.env.ADAPTER === 'memory') {
+    global.PouchDB.plugin(require('../../packages/node_modules/' +
+      'pouchdb-adapter-memory'));
+    global.PouchDB.preferredAdapters = ['memory', 'leveldb'];
   } else {
     // test regular leveldown in node
     global.PouchDB = global.PouchDB.defaults({


### PR DESCRIPTION
First stab at this, hopefully the configuration is correct.

Main changes:

- removed many tests, including CSG, pouchdb-server, pouchdb-express-router, Edge, LEVEL_PREFIX
- use ADAPTER=memory to test Node in-memory, no more LEVEL_ADAPTER or SERVER_ADAPTER
- Using Firefox 41.0.1 because IME it's the latest we can reliably test, better than 37 at least

I'm going to try to think of other ways to make the build faster (I bought an ngrok account; we could use that for tunneling maybe?) but this is a good start.