### PR TITLE
(#5948) - update 6.1.0 blog post slightly

### DIFF
--- a/docs/_posts/2016-12-12-pouchdb-6.1.0.md
+++ b/docs/_posts/2016-12-12-pouchdb-6.1.0.md
@@ -74,7 +74,7 @@ This warning has been removed in 6.1.0 because it caused confusion more often th
 
 Unfortunately npm offers no way to emit a `peerDependency` warning only if _any one of_ possible peers (e.g. `pouchdb-core`, `pouchdb`, `pouchdb-browser`, or `pouchdb-node`) are not installed or have the wrong version, so we removed the `peerDependency` entirely.
 
-If you're wondering how to correctly use PouchDB plugins with core PouchDB packages, the answer is fairly simple: first-party plugins should always have the same version as the other core PouchDB packages. These packages are published at the same time with the same versions, so you just need to be sure to keep them synchronized. For instances:
+If you're wondering how to correctly use PouchDB plugins with core PouchDB packages, the answer is fairly simple: first-party plugins should always have the same version as the other core PouchDB packages. These packages are published at the same time with the same versions, so you just need to be sure to keep them synchronized. For instance:
 
 ```json
 {
@@ -93,7 +93,7 @@ Note that third-party dependencies (such as `pouchdb-find`, `worker-pouch`, and 
 
 ## Smaller code, fewer dependencies
 
-Like any codebase, PouchDB's has accumulated some cruft over time. As part of [an](https://github.com/pouchdb/pouchdb/pull/5930) [effort](https://github.com/pouchdb/pouchdb/pull/5898) [to](https://github.com/pouchdb/pouchdb/pull/5905) [simplify](https://github.com/pouchdb/pouchdb/pull/5899) the codebase, PouchDB 6.1.0 now has one less dependency ([es6-promise-pool](https://github.com/timdp/es6-promise-pool), replaced with a smaller custom implementation) and actually has a slightly smaller bundle size than 6.0.7 (45337 bytes min+gz to 45194).
+Like any codebase, PouchDB's has accumulated some cruft over time. As part of [an](https://github.com/pouchdb/pouchdb/pull/5930) [effort](https://github.com/pouchdb/pouchdb/pull/5898) [to](https://github.com/pouchdb/pouchdb/pull/5905) [simplify](https://github.com/pouchdb/pouchdb/pull/5899) the codebase, PouchDB 6.1.0 now has one less dependency ([es6-promise-pool](https://github.com/timdp/es6-promise-pool), replaced with a smaller custom implementation) and actually has a slightly smaller bundle size than 6.0.7 (45337 bytes min+gz to 45299).
 
 Furthermore, PouchDB's internal timer system has been vastly simplified, relying on the built-in browser `setTimeout()` rather than `process.nextTick()` (thus avoiding [a rather large Browserify/Webpack dependency](https://github.com/defunctzombie/node-process/blob/7d8c3702a8bbc43fa55f4bab74b150aef37001dd/browser.js)), as well as eliminating timeouts entirely where they were found to be unnecessary. This will actually result in a performance boost to most PouchDB operations in terms of latency, since PouchDB is no longer yielding to the event loop so frequently.
 


### PR DESCRIPTION
Looks like something increased the size slightly from the last time I measured, lol. Still smaller tahn 6.0.7 though, and once the `debug` fix is in we'll lose 500 bytes more.