### PR TITLE
WIP - (#6031) - faster IDB changes() using getAll()

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
@@ -27,7 +27,9 @@ import {
   openTransactionSafely
 } from './utils';
 
-function idbBulkDocs(dbOpts, req, opts, api, idb, idbChanges, callback) {
+import changesHandler from './changesHandler';
+
+function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
   var docInfos = req.docs;
   var txn;
   var docStore;
@@ -137,7 +139,7 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, idbChanges, callback) {
       return;
     }
 
-    idbChanges.notify(api._meta.name);
+    changesHandler.notify(api._meta.name);
     api._meta.docCount += docCountDelta;
     callback(null, results);
   }

--- a/packages/node_modules/pouchdb-adapter-idb/src/changes.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/changes.js
@@ -1,0 +1,354 @@
+import changesHandler from './changesHandler';
+import {
+  clone,
+  filterChange,
+  uuid
+} from 'pouchdb-utils';
+import {
+  Map,
+  Set
+} from 'pouchdb-collections';
+import {
+  ATTACH_STORE,
+  BY_SEQ_STORE,
+  DOC_STORE
+} from './constants';
+import {
+  decodeDoc,
+  decodeMetadata,
+  fetchAttachmentsIfNecessary,
+  idbError,
+  postProcessAttachments,
+  openTransactionSafely
+} from './utils';
+
+var numSlow = 0;
+var numFast = 0;
+
+// If the changes() query is complex enough or the browser doesn't
+// support getAll(), we do this slower, cursor-based method
+function doSlowCursorBasedChanges(txn, bySeqStore, docStore, docIdRevIndex,
+                              lastSeq, limit, docIds, returnDocs, opts, onComplete) {
+
+  var numResults = 0;
+  var filter = filterChange(opts);
+  var docIdsToMetadata = new Map();
+  var results = [];
+
+  function onTxnComplete() {
+    console.log('numSlow', ++numSlow);
+    onComplete(lastSeq, results);
+  }
+
+  function onGetCursor(cursor) {
+
+    var doc = decodeDoc(cursor.value);
+    var seq = cursor.key;
+
+    if (docIds && !docIds.has(doc._id)) {
+      return cursor.continue();
+    }
+
+    var metadata;
+
+    function onGetMetadata() {
+      if (metadata.seq !== seq) {
+        // some other seq is later
+        return cursor.continue();
+      }
+
+      lastSeq = seq;
+
+      if (metadata.winningRev === doc._rev) {
+        return onGetWinningDoc(doc);
+      }
+
+      fetchWinningDoc();
+    }
+
+    function fetchWinningDoc() {
+      var docIdRev = doc._id + '::' + metadata.winningRev;
+      var req = docIdRevIndex.get(docIdRev);
+      req.onsuccess = function (e) {
+        onGetWinningDoc(decodeDoc(e.target.result));
+      };
+    }
+
+    function onGetWinningDoc(winningDoc) {
+
+      var change = opts.processChange(winningDoc, metadata, opts);
+      change.seq = metadata.seq;
+
+      var filtered = filter(change);
+      if (typeof filtered === 'object') {
+        return opts.complete(filtered);
+      }
+
+      if (filtered) {
+        numResults++;
+        if (returnDocs) {
+          results.push(change);
+        }
+        // process the attachment immediately
+        // for the benefit of live listeners
+        if (opts.attachments && opts.include_docs) {
+          fetchAttachmentsIfNecessary(winningDoc, opts, txn, function () {
+            postProcessAttachments([change], opts.binary).then(function () {
+              opts.onChange(change);
+            });
+          });
+        } else {
+          opts.onChange(change);
+        }
+      }
+      if (numResults !== limit) {
+        cursor.continue();
+      }
+    }
+
+    metadata = docIdsToMetadata.get(doc._id);
+    if (metadata) { // cached
+      return onGetMetadata();
+    }
+    // metadata not cached, have to go fetch it
+    docStore.get(doc._id).onsuccess = function (event) {
+      metadata = decodeMetadata(event.target.result);
+      docIdsToMetadata.set(doc._id, metadata);
+      onGetMetadata();
+    };
+  }
+
+  function onsuccess(event) {
+    var cursor = event.target.result;
+
+    if (!cursor) {
+      return;
+    }
+    onGetCursor(cursor);
+  }
+
+  txn.oncomplete = onTxnComplete;
+
+  var req;
+
+  if (opts.descending) {
+    req = bySeqStore.openCursor(null, 'prev');
+  } else {
+    req = bySeqStore.openCursor(IDBKeyRange.lowerBound(opts.since, true));
+  }
+
+  req.onsuccess = onsuccess;
+
+}
+
+// Use this faster method in browsers that support getAll() and when the query is not too complex
+function doFastBulkChanges(txn, bySeqStore, docStore, docIdRevIndex,
+                         lastSeq, limit, docIds, returnDocs, opts, onComplete) {
+
+  var docIdsToMetadata = new Map();
+  var filter = filterChange(opts);
+  var results = [];
+  var allSeqs;
+  var allDocs;
+  var bailedOut;
+
+  var range = IDBKeyRange.lowerBound(opts.since, true);
+  var getAllKeysReq;
+  var getAllReq;
+  if (limit < 0) {
+    // if the limit is -1 then don't pass it to getAll()/getAllKeys()
+    getAllKeysReq = bySeqStore.getAllKeys(range);
+    getAllReq = bySeqStore.getAll(range);
+  } else {
+    getAllKeysReq = bySeqStore.getAllKeys(range, limit);
+    getAllReq = bySeqStore.getAll(range, limit);
+  }
+
+  function bailOut() {
+    // In the case where we encounter some state that we can't handle
+    // (e.g. a later winning seq than the current seq, a document whose winner
+    // is not the current doc), then bail out and do the slower cursor-based changes.
+    // The idea is that the vast, vast majority of cases do not exhibit these rare
+    // characteristics and thus on the whole we will usually do the fast route rather than
+    // the slow route.
+    doSlowCursorBasedChanges(txn, bySeqStore, docStore, docIdRevIndex,
+      lastSeq, limit, docIds, returnDocs, opts, onComplete);
+  }
+
+  function onGetAllKeys(event) {
+    allSeqs = event.target.result;
+    if (allSeqs && allDocs) {
+      onGetAllKeysAndGetAll();
+    }
+  }
+
+  function onGetAll(event) {
+    allDocs = event.target.result;
+    if (allSeqs && allDocs) {
+      onGetAllKeysAndGetAll();
+    }
+  }
+
+  function onGetAllKeysAndGetAll() {
+    if (allSeqs.length) {
+      lastSeq = Math.max.apply(null, allSeqs);
+    }
+    allDocs.forEach(function (rawDoc, i) {
+      if (bailedOut) {
+        return;
+      }
+      var doc = decodeDoc(rawDoc);
+      var seq = allSeqs[i];
+      var metadata;
+
+      function onGetMetadata() {
+        if (metadata.seq === seq && metadata.winningRev === doc._rev) {
+          onGetWinningDoc(doc);
+        } else if (!bailedOut) {
+          bailedOut = true;
+          bailOut();
+        }
+      }
+
+      function onGetWinningDoc(winningDoc) {
+        var change = opts.processChange(winningDoc, metadata, opts);
+        change.seq = metadata.seq;
+
+        // somewhat confusingly, we still need to call this even if opts.filter is undefined
+        // because this removes change.doc if include_docs is false and removes attachments
+        // if include_attachments is false
+        filter(change);
+
+        if (returnDocs) {
+          results.push(change);
+        }
+        // process the attachment immediately
+        // for the benefit of live listeners
+        if (opts.attachments && opts.include_docs) {
+          fetchAttachmentsIfNecessary(winningDoc, opts, txn, function () {
+            postProcessAttachments([change], opts.binary).then(function () {
+              opts.onChange(change);
+            });
+          });
+        } else {
+          opts.onChange(change);
+        }
+      }
+
+      metadata = docIdsToMetadata.get(doc._id);
+      if (metadata) { // cached
+        return onGetMetadata();
+      }
+      // metadata not cached, have to go fetch it
+      docStore.get(doc._id).onsuccess = function (event) {
+        metadata = decodeMetadata(event.target.result);
+        docIdsToMetadata.set(doc._id, metadata);
+        onGetMetadata();
+      };
+
+    });
+
+  }
+
+  function onTxnComplete() {
+    if (bailedOut) {
+      return;
+    }
+    console.log('numFast', ++numFast);
+    onComplete(lastSeq, results);
+  }
+
+  txn.oncomplete = onTxnComplete;
+
+  getAllReq.onsuccess = onGetAll;
+  getAllKeysReq.onsuccess = onGetAllKeys;
+}
+
+
+function changes(opts, api, dbName, idb) {
+  opts = clone(opts);
+
+  if (opts.continuous) {
+    var id = dbName + ':' + uuid();
+    changesHandler.addListener(dbName, id, api, opts);
+    changesHandler.notify(dbName);
+    return {
+      cancel: function () {
+        changesHandler.removeListener(dbName, id);
+      }
+    };
+  }
+
+  var docIds = opts.doc_ids && new Set(opts.doc_ids);
+
+  opts.since = opts.since || 0;
+  var lastSeq = opts.since;
+
+  var limit = 'limit' in opts ? opts.limit : -1;
+  if (limit === 0) {
+    limit = 1; // per CouchDB _changes spec
+  }
+  var returnDocs;
+  if ('return_docs' in opts) {
+    returnDocs = opts.return_docs;
+  } else if ('returnDocs' in opts) {
+    // TODO: Remove 'returnDocs' in favor of 'return_docs' in a future release
+    returnDocs = opts.returnDocs;
+  } else {
+    returnDocs = true;
+  }
+
+  function onComplete(newLastSeq, results) {
+    function finish() {
+      opts.complete(null, {
+        results: results,
+        last_seq: newLastSeq
+      });
+    }
+
+    if (!opts.continuous && opts.attachments) {
+      // cannot guarantee that postProcessing was already done,
+      // so do it again
+      postProcessAttachments(results).then(finish);
+    } else {
+      finish();
+    }
+  }
+
+  var objectStores = [DOC_STORE, BY_SEQ_STORE];
+  if (opts.attachments) {
+    objectStores.push(ATTACH_STORE);
+  }
+  var txnResult = openTransactionSafely(idb, objectStores, 'readonly');
+  if (txnResult.error) {
+    return opts.complete(txnResult.error);
+  }
+  var txn = txnResult.txn;
+  var bySeqStore = txn.objectStore(BY_SEQ_STORE);
+  var docStore = txn.objectStore(DOC_STORE);
+  var docIdRevIndex = bySeqStore.index('_doc_id_rev');
+  txn.onabort = idbError(opts.complete);
+
+  // Prefer the fast route, fall back to the slow route as necessary.
+  // The way the getAll() method works is by assuming that, for most queries, we can
+  // simply fetch the first `limit` documents with `doc.seq >= seq`. The only cases where
+  // this doesn't work are:
+  // 1) filters like opts.filter and opts.doc_ids, since those require us to run some JavaScript
+  //    on each doc to ensure it matches the filter
+  // 2) opts.descending, because there's no way to do getAll() in descending order
+  // 3) browsers that don't support getAll() or getAllKeys()
+  // However for cases where we can do the fast path (e.g. secondary indexes), it's preferred to
+  // do it this way because it's much faster than the stair-step IDBCursor approach.
+
+  if (!opts.filter && !docIds && !opts.descending &&
+      typeof docStore.getAll === 'function' && typeof docStore.getAllKeys === 'function') {
+    doFastBulkChanges(txn, bySeqStore, docStore, docIdRevIndex,
+        lastSeq, limit, docIds, returnDocs, opts, onComplete);
+  } else {
+    doSlowCursorBasedChanges(txn, bySeqStore, docStore, docIdRevIndex,
+      lastSeq, limit, docIds, returnDocs, opts, onComplete);
+  }
+
+}
+
+export default changes;

