### PR TITLE
(#5930) - use Firefox 41.0.1 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,10 @@ before_install:
   - "if [ -z \"$COUCH_HOST\" ]; then export COUCH_HOST=http://127.0.0.1:3000; fi"
 
 before_script:
-  - echo "using firefox $(/usr/local/bin/firefox --version)"
-  - export FIREFOX_BIN=/usr/local/bin/firefox
+  - tar -xjf /tmp/firefox-50.0.tar.bz2 --directory /tmp
+  - export PATH="/tmp/firefox:$PATH"
+  - echo "using firefox $(firefox --version)"
+  - export FIREFOX_BIN=$(which firefox)
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
     # Fail early so we dont run hours of saucelabs if we know there
@@ -40,11 +42,9 @@ env:
   - secure: "SSRTzT8OTeTpkGCLga74EGRfGmmRtsmAXbiXm1Xkg6tgQQmahxQJcrxr5QwHkdGdWkEIEudTd53AvZ/5KPmokmX/HiWsamdIj3WkrLdYvbEF4+mfqNa4oBBfrWXtPgPOG0vP1u5jPCK76S8qd7Ih8YrmAPUvecb04TnpVcLy+JM="
 
   matrix:
-  - RUN=0 CLIENT=selenium:firefox:50 COMMAND=test
+  - RUN=0 CLIENT=selenium:firefox COMMAND=test
   - RUN=1 CLIENT=selenium:firefox:50 COMMAND=test
-  - RUN=2 CLIENT=selenium:firefox:50 COMMAND=test
-  - RUN=3 CLIENT=selenium:firefox:50 COMMAND=test
-  - RUN=4 CLIENT=selenium:firefox:50 COMMAND=test
+  - RUN=2 CLIENT=selenium:firefox:50.0 COMMAND=test
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,79 +40,11 @@ env:
   - secure: "SSRTzT8OTeTpkGCLga74EGRfGmmRtsmAXbiXm1Xkg6tgQQmahxQJcrxr5QwHkdGdWkEIEudTd53AvZ/5KPmokmX/HiWsamdIj3WkrLdYvbEF4+mfqNa4oBBfrWXtPgPOG0vP1u5jPCK76S8qd7Ih8YrmAPUvecb04TnpVcLy+JM="
 
   matrix:
-  - CLIENT=node COMMAND=test
-
-  # Test WebSQL in Node (using node-websql)
-  - CLIENT=node ADAPTER=websql COMMAND=test
-
-  # Test in firefox/phantomjs running on travis
-  - CLIENT=selenium:firefox COMMAND=test
-  - CLIENT=selenium:phantomjs COMMAND=test
-
-  # Test auto-compaction in Node, Phantom, and Firefox
-  - AUTO_COMPACTION=true CLIENT=node COMMAND=test
-  - AUTO_COMPACTION=true CLIENT=selenium:firefox COMMAND=test
-  - AUTO_COMPACTION=true CLIENT=selenium:phantomjs COMMAND=test
-
-  # Test map/reduce
-  - TYPE=mapreduce CLIENT=node COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:firefox COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:phantomjs COMMAND=test
-
-  # Testing in saucelabs
-  - CLIENT=saucelabs:chrome COMMAND=test
-  - FETCH=1 CLIENT=selenium:firefox COMMAND=test
-  - CLIENT=saucelabs:safari:6 COMMAND=test
-  - CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
-
-  # split up the android+iphone tests as it goes over time
-  - SKIP_MIGRATION=true CLIENT="saucelabs:iphone:8.1:OS X 10.10" COMMAND=test
-  - CLIENT="saucelabs:Android:5.1:Linux" COMMAND=test
-
-  # Test memory / fruitdown etc
-  - CLIENT="saucelabs:iphone:8.4:OS X 10.11" ADAPTERS=fruitdown COMMAND=test
-  - CLIENT=selenium:firefox ADAPTERS=memory COMMAND=test
-  - CLIENT=selenium:firefox ADAPTERS=localstorage COMMAND=test
-
-  # Test Webpack bundle
-  - CLIENT=selenium:firefox COMMAND=test-webpack
-
-  # Test CouchDB master (aka bigcouch branch)
-  - COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox SERVER=couchdb-master COMMAND=test
-
-  # Performance tests
-  - CLIENT=selenium:firefox PERF=1 COMMAND=test
-  - PERF=1 COMMAND=test
-
-  # Test Webpack bundle
-  - CLIENT=selenium:firefox NEXT=1 COMMAND=test
-
-  - COMMAND=test-unit
-  - COMMAND=test-component
-  - COMMAND=test-fuzzy
-  # need extra env variable COVERAGE here because of some subtlety in Travis containers not
-  # passing the process.env.COVERAGE to the node process
-  - COMMAND=report-coverage COVERAGE=1
-  - COMMAND=verify-build
-
-matrix:
-  fast_finish: true
-  include:
-    - node_js: "4"
-      services: docker
-      env: CLIENT=node COMMAND=test
-    - node_js: "stable"
-      services: docker
-      env: CLIENT=node COMMAND=test
-  allow_failures:
-  - env: COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox SERVER=couchdb-master COMMAND=test
-  - env: CLIENT=selenium:firefox PERF=1 COMMAND=test
-  - env: CLIENT=selenium:firefox NEXT=1 COMMAND=test
-  - node_js: "stable"
-    services: docker
-    env: CLIENT=node COMMAND=test
+  - RUN=0 CLIENT=selenium:firefox:50 COMMAND=test
+  - RUN=1 CLIENT=selenium:firefox:50 COMMAND=test
+  - RUN=2 CLIENT=selenium:firefox:50 COMMAND=test
+  - RUN=3 CLIENT=selenium:firefox:50 COMMAND=test
+  - RUN=4 CLIENT=selenium:firefox:50 COMMAND=test
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,8 @@ before_install:
   - "if [ -z \"$COUCH_HOST\" ]; then export COUCH_HOST=http://127.0.0.1:3000; fi"
 
 before_script:
-  - tar -xjf /tmp/firefox-50.0.tar.bz2 --directory /tmp
-  - export PATH="/tmp/firefox:$PATH"
-  - alias firefox-bin="firefox"
-  - echo "using firefox $(firefox --version)"
+  - echo "using firefox $(/usr/local/bin/firefox --version)"
+  - export FIREFOX_BIN=/usr/local/bin/firefox
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
     # Fail early so we dont run hours of saucelabs if we know there
@@ -48,22 +46,22 @@ env:
   - CLIENT=node ADAPTER=websql COMMAND=test
 
   # Test in firefox/phantomjs running on travis
-  - CLIENT=selenium:firefox:50 COMMAND=test
+  - CLIENT=selenium:firefox COMMAND=test
   - CLIENT=selenium:phantomjs COMMAND=test
 
   # Test auto-compaction in Node, Phantom, and Firefox
   - AUTO_COMPACTION=true CLIENT=node COMMAND=test
-  - AUTO_COMPACTION=true CLIENT=selenium:firefox:50 COMMAND=test
+  - AUTO_COMPACTION=true CLIENT=selenium:firefox COMMAND=test
   - AUTO_COMPACTION=true CLIENT=selenium:phantomjs COMMAND=test
 
   # Test map/reduce
   - TYPE=mapreduce CLIENT=node COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:firefox:50 COMMAND=test
+  - TYPE=mapreduce CLIENT=selenium:firefox COMMAND=test
   - TYPE=mapreduce CLIENT=selenium:phantomjs COMMAND=test
 
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome COMMAND=test
-  - FETCH=1 CLIENT=selenium:firefox:50 COMMAND=test
+  - FETCH=1 CLIENT=selenium:firefox COMMAND=test
   - CLIENT=saucelabs:safari:6 COMMAND=test
   - CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
 
@@ -73,22 +71,22 @@ env:
 
   # Test memory / fruitdown etc
   - CLIENT="saucelabs:iphone:8.4:OS X 10.11" ADAPTERS=fruitdown COMMAND=test
-  - CLIENT=selenium:firefox:50 ADAPTERS=memory COMMAND=test
-  - CLIENT=selenium:firefox:50 ADAPTERS=localstorage COMMAND=test
+  - CLIENT=selenium:firefox ADAPTERS=memory COMMAND=test
+  - CLIENT=selenium:firefox ADAPTERS=localstorage COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:50 COMMAND=test-webpack
+  - CLIENT=selenium:firefox COMMAND=test-webpack
 
   # Test CouchDB master (aka bigcouch branch)
   - COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:50 SERVER=couchdb-master COMMAND=test
+  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox SERVER=couchdb-master COMMAND=test
 
   # Performance tests
-  - CLIENT=selenium:firefox:50 PERF=1 COMMAND=test
+  - CLIENT=selenium:firefox PERF=1 COMMAND=test
   - PERF=1 COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:50 NEXT=1 COMMAND=test
+  - CLIENT=selenium:firefox NEXT=1 COMMAND=test
 
   - COMMAND=test-unit
   - COMMAND=test-component
@@ -109,9 +107,9 @@ matrix:
       env: CLIENT=node COMMAND=test
   allow_failures:
   - env: COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:50 SERVER=couchdb-master COMMAND=test
-  - env: CLIENT=selenium:firefox:50 PERF=1 COMMAND=test
-  - env: CLIENT=selenium:firefox:50 NEXT=1 COMMAND=test
+  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox SERVER=couchdb-master COMMAND=test
+  - env: CLIENT=selenium:firefox PERF=1 COMMAND=test
+  - env: CLIENT=selenium:firefox NEXT=1 COMMAND=test
   - node_js: "stable"
     services: docker
     env: CLIENT=node COMMAND=test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo:
   false
 
 addons:
-  firefox: "41.0.1"
+  firefox: "46.0.1"
 
 before_install:
   # Because Saucelabs doesnt proxy 5984 on OSX
@@ -40,11 +40,11 @@ env:
   - secure: "SSRTzT8OTeTpkGCLga74EGRfGmmRtsmAXbiXm1Xkg6tgQQmahxQJcrxr5QwHkdGdWkEIEudTd53AvZ/5KPmokmX/HiWsamdIj3WkrLdYvbEF4+mfqNa4oBBfrWXtPgPOG0vP1u5jPCK76S8qd7Ih8YrmAPUvecb04TnpVcLy+JM="
 
   matrix:
-  - RUN=1 CLIENT=selenium:firefox:41.0.1 COMMAND=test
-  - RUN=2 CLIENT=selenium:firefox:41.0.1 COMMAND=test
-  - RUN=3 CLIENT=selenium:firefox:41.0.1 COMMAND=test
-  - RUN=4 CLIENT=selenium:firefox:41.0.1 COMMAND=test
-  - RUN=5 CLIENT=selenium:firefox:41.0.1 COMMAND=test
+  - RUN=1 CLIENT=selenium:firefox:46.0.1 COMMAND=test
+  - RUN=2 CLIENT=selenium:firefox:46.0.1 COMMAND=test
+  - RUN=3 CLIENT=selenium:firefox:46.0.1 COMMAND=test
+  - RUN=4 CLIENT=selenium:firefox:46.0.1 COMMAND=test
+  - RUN=5 CLIENT=selenium:firefox:46.0.1 COMMAND=test
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,17 @@ sudo:
   false
 
 addons:
-  firefox: "48.0"
+  firefox: "49.0.2"
 
 before_install:
   # Because Saucelabs doesnt proxy 5984 on OSX
   - "if [ -z \"$COUCH_HOST\" ]; then export COUCH_HOST=http://127.0.0.1:3000; fi"
 
 before_script:
+  - tar -xjf /tmp/firefox-49.0.2.tar.bz2 --directory /tmp
+  - export PATH="/tmp/firefox:$PATH"
+  - alias firefox-bin="firefox"
+  - echo "using firefox $(firefox --version)"
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
     # Fail early so we dont run hours of saucelabs if we know there
@@ -44,22 +48,22 @@ env:
   - CLIENT=node ADAPTER=websql COMMAND=test
 
   # Test in firefox/phantomjs running on travis
-  - CLIENT=selenium:firefox:48.0 COMMAND=test
+  - CLIENT=selenium:firefox:49.0.2 COMMAND=test
   - CLIENT=selenium:phantomjs COMMAND=test
 
   # Test auto-compaction in Node, Phantom, and Firefox
   - AUTO_COMPACTION=true CLIENT=node COMMAND=test
-  - AUTO_COMPACTION=true CLIENT=selenium:firefox:48.0 COMMAND=test
+  - AUTO_COMPACTION=true CLIENT=selenium:firefox:49.0.2 COMMAND=test
   - AUTO_COMPACTION=true CLIENT=selenium:phantomjs COMMAND=test
 
   # Test map/reduce
   - TYPE=mapreduce CLIENT=node COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:firefox:48.0 COMMAND=test
+  - TYPE=mapreduce CLIENT=selenium:firefox:49.0.2 COMMAND=test
   - TYPE=mapreduce CLIENT=selenium:phantomjs COMMAND=test
 
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome COMMAND=test
-  - FETCH=1 CLIENT=saucelabs:firefox:49 COMMAND=test
+  - FETCH=1 CLIENT=selenium:firefox:49.0.2 COMMAND=test
   - CLIENT=saucelabs:safari:6 COMMAND=test
   - CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
 
@@ -69,22 +73,22 @@ env:
 
   # Test memory / fruitdown etc
   - CLIENT="saucelabs:iphone:8.4:OS X 10.11" ADAPTERS=fruitdown COMMAND=test
-  - CLIENT=selenium:firefox:48.0 ADAPTERS=memory COMMAND=test
-  - CLIENT=selenium:firefox:48.0 ADAPTERS=localstorage COMMAND=test
+  - CLIENT=selenium:firefox:49.0.2 ADAPTERS=memory COMMAND=test
+  - CLIENT=selenium:firefox:49.0.2 ADAPTERS=localstorage COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:48.0 COMMAND=test-webpack
+  - CLIENT=selenium:firefox:49.0.2 COMMAND=test-webpack
 
   # Test CouchDB master (aka bigcouch branch)
   - COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:48.0 SERVER=couchdb-master COMMAND=test
+  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:49.0.2 SERVER=couchdb-master COMMAND=test
 
   # Performance tests
-  - CLIENT=selenium:firefox:48.0 PERF=1 COMMAND=test
+  - CLIENT=selenium:firefox:49.0.2 PERF=1 COMMAND=test
   - PERF=1 COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:48.0 NEXT=1 COMMAND=test
+  - CLIENT=selenium:firefox:49.0.2 NEXT=1 COMMAND=test
 
   - COMMAND=test-unit
   - COMMAND=test-component
@@ -105,9 +109,9 @@ matrix:
       env: CLIENT=node COMMAND=test
   allow_failures:
   - env: COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:48.0 SERVER=couchdb-master COMMAND=test
-  - env: CLIENT=selenium:firefox:48.0 PERF=1 COMMAND=test
-  - env: CLIENT=selenium:firefox:48.0 NEXT=1 COMMAND=test
+  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:49.0.2 SERVER=couchdb-master COMMAND=test
+  - env: CLIENT=selenium:firefox:49.0.2 PERF=1 COMMAND=test
+  - env: CLIENT=selenium:firefox:49.0.2 NEXT=1 COMMAND=test
   - node_js: "stable"
     services: docker
     env: CLIENT=node COMMAND=test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ before_install:
   - "if [ -z \"$COUCH_HOST\" ]; then export COUCH_HOST=http://127.0.0.1:3000; fi"
 
 before_script:
-  - tar -xjf /tmp/firefox-41.0.1.tar.bz2 --directory /tmp
-  - export PATH="/tmp/firefox:$PATH"
   - echo "using firefox $(firefox --version)"
   - export FIREFOX_BIN=$(which firefox)
   - "export DISPLAY=:99.0"
@@ -42,12 +40,11 @@ env:
   - secure: "SSRTzT8OTeTpkGCLga74EGRfGmmRtsmAXbiXm1Xkg6tgQQmahxQJcrxr5QwHkdGdWkEIEudTd53AvZ/5KPmokmX/HiWsamdIj3WkrLdYvbEF4+mfqNa4oBBfrWXtPgPOG0vP1u5jPCK76S8qd7Ih8YrmAPUvecb04TnpVcLy+JM="
 
   matrix:
-  - RUN=0 CLIENT=selenium:firefox COMMAND=test
-  - RUN=1 CLIENT=selenium:firefox:41 COMMAND=test
+  - RUN=1 CLIENT=selenium:firefox:41.0.1 COMMAND=test
   - RUN=2 CLIENT=selenium:firefox:41.0.1 COMMAND=test
-  - RUN=3 FIREFOX_BIN=/usr/local/bin/firefox CLIENT=selenium:firefox COMMAND=test
-  - RUN=4 FIREFOX_BIN=/usr/local/bin/firefox CLIENT=selenium:firefox:41 COMMAND=test
-  - RUN=5 FIREFOX_BIN=/usr/local/bin/firefox CLIENT=selenium:firefox:41.0.1 COMMAND=test
+  - RUN=3 CLIENT=selenium:firefox:41.0.1 COMMAND=test
+  - RUN=4 CLIENT=selenium:firefox:41.0.1 COMMAND=test
+  - RUN=5 CLIENT=selenium:firefox:41.0.1 COMMAND=test
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,14 @@ sudo:
   false
 
 addons:
-  firefox: "50.0"
+  firefox: "41.0.1"
 
 before_install:
   # Because Saucelabs doesnt proxy 5984 on OSX
   - "if [ -z \"$COUCH_HOST\" ]; then export COUCH_HOST=http://127.0.0.1:3000; fi"
 
 before_script:
-  - tar -xjf /tmp/firefox-50.0.tar.bz2 --directory /tmp
+  - tar -xjf /tmp/firefox-41.0.1.tar.bz2 --directory /tmp
   - export PATH="/tmp/firefox:$PATH"
   - echo "using firefox $(firefox --version)"
   - export FIREFOX_BIN=$(which firefox)
@@ -43,8 +43,11 @@ env:
 
   matrix:
   - RUN=0 CLIENT=selenium:firefox COMMAND=test
-  - RUN=1 CLIENT=selenium:firefox:50 COMMAND=test
-  - RUN=2 CLIENT=selenium:firefox:50.0 COMMAND=test
+  - RUN=1 CLIENT=selenium:firefox:41 COMMAND=test
+  - RUN=2 CLIENT=selenium:firefox:41.0.1 COMMAND=test
+  - RUN=3 FIREFOX_BIN=/usr/local/bin/firefox CLIENT=selenium:firefox COMMAND=test
+  - RUN=4 FIREFOX_BIN=/usr/local/bin/firefox CLIENT=selenium:firefox:41 COMMAND=test
+  - RUN=5 FIREFOX_BIN=/usr/local/bin/firefox CLIENT=selenium:firefox:41.0.1 COMMAND=test
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,14 @@ sudo:
   false
 
 addons:
-  firefox: "49.0.2"
+  firefox: "50.0"
 
 before_install:
   # Because Saucelabs doesnt proxy 5984 on OSX
   - "if [ -z \"$COUCH_HOST\" ]; then export COUCH_HOST=http://127.0.0.1:3000; fi"
 
 before_script:
-  - tar -xjf /tmp/firefox-49.0.2.tar.bz2 --directory /tmp
+  - tar -xjf /tmp/firefox-50.0.tar.bz2 --directory /tmp
   - export PATH="/tmp/firefox:$PATH"
   - alias firefox-bin="firefox"
   - echo "using firefox $(firefox --version)"
@@ -48,22 +48,22 @@ env:
   - CLIENT=node ADAPTER=websql COMMAND=test
 
   # Test in firefox/phantomjs running on travis
-  - CLIENT=selenium:firefox:49.0.2 COMMAND=test
+  - CLIENT=selenium:firefox:50 COMMAND=test
   - CLIENT=selenium:phantomjs COMMAND=test
 
   # Test auto-compaction in Node, Phantom, and Firefox
   - AUTO_COMPACTION=true CLIENT=node COMMAND=test
-  - AUTO_COMPACTION=true CLIENT=selenium:firefox:49.0.2 COMMAND=test
+  - AUTO_COMPACTION=true CLIENT=selenium:firefox:50 COMMAND=test
   - AUTO_COMPACTION=true CLIENT=selenium:phantomjs COMMAND=test
 
   # Test map/reduce
   - TYPE=mapreduce CLIENT=node COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:firefox:49.0.2 COMMAND=test
+  - TYPE=mapreduce CLIENT=selenium:firefox:50 COMMAND=test
   - TYPE=mapreduce CLIENT=selenium:phantomjs COMMAND=test
 
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome COMMAND=test
-  - FETCH=1 CLIENT=selenium:firefox:49.0.2 COMMAND=test
+  - FETCH=1 CLIENT=selenium:firefox:50 COMMAND=test
   - CLIENT=saucelabs:safari:6 COMMAND=test
   - CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
 
@@ -73,22 +73,22 @@ env:
 
   # Test memory / fruitdown etc
   - CLIENT="saucelabs:iphone:8.4:OS X 10.11" ADAPTERS=fruitdown COMMAND=test
-  - CLIENT=selenium:firefox:49.0.2 ADAPTERS=memory COMMAND=test
-  - CLIENT=selenium:firefox:49.0.2 ADAPTERS=localstorage COMMAND=test
+  - CLIENT=selenium:firefox:50 ADAPTERS=memory COMMAND=test
+  - CLIENT=selenium:firefox:50 ADAPTERS=localstorage COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:49.0.2 COMMAND=test-webpack
+  - CLIENT=selenium:firefox:50 COMMAND=test-webpack
 
   # Test CouchDB master (aka bigcouch branch)
   - COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:49.0.2 SERVER=couchdb-master COMMAND=test
+  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:50 SERVER=couchdb-master COMMAND=test
 
   # Performance tests
-  - CLIENT=selenium:firefox:49.0.2 PERF=1 COMMAND=test
+  - CLIENT=selenium:firefox:50 PERF=1 COMMAND=test
   - PERF=1 COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:49.0.2 NEXT=1 COMMAND=test
+  - CLIENT=selenium:firefox:50 NEXT=1 COMMAND=test
 
   - COMMAND=test-unit
   - COMMAND=test-component
@@ -109,9 +109,9 @@ matrix:
       env: CLIENT=node COMMAND=test
   allow_failures:
   - env: COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:49.0.2 SERVER=couchdb-master COMMAND=test
-  - env: CLIENT=selenium:firefox:49.0.2 PERF=1 COMMAND=test
-  - env: CLIENT=selenium:firefox:49.0.2 NEXT=1 COMMAND=test
+  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:50 SERVER=couchdb-master COMMAND=test
+  - env: CLIENT=selenium:firefox:50 PERF=1 COMMAND=test
+  - env: CLIENT=selenium:firefox:50 NEXT=1 COMMAND=test
   - node_js: "stable"
     services: docker
     env: CLIENT=node COMMAND=test

--- a/TESTING.md
+++ b/TESTING.md
@@ -63,6 +63,12 @@ or
 * `POUCHDB_SRC=../../dist/pouchdb.js` can be used to treat another file as the PouchDB source file.
 * `npm run test-webpack` will build with Webpack and then test that in a browser.
 
+#### Test against custom Firefox
+
+You can specify a custom Firefox path using `FIREFOX_BIN`
+
+    $ FIREFOX_BIN=/path/to/firefox npm run test-browser
+
 #### Run the map/reduce tests
 
 The map/reduce tests are done separately from the normal integration tests, because

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -17,6 +17,7 @@ var username = process.env.SAUCE_USERNAME;
 var accessKey = process.env.SAUCE_ACCESS_KEY;
 
 var SELENIUM_VERSION = process.env.SELENIUM_VERSION || '2.53.1';
+var FIREFOX_BIN = process.env.FIREFOX_BIN;
 
 // BAIL=0 to disable bailing
 var bail = process.env.BAIL !== '0';
@@ -187,6 +188,9 @@ function startTest() {
     'idle-timeout': 599,
     'tunnel-identifier': tunnelId
   };
+  if (FIREFOX_BIN) {
+    opts.firefox_binary = FIREFOX_BIN;
+  }
 
   sauceClient.init(opts).get(testUrl, function () {
 

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -19,6 +19,8 @@ var accessKey = process.env.SAUCE_ACCESS_KEY;
 var SELENIUM_VERSION = process.env.SELENIUM_VERSION || '2.53.1';
 var FIREFOX_BIN = process.env.FIREFOX_BIN;
 
+console.log('using FIREFOX_BIN', FIREFOX_BIN);
+
 // BAIL=0 to disable bailing
 var bail = process.env.BAIL !== '0';
 


### PR DESCRIPTION
Look, I have no idea why, but according to my testing 41.0.1 is the most consistent. It also works best apparently when you actually specify the version number (i.e. `selenium:firefox:41.0.1`).

See https://github.com/pouchdb/pouchdb/pull/5939#issuecomment-263025848 for details.