### PR TITLE
(#5956) - fix README for pouchdb-adapter-leveldb

### DIFF
--- a/packages/node_modules/pouchdb-adapter-leveldb/README.md
+++ b/packages/node_modules/pouchdb-adapter-leveldb/README.md
@@ -10,8 +10,8 @@ npm install pouchdb
 ```
 
 ```js
-var PouchDB = require('pouchdb');
-var db = new PouchDB('my_db');
+PouchDB.plugin(require('pouchdb-adapter-leveldb'));
+var db = new PouchDB('my_db', {adapter: 'leveldb'});
 ```
 
 For full API documentation and guides on PouchDB, see [PouchDB.com](http://pouchdb.com/). For details on PouchDB sub-packages, see the [Custom Builds documentation](http://pouchdb.com/custom.html).


### PR DESCRIPTION
Noticed this part of the docs were wrong when looking at #5956.