### PR TITLE
(#6040) - fix coveralls badge issue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [PouchDB](http://pouchdb.com/) – The Database that Syncs!
 =========
 
-[![Build Status](https://travis-ci.org/pouchdb/pouchdb.svg)](https://travis-ci.org/pouchdb/pouchdb) [![Coverage Status](https://coveralls.io/repos/pouchdb/pouchdb/badge.svg?branch=master&service=github)](https://coveralls.io/github/pouchdb/pouchdb?branch=master)
+[![Build Status](https://travis-ci.org/pouchdb/pouchdb.svg)](https://travis-ci.org/pouchdb/pouchdb) [![Coverage Status](https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_100.svg)](https://coveralls.io/github/pouchdb/pouchdb?branch=master)
 
 PouchDB is an open-source JavaScript database inspired by [Apache CouchDB](http://couchdb.apache.org/) that is designed to run well within the browser.
 


### PR DESCRIPTION
Apparently Coveralls has a bug where it's not showing 100% even though when you click through clearly everything is at 100%, and the bug has been open for a few years ( https://github.com/lemurheavy/coveralls-public/issues/414#issuecomment-268376344 ). Since our build straight-up fails if we're at <100 I feel comfortable pulling a Volkswagen here and just cheating.