### PR TITLE
(#5925) - remove peerDependency on pouchdb-core

### DIFF
--- a/bin/update-dependencies.js
+++ b/bin/update-dependencies.js
@@ -22,14 +22,6 @@ modules.forEach(function (mod) {
   var pkgPath = path.join(pkgDir, 'package.json');
   var pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
 
-  // All adapters should declare pouchdb-core as a peerDep, to warn
-  // users if they install with the wrong version.
-  // For other packages, they *may* be installed without pouchdb-core, so
-  // there's no need to add a peerDep.
-  if (/-adapter-/.test(pkg.name)) {
-    pkg.peerDependencies = { 'pouchdb-core' : mainVersion };
-  }
-
   // for the dependencies, find all require() calls
   var srcFiles = glob.sync(path.join(pkgDir, 'lib/**/*.js'));
   var uniqDeps = uniq(flatten(srcFiles.map(function (srcFile) {


### PR DESCRIPTION
Currently when you install e.g. `pouchdb-adapter-memory` along with `pouchdb`, you will get this warning because technically you have not installed `pouchdb-core`. The reason for this is that `pouchdb` is aggressively bundled (as is `pouchdb-node` and `pouchdb-browser`), so neither one contains `pouchdb-core`.

Since there's apparetly no way to have "optional" peerDeps (e.g. `pouchdb-core | pouchdb | pouchdb-browser | pouchdb-node`) I would prefer to just remove this peerDep altogether and avoid the potentially confusing warning. The downside is that people will have to just "know" that if they install multiple pouchdb-* packages they should all have the same version number or the behavior is undefined. I'm okay with this.