### PR TITLE
(#5991) - use fork of debug to avoid process polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "argsarray": "0.0.1",
-    "debug": "2.3.2",
+    "debug": "nolanlawson/debug#abbe8a8",
     "double-ended-queue": "2.1.0-0",
     "fruitdown": "1.0.2",
     "immediate": "3.0.6",


### PR DESCRIPTION
I have a PR on debug (https://github.com/visionmedia/debug/pull/345) to avoid pulling in the entire [node-process](https://github.com/defunctzombie/node-process) polyfill, but since we're going to do a release soon, let's just use my fork for now.

PouchDB min+gz size before: **45298**
After: **44796** (502 bytes saved)