### PR TITLE
(#5930) - use default Firefox 37 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ git:
 sudo:
   false
 
-addons:
-  firefox: "48.0"
-
 before_install:
   # Because Saucelabs doesnt proxy 5984 on OSX
   - "if [ -z \"$COUCH_HOST\" ]; then export COUCH_HOST=http://127.0.0.1:3000; fi"
@@ -44,17 +41,17 @@ env:
   - CLIENT=node ADAPTER=websql COMMAND=test
 
   # Test in firefox/phantomjs running on travis
-  - CLIENT=selenium:firefox:48.0 COMMAND=test
+  - CLIENT=selenium:firefox COMMAND=test
   - CLIENT=selenium:phantomjs COMMAND=test
 
   # Test auto-compaction in Node, Phantom, and Firefox
   - AUTO_COMPACTION=true CLIENT=node COMMAND=test
-  - AUTO_COMPACTION=true CLIENT=selenium:firefox:48.0 COMMAND=test
+  - AUTO_COMPACTION=true CLIENT=selenium:firefox COMMAND=test
   - AUTO_COMPACTION=true CLIENT=selenium:phantomjs COMMAND=test
 
   # Test map/reduce
   - TYPE=mapreduce CLIENT=node COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:firefox:48.0 COMMAND=test
+  - TYPE=mapreduce CLIENT=selenium:firefox COMMAND=test
   - TYPE=mapreduce CLIENT=selenium:phantomjs COMMAND=test
 
   # Testing in saucelabs
@@ -68,22 +65,22 @@ env:
 
   # Test memory / fruitdown etc
   - CLIENT="saucelabs:iphone:8.4:OS X 10.11" ADAPTERS=fruitdown COMMAND=test
-  - CLIENT=selenium:firefox:48.0 ADAPTERS=memory COMMAND=test
-  - CLIENT=selenium:firefox:48.0 ADAPTERS=localstorage COMMAND=test
+  - CLIENT=selenium:firefox ADAPTERS=memory COMMAND=test
+  - CLIENT=selenium:firefox ADAPTERS=localstorage COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:48.0 COMMAND=test-webpack
+  - CLIENT=selenium:firefox COMMAND=test-webpack
 
   # Test CouchDB master (aka bigcouch branch)
   - COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:48.0 SERVER=couchdb-master COMMAND=test
+  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox SERVER=couchdb-master COMMAND=test
 
   # Performance tests
-  - CLIENT=selenium:firefox:48.0 PERF=1 COMMAND=test
+  - CLIENT=selenium:firefox PERF=1 COMMAND=test
   - PERF=1 COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:48.0 NEXT=1 COMMAND=test
+  - CLIENT=selenium:firefox NEXT=1 COMMAND=test
 
   - COMMAND=test-unit
   - COMMAND=test-component
@@ -104,9 +101,9 @@ matrix:
       env: CLIENT=node COMMAND=test
   allow_failures:
   - env: COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:48.0 SERVER=couchdb-master COMMAND=test
-  - env: CLIENT=selenium:firefox:48.0 PERF=1 COMMAND=test
-  - env: CLIENT=selenium:firefox:48.0 NEXT=1 COMMAND=test
+  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox SERVER=couchdb-master COMMAND=test
+  - env: CLIENT=selenium:firefox PERF=1 COMMAND=test
+  - env: CLIENT=selenium:firefox NEXT=1 COMMAND=test
   - node_js: "stable"
     services: docker
     env: CLIENT=node COMMAND=test


### PR DESCRIPTION
If we're not actually testing Firefox 48.0, then there's no point in installing it or referencing it in `.travis.yml`.

Additionally, I think this may be the cause of some of the intermittent `No output has been received in the last 10m0s` errors I've been seeing.

I would love to actually test the latest Firefox, but until we can figure out the right Travis+Selenium+Firefox combo that works, we should just remove this.