### PR TITLE
(#5908) - remove pouchdb-server from devDeps

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -90,6 +90,8 @@ Then in the PouchDB project, run:
 
 This works because `npm run dev` does not start up the pouchdb-server itself (only `npm test` does).
 
+Note that you must `npm install pouchdb-server` or `npm install express-pouchdb` yourself for this test to work.
+
 ### Testing the in-memory adapter
 
 `pouchdb-server` uses the `--in-memory` flag to use MemDOWN.  To enable this, set

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "ncp": "2.0.0",
     "nock": "9.0.2",
     "pouchdb-express-router": "0.0.9",
-    "pouchdb-server": "1.2.1",
     "replace": "0.3.0",
     "rimraf": "2.5.4",
     "rollup": "0.34.13",


### PR DESCRIPTION
This actually adds a bit to our `npm install` and is no longer necessary.