### PR TITLE
(#6039) - include id in all bulk_docs results

### DIFF
--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -826,7 +826,8 @@ AbstractPouchDB.prototype.bulkDocs =
     }
   }
 
-  if (!opts.new_edits && this.type() !== 'http') {
+  var adapter = this;
+  if (!opts.new_edits && adapter.type() !== 'http') {
     // ensure revisions of the same doc are sorted, so that
     // the local adapter processes them correctly (#2935)
     req.docs.sort(compareByIdThenRev);
@@ -843,6 +844,14 @@ AbstractPouchDB.prototype.bulkDocs =
       res = res.filter(function (x) {
         return x.error;
       });
+    }
+
+    // add ids for error / conflict responses
+    // not required for CouchDB
+    if (adapter.type() !== 'http') {
+      for (var i = 0, l = res.length; i < l; i++) {
+        res[i].id = res[i].id || req.docs[i]._id;
+      }
     }
     callback(null, res);
   });

--- a/tests/integration/test.bulk_docs.js
+++ b/tests/integration/test.bulk_docs.js
@@ -67,6 +67,8 @@ adapters.forEach(function (adapter) {
               results[0].name.should.equal(
                 'conflict', 'First doc should be in conflict');
               should.not.exist(results[0].rev, 'no rev in conflict');
+              should.exist(results[0].id);
+              results[0].id.should.equal("0");
               for (i = 1; i < 5; i++) {
                 results[i].id.should.equal(i.toString());
                 should.exist(results[i].rev);


### PR DESCRIPTION
CouchDB already includes an id field for each result in a `_bulk_docs` response. For non-http adapters, ensure we do the same.

It seems simpler to do this in the core adapter code rather than patch up each individual storage engine.