### PR TITLE
(#6031) - faster IDB changes() with batched cursor

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
@@ -27,7 +27,9 @@ import {
   openTransactionSafely
 } from './utils';
 
-function idbBulkDocs(dbOpts, req, opts, api, idb, idbChanges, callback) {
+import changesHandler from './changesHandler';
+
+function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
   var docInfos = req.docs;
   var txn;
   var docStore;
@@ -137,7 +139,7 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, idbChanges, callback) {
       return;
     }
 
-    idbChanges.notify(api._meta.name);
+    changesHandler.notify(api._meta.name);
     api._meta.docCount += docCountDelta;
     callback(null, results);
   }

--- a/packages/node_modules/pouchdb-adapter-idb/src/changes.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/changes.js
@@ -1,0 +1,212 @@
+import changesHandler from './changesHandler';
+import {
+  clone,
+  filterChange,
+  uuid
+} from 'pouchdb-utils';
+import {
+  Map,
+  Set
+} from 'pouchdb-collections';
+import {
+  ATTACH_STORE,
+  BY_SEQ_STORE,
+  DOC_STORE
+} from './constants';
+import {
+  decodeDoc,
+  decodeMetadata,
+  fetchAttachmentsIfNecessary,
+  idbError,
+  postProcessAttachments,
+  openTransactionSafely
+} from './utils';
+import runBatchedCursor from './runBatchedCursor';
+
+function changes(opts, api, dbName, idb) {
+  opts = clone(opts);
+
+  if (opts.continuous) {
+    var id = dbName + ':' + uuid();
+    changesHandler.addListener(dbName, id, api, opts);
+    changesHandler.notify(dbName);
+    return {
+      cancel: function () {
+        changesHandler.removeListener(dbName, id);
+      }
+    };
+  }
+
+  var docIds = opts.doc_ids && new Set(opts.doc_ids);
+
+  opts.since = opts.since || 0;
+  var lastSeq = opts.since;
+
+  var limit = 'limit' in opts ? opts.limit : -1;
+  if (limit === 0) {
+    limit = 1; // per CouchDB _changes spec
+  }
+  var returnDocs;
+  if ('return_docs' in opts) {
+    returnDocs = opts.return_docs;
+  } else if ('returnDocs' in opts) {
+    // TODO: Remove 'returnDocs' in favor of 'return_docs' in a future release
+    returnDocs = opts.returnDocs;
+  } else {
+    returnDocs = true;
+  }
+
+  var results = [];
+  var numResults = 0;
+  var filter = filterChange(opts);
+  var docIdsToMetadata = new Map();
+
+  var txn;
+  var bySeqStore;
+  var docStore;
+  var docIdRevIndex;
+
+  function onBatch(batchKeys, batchValues, cursor) {
+    if (!cursor || !batchKeys.length) { // done
+      return;
+    }
+
+    var winningDocs = new Array(batchKeys.length);
+    var metadatas = new Array(batchKeys.length);
+
+    function processMetadataAndWinningDoc(metadata, winningDoc) {
+      var change = opts.processChange(winningDoc, metadata, opts);
+      lastSeq = change.seq = metadata.seq;
+
+      var filtered = filter(change);
+      if (typeof filtered === 'object') { // anything but true/false indicates error
+        return opts.complete(filtered);
+      }
+
+      if (filtered) {
+        numResults++;
+        if (returnDocs) {
+          results.push(change);
+        }
+        // process the attachment immediately
+        // for the benefit of live listeners
+        if (opts.attachments && opts.include_docs) {
+          fetchAttachmentsIfNecessary(winningDoc, opts, txn, function () {
+            postProcessAttachments([change], opts.binary).then(function () {
+              opts.onChange(change);
+            });
+          });
+        } else {
+          opts.onChange(change);
+        }
+      }
+    }
+
+    function onBatchDone() {
+      for (var i = 0, len = winningDocs.length; i < len; i++) {
+        if (numResults === limit) {
+          break;
+        }
+        var winningDoc = winningDocs[i];
+        if (!winningDoc) {
+          continue;
+        }
+        var metadata = metadatas[i];
+        processMetadataAndWinningDoc(metadata, winningDoc);
+      }
+
+      if (numResults !== limit) {
+        cursor.continue();
+      }
+    }
+
+    // Fetch all metadatas/winningdocs from this batch in parallel, then process
+    // them all only once all data has been collected. This is done in parallel
+    // because it's faster than doing it one-at-a-time.
+    var numDone = 0;
+    batchValues.forEach(function (value, i) {
+      var doc = decodeDoc(value);
+      var seq = batchKeys[i];
+      fetchWinningDocAndMetadata(doc, seq, function (metadata, winningDoc) {
+        metadatas[i] = metadata;
+        winningDocs[i] = winningDoc;
+        if (++numDone === batchKeys.length) {
+          onBatchDone();
+        }
+      });
+    });
+  }
+
+  function onGetMetadata(doc, seq, metadata, cb) {
+    if (metadata.seq !== seq) {
+      // some other seq is later
+      return cb();
+    }
+
+    if (metadata.winningRev === doc._rev) {
+      // this is the winning doc
+      return cb(metadata, doc);
+    }
+
+    // fetch winning doc in separate request
+    var docIdRev = doc._id + '::' + metadata.winningRev;
+    var req = docIdRevIndex.get(docIdRev);
+    req.onsuccess = function (e) {
+      cb(metadata, decodeDoc(e.target.result));
+    };
+  }
+
+  function fetchWinningDocAndMetadata(doc, seq, cb) {
+    if (docIds && !docIds.has(doc._id)) {
+      return cb();
+    }
+
+    var metadata = docIdsToMetadata.get(doc._id);
+    if (metadata) { // cached
+      return onGetMetadata(doc, seq, metadata, cb);
+    }
+    // metadata not cached, have to go fetch it
+    docStore.get(doc._id).onsuccess = function (e) {
+      metadata = decodeMetadata(e.target.result);
+      docIdsToMetadata.set(doc._id, metadata);
+      onGetMetadata(doc, seq, metadata, cb);
+    };
+  }
+
+  function finish() {
+    opts.complete(null, {
+      results: results,
+      last_seq: lastSeq
+    });
+  }
+
+  function onTxnComplete() {
+    if (!opts.continuous && opts.attachments) {
+      // cannot guarantee that postProcessing was already done,
+      // so do it again
+      postProcessAttachments(results).then(finish);
+    } else {
+      finish();
+    }
+  }
+
+  var objectStores = [DOC_STORE, BY_SEQ_STORE];
+  if (opts.attachments) {
+    objectStores.push(ATTACH_STORE);
+  }
+  var txnResult = openTransactionSafely(idb, objectStores, 'readonly');
+  if (txnResult.error) {
+    return opts.complete(txnResult.error);
+  }
+  txn = txnResult.txn;
+  txn.onabort = idbError(opts.complete);
+  txn.oncomplete = onTxnComplete;
+
+  bySeqStore = txn.objectStore(BY_SEQ_STORE);
+  docStore = txn.objectStore(DOC_STORE);
+  docIdRevIndex = bySeqStore.index('_doc_id_rev');
+
+  runBatchedCursor(bySeqStore, opts.since, opts.descending, limit, onBatch);
+}
+
+export default changes;