--- a/packages/node_modules/pouchdb-adapter-idb/src/changesHandler.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/changesHandler.js
@@ -1,0 +1,2 @@
+import { changesHandler as Changes } from 'pouchdb-utils';
+export default new Changes();

--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -1,10 +1,7 @@
 import {
-  clone,
-  filterChange,
   guardedConsole,
   toPromise,
   hasLocalStorage,
-  changesHandler as Changes,
   uuid,
   nextTick
 } from 'pouchdb-utils';
@@ -16,7 +13,7 @@ import {
   latest as getLatest
 } from 'pouchdb-merge';
 
-import { Map, Set } from 'pouchdb-collections';
+import { Map } from 'pouchdb-collections';
 import idbBulkDocs from './bulkDocs';
 import idbAllDocs from './allDocs';
 import checkBlobSupport from './blobSupport';
@@ -44,18 +41,18 @@ import {
   decodeDoc,
   decodeMetadata,
   encodeMetadata,
-  fetchAttachmentsIfNecessary,
   idbError,
-  postProcessAttachments,
   readBlobData,
   openTransactionSafely
 } from './utils';
 
 import { enqueueTask } from './taskQueue';
 
+import changesHandler from './changesHandler';
+import changes from './changes';
+
 var cachedDBs = new Map();
 var blobSupportPromise;
