### PR TITLE
(#5501) - fall back from bulk_get on any error

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -341,19 +341,13 @@ function HttpPouch(opts, callback) {
       doBulkGet(function (err, res) {
         /* istanbul ignore else */
         if (err) {
-          var status = Math.floor(err.status / 100);
-          /* istanbul ignore else */
-          if (status === 4 || status === 5) { // 40x or 50x
-            supportsBulkGetMap[dbUrl] = false;
-            explainError(
-              err.status,
-              'PouchDB is just detecting if the remote ' +
-              'supports the _bulk_get API.'
-            );
-            doBulkGetShim();
-          } else {
-            callback(err);
-          }
+          supportsBulkGetMap[dbUrl] = false;
+          explainError(
+            err.status,
+            'PouchDB is just detecting if the remote ' +
+            'supports the _bulk_get API.'
+          );
+          doBulkGetShim();
         } else {
           supportsBulkGetMap[dbUrl] = true;
           callback(null, res);


### PR DESCRIPTION
Multiple users have reported connectivity issues during our test
for the _bulk_get endpoint. Rather than raise a user error in these
situations, fall back to individual document GETs - any real
connection issues will get raised at that point.

Fixes #5810, #5501