### PR TITLE
(#5988) - remove unsafe `new Buffer()` usages

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
   },
   "dependencies": {
     "argsarray": "0.0.1",
+    "buffer-from": "0.1.1",
+    "clone-buffer": "1.0.0",
     "debug": "2.3.2",
     "double-ended-queue": "2.1.0-0",
     "fruitdown": "1.0.2",
@@ -42,6 +44,7 @@
     "inherits": "2.0.3",
     "level-codec": "6.2.0",
     "level-write-stream": "1.0.0",
+    "leveldown": "1.5.0",
     "levelup": "1.3.3",
     "lie": "3.1.0",
     "localstorage-down": "0.6.6",
@@ -53,7 +56,6 @@
     "spark-md5": "3.0.0",
     "through2": "2.0.1",
     "vuvuzela": "1.0.3",
-    "leveldown": "1.5.0",
     "websql": "0.4.4"
   },
   "devDependencies": {

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -5,6 +5,7 @@ import getArguments from 'argsarray';
 import { Map, Set } from 'pouchdb-collections';
 import Deque from 'double-ended-queue';
 import Promise from 'pouchdb-promise';
+import bufferFrom from 'buffer-from'; // ponyfill for Node <6
 import {
   clone,
   changesHandler as Changes,
@@ -783,7 +784,7 @@ function LevelPouch(opts, callback) {
           type: 'put',
           prefix: stores.binaryStore,
           key: digest,
-          value: new Buffer(data, 'binary')
+          value: bufferFrom(data, 'binary')
         }]);
         callback();
       });

--- a/packages/node_modules/pouchdb-ajax/src/createBlobOrBufferFromParts.js
+++ b/packages/node_modules/pouchdb-ajax/src/createBlobOrBufferFromParts.js
@@ -1,6 +1,8 @@
+import bufferFrom from 'buffer-from'; // ponyfill for Node <6
+
 function createBlobOrBufferFromParts(parts) {
   return Buffer.concat(parts.map(function (part) {
-    return new Buffer(part, 'binary');
+    return bufferFrom(part, 'binary');
   }));
 }
 

--- a/packages/node_modules/pouchdb-ajax/src/defaultBody.js
+++ b/packages/node_modules/pouchdb-ajax/src/defaultBody.js
@@ -1,5 +1,7 @@
+import bufferFrom from 'buffer-from'; // ponyfill for Node <6
+
 function defaultBody() {
-  return new Buffer('', 'binary');
+  return bufferFrom('', 'binary');
 }
 
 export default defaultBody;

--- a/packages/node_modules/pouchdb-binary-utils/src/base64.js
+++ b/packages/node_modules/pouchdb-binary-utils/src/base64.js
@@ -1,3 +1,5 @@
+import bufferFrom from 'buffer-from'; // ponyfill for Node <6
+
 function thisAtob(str) {
   var base64 = new Buffer(str, 'base64');
   // Node.js will just skip the characters it can't decode instead of
@@ -9,7 +11,7 @@ function thisAtob(str) {
 }
 
 function thisBtoa(str) {
-  return new Buffer(str, 'binary').toString('base64');
+  return bufferFrom(str, 'binary').toString('base64');
 }
 
 export {

--- a/packages/node_modules/pouchdb-binary-utils/src/typedBuffer.js
+++ b/packages/node_modules/pouchdb-binary-utils/src/typedBuffer.js
@@ -1,6 +1,8 @@
+import bufferFrom from 'buffer-from'; // ponyfill for Node <6
+
 function typedBuffer(binString, buffType, type) {
   // buffType is either 'binary' or 'base64'
-  var buff = new Buffer(binString, buffType);
+  var buff = bufferFrom(binString, buffType);
   buff.type = type; // non-standard, but used for consistency with the browser
   return buff;
 }

--- a/packages/node_modules/pouchdb-utils/src/cloneBinaryObject.js
+++ b/packages/node_modules/pouchdb-utils/src/cloneBinaryObject.js
@@ -1,7 +1,2 @@
-function cloneBinaryObject(object) {
-  var copy = new Buffer(object.length);
-  object.copy(copy);
-  return copy;
-}
-
-export default cloneBinaryObject;
+import cloneBuffer from 'clone-buffer'; // correctly uses Buffer.from when available
+export default cloneBuffer;

--- a/tests/integration/test.issue915.js
+++ b/tests/integration/test.issue915.js
@@ -5,6 +5,7 @@ if (!process.env.LEVEL_ADAPTER &&
     !process.env.ADAPTER) {
   // these tests don't make sense for anything other than default leveldown
   var fs = require('fs');
+  var bufferFrom = require('buffer-from');
   describe('test.issue915.js', function () {
     afterEach(function (done) {
       fs.unlink('./tmp/_pouch_veryimportantfiles/something', function () {
@@ -16,7 +17,7 @@ if (!process.env.LEVEL_ADAPTER &&
     it('Put a file in the db, then destroy it', function (done) {
       var db = new PouchDB('veryimportantfiles');
       fs.writeFile('./tmp/_pouch_veryimportantfiles/something',
-                   new Buffer('lalala'), function () {
+                   bufferFrom('lalala'), function () {
         db.destroy(function (err) {
           if (err) {
             return done(err);


### PR DESCRIPTION
This adds two new dependencies, but they should only affect Node.js users. I also
inspected their codebases and found them to be reasonably small and straightforward.