--- a/packages/node_modules/pouchdb-adapter-idb/src/changesHandler.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/changesHandler.js
@@ -1,0 +1,2 @@
+import { changesHandler as Changes } from 'pouchdb-utils';
+export default new Changes();

--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -1,10 +1,7 @@
 import {
-  clone,
-  filterChange,
   guardedConsole,
   toPromise,
   hasLocalStorage,
-  changesHandler as Changes,
   uuid,
   nextTick
 } from 'pouchdb-utils';
@@ -16,7 +13,7 @@ import {
   latest as getLatest
 } from 'pouchdb-merge';
 
-import { Map, Set } from 'pouchdb-collections';
+import { Map } from 'pouchdb-collections';
 import idbBulkDocs from './bulkDocs';
 import idbAllDocs from './allDocs';
 import checkBlobSupport from './blobSupport';
@@ -44,18 +41,18 @@ import {
   decodeDoc,
   decodeMetadata,
   encodeMetadata,
-  fetchAttachmentsIfNecessary,
   idbError,
-  postProcessAttachments,
   readBlobData,
   openTransactionSafely
 } from './utils';
 
 import { enqueueTask } from './taskQueue';
 
+import changesHandler from './changesHandler';
+import changes from './changes';
+
 var cachedDBs = new Map();
 var blobSupportPromise;
-var idbChanges = new Changes();
 var openReqList = new Map();
 
 function IdbPouch(opts, callback) {
@@ -302,7 +299,7 @@ function init(api, opts, callback) {
   });
 
   api._bulkDocs = function idb_bulkDocs(req, reqOpts, callback) {
-    idbBulkDocs(opts, req, reqOpts, api, idb, idbChanges, callback);
+    idbBulkDocs(opts, req, reqOpts, api, idb, callback);
   };
 
   // First we look up the metadata in the ids database, then we fetch the
@@ -426,183 +423,8 @@ function init(api, opts, callback) {
     idbAllDocs(opts, api, idb, callback);
   };
 
-  api._changes = function (opts) {
-    opts = clone(opts);
-
-    if (opts.continuous) {
-      var id = dbName + ':' + uuid();
-      idbChanges.addListener(dbName, id, api, opts);
-      idbChanges.notify(dbName);
-      return {
-        cancel: function () {
-          idbChanges.removeListener(dbName, id);
-        }
-      };
-    }
-
-    var docIds = opts.doc_ids && new Set(opts.doc_ids);
-
-    opts.since = opts.since || 0;
-    var lastSeq = opts.since;
-
-    var limit = 'limit' in opts ? opts.limit : -1;
-    if (limit === 0) {
-      limit = 1; // per CouchDB _changes spec
-    }
-    var returnDocs;
-    if ('return_docs' in opts) {
-      returnDocs = opts.return_docs;
-    } else if ('returnDocs' in opts) {
-      // TODO: Remove 'returnDocs' in favor of 'return_docs' in a future release
-      returnDocs = opts.returnDocs;
-    } else {
-      returnDocs = true;
-    }
-
-    var results = [];
-    var numResults = 0;
-    var filter = filterChange(opts);
-    var docIdsToMetadata = new Map();
-
-    var txn;
-    var bySeqStore;
-    var docStore;
-    var docIdRevIndex;
-
-    function onGetCursor(cursor) {
-
-      var doc = decodeDoc(cursor.value);
-      var seq = cursor.key;
-
-      if (docIds && !docIds.has(doc._id)) {
-        return cursor.continue();
-      }
-
-      var metadata;
-
-      function onGetMetadata() {
-        if (metadata.seq !== seq) {
-          // some other seq is later
-          return cursor.continue();
-        }
-
-        lastSeq = seq;
-
-        if (metadata.winningRev === doc._rev) {
-          return onGetWinningDoc(doc);
-        }
-
-        fetchWinningDoc();
-      }
-
-      function fetchWinningDoc() {
-        var docIdRev = doc._id + '::' + metadata.winningRev;
-        var req = docIdRevIndex.get(docIdRev);
-        req.onsuccess = function (e) {
-          onGetWinningDoc(decodeDoc(e.target.result));
-        };
-      }
-
-      function onGetWinningDoc(winningDoc) {
-
-        var change = opts.processChange(winningDoc, metadata, opts);
-        change.seq = metadata.seq;
-
-        var filtered = filter(change);
-        if (typeof filtered === 'object') {
-          return opts.complete(filtered);
-        }
-
-        if (filtered) {
-          numResults++;
-          if (returnDocs) {
-            results.push(change);
-          }
-          // process the attachment immediately
-          // for the benefit of live listeners
-          if (opts.attachments && opts.include_docs) {
-            fetchAttachmentsIfNecessary(winningDoc, opts, txn, function () {
-              postProcessAttachments([change], opts.binary).then(function () {
-                opts.onChange(change);
-              });
-            });
-          } else {
-            opts.onChange(change);
-          }
-        }
-        if (numResults !== limit) {
-          cursor.continue();
-        }
-      }
-
-      metadata = docIdsToMetadata.get(doc._id);
-      if (metadata) { // cached
-        return onGetMetadata();
-      }
-      // metadata not cached, have to go fetch it
-      docStore.get(doc._id).onsuccess = function (event) {
-        metadata = decodeMetadata(event.target.result);
-        docIdsToMetadata.set(doc._id, metadata);
-        onGetMetadata();
-      };
-    }
-
-    function onsuccess(event) {
-      var cursor = event.target.result;
-
-      if (!cursor) {
-        return;
-      }
-      onGetCursor(cursor);
-    }
-
-    function fetchChanges() {
-      var objectStores = [DOC_STORE, BY_SEQ_STORE];
-      if (opts.attachments) {
-        objectStores.push(ATTACH_STORE);
-      }
-      var txnResult = openTransactionSafely(idb, objectStores, 'readonly');
-      if (txnResult.error) {
-        return opts.complete(txnResult.error);
-      }
-      txn = txnResult.txn;
-      txn.onabort = idbError(opts.complete);
-      txn.oncomplete = onTxnComplete;
-
-      bySeqStore = txn.objectStore(BY_SEQ_STORE);
-      docStore = txn.objectStore(DOC_STORE);
-      docIdRevIndex = bySeqStore.index('_doc_id_rev');
-
-      var req;
-
-      if (opts.descending) {
-        req = bySeqStore.openCursor(null, 'prev');
-      } else {
-        req = bySeqStore.openCursor(IDBKeyRange.lowerBound(opts.since, true));
-      }
-
-      req.onsuccess = onsuccess;
-    }
-
-    fetchChanges();
-
-    function onTxnComplete() {
-
-      function finish() {
-        opts.complete(null, {
-          results: results,
-          last_seq: lastSeq
-        });
-      }
-
-      if (!opts.continuous && opts.attachments) {
-        // cannot guarantee that postProcessing was already done,
-        // so do it again
-        postProcessAttachments(results).then(finish);
-      } else {
-        finish();
-      }
-    }
+  api._changes = function idbChanges(opts) {
+    changes(opts, api, dbName, idb);
   };
 
   api._close = function (callback) {
@@ -799,7 +621,7 @@ function init(api, opts, callback) {
   };
 
   api._destroy = function (opts, callback) {
-    idbChanges.removeAllListeners(dbName);
+    changesHandler.removeAllListeners(dbName);
 
     //Close open request for "dbName" database to fix ie delay.
     var openReq = openReqList.get(dbName);

--- a/packages/node_modules/pouchdb-adapter-idb/src/runBatchedCursor.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/runBatchedCursor.js
@@ -1,0 +1,68 @@
+// Abstraction over IDBCursor and getAll()/getAllKeys() that allows us to batch our operations
+// while falling back to a normal IDBCursor operation on browsers that don't support getAll() or
+// getAllKeys(). This allows for a much faster implementation than just straight-up cursors, because
+// we're not processing each document one-at-a-time.
+function runBatchedCursor(objectStore, startKey, descending, batchSize, onBatch) {
+
+  // Bail out of getAll()/getAllKeys() in the following cases:
+  // 1) either method is unsupported (we need both)
+  // 2) batchSize is 1 (might as well use IDBCursor), or batchSize is -1 (i.e. batchSize unlimited,
+  //    not really clear the user wants a batched approach where the entire DB is read into memory,
+  //    perhaps they are filtering on a per-doc basis)
+  // 3) descending – no real way to do this via getAll()/getAllKeys()
+  var useGetAll = typeof objectStore.getAll === 'function' &&
+    typeof objectStore.getAllKeys === 'function' && batchSize > 1 && !descending;
+
+  var keysBatch;
+  var valuesBatch;
+  var pseudoCursor;
+
+  function onGetAll(e) {
+    valuesBatch = e.target.result;
+    if (keysBatch) {
+      onBatch(keysBatch, valuesBatch, pseudoCursor);
+    }
+  }
+
+  function onGetAllKeys(e) {
+    keysBatch = e.target.result;
+    if (valuesBatch) {
+      onBatch(keysBatch, valuesBatch, pseudoCursor);
+    }
+  }
+
+  function continuePseudoCursor() {
+    if (!keysBatch.length) { // no more results
+      return onBatch();
+    }
+    // fetch next batch, exclusive start
+    range = IDBKeyRange.lowerBound(keysBatch[keysBatch.length - 1], true);
+    keysBatch = null;
+    valuesBatch = null;
+    objectStore.getAll(range, batchSize).onsuccess = onGetAll;
+    objectStore.getAllKeys(range, batchSize).onsuccess = onGetAllKeys;
+  }
+
+  function onCursor(e) {
+    var cursor = e.target.result;
+    if (!cursor) { // done
+      return onBatch();
+    }
+    // regular IDBCursor acts like a batch where batch size is always 1
+    onBatch([cursor.key], [cursor.value], cursor);
+  }
+
+  var range = (startKey && !descending) ? IDBKeyRange.lowerBound(startKey, true) : null;
+
+  if (useGetAll) {
+    pseudoCursor = {"continue": continuePseudoCursor};
+    objectStore.getAll(range, batchSize).onsuccess = onGetAll;
+    objectStore.getAllKeys(range, batchSize).onsuccess = onGetAllKeys;
+  } else if (descending) {
+    objectStore.openCursor(range, 'prev').onsuccess = onCursor;
+  } else {
+    objectStore.openCursor(range).onsuccess = onCursor;
+  }
+}
+
+export default runBatchedCursor;

--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -904,6 +904,40 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('changes w/ many modifications of same doc', function () {
+      var db = new PouchDB(dbs.name);
+      var promise = testUtils.Promise.resolve();
+      var doc = {_id: '1'};
+      function modifyDoc() {
+        return db.put(doc).then(function (res) {
+          doc._rev = res.rev;
+        });
+      }
+      for (var i  = 0; i < 5; i++) {
+        promise = promise.then(modifyDoc);
+      }
+      return promise.then(function () {
+        return db.bulkDocs([
+          {_id: '2'},
+          {_id: '3'},
+          {_id: '4'},
+          {_id: '5'}
+        ]);
+      }).then(function () {
+        return db.changes({since: 0, limit: 3}).then(function (res) {
+          res.results.map(function (x) {
+            delete x.changes;
+            delete x.seq;
+            return x;
+          }).should.deep.equal([
+            { "id": "1" },
+            { "id": "2" },
+            { "id": "3" }
+          ]);
+        });
+      });
+    });
+
     it('live-changes', function (done) {
       var db = new PouchDB(dbs.name);
       var count = 0;


### PR DESCRIPTION
This is a rewrite of #6031. Instead of having two separate implementations of `changes()`, I've implemented a new `runBatchedCursor()` routine that abstracts away two implementations:

1. `getAll()`/`getAllKeys()`-based, for browsers that support it
2. `IDBCursor`-based, for browsers that don't support `getAll()`/`getAllKeys()` or for queries where we need cursors (e.g. descending)

**Mode 1** essentially works by fetching `n` changes for every batch, where `n` corresponds to `limit` in the `changes()` API. In the case of `auto_compact`ed databases with no conflicts, and when we're not using `opts.filter` or `opts.doc_ids`, this means that we can accomplish `changes()` with a single batch (notably this applies to secondary indexes, giving them quite a perf boost).

In other cases, we may slightly overfetch, but I'd argue this is still better than fetching one-at-a-time, and that we're still honoring the user's preferences for memory consumption (communicated via `limit`). In cases where `limit` is -1/undefined we do not use Mode 1 since it would mean reading the whole DB into memory.

**Mode 2** works like a classic IDBCursor, as we've done in the past. It's abstracted into Mode 1 by acting like a batched cursor where the batch size is 1.

I ran a benchmark using Firefox 50 and Chrome 55 on a MacBook Air, and got the following results for `temp-views` with 10 iterations:

| | Before | After | Improvement |
| --- | ---- | ---- | ---- |
| Chrome | 104826ms | 51566ms | 50.8% |
| Firefox | 97959ms | 55441ms | 43.4% |

So roughly, this makes secondary index creation in IDB about 2x faster in Chrome and Firefox. It also has the potential to make replication faster (when pulling from IDB databases) but I need to write a new benchmark to confirm it.