### PR TITLE
(#5923) add financier to users.md

### DIFF
--- a/docs/users.md
+++ b/docs/users.md
@@ -31,6 +31,10 @@ A list of known products and services that are using PouchDB.
 
 [eHealth Africa](http://ehealthafrica.org/) is an American-Nigerian NGO specialising in the development and deployment of tech for health. To tackle the Ebola outbreak, they built [mobile apps and dashboards](https://github.com/eHealthAfrica) to help track the spread of infection in the field. The combination of CouchDB and PouchDB enabled these apps to work consistently despite the extreme network unreliability of sub-saharan Africa.
 
+## Financier
+
+[Financier](https://financier.io) is a freemium personal budgeting app that uses PouchDB to store your budget data. The paid version syncs data with CouchDB 2 for data persistence and sharing across devices. The app is fully integrated with the PouchDB changes feed for instant updates. More about the stack is available in [humans.txt](https://app.financier.io/humans.txt).
+
 ## GRADEpro GDT
 
 {% include img.html width=150 src="gradepro.png" alt="GRADEpro GDT" href="http://gradepro.org/" %}


### PR DESCRIPTION
PouchDB is great. It made [Financier](https://financier.io) possible, and I'd love to add it as a user to the docs!