-var idbChanges = new Changes();
 var openReqList = new Map();
 
 function IdbPouch(opts, callback) {
@@ -302,7 +299,7 @@ function init(api, opts, callback) {
   });
 
   api._bulkDocs = function idb_bulkDocs(req, reqOpts, callback) {
-    idbBulkDocs(opts, req, reqOpts, api, idb, idbChanges, callback);
+    idbBulkDocs(opts, req, reqOpts, api, idb, callback);
   };
 
   // First we look up the metadata in the ids database, then we fetch the
@@ -426,183 +423,8 @@ function init(api, opts, callback) {
     idbAllDocs(opts, api, idb, callback);
   };
 
-  api._changes = function (opts) {
-    opts = clone(opts);
-
-    if (opts.continuous) {
-      var id = dbName + ':' + uuid();
-      idbChanges.addListener(dbName, id, api, opts);
-      idbChanges.notify(dbName);
-      return {
-        cancel: function () {
-          idbChanges.removeListener(dbName, id);
-        }
-      };
-    }
-
-    var docIds = opts.doc_ids && new Set(opts.doc_ids);
-
-    opts.since = opts.since || 0;
-    var lastSeq = opts.since;
-
-    var limit = 'limit' in opts ? opts.limit : -1;
-    if (limit === 0) {
-      limit = 1; // per CouchDB _changes spec
-    }
-    var returnDocs;
-    if ('return_docs' in opts) {
-      returnDocs = opts.return_docs;
-    } else if ('returnDocs' in opts) {
-      // TODO: Remove 'returnDocs' in favor of 'return_docs' in a future release
-      returnDocs = opts.returnDocs;
-    } else {
-      returnDocs = true;
-    }
-
-    var results = [];
-    var numResults = 0;
-    var filter = filterChange(opts);
-    var docIdsToMetadata = new Map();
-
-    var txn;
-    var bySeqStore;
-    var docStore;
-    var docIdRevIndex;
-
-    function onGetCursor(cursor) {
-
-      var doc = decodeDoc(cursor.value);
-      var seq = cursor.key;
-
-      if (docIds && !docIds.has(doc._id)) {
-        return cursor.continue();
-      }
-
-      var metadata;
-
-      function onGetMetadata() {
-        if (metadata.seq !== seq) {
-          // some other seq is later
-          return cursor.continue();
-        }
-
-        lastSeq = seq;
-
-        if (metadata.winningRev === doc._rev) {
-          return onGetWinningDoc(doc);
-        }
-
-        fetchWinningDoc();
-      }
-
-      function fetchWinningDoc() {
-        var docIdRev = doc._id + '::' + metadata.winningRev;
-        var req = docIdRevIndex.get(docIdRev);
-        req.onsuccess = function (e) {
-          onGetWinningDoc(decodeDoc(e.target.result));
-        };
-      }
-
-      function onGetWinningDoc(winningDoc) {
-
-        var change = opts.processChange(winningDoc, metadata, opts);
-        change.seq = metadata.seq;
-
-        var filtered = filter(change);
-        if (typeof filtered === 'object') {
-          return opts.complete(filtered);
-        }
-
-        if (filtered) {
-          numResults++;
-          if (returnDocs) {
-            results.push(change);
-          }
-          // process the attachment immediately
-          // for the benefit of live listeners
-          if (opts.attachments && opts.include_docs) {
-            fetchAttachmentsIfNecessary(winningDoc, opts, txn, function () {
-              postProcessAttachments([change], opts.binary).then(function () {
-                opts.onChange(change);
-              });
-            });
-          } else {
-            opts.onChange(change);
-          }
-        }
-        if (numResults !== limit) {
-          cursor.continue();
-        }
-      }
-
-      metadata = docIdsToMetadata.get(doc._id);
-      if (metadata) { // cached
-        return onGetMetadata();
-      }
-      // metadata not cached, have to go fetch it
-      docStore.get(doc._id).onsuccess = function (event) {
-        metadata = decodeMetadata(event.target.result);
-        docIdsToMetadata.set(doc._id, metadata);
-        onGetMetadata();
-      };
-    }
-
-    function onsuccess(event) {
-      var cursor = event.target.result;
-
-      if (!cursor) {
-        return;
-      }
-      onGetCursor(cursor);
-    }
-
-    function fetchChanges() {
-      var objectStores = [DOC_STORE, BY_SEQ_STORE];
-      if (opts.attachments) {
-        objectStores.push(ATTACH_STORE);
-      }
-      var txnResult = openTransactionSafely(idb, objectStores, 'readonly');
-      if (txnResult.error) {
-        return opts.complete(txnResult.error);
-      }
-      txn = txnResult.txn;
-      txn.onabort = idbError(opts.complete);
-      txn.oncomplete = onTxnComplete;
-
-      bySeqStore = txn.objectStore(BY_SEQ_STORE);
-      docStore = txn.objectStore(DOC_STORE);
-      docIdRevIndex = bySeqStore.index('_doc_id_rev');
-
-      var req;
-
-      if (opts.descending) {
-        req = bySeqStore.openCursor(null, 'prev');
-      } else {
-        req = bySeqStore.openCursor(IDBKeyRange.lowerBound(opts.since, true));
-      }
-
-      req.onsuccess = onsuccess;
-    }
-
-    fetchChanges();
-
-    function onTxnComplete() {
-
-      function finish() {
-        opts.complete(null, {
-          results: results,
-          last_seq: lastSeq
-        });
-      }
-
-      if (!opts.continuous && opts.attachments) {
-        // cannot guarantee that postProcessing was already done,
-        // so do it again
-        postProcessAttachments(results).then(finish);
-      } else {
-        finish();
-      }
-    }
+  api._changes = function idbChanges(opts) {
+    changes(opts, api, dbName, idb);
   };
 
   api._close = function (callback) {
@@ -799,7 +621,7 @@ function init(api, opts, callback) {
   };
 
   api._destroy = function (opts, callback) {
-    idbChanges.removeAllListeners(dbName);
+    changesHandler.removeAllListeners(dbName);
 
     //Close open request for "dbName" database to fix ie delay.
     var openReq = openReqList.get(dbName);


### PR DESCRIPTION
I've been trying to find ways to improve the performance of secondary indexes. Obviously we'd rather go with native secondary indexes, but that may be a ways off, and I think there are ways we can at least stop the bleeding for current slow paths in secondary indexes.

From profiling, I noticed that a large amount of time is spent using `IDBCursor`s in our IDB `changes()` implementation. Cursors are slow because we effectively do a stair-step pattern pulling in all `changes()` (e.g. the first 50 changes after `seq` 2), applying filters and limits and checking `doc_ids` and checking that the document is the winning doc and checking that the sequence is the winning sequence, etc. We do this using cursors because the filters often need to be applied in JavaScript and then checked against the `limit` to ensure we return exactly the right results in exactly the right order.

However, for the vast majority of cases (and for the cases that affect secondary indexes), the `changes()` queries are rather simple, and can essentially be expressed as "fetch all documents with `doc.seq >= seq` and with limit `limit` for the given `seq` and `limit`". If none of the documents have later `seq`s (e.g. in the rare case of a non-winning document being replicated after a winning document), then this query is all we need, and can get done with two simple IDB operations: `getAll()` and `getAllKeys()` (for browsers that support it, currently Chrome and Firefox but Safari is implementing it as well and it's under consideration for Edge).

So my technique is to write a separate `changes()` implementation that uses the "fast" strategy, and then we fall back to the old "slow" strategy whenever necessary. Running the mapreduce and integration tests, I found that the fast path was hit 6587 times and the slow path was hit 545 times, so 92% of the time we're using the fast option (in Firefox/Chrome anyway).

Furthermore this has a huge impact on our perf. Using the `temp-views` test (which is a good proxy for intense secondary index usage), I got the following improvement (10 iterations):

| | Before | After | Improvement |
| ---- | --- | --- | --- |
| Chrome 55 | 100185ms | 47574ms | 52.5% |
| Firefox 50 | 96430ms | 61164ms | 35.6% |