### PR TITLE
(#5930) - cache selenium and phantomjs in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,23 @@ before_install:
   - "if [ -z \"$COUCH_HOST\" ]; then export COUCH_HOST=http://127.0.0.1:3000; fi"
 
 before_script:
+  # Our test-browser.js script uses FIREFOX_BIN to find the Firefox binary
+  # See https://github.com/travis-ci/travis-ci/issues/4649
   - echo "using firefox $(firefox --version)"
   - export FIREFOX_BIN=$(which firefox)
+  # The next two lines are required for Firefox to run on Travis
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-    # Fail early so we dont run hours of saucelabs if we know there
-    # is a lint failure
+  # Install PhantomJS and cache it
+  # See https://github.com/Medium/phantomjs#continuous-integration
+  - "export PHANTOMJS_VERSION=2.1.1"
+  - "export PATH=$PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin:$PATH"
+  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
+  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then wget https://github.com/Medium/phantomjs/releases/download/v$PHANTOMJS_VERSION/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
+  - "phantomjs --version"
+  # Fail early so we dont run hours of saucelabs if we know there
+  # is a lint failure
   - npm run eslint
 
 script: npm run $COMMAND
@@ -124,3 +135,7 @@ branches:
 cache:
   directories:
   - $HOME/.npm
+  # See https://github.com/gr2m/selsa
+  - node_modules/selenium-standalone/.selenium
+  # See https://github.com/Medium/phantomjs#continuous-integration
+  - travis_phantomjs

--- a/TESTING.md
+++ b/TESTING.md
@@ -25,6 +25,11 @@ or you can run:
 
 and open [http://127.0.0.1:8000/tests/integration/index.html](http://127.0.0.1:8000/tests/integration/index.html) in your browser of choice. The performance tests are located @ [http://localhost:8000/tests/performance/index.html](http://localhost:8000/tests/performance/index.html).
 
+You can also test against phantomjs, but you'll need to install phantomjs yourself:
+
+    $ npm install phantomjs-prebuilt
+    $ CLIENT=selenium:phantomjs npm test
+
 ### Unit tests
 
     $ npm run build-as-modular-es5

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -50,10 +50,6 @@ if [ ! -z $TRAVIS ]; then
   source ./bin/run-couchdb-on-travis.sh
 fi
 
-if [ "$CLIENT" == "selenium:phantomjs" ]; then
-  npm install phantomjs@2.1.2 # do this on-demand to avoid slow installs
-fi
-
 printf 'Waiting for host to start .'
 WAITING=0
 until $(curl --output /dev/null --silent --head --fail --max-time 2 $COUCH_HOST); do


### PR DESCRIPTION
Did some research on best practices here, see:

- https://github.com/gr2m/selsa
- https://github.com/Medium/phantomjs#continuous-integration

Also now you are expected to manually install phantomjs yourself, except on Travis where we use the caching mechanism recommended by the `phantomjs-prebuilt` authors.