### PR TITLE
(#6015) - use Map and Set in mapreduce

### DIFF
--- a/packages/node_modules/pouchdb-collections/src/Set.js
+++ b/packages/node_modules/pouchdb-collections/src/Set.js
@@ -16,5 +16,15 @@ Set.prototype.add = function (key) {
 Set.prototype.has = function (key) {
   return this._store.has(key);
 };
+Set.prototype.forEach = function (cb) {
+  this._store.forEach(function (value, key) {
+    cb(key);
+  });
+};
+Object.defineProperty(Set.prototype, 'size', {
+  get: function () {
+    return this._store.size;
+  }
+});
 
 export default Set;

--- a/packages/node_modules/pouchdb-mapreduce-utils/src/index.js
+++ b/packages/node_modules/pouchdb-mapreduce-utils/src/index.js
@@ -1,7 +1,8 @@
 import argsarray from 'argsarray';
 import { nextTick } from 'pouchdb-utils';
+import { Set } from 'pouchdb-collections';
 
-var promisedCallback = function (promise, callback) {
+function promisedCallback(promise, callback) {
   if (callback) {
     promise.then(function (res) {
       nextTick(function () {
@@ -14,9 +15,9 @@ var promisedCallback = function (promise, callback) {
     });
   }
   return promise;
-};
+}
 
-var callbackify = function (fun) {
+function callbackify(fun) {
   return argsarray(function (args) {
     var cb = args.pop();
     var promise = fun.apply(this, args);
@@ -25,10 +26,10 @@ var callbackify = function (fun) {
     }
     return promise;
   });
-};
+}
 
 // Promise finally util similar to Q.finally
-var fin = function (promise, finalPromiseFactory) {
+function fin(promise, finalPromiseFactory) {
   return promise.then(function (res) {
     return finalPromiseFactory().then(function () {
       return res;
@@ -38,9 +39,9 @@ var fin = function (promise, finalPromiseFactory) {
       throw reason;
     });
   });
-};
+}
 
-var sequentialize = function (queue, promiseFactory) {
+function sequentialize(queue, promiseFactory) {
   return function () {
     var args = arguments;
     var that = this;
@@ -48,30 +49,34 @@ var sequentialize = function (queue, promiseFactory) {
       return promiseFactory.apply(that, args);
     });
   };
-};
+}
 
 // uniq an array of strings, order not guaranteed
 // similar to underscore/lodash _.uniq
-var uniq = function (arr) {
-  var map = {};
+function uniq(arr) {
+  var theSet = new Set(arr);
+  var result = new Array(theSet.size);
+  var index = -1;
+  theSet.forEach(function (value) {
+    result[++index] = value;
+  });
+  return result;
+}
 
-  for (var i = 0, len = arr.length; i < len; i++) {
-    map['$' + arr[i]] = true;
-  }
-
-  var keys = Object.keys(map);
-  var output = new Array(keys.length);
-
-  for (i = 0, len = keys.length; i < len; i++) {
-    output[i] = keys[i].substring(1);
-  }
-  return output;
-};
+function mapToKeysArray(map) {
+  var result = new Array(map.size);
+  var index = -1;
+  map.forEach(function (value, key) {
+    result[++index] = key;
+  });
+  return result;
+}
 
 export {
   uniq,
   sequentialize,
   fin,
   callbackify,
-  promisedCallback
+  promisedCallback,
+  mapToKeysArray
 };

--- a/packages/node_modules/pouchdb-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-mapreduce/src/index.js
@@ -23,13 +23,15 @@ import {
   sequentialize,
   uniq,
   fin,
-  promisedCallback
+  promisedCallback,
+  mapToKeysArray
 } from 'pouchdb-mapreduce-utils';
 import {
   QueryParseError,
   NotFoundError,
   BuiltInError
 } from './errors';
+import { Map } from 'pouchdb-collections';
 import Promise from 'pouchdb-promise';
 import sum from './sum';
 
@@ -344,7 +346,7 @@ function defaultsTo(value) {
 function getDocsToPersist(docId, view, docIdsToChangesAndEmits) {
   var metaDocId = '_local/doc_' + docId;
   var defaultMetaDoc = {_id: metaDocId, keys: []};
-  var docData = docIdsToChangesAndEmits[docId];
+  var docData = docIdsToChangesAndEmits.get(docId);
   var indexableKeysToKeyValues = docData.indexableKeysToKeyValues;
   var changes = docData.changes;
 
@@ -423,7 +425,7 @@ function saveKeyValues(view, docIdsToChangesAndEmits, seq) {
   return view.db.get(seqDocId)
   .catch(defaultsTo({_id: seqDocId, seq: 0}))
   .then(function (lastSeqDoc) {
-    var docIds = Object.keys(docIdsToChangesAndEmits);
+    var docIds = mapToKeysArray(docIdsToChangesAndEmits);
     return Promise.all(docIds.map(function (docId) {
       return getDocsToPersist(docId, view, docIdsToChangesAndEmits);
     })).then(function (listOfDocsToPersist) {
@@ -499,7 +501,7 @@ function updateViewInQueue(view) {
       if (!results.length) {
         return;
       }
-      var docIdsToChangesAndEmits = {};
+      var docIdsToChangesAndEmits = new Map();
       for (var i = 0, l = results.length; i < l; i++) {
         var change = results[i];
         if (change.doc._id[0] !== '_') {
@@ -523,10 +525,10 @@ function updateViewInQueue(view) {
             indexableKeysToKeyValues[indexableKey] = obj;
             lastKey = obj.key;
           }
-          docIdsToChangesAndEmits[change.doc._id] = {
+          docIdsToChangesAndEmits.set(change.doc._id, {
             indexableKeysToKeyValues: indexableKeysToKeyValues,
             changes: change.changes
-          };
+          });
         }
         currentSeq = change.seq;
       }
@@ -669,15 +671,13 @@ function queryViewInQueue(view, opts) {
         attachments: opts.attachments,
         binary: opts.binary
       }).then(function (allDocsRes) {
-        var docIdsToDocs = {};
+        var docIdsToDocs = new Map();
         allDocsRes.rows.forEach(function (row) {
-          if (row.doc) {
-            docIdsToDocs['$' + row.id] = row.doc;
-          }
+          docIdsToDocs.set(row.id, row.doc);
         });
         rows.forEach(function (row) {
           var docId = rowToDocId(row);
-          var doc = docIdsToDocs['$' + docId];
+          var doc = docIdsToDocs.get(docId);
           if (doc) {
             row.doc = doc;
           }


### PR DESCRIPTION
Been trying to find ways to improve perf for secondary indexes, this seemed like an obvious change given #5991 showed that the native Map/Set implementations are faster than our shims. Citation needed, but should be a perf boost.  

Rebased on #5991 to avoid bitrotting myself.