### PR TITLE
(#5934) - simplify parseAdapter.js

### DIFF
--- a/packages/node_modules/pouchdb-core/src/parseAdapter.js
+++ b/packages/node_modules/pouchdb-core/src/parseAdapter.js
@@ -5,26 +5,24 @@ function parseAdapter(name, opts) {
   var match = name.match(/([a-z\-]*):\/\/(.*)/);
   if (match) {
     // the http adapter expects the fully qualified name
-    name = /http(s?)/.test(match[1]) ? match[1] + '://' + match[2] : match[2];
-    return {name: name, adapter: match[1]};
+    return {
+      name: /https?/.test(match[1]) ? match[1] + '://' + match[2] : match[2],
+      adapter: match[1]
+    };
   }
 
-  // check for browsers that have been upgraded from websql-only to websql+idb
-  var skipIdb = 'idb' in PouchDB.adapters && 'websql' in PouchDB.adapters &&
-    hasLocalStorage() &&
-    localStorage['_pouch__websqldb_' + PouchDB.prefix + name];
+  var adapters = PouchDB.adapters;
+  var preferredAdapters = PouchDB.preferredAdapters;
+  var prefix = PouchDB.prefix;
+  var adapterName = opts.adapter;
 
-  var adapterName;
-
-  if (opts.adapter) {
-    adapterName = opts.adapter;
-  } else if (typeof opts !== 'undefined' && opts.db) {
-    adapterName = 'leveldb';
-  } else { // automatically determine adapter
-    for (var i = 0; i < PouchDB.preferredAdapters.length; ++i) {
-      adapterName = PouchDB.preferredAdapters[i];
+  if (!adapterName) { // automatically determine adapter
+    for (var i = 0; i < preferredAdapters.length; ++i) {
+      adapterName = preferredAdapters[i];
+      // check for browsers that have been upgraded from websql-only to websql+idb
       /* istanbul ignore if */
-      if (skipIdb && adapterName === 'idb') {
+      if (adapterName === 'idb' && 'websql' in adapters &&
+          hasLocalStorage() && localStorage['_pouch__websqldb_' + prefix + name]) {
         // log it, because this can be confusing during development
         guardedConsole('log', 'PouchDB is downgrading "' + name + '" to WebSQL to' +
           ' avoid data loss, because it was already opened with WebSQL.');
@@ -34,14 +32,14 @@ function parseAdapter(name, opts) {
     }
   }
 
-  var adapter = PouchDB.adapters[adapterName];
+  var adapter = adapters[adapterName];
 
   // if adapter is invalid, then an error will be thrown later
   var usePrefix = (adapter && 'use_prefix' in adapter) ?
     adapter.use_prefix : true;
 
   return {
-    name: usePrefix ? (PouchDB.prefix + name) : name,
+    name: usePrefix ? (prefix + name) : name,
     adapter: adapterName
   };
 }


### PR DESCRIPTION
Cleans up this code a bit.

pouchdb.min.js size before: 138935
pouchdb.min.js size after: 138819 (116 fewer bytes)