### PR TITLE
use global-replaceify to avoid process polyfill

### DIFF
--- a/bin/build-pouchdb.js
+++ b/bin/build-pouchdb.js
@@ -129,8 +129,19 @@ function doBrowserify(filepath, opts, exclude) {
             path.dirname(filepath) + '/' + path.basename(filepath));
         });
     } else {
-      bundler = browserify(addPath(filepath), opts)
-        .transform('es3ify')
+      bundler = browserify(addPath(filepath), opts);
+      if (opts.standalone === 'PouchDB') {
+        // Force Browserify to ignore global `process` references, since `debug` pulls this in and
+        // it's large. Only do it for the main PouchDB package, though; for the plugin adapters, they
+        // actually require `process`.
+        bundler.transform('global-replaceify', {
+          replacements: {
+            process: '__process'
+          },
+          global: true
+        });
+      }
+      bundler.transform('es3ify')
         .plugin('bundle-collapser/plugin');
     }
 

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "express-pouchdb": "2.1.1",
     "find-requires": "0.2.2",
     "glob": "7.1.1",
+    "global-replaceify": "^1.0.0",
     "http-server": "0.9.0",
     "istanbul": "0.4.5",
     "istanbul-coveralls": "1.0.3",


### PR DESCRIPTION
I wrote [a simple Browserify transform](https://github.com/nolanlawson/global-replaceify) to replace global variables at build time. Using it to rename `debug`'s usage of `process` to `__process` and thus avoid Browserify pulling in [node-process](https://github.com/defunctzombie/node-process) as a dependency, we get these savings:

- min+gz before: 45297
- min+gz after: 44780 (517 bytes saved)