### PR TITLE
(#5857) - latest=true support

### DIFF
--- a/docs/_includes/api/fetch_document.html
+++ b/docs/_includes/api/fetch_document.html
@@ -20,6 +20,7 @@ All options default to `false` unless otherwise specified.
   * `options.binary`: Return attachment data as Blobs/Buffers, instead of as base64-encoded strings.
 * `options.ajax`: An object of options to be sent to the ajax requester. In Node they are sent verbatim to [request][] with the exception of:
 * `options.ajax.cache`: Appends a random string to the end of all HTTP GET requests to avoid them being cached on IE. Set this to `true` to prevent this happening.
+* `options.latest`: Forces retrieving latest “leaf” revision, no matter what rev was requested. Default is `false`.
 
 #### Example Usage:
 

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -321,7 +321,7 @@ function HttpPouch(opts, callback) {
       }
 
       for (var i = 0; i < numBatches; i++) {
-        var subOpts = pick(opts, ['revs', 'attachments']);
+        var subOpts = pick(opts, ['revs', 'attachments', 'latest']);
         subOpts.ajax = ajaxOpts;
         subOpts.docs = opts.docs.slice(i * batchSize,
           Math.min(opts.docs.length, (i + 1) * batchSize));
@@ -403,6 +403,10 @@ function HttpPouch(opts, callback) {
 
     if (opts.revs_info) {
       params.revs_info = true;
+    }
+
+    if (opts.latest) {
+      params.latest = true;
     }
 
     if (opts.open_revs) {

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -296,6 +296,9 @@ function HttpPouch(opts, callback) {
         /* istanbul ignore next */
         params.attachments = true;
       }
+      if (opts.latest) {
+        params.latest = true;
+      }
       ajax(opts, {
         url: genDBUrl(host, '_bulk_get' + paramsToStr(params)),
         method: 'POST',

--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -12,7 +12,8 @@ import {
   isDeleted,
   isLocalId,
   traverseRevTree,
-  winningRev as calculateWinningRev
+  winningRev as calculateWinningRev,
+  latest as getLatest
 } from 'pouchdb-merge';
 
 import { Map, Set } from 'pouchdb-collections';
@@ -335,13 +336,20 @@ function init(api, opts, callback) {
         err = createError(MISSING_DOC, 'missing');
         return finish();
       }
-      if (isDeleted(metadata) && !opts.rev) {
-        err = createError(MISSING_DOC, "deleted");
-        return finish();
-      }
-      var objectStore = txn.objectStore(BY_SEQ_STORE);
 
-      var rev = opts.rev || metadata.winningRev;
+      var rev;
+      if(!opts.rev) {
+        rev = metadata.winningRev;
+        var deleted = isDeleted(metadata);
+        if (deleted) {
+          err = createError(MISSING_DOC, "deleted");
+          return finish();
+        }
+      } else {
+        rev = opts.latest ? getLatest(opts.rev, metadata) : opts.rev;
+      }
+
+      var objectStore = txn.objectStore(BY_SEQ_STORE);
       var key = metadata.id + '::' + rev;
 
       objectStore.index('_doc_id_rev').get(key).onsuccess = function (e) {

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/get.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/get.js
@@ -4,6 +4,8 @@ import { createError, MISSING_DOC } from 'pouchdb-errors';
 
 import { DOC_STORE, openTransactionSafely } from './util';
 
+import { latest as getLatest } from 'pouchdb-merge';
+
 export default function (db, id, opts, callback) {
 
   var openTxn = openTransactionSafely(db, [DOC_STORE], 'readonly');
@@ -14,7 +16,12 @@ export default function (db, id, opts, callback) {
   openTxn.txn.objectStore(DOC_STORE).get(id).onsuccess = function (e) {
 
     var doc = e.target.result;
-    var rev = opts.rev || (doc && doc.rev);
+    var rev;
+    if(!opts.rev) {
+      rev = (doc && doc.rev);
+    } else {
+      rev = opts.latest ? getLatest(opts.rev, doc.metadata) : opts.rev;
+    }
 
     if (!doc || (doc.deleted && !opts.rev) || !(rev in doc.revs)) {
       callback(createError(MISSING_DOC, 'missing'));

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -23,7 +23,8 @@ import {
   winningRev as calculateWinningRev,
   traverseRevTree,
   compactTree,
-  collectConflicts
+  collectConflicts,
+  latest as getLatest
 } from 'pouchdb-merge';
 import {
   safeJsonParse,
@@ -372,13 +373,16 @@ function LevelPouch(opts, callback) {
         return callback(createError(MISSING_DOC, 'missing'));
       }
 
-      var rev = getWinningRev(metadata);
-      var deleted = getIsDeleted(metadata, rev);
-      if (deleted && !opts.rev) {
-        return callback(createError(MISSING_DOC, "deleted"));
+      var rev;
+      if(!opts.rev) {
+        rev = getWinningRev(metadata);
+        var deleted = getIsDeleted(metadata, rev);
+        if (deleted) {
+          return callback(createError(MISSING_DOC, "deleted"));
+        }
+      } else {
+        rev = opts.latest ? getLatest(opts.rev, metadata) : opts.rev;
       }
-
-      rev = opts.rev ? opts.rev : rev;
 
       var seq = metadata.rev_map[rev];
 

--- a/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
@@ -14,7 +14,8 @@ import {
 } from 'pouchdb-adapter-utils';
 import {
   collectConflicts,
-  traverseRevTree
+  traverseRevTree,
+  latest as getLatest
 } from 'pouchdb-merge';
 import {
   safeJsonParse,
@@ -559,10 +560,28 @@ function WebSqlPouch(opts, callback) {
     websqlBulkDocs(opts, req, reqOpts, api, db, websqlChanges, callback);
   };
 
+  function latest(tx, id, rev, callback, finish) {
+    var sql = select(
+        SELECT_DOCS,
+        [DOC_STORE, BY_SEQ_STORE],
+        DOC_STORE_AND_BY_SEQ_JOINER,
+        DOC_STORE + '.id=?');
+    var sqlArgs = [id];
+
+    tx.executeSql(sql, sqlArgs, function (a, results) {
+      if (!results.rows.length) {
+        var err = createError(MISSING_DOC, 'missing');
+        return finish(err);
+      }
+      var item = results.rows.item(0);
+      var metadata = safeJsonParse(item.metadata);
+      callback(getLatest(rev, metadata));
+    });
+  }
+
   api._get = function (id, opts, callback) {
     var doc;
     var metadata;
-    var err;
     var tx = opts.ctx;
     if (!tx) {
       return db.readTransaction(function (txn) {
@@ -570,37 +589,46 @@ function WebSqlPouch(opts, callback) {
       });
     }
 
-    function finish() {
+    function finish(err) {
       callback(err, {doc: doc, metadata: metadata, ctx: tx});
     }
 
     var sql;
     var sqlArgs;
-    if (opts.rev) {
-      sql = select(
-        SELECT_DOCS,
-        [DOC_STORE, BY_SEQ_STORE],
-        DOC_STORE + '.id=' + BY_SEQ_STORE + '.doc_id',
-        [BY_SEQ_STORE + '.doc_id=?', BY_SEQ_STORE + '.rev=?']);
-      sqlArgs = [id, opts.rev];
-    } else {
+
+    if(!opts.rev) {
       sql = select(
         SELECT_DOCS,
         [DOC_STORE, BY_SEQ_STORE],
         DOC_STORE_AND_BY_SEQ_JOINER,
         DOC_STORE + '.id=?');
       sqlArgs = [id];
+    } else if (opts.latest) {
+      latest(tx, id, opts.rev, function (latestRev) {
+        opts.latest = false;
+        opts.rev = latestRev;
+        api._get(id, opts, callback);
+      }, finish);
+      return;
+    } else {
+      sql = select(
+        SELECT_DOCS,
+        [DOC_STORE, BY_SEQ_STORE],
+        DOC_STORE + '.id=' + BY_SEQ_STORE + '.doc_id',
+        [BY_SEQ_STORE + '.doc_id=?', BY_SEQ_STORE + '.rev=?']);
+      sqlArgs = [id, opts.rev];
     }
+
     tx.executeSql(sql, sqlArgs, function (a, results) {
       if (!results.rows.length) {
-        err = createError(MISSING_DOC, 'missing');
-        return finish();
+        var missingErr = createError(MISSING_DOC, 'missing');
+        return finish(missingErr);
       }
       var item = results.rows.item(0);
       metadata = safeJsonParse(item.metadata);
       if (item.deleted && !opts.rev) {
-        err = createError(MISSING_DOC, 'deleted');
-        return finish();
+        var deletedErr = createError(MISSING_DOC, 'deleted');
+        return finish(deletedErr);
       }
       doc = unstringifyDoc(item.data, metadata.id, item.rev);
       finish();

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -515,15 +515,27 @@ AbstractPouchDB.prototype.get = adapterFun('get', function (id, opts, cb) {
     if (!count) {
       return cb(null, result);
     }
+
     // order with open_revs is unspecified
     leaves.forEach(function (leaf) {
       self.get(id, {
         rev: leaf,
         revs: opts.revs,
+        latest: opts.latest,
         attachments: opts.attachments
       }, function (err, doc) {
         if (!err) {
-          result.push({ok: doc});
+          // using latest=true can produce duplicates
+          var existing;
+          for (var i = 0, l = result.length; i < l; i++) {
+            if (result[i].ok && result[i].ok._rev === doc._rev) {
+              existing = true;
+              break;
+            }
+          }
+          if (!existing) {
+            result.push({ok: doc});
+          }
         } else {
           result.push({missing: leaf});
         }

--- a/packages/node_modules/pouchdb-merge/src/index.js
+++ b/packages/node_modules/pouchdb-merge/src/index.js
@@ -8,6 +8,7 @@ import traverseRevTree from './traverseRevTree';
 import winningRev from './winningRev';
 import isDeleted from './isDeleted';
 import isLocalId from './isLocalId';
+import latest from './latest';
 
 export {
   collectConflicts,
@@ -19,5 +20,6 @@ export {
   revExists,
   rootToLeaf,
   traverseRevTree,
-  winningRev
+  winningRev,
+  latest
 };

--- a/packages/node_modules/pouchdb-merge/src/latest.js
+++ b/packages/node_modules/pouchdb-merge/src/latest.js
@@ -1,0 +1,37 @@
+// returns the current leaf node for a given revision
+function latest(rev, metadata) {
+  var toVisit = metadata.rev_tree.slice();
+  var node;
+  while ((node = toVisit.pop())) {
+    var pos = node.pos;
+    var tree = node.ids;
+    var id = tree[0];
+    var opts = tree[1];
+    var branches = tree[2];
+    var isLeaf = branches.length === 0;
+
+    var history = node.history ? node.history.slice() : [];
+    history.push({id: id, pos: pos, opts: opts});
+
+    if (isLeaf) {
+      for (var i = 0, len = history.length; i < len; i++) {
+        var historyNode = history[i];
+        var historyRev = historyNode.pos + '-' + historyNode.id;
+
+        if (historyRev === rev) {
+          // return the rev of this leaf
+          return pos + '-' + id;
+        }
+      }
+    }
+
+    for (var j = 0, l = branches.length; j < l; j++) {
+      toVisit.push({pos: pos + 1, ids: branches[j], history: history});
+    }
+  }
+
+  /* istanbul ignore next */
+  throw new Error('Unable to resolve latest revision for id ' + metadata.id + ', rev ' + rev);
+}
+
+export default latest;

--- a/packages/node_modules/pouchdb-replication/src/getDocs.js
+++ b/packages/node_modules/pouchdb-replication/src/getDocs.js
@@ -58,7 +58,8 @@ function createBulkGetOpts(diffs) {
 
   return {
     docs: requests,
-    revs: true
+    revs: true,
+    latest: true
   };
 }
 

--- a/packages/node_modules/pouchdb-utils/src/bulkGetShim.js
+++ b/packages/node_modules/pouchdb-utils/src/bulkGetShim.js
@@ -109,7 +109,7 @@ function bulkGet(db, opts, callback) {
       }
 
       // globally-supplied options
-      ['revs', 'attachments', 'binary', 'ajax'].forEach(function (param) {
+      ['revs', 'attachments', 'binary', 'ajax', 'latest'].forEach(function (param) {
         if (param in opts) {
           docOpts[param] = opts[param];
         }

--- a/tests/integration/test.bulk_get.js
+++ b/tests/integration/test.bulk_get.js
@@ -32,6 +32,31 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('test bulk get with latest=true', function () {
+      var db = new PouchDB(dbs.name);
+      var first;
+
+      return db.post({ version: 'first' })
+        .then(function (info) {
+          first = info.rev;
+          return db.put({
+          _id: info.id,
+          _rev: info.rev,
+          version: 'second'
+        }).then(function (info) {
+          return db.bulkGet({
+            docs: [
+              {id: info.id, rev: first }
+            ],
+            latest: true
+          });
+        }).then(function (response) {
+          var result = response.results[0];
+          result.docs[0].ok.version.should.equal('second');
+        });
+      });
+    });
+
     it('test bulk get with no rev specified', function (done) {
       var db = new PouchDB(dbs.name);
       db.put({_id: 'foo', val: 1}).then(function (response) {


### PR DESCRIPTION
 * Add support for the `latest` parameter to `get()` and `bulkGet()`
 * Replicator uses `latest:true` when fetching specific revisions
 * `pouchdb-merge` now has a method to find the leaf node associated with a given rev. This isn't perfect but matches the behaviour of CouchDB 1.6. I have a slight concern about push replication performance as a result of this - it's this code which probably warrants the most review as perhaps there's possibly a more efficient solution (I'm not super-familiar with the various internal tree structures that Pouch uses).