### PR TITLE
(#6002) - remove excessive debug dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "chai-as-promised": "5.3.0",
     "child-process-promise": "2.2.0",
     "cssmin": "0.4.3",
-    "debug": "2.2.0",
     "denodeify": "1.2.1",
     "derequire": "2.0.3",
     "es3ify": "0.2.2",


### PR DESCRIPTION
We have two dependencies on `debug` (a regular dep and a devDep); we only need one.