### PR TITLE
fix plugin-import in readme

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/README.md
+++ b/packages/node_modules/pouchdb-adapter-http/README.md
@@ -10,7 +10,7 @@ npm install pouchdb-adapter-http
 ```
 
 ```js
-var PouchDB = require('pouchdb-adapter-http');
+PouchDB.plugin(require('pouchdb-adapter-http'));
 var db = new PouchDB('http://127.0.0.1:5984/mydb');
 ```
 
@@ -21,5 +21,3 @@ For full API documentation and guides on PouchDB, see [PouchDB.com](http://pouch
 PouchDB and its sub-packages are distributed as a [monorepo](https://github.com/babel/babel/blob/master/doc/design/monorepo.md).
 
 For a full list of packages, see [the GitHub source](https://github.com/pouchdb/pouchdb/tree/master/packages).
-
-


### PR DESCRIPTION
In the docs there is a mistake on how to import the adapter into the PouchDB-module.