### PR TITLE
(#5930) - use Firefox 47.0.2 for all Firefox tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo:
   false
 
 addons:
-  firefox: "46.0.1"
+  firefox: "47.0.2"
 
 before_install:
   # Because Saucelabs doesnt proxy 5984 on OSX
@@ -49,22 +49,22 @@ env:
   - CLIENT=node ADAPTER=memory COMMAND=test
 
   # Test in firefox/phantomjs running on travis
-  - CLIENT=selenium:firefox:46.0.1 COMMAND=test
+  - CLIENT=selenium:firefox:47.0.2 COMMAND=test
   - CLIENT=selenium:phantomjs COMMAND=test
 
   # Test auto-compaction in Node, Phantom, and Firefox
   - AUTO_COMPACTION=true CLIENT=node COMMAND=test
-  - AUTO_COMPACTION=true CLIENT=selenium:firefox:46.0.1 COMMAND=test
+  - AUTO_COMPACTION=true CLIENT=selenium:firefox:47.0.2 COMMAND=test
   - AUTO_COMPACTION=true CLIENT=selenium:phantomjs COMMAND=test
 
   # Test map/reduce
   - TYPE=mapreduce CLIENT=node COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:firefox:46.0.1 COMMAND=test
+  - TYPE=mapreduce CLIENT=selenium:firefox:47.0.2 COMMAND=test
   - TYPE=mapreduce CLIENT=selenium:phantomjs COMMAND=test
 
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome COMMAND=test
-  - FETCH=1 CLIENT=saucelabs:firefox:49 COMMAND=test
+  - FETCH=1 CLIENT=selenium:firefox:47.0.2 COMMAND=test
   - CLIENT=saucelabs:safari:6 COMMAND=test
   - CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
 
@@ -74,22 +74,22 @@ env:
 
   # Test memory / fruitdown etc
   - CLIENT="saucelabs:iphone:8.4:OS X 10.11" ADAPTERS=fruitdown COMMAND=test
-  - CLIENT=selenium:firefox:46.0.1 ADAPTERS=memory COMMAND=test
-  - CLIENT=selenium:firefox:46.0.1 ADAPTERS=localstorage COMMAND=test
+  - CLIENT=selenium:firefox:47.0.2 ADAPTERS=memory COMMAND=test
+  - CLIENT=selenium:firefox:47.0.2 ADAPTERS=localstorage COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:46.0.1 COMMAND=test-webpack
+  - CLIENT=selenium:firefox:47.0.2 COMMAND=test-webpack
 
   # Test CouchDB master (aka bigcouch branch)
   - COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:46.0.1 SERVER=couchdb-master COMMAND=test
+  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:47.0.2 SERVER=couchdb-master COMMAND=test
 
   # Performance tests
-  - CLIENT=selenium:firefox:46.0.1 PERF=1 COMMAND=test
+  - CLIENT=selenium:firefox:47.0.2 PERF=1 COMMAND=test
   - PERF=1 COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:46.0.1 NEXT=1 COMMAND=test
+  - CLIENT=selenium:firefox:47.0.2 NEXT=1 COMMAND=test
 
   - COMMAND=test-unit
   - COMMAND=test-component
@@ -110,9 +110,9 @@ matrix:
       env: CLIENT=node COMMAND=test
   allow_failures:
   - env: COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:46.0.1 SERVER=couchdb-master COMMAND=test
-  - env: CLIENT=selenium:firefox:46.0.1 PERF=1 COMMAND=test
-  - env: CLIENT=selenium:firefox:46.0.1 NEXT=1 COMMAND=test
+  - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:47.0.2 SERVER=couchdb-master COMMAND=test
+  - env: CLIENT=selenium:firefox:47.0.2 PERF=1 COMMAND=test
+  - env: CLIENT=selenium:firefox:47.0.2 NEXT=1 COMMAND=test
   - node_js: "stable"
     services: docker
     env: CLIENT=node COMMAND=test


### PR DESCRIPTION
See https://github.com/pouchdb/pouchdb/pull/5950 and https://github.com/pouchdb/pouchdb/pull/5951