### PR TITLE
(#5908) - don't run minify on travis

### DIFF
--- a/bin/build-pouchdb.js
+++ b/bin/build-pouchdb.js
@@ -6,6 +6,7 @@
 // from the others due to legacy support (dist/, extras/, etc.).
 
 var DEV_MODE = process.env.CLIENT === 'dev';
+var TRAVIS = process.env.TRAVIS;
 
 var lie = require('lie');
 if (typeof Promise === 'undefined') {
@@ -97,7 +98,7 @@ function addVersion(code) {
 
 // do uglify in a separate process for better perf
 function doUglify(code, prepend, fileOut) {
-  if (DEV_MODE) { // skip uglify in "npm run dev" mode
+  if (DEV_MODE || TRAVIS) { // skip uglify in "npm run dev" mode and on Travis
     return Promise.resolve();
   }
   var binPath = require.resolve('uglify-js/bin/uglifyjs');


### PR DESCRIPTION
None of our Travis tests actually use the `.min.js` files, and running uglify is expensive, so this is a waste. I clocked it on a MBA and found that `npm run build` took 42.8s whereas now `TRAVIS=1 npm run build` takes 27.27s, so this could shave off around 15 seconds from each build.