### PR TITLE
(#5930) - simplify setTimeout/nextTick/immediate usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "debug": "2.3.2",
     "double-ended-queue": "2.1.0-0",
     "fruitdown": "1.0.2",
+    "immediate": "3.0.6",
     "inherits": "2.0.3",
     "level-codec": "6.2.0",
     "level-write-stream": "1.0.0",

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -3,7 +3,7 @@ var MAX_SIMULTANEOUS_REVS = 50;
 
 var supportsBulkGetMap = {};
 
-import { jsExtend as extend } from 'pouchdb-utils';
+import { jsExtend as extend, nextTick } from 'pouchdb-utils';
 import Promise from 'pouchdb-promise';
 import ajaxCore from 'pouchdb-ajax';
 import getArguments from 'argsarray';
@@ -237,7 +237,7 @@ function HttpPouch(opts, callback) {
     return setupPromise;
   }
 
-  setTimeout(function () {
+  nextTick(function () {
     callback(null, api);
   });
 
@@ -932,7 +932,7 @@ function HttpPouch(opts, callback) {
 
       if ((opts.continuous && !(limit && leftToFetch <= 0)) || !finished) {
         // Queue a call to fetch again with the newest sequence number
-        setTimeout(function () { fetch(lastFetchedSeq, fetched); }, 0);
+        nextTick(function () { fetch(lastFetchedSeq, fetched); });
       } else {
         // We're done, call the callback
         opts.complete(null, results);

--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -39,7 +39,6 @@ import {
 } from './constants';
 
 import {
-  applyNext,
   compactRevs,
   decodeDoc,
   decodeMetadata,
@@ -48,9 +47,10 @@ import {
   idbError,
   postProcessAttachments,
   readBlobData,
-  openTransactionSafely,
-  taskQueue
+  openTransactionSafely
 } from './utils';
+
+import { enqueueTask } from './taskQueue';
 
 var cachedDBs = new Map();
 var blobSupportPromise;
@@ -60,13 +60,9 @@ var openReqList = new Map();
 function IdbPouch(opts, callback) {
   var api = this;
 
-  taskQueue.queue.push({
-    action: function (thisCallback) {
-      init(api, opts, thisCallback);
-    },
-    callback: callback
-  });
-  applyNext(api.constructor);
+  enqueueTask(function (thisCallback) {
+    init(api, opts, thisCallback);
+  }, callback, api.constructor);
 }
 
 function init(api, opts, callback) {
@@ -822,10 +818,9 @@ function init(api, opts, callback) {
   if (cached) {
     idb = cached.idb;
     api._meta = cached.global;
-    nextTick(function () {
+    return nextTick(function () {
       callback(null, api);
     });
-    return;
   }
 
   var req;

--- a/packages/node_modules/pouchdb-adapter-idb/src/taskQueue.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/taskQueue.js
@@ -1,0 +1,44 @@
+// This task queue ensures that IDB open calls are done in their own tick
+// and sequentially - i.e. we wait for the async IDB open to *fully* complete
+// before calling the next one. This works around IE/Edge race conditions in IDB.
+
+import { nextTick } from 'pouchdb-utils';
+
+var running = false;
+var queue = [];
+
+function tryCode(fun, err, res, PouchDB) {
+  try {
+    fun(err, res);
+  } catch (err) {
+    // Shouldn't happen, but in some odd cases
+    // IndexedDB implementations might throw a sync
+    // error, in which case this will at least log it.
+    PouchDB.emit('error', err);
+  }
+}
+
+function applyNext() {
+  if (running || !queue.length) {
+    return;
+  }
+  running = true;
+  queue.shift()();
+}
+
+function enqueueTask(action, callback, PouchDB) {
+  queue.push(function runAction() {
+    action(function runCallback(err, res) {
+      tryCode(callback, err, res, PouchDB);
+      running = false;
+      nextTick(function runNext() {
+        applyNext(PouchDB);
+      });
+    });
+  });
+  applyNext();
+}
+
+export {
+  enqueueTask,
+};

--- a/packages/node_modules/pouchdb-adapter-idb/src/utils.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/utils.js
@@ -2,8 +2,7 @@ import { jsExtend as extend } from 'pouchdb-utils';
 import Promise from 'pouchdb-promise';
 import { createError, IDB_ERROR } from 'pouchdb-errors';
 import {
-  pick,
-  nextTick
+  pick
 } from 'pouchdb-utils';
 import {
   safeJsonParse,
@@ -16,37 +15,6 @@ import {
   blob as createBlob
 } from 'pouchdb-binary-utils';
 import { ATTACH_AND_SEQ_STORE, ATTACH_STORE, BY_SEQ_STORE } from './constants';
-
-function tryCode(fun, that, args, PouchDB) {
-  try {
-    fun.apply(that, args);
-  } catch (err) {
-    // Shouldn't happen, but in some odd cases
-    // IndexedDB implementations might throw a sync
-    // error, in which case this will at least log it.
-    PouchDB.emit('error', err);
-  }
-}
-
-var taskQueue = {
-  running: false,
-  queue: []
-};
-
-function applyNext(PouchDB) {
-  if (taskQueue.running || !taskQueue.queue.length) {
-    return;
-  }
-  taskQueue.running = true;
-  var item = taskQueue.queue.shift();
-  item.action(function (err, res) {
-    tryCode(item.callback, this, [err, res], PouchDB);
-    taskQueue.running = false;
-    nextTick(function () {
-      applyNext(PouchDB);
-    });
-  });
-}
 
 function idbError(callback) {
   return function (evt) {
@@ -264,11 +232,9 @@ export {
   openTransactionSafely,
   compactRevs,
   postProcessAttachments,
-  applyNext,
   idbError,
   encodeMetadata,
   decodeMetadata,
   decodeDoc,
-  taskQueue,
   readBlobData
 };

--- a/packages/node_modules/pouchdb-utils/src/changesHandler.js
+++ b/packages/node_modules/pouchdb-utils/src/changesHandler.js
@@ -3,6 +3,7 @@ import inherits from 'inherits';
 import isChromeApp from './env/isChromeApp';
 import hasLocalStorage from './env/hasLocalStorage';
 import pick from './pick';
+import { nextTick } from 'pouchdb-utils';
 
 inherits(Changes, EventEmitter);
 
@@ -69,9 +70,7 @@ Changes.prototype.addListener = function (dbName, id, db, opts) {
       }
     }).on('complete', function () {
       if (inprogress === 'waiting') {
-        setTimeout(function (){
-          eventFunction();
-        },0);
+        nextTick(eventFunction);
       }
       inprogress = false;
     }).on('error', onError);

--- a/packages/node_modules/pouchdb-utils/src/nextTick-browser.js
+++ b/packages/node_modules/pouchdb-utils/src/nextTick-browser.js
@@ -1,5 +1,13 @@
-// lightweight process.nextTick, avoids pulling in huge process polyfill
-function nextTick(fn) {
-  setTimeout(fn, 0);
-}
-export default nextTick;
+// Custom nextTick() shim for browsers. In node, this will just be process.nextTick(). We
+// avoid using process.nextTick() directly because the polyfill is very large and we don't
+// need all of it (see: https://github.com/defunctzombie/node-process).
+// "immediate" 3.0.8 is used by lie, and it's a smaller version of the latest "immediate"
+// package, so it's the one we use.
+// When we use nextTick() in our codebase, we only care about not releasing Zalgo
+// (see: http://blog.izs.me/post/59142742143/designing-apis-for-asynchrony).
+// Microtask vs macrotask doesn't matter to us. So we're free to use the fastest
+// (least latency) option, which is "immediate" due to use of microtasks.
+// All of our nextTicks are isolated to this one function so we can easily swap out one
+// implementation for another.
+import immediate from 'immediate';
+export default immediate;

--- a/packages/node_modules/pouchdb-utils/src/toPromise.js
+++ b/packages/node_modules/pouchdb-utils/src/toPromise.js
@@ -2,7 +2,6 @@ import Promise from 'pouchdb-promise';
 import getArguments from 'argsarray';
 import clone from './clone';
 import once from './once';
-import nextTick from './nextTick';
 
 function toPromise(func) {
   //create the function we will be returning
@@ -10,19 +9,8 @@ function toPromise(func) {
     // Clone arguments
     args = clone(args);
     var self = this;
-    var tempCB =
-      (typeof args[args.length - 1] === 'function') ? args.pop() : false;
     // if the last argument is a function, assume its a callback
-    var usedCB;
-    if (tempCB) {
-      // if it was a callback, create a new callback which calls it,
-      // but do so async so we don't trap any errors
-      usedCB = function (err, resp) {
-        nextTick(function () {
-          tempCB(err, resp);
-        });
-      };
-    }
+    var usedCB = (typeof args[args.length - 1] === 'function') ? args.pop() : false;
     var promise = new Promise(function (fulfill, reject) {
       var resp;
       try {


### PR DESCRIPTION
### The goal

Reduce Travis flakiness. In particular, reduce flakiness of IE10 tests.

### The problem

Our current code calls `setTimeout(fn, 0)` a _lot_. We do it for nearly every API call. From my work on the Edge team I can tell you that IE/Edge did not have a great timer implementation before Edge 14 (and in fact it's still being improved in Edge 15). Random hangs and high latency do not surprise me.

Before https://github.com/pouchdb/pouchdb/commit/4eb786b702f0db9fb2db049c71f29d7acbf18fc4 this was less of a problem because the `node-process` browserify implementation essentially queues all tasks and then executes them in a single `setTimeout()` call. But since I replaced all `process.nextTick()` with `setTimeout()` the IE10 tests are failing like ~90% of the time.

### Proposed solution

In this PR, I do a few things:

1. Remove `nextTick`/`setTimeout` entirely where it's not necessary. We only usually use it to avoid [releasing Zalgo](http://blog.izs.me/post/59142742143/designing-apis-for-asynchrony), and sometimes we are seriously overusing it.
2. Replace current `nextTick()` implementation with `immediate`. We're already shipping `immediate` in PouchDB because of `lie`, and it's a tiny codebase (1KB minified). This library has the advantage of using MutationObserver where supported, meaning that it uses microtasks and thus has very low latency. This works well even in IE10.
3. Refactor the IDB task queue so that it minifies better. This isn't strictly necessary, but I just wanted to clean up that part of the codebase.

If all goes well, we should see way fewer IE10 failures and also faster tests in general because there is a lot less `setTimeout()` indirection. I've tested locally with IE, Edge, Chrome, and FF, and everything looks good. I'm opening a PR so we can actually verify this in Travis though.