### PR TITLE
(#5908) - test in-memory in Node, remove LEVEL_ADAPTER/LEVEL_PREFIX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,9 @@ env:
   # Test WebSQL in Node (using node-websql)
   - CLIENT=node ADAPTER=websql COMMAND=test
 
+  # Test in-memory in Node
+  - CLIENT=node ADAPTER=memory COMMAND=test
+
   # Test in firefox/phantomjs running on travis
   - CLIENT=selenium:firefox:48.0 COMMAND=test
   - CLIENT=selenium:phantomjs COMMAND=test

--- a/TESTING.md
+++ b/TESTING.md
@@ -90,21 +90,11 @@ Then in the PouchDB project, run:
 
 This works because `npm run dev` does not start up the pouchdb-server itself (only `npm test` does).
 
-### Testing the in-memory adapter
+### Testing different Node adapters
 
-`pouchdb-server` uses the `--in-memory` flag to use MemDOWN.  To enable this, set
+Use this option to test the in-memory adapter:
 
-    SERVER_ADAPTER=memory
-
-Whereas on the client this is configured using `PouchDB.defaults()`, so you can enable it like so:
-
-    LEVEL_ADAPTER=memdown
-
-The value is a comma-separated list of key values, where the key-values are separated by colons.
-
-Some Level adapters also require a standard database name prefix (e.g. `riak://` or `mysql://`), which you can specify like so:
-
-    LEVEL_PREFIX=riak://localhost:8087/
+    ADAPTER=memory
 
 To run the node-websql test in Node, run the tests with:
 

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -14,12 +14,6 @@ if [[ ! -z $SERVER ]]; then
     TESTDIR=./tests/pouchdb_server
     rm -rf $TESTDIR && mkdir -p $TESTDIR
     FLAGS="--dir $TESTDIR"
-    if [[ ! -z $SERVER_ADAPTER ]]; then
-      FLAGS="$FLAGS --level-backend $SERVER_ADAPTER"
-    fi
-    if [[ ! -z $SERVER_PREFIX ]]; then
-      FLAGS="$FLAGS --level-prefix $SERVER_PREFIX"
-    fi
     echo -e "Starting up pouchdb-server with flags: $FLAGS \n"
     ./node_modules/.bin/pouchdb-server -n -p 6984 $FLAGS &
     export SERVER_PID=$!

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -337,21 +337,7 @@ if (typeof process !== 'undefined' && !process.browser) {
     global.PouchDB = require('../../packages/node_modules/pouchdb');
   }
 
-  if (process.env.LEVEL_ADAPTER || process.env.LEVEL_PREFIX) {
-    // test a special *down adapter and/or prefix
-    var defaults = {};
-
-    if (process.env.LEVEL_ADAPTER) {
-      defaults.db = require(process.env.LEVEL_ADAPTER);
-      console.log('Using client-side leveldown adapter: ' +
-        process.env.LEVEL_ADAPTER);
-    }
-    if (process.env.LEVEL_PREFIX) {
-      defaults.prefix = process.env.LEVEL_PREFIX;
-      console.log('Using client-side leveldown prefix: ' + defaults.prefix);
-    }
-    global.PouchDB = global.PouchDB.defaults(defaults);
-  } else if (process.env.AUTO_COMPACTION) {
+  if (process.env.AUTO_COMPACTION) {
     // test autocompaction
     global.PouchDB = global.PouchDB.defaults({
       auto_compaction: true,
@@ -361,12 +347,16 @@ if (typeof process !== 'undefined' && !process.browser) {
     // test WebSQL in Node
     // (the two strings are just to fool Browserify because sqlite3 fails
     // in Node 0.11-0.12)
-    global.PouchDB.plugin(require('../../packages/node_modules/' +
+   global.PouchDB.plugin(require('../../packages/node_modules/' +
       'pouchdb-adapter-node-websql'));
     global.PouchDB.preferredAdapters = ['websql', 'leveldb'];
     global.PouchDB = global.PouchDB.defaults({
       prefix: path.resolve('./tmp/_pouch_')
     });
+  } else if (process.env.ADAPTER === 'memory') {
+    global.PouchDB.plugin(require('../../packages/node_modules/' +
+      'pouchdb-adapter-memory'));
+    global.PouchDB.preferredAdapters = ['memory', 'leveldb'];
   } else {
     // test regular leveldown in node
     global.PouchDB = global.PouchDB.defaults({


### PR DESCRIPTION
Follow-up to #5919.

I think it is important to test in-memory in Node since it's used pretty frequently for e.g. unit tests and the `--in-memory` mode of pouchdb-server, but we can remove the `LEVEL_ADAPTER`/`LEVEL_PREFIX` code entirely.