### PR TITLE
(#6016) - separate funcs for map vs reduce

### DIFF
--- a/packages/node_modules/pouchdb-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-mapreduce/src/index.js
@@ -61,14 +61,23 @@ function emitError(db, e) {
     guardedConsole('error', e);
   }
 }
-
-function tryCode(db, fun, args) {
-  // emit an event if there was an error thrown by a map/reduce function.
+function tryMap(db, fun, doc) {
+  // emit an event if there was an error thrown by a map function.
   // putting try/catches in a single function also avoids deoptimizations.
   try {
-    return {
-      output : fun.apply(null, args)
-    };
+    fun(doc);
+  } catch (e) {
+    emitError(db, e);
+  }
+}
+
+function tryReduce(db, fun, keys, values, rereduce) {
+  // same as above, but returning the result or an error. there are two separate
+  // functions to avoid extra memory allocations since the tryCode() case is used
+  // for custom map functions (common) vs this function, which is only used for
+  // custom reduce functions (rare)
+  try {
+    return {output : fun(keys, values, rereduce)};
   } catch (e) {
     emitError(db, e);
     return {error: e};
@@ -507,7 +516,7 @@ function updateViewInQueue(view) {
           doc = change.doc;
 
           if (!doc._deleted) {
-            tryCode(view.sourceDB, mapFun, [doc]);
+            tryMap(view.sourceDB, mapFun, doc);
           }
           mapResults.sort(sortByKeyThenValue);
 
@@ -585,8 +594,7 @@ function reduceView(view, results, options) {
   results = [];
   for (var i = 0, len = groups.length; i < len; i++) {
     var e = groups[i];
-    var reduceTry = tryCode(view.sourceDB, reduceFun,
-      [e.keys, e.values, false]);
+    var reduceTry = tryReduce(view.sourceDB, reduceFun, e.keys, e.values, false);
     if (reduceTry.error && reduceTry.error instanceof BuiltInError) {
       // CouchDB returns an error if a built-in errors out
       throw reduceTry.error;


### PR DESCRIPTION
This is another function that showed up as a major offender in terms of unnecessary memory allocations. But given that we only need to allocate new memory during the custom reduce functions (which are rarer than the custom map functions), this is a fairly easy fix.