### PR TITLE
(#5930) - run Firefox 50 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo:
   false
 
 addons:
-  firefox: "46.0.1"
+  firefox: "50.0"
 
 before_install:
   # Because Saucelabs doesnt proxy 5984 on OSX
@@ -49,22 +49,22 @@ env:
   - CLIENT=node ADAPTER=memory COMMAND=test
 
   # Test in firefox/phantomjs running on travis
-  - CLIENT=selenium:firefox:46.0.1 COMMAND=test
+  - CLIENT=selenium:firefox:50.0 COMMAND=test
   - CLIENT=selenium:phantomjs COMMAND=test
 
   # Test auto-compaction in Node, Phantom, and Firefox
   - AUTO_COMPACTION=true CLIENT=node COMMAND=test
-  - AUTO_COMPACTION=true CLIENT=selenium:firefox:46.0.1 COMMAND=test
+  - AUTO_COMPACTION=true CLIENT=selenium:firefox:50.0 COMMAND=test
   - AUTO_COMPACTION=true CLIENT=selenium:phantomjs COMMAND=test
 
   # Test map/reduce
   - TYPE=mapreduce CLIENT=node COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:firefox:46.0.1 COMMAND=test
+  - TYPE=mapreduce CLIENT=selenium:firefox:50.0 COMMAND=test
   - TYPE=mapreduce CLIENT=selenium:phantomjs COMMAND=test
 
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome COMMAND=test
-  - FETCH=1 CLIENT=saucelabs:firefox:49 COMMAND=test
+  - FETCH=1 CLIENT=selenium:firefox:50.0 COMMAND=test
   - CLIENT=saucelabs:safari:6 COMMAND=test
   - CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
 
@@ -74,22 +74,22 @@ env:
 
   # Test memory / fruitdown etc
   - CLIENT="saucelabs:iphone:8.4:OS X 10.11" ADAPTERS=fruitdown COMMAND=test
-  - CLIENT=selenium:firefox:46.0.1 ADAPTERS=memory COMMAND=test
-  - CLIENT=selenium:firefox:46.0.1 ADAPTERS=localstorage COMMAND=test
+  - CLIENT=selenium:firefox:50.0 ADAPTERS=memory COMMAND=test
+  - CLIENT=selenium:firefox:50.0 ADAPTERS=localstorage COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:46.0.1 COMMAND=test-webpack
+  - CLIENT=selenium:firefox:50.0 COMMAND=test-webpack
 
   # Test CouchDB master (aka bigcouch branch)
   - COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:46.0.1 SERVER=couchdb-master COMMAND=test
+  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:50.0 SERVER=couchdb-master COMMAND=test
 
   # Performance tests
-  - CLIENT=selenium:firefox:46.0.1 PERF=1 COMMAND=test
+  - CLIENT=selenium:firefox:50.0 PERF=1 COMMAND=test
   - PERF=1 COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:46.0.1 NEXT=1 COMMAND=test
+  - CLIENT=selenium:firefox:50.0 NEXT=1 COMMAND=test
 
   - COMMAND=test-unit
   - COMMAND=test-component
@@ -110,9 +110,9 @@ matrix:
       env: CLIENT=node COMMAND=test
   allow_failures:
   - env: COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:46.0.1 SERVER=couchdb-master COMMAND=test
-  - env: CLIENT=selenium:firefox:46.0.1 PERF=1 COMMAND=test
-  - env: CLIENT=selenium:firefox:46.0.1 NEXT=1 COMMAND=test
+  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:50.0 SERVER=couchdb-master COMMAND=test
+  - env: CLIENT=selenium:firefox:50.0 PERF=1 COMMAND=test
+  - env: CLIENT=selenium:firefox:50.0 NEXT=1 COMMAND=test
   - node_js: "stable"
     services: docker
     env: CLIENT=node COMMAND=test


### PR DESCRIPTION
OK, so mea culpa time. It turns out 86c5694fafe592adf535ac80d0f5b84d94340dad actually does break the build, because it turns out adding FIREFOX_BIN to `saucelabs:firefox` prevents Selenium from figuring out to use Firefox in SauceLabs rather than Selenium (I guess that's what's going on?). Also unfortunately Firefox 46.0.1 legit fails our fetch tests.

I think we can just upgrade to Firefox 50. It might fail a few times but we can just restart it. Oddly it seems like these tests always fail the first time and then succeed after. So hopefully this will work.