### PR TITLE
(#6017) - fix typo in changes.js

### DIFF
--- a/packages/node_modules/pouchdb-core/src/changes.js
+++ b/packages/node_modules/pouchdb-core/src/changes.js
@@ -65,7 +65,7 @@ function Changes(db, opts, callback) {
 
   opts.onChange = function (change) {
     /* istanbul ignore if */
-    if (opts.isCancelled) {
+    if (self.isCancelled) {
       return;
     }
     tryCatchInChangeListener(self, change);


### PR DESCRIPTION
This is untested, but it's almost certainly a typo. `opts.isCancelled` is never defined anywhere.