### PR TITLE
(#5926) - simplify migration test code

### DIFF
--- a/tests/integration/index.html
+++ b/tests/integration/index.html
@@ -18,12 +18,6 @@
       var should = chai.should();
       var assert = chai.assert;
     </script>
-    <script src='deps/pouchdb-1.1.0-postfixed.js'></script>
-    <script src='deps/pouchdb-2.0.0-postfixed.js'></script>
-    <script src='deps/pouchdb-2.2.0-postfixed.js'></script>
-    <script src='deps/pouchdb-3.0.6-postfixed.js'></script>
-    <script src='deps/pouchdb-3.2.0-postfixed.js'></script>
-    <script src='deps/pouchdb-3.6.0-postfixed.js'></script>
     <script src='utils-bundle.js'></script>
     <script src='test.setup_global_hooks.js'></script>
     <script src='test.ajax.js'></script>


### PR DESCRIPTION
A few changes to simplify the test code:

1. Load `pouchdb-vXXXpostfiled.js` only if we're actually going to run the migration tests
2. Delete them from the `window` object after the test is run to free memory
3. Fix a bug where we weren't actually running the tests in Firefox (only Chrome) due to a mistake in `isUsingDefaultPreferredAdapters()`