### PR TITLE
(#6014) - update memdown to 1.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lie": "3.1.0",
     "localstorage-down": "0.6.7",
     "ltgt": "2.1.2",
-    "memdown": "1.2.2",
+    "memdown": "1.2.4",
     "readable-stream": "1.0.33",
     "request": "2.78.0",
     "scope-eval": "0.0.3",

--- a/tests/integration/test.issue3179.js
+++ b/tests/integration/test.issue3179.js
@@ -134,7 +134,11 @@ adapters.forEach(function (adapters) {
             var conflictsEqual = JSON.stringify(localDoc._conflicts || []) ===
               JSON.stringify(remoteDoc._conflicts || []);
             if (!revsEqual || !conflictsEqual) {
-              return waitForUptodate();
+              // we can get caught in an infinite loop here when using adapters based
+              // on microtasks, e.g. memdown, so use setTimeout() to get a macrotask
+              return new testUtils.Promise(function (resolve) {
+                setTimeout(resolve, 0);
+              }).then(waitForUptodate);
             }
           });
         });
@@ -252,7 +256,11 @@ adapters.forEach(function (adapters) {
             var conflictsEqual = JSON.stringify(localDoc._conflicts || []) ===
               JSON.stringify(remoteDoc._conflicts || []);
             if (!revsEqual || !conflictsEqual) {
-              return waitForUptodate();
+              // we can get caught in an infinite loop here when using adapters based
+              // on microtasks, e.g. memdown, so use setTimeout() to get a macrotask
+              return new testUtils.Promise(function (resolve) {
+                setTimeout(resolve, 0);
+              }).then(waitForUptodate);
             }
           });
         });


### PR DESCRIPTION
Based on some quick performance testing, this seems like it should be a big boost thanks to the nextTick -> immediate change. I can run some benchmarks once we see that it's green.