### PR TITLE
(#5908 #5930) - cache CouchDB 1.6.1 Docker image on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,6 +137,7 @@ branches:
 
 cache:
   directories:
+  - $HOME/docker
   - $HOME/.npm
   # See https://github.com/gr2m/selsa
   - node_modules/selenium-standalone/.selenium

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ sudo:
 addons:
   firefox: "47.0.2"
 
+# Workaround for https://github.com/travis-ci/travis-ci/issues/6928#issuecomment-264227708
+group: deprecated
+
 before_install:
   # Because Saucelabs doesnt proxy 5984 on OSX
   - "if [ -z \"$COUCH_HOST\" ]; then export COUCH_HOST=http://127.0.0.1:3000; fi"

--- a/bin/run-couchdb-on-travis.sh
+++ b/bin/run-couchdb-on-travis.sh
@@ -7,7 +7,19 @@ if [ "$SERVER" = "couchdb-master" ]; then
   COUCH_PORT=3001
 else
   # Install CouchDB Stable
-  docker run -d -p 3000:5984 klaemo/couchdb:1.6.1
+  mkdir -p $HOME/docker
+  export DOCKER_CACHE_FILE=$HOME/docker/couchdb-1.6.1.tgz
+  if [ -f "$DOCKER_CACHE_FILE" ]; then
+    echo "Using cached Docker image for CouchDB 1.6.1..."
+    gunzip -c "$DOCKER_CACHE_FILE" | docker import - couchdb-1.6.1
+    docker run --name couchdb-1.6.1 -d -p 3000:5984
+  else
+    echo "Using uncached Docker image for CouchDB 1.6.1..."
+    # Cache CouchDB 1.6.1 Docker image on Travis; it won't ever change
+    # See https://giorgos.sealabs.net/docker-cache-on-travis-and-docker-112.html
+    docker run --name couchdb-1.6.1 -d -p 3000:5984 klaemo/couchdb:1.6.1
+    docker export couchdb-1.6.1 | gzip > "$DOCKER_CACHE_FILE"
+  fi
   COUCH_PORT=3000
 fi
 


### PR DESCRIPTION
Another idea to cut down build times. No need to keep downloading the `klaemo/couchdb:1.6.1` image over and over again. Let's see if this works!