### PR TITLE
(#5930) - use Firefox 46.0.1 in Travis, add FIREFOX_BIN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,15 @@ sudo:
   false
 
 addons:
-  firefox: "48.0"
+  firefox: "46.0.1"
 
 before_install:
   # Because Saucelabs doesnt proxy 5984 on OSX
   - "if [ -z \"$COUCH_HOST\" ]; then export COUCH_HOST=http://127.0.0.1:3000; fi"
 
 before_script:
+  - echo "using firefox $(firefox --version)"
+  - export FIREFOX_BIN=$(which firefox)
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
     # Fail early so we dont run hours of saucelabs if we know there
@@ -44,22 +46,22 @@ env:
   - CLIENT=node ADAPTER=websql COMMAND=test
 
   # Test in firefox/phantomjs running on travis
-  - CLIENT=selenium:firefox:48.0 COMMAND=test
+  - CLIENT=selenium:firefox:46.0.1 COMMAND=test
   - CLIENT=selenium:phantomjs COMMAND=test
 
   # Test auto-compaction in Node, Phantom, and Firefox
   - AUTO_COMPACTION=true CLIENT=node COMMAND=test
-  - AUTO_COMPACTION=true CLIENT=selenium:firefox:48.0 COMMAND=test
+  - AUTO_COMPACTION=true CLIENT=selenium:firefox:46.0.1 COMMAND=test
   - AUTO_COMPACTION=true CLIENT=selenium:phantomjs COMMAND=test
 
   # Test map/reduce
   - TYPE=mapreduce CLIENT=node COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:firefox:48.0 COMMAND=test
+  - TYPE=mapreduce CLIENT=selenium:firefox:46.0.1 COMMAND=test
   - TYPE=mapreduce CLIENT=selenium:phantomjs COMMAND=test
 
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome COMMAND=test
-  - FETCH=1 CLIENT=saucelabs:firefox:49 COMMAND=test
+  - FETCH=1 CLIENT=selenium:firefox:46.0.1 COMMAND=test
   - CLIENT=saucelabs:safari:6 COMMAND=test
   - CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
 
@@ -69,22 +71,22 @@ env:
 
   # Test memory / fruitdown etc
   - CLIENT="saucelabs:iphone:8.4:OS X 10.11" ADAPTERS=fruitdown COMMAND=test
-  - CLIENT=selenium:firefox:48.0 ADAPTERS=memory COMMAND=test
-  - CLIENT=selenium:firefox:48.0 ADAPTERS=localstorage COMMAND=test
+  - CLIENT=selenium:firefox:46.0.1 ADAPTERS=memory COMMAND=test
+  - CLIENT=selenium:firefox:46.0.1 ADAPTERS=localstorage COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:48.0 COMMAND=test-webpack
+  - CLIENT=selenium:firefox:46.0.1 COMMAND=test-webpack
 
   # Test CouchDB master (aka bigcouch branch)
   - COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:48.0 SERVER=couchdb-master COMMAND=test
+  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:46.0.1 SERVER=couchdb-master COMMAND=test
 
   # Performance tests
-  - CLIENT=selenium:firefox:48.0 PERF=1 COMMAND=test
+  - CLIENT=selenium:firefox:46.0.1 PERF=1 COMMAND=test
   - PERF=1 COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:48.0 NEXT=1 COMMAND=test
+  - CLIENT=selenium:firefox:46.0.1 NEXT=1 COMMAND=test
 
   - COMMAND=test-unit
   - COMMAND=test-component
@@ -105,9 +107,9 @@ matrix:
       env: CLIENT=node COMMAND=test
   allow_failures:
   - env: COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:48.0 SERVER=couchdb-master COMMAND=test
-  - env: CLIENT=selenium:firefox:48.0 PERF=1 COMMAND=test
-  - env: CLIENT=selenium:firefox:48.0 NEXT=1 COMMAND=test
+  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:46.0.1 SERVER=couchdb-master COMMAND=test
+  - env: CLIENT=selenium:firefox:46.0.1 PERF=1 COMMAND=test
+  - env: CLIENT=selenium:firefox:46.0.1 NEXT=1 COMMAND=test
   - node_js: "stable"
     services: docker
     env: CLIENT=node COMMAND=test

--- a/TESTING.md
+++ b/TESTING.md
@@ -63,6 +63,12 @@ or
 * `POUCHDB_SRC=../../dist/pouchdb.js` can be used to treat another file as the PouchDB source file.
 * `npm run test-webpack` will build with Webpack and then test that in a browser.
 
+#### Test against custom Firefox
+
+You can specify a custom Firefox path using `FIREFOX_BIN`
+
+    $ FIREFOX_BIN=/path/to/firefox npm run test-browser
+
 #### Run the map/reduce tests
 
 The map/reduce tests are done separately from the normal integration tests, because

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -17,6 +17,7 @@ var username = process.env.SAUCE_USERNAME;
 var accessKey = process.env.SAUCE_ACCESS_KEY;
 
 var SELENIUM_VERSION = process.env.SELENIUM_VERSION || '2.53.1';
+var FIREFOX_BIN = process.env.FIREFOX_BIN;
 
 // BAIL=0 to disable bailing
 var bail = process.env.BAIL !== '0';
@@ -187,6 +188,9 @@ function startTest() {
     'idle-timeout': 599,
     'tunnel-identifier': tunnelId
   };
+  if (FIREFOX_BIN) {
+    opts.firefox_binary = FIREFOX_BIN;
+  }
 
   sauceClient.init(opts).get(testUrl, function () {
 


### PR DESCRIPTION
See https://github.com/pouchdb/pouchdb/pull/5944 and https://github.com/pouchdb/pouchdb/pull/5939#issuecomment-263025848 for previous discussion.

I tried [this configuration](https://travis-ci.org/pouchdb/pouchdb/builds/179077464) 5 times, and it passed 4/5 times. I would of course prefer to use a later version of Firefox than 46 but I'm not sure if I can get them to consistently work. I couldn't get v50 to consistently work.

I don't know if this is the least faily combination, but I'm getting seriously exhausted of poking at config files and babysitting Travis, and with this configuration at least, we know there's a 0% chance that it will run the built-in Travis Firefox (v38 iirc) because I'm explicitly specifying a firefox binary when using Selenium.