### PR TITLE
(#6013) - use rollup-plugin-inline-typeof

### DIFF
--- a/bin/build-pouchdb.js
+++ b/bin/build-pouchdb.js
@@ -18,6 +18,7 @@ var browserify = require('browserify');
 var browserifyIncremental = require('browserify-incremental');
 var rollup = require('rollup');
 var nodeResolve = require('rollup-plugin-node-resolve');
+var inlineTypeof = require('rollup-plugin-inline-typeof');
 var replace = require('rollup-plugin-replace');
 var derequire = require('derequire');
 var fs = require('fs');
@@ -154,6 +155,7 @@ function doRollup(entry, browser, formatsToFiles) {
     entry: addPath(entry),
     external: external,
     plugins: [
+      inlineTypeof(),
       nodeResolve({
         skip: external,
         jsnext: true,

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "replace": "0.3.0",
     "rimraf": "2.5.4",
     "rollup": "0.34.13",
+    "rollup-plugin-inline-typeof": "0.1.0",
     "rollup-plugin-node-resolve": "2.0.0",
     "rollup-plugin-replace": "1.1.1",
     "sauce-connect-launcher": "0.17.0",


### PR DESCRIPTION
This adds a new Rollup plugin I wrote that inlines `typeof` invocations (see [the explanation](https://github.com/nolanlawson/rollup-plugin-inline-typeof#why)) for details). This reduces our min+gz size from 45297 to 45261 and our min size from 140561 to 138467 (0.14% smaller, but hey, at least we didn't grow!).

I haven't yet run performance tests to see if this moves the needle on any of our perf tests, but it reduces the bundle size and doesn't add much weight to the build, and furthermore I want to double-check that our tests still pass in Travis. Consider this experimental until it's green and I've run some more perf tests.