### PR TITLE
(#6023) - travis: fail if Node 6 fails, test in Node 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "5"
+  - "6"
 
 services:
   - docker
@@ -116,7 +116,7 @@ matrix:
     - node_js: "4"
       services: docker
       env: CLIENT=node COMMAND=test
-    - node_js: "stable"
+    - node_js: "7"
       services: docker
       env: CLIENT=node COMMAND=test
   allow_failures:
@@ -124,7 +124,7 @@ matrix:
   - env: COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:47.0.2 SERVER=couchdb-master COMMAND=test
   - env: CLIENT=selenium:firefox:47.0.2 PERF=1 COMMAND=test
   - env: CLIENT=selenium:firefox:47.0.2 NEXT=1 COMMAND=test
-  - node_js: "stable"
+  - node_js: "7"
     services: docker
     env: CLIENT=node COMMAND=test
 


### PR DESCRIPTION
Node 6 has been passing for awhile, so we can remove it from the "allowed failures." However it may be a good idea to start look at Node 7 and see if we are passing in that version or not. Node 4 is LTS and so I left it in.

I avoided terms like `stable` because I'm not a fan of rolling versions; I prefer to nail these down as we currently do for most browsers we test.