### PR TITLE
(#6055) - remove docCount optimization from IDB

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/allDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/allDocs.js
@@ -15,6 +15,8 @@ import {
   openTransactionSafely
 } from './utils';
 
+import countDocs from './countDocs';
+
 function createKeyRange(start, end, inclusiveEnd, key, descending) {
   try {
     if (start && end) {
@@ -44,19 +46,7 @@ function createKeyRange(start, end, inclusiveEnd, key, descending) {
   return null;
 }
 
-function handleKeyRangeError(api, opts, err, callback) {
-  if (err.name === "DataError" && err.code === 0) {
-    // data error, start is less than end
-    return callback(null, {
-      total_rows: api._meta.docCount,
-      offset: opts.skip,
-      rows: []
-    });
-  }
-  callback(createError(IDB_ERROR, err.name, err.message));
-}
-
-function idbAllDocs(opts, api, idb, callback) {
+function idbAllDocs(opts, idb, callback) {
 
   function allDocsQuery(opts, callback) {
     var start = 'startkey' in opts ? opts.startkey : false;
@@ -68,8 +58,13 @@ function idbAllDocs(opts, api, idb, callback) {
     var descending = 'descending' in opts && opts.descending ? 'prev' : null;
 
     var keyRange = createKeyRange(start, end, inclusiveEnd, key, descending);
-    if (keyRange && keyRange.error) {
-      return handleKeyRangeError(api, opts, keyRange.error, callback);
+    var keyRangeError = keyRange && keyRange.error;
+    if (keyRangeError && !(keyRangeError.name === "DataError" &&
+        keyRangeError.code === 0)) {
+      // DataError with error code 0 indicates start is less than end, so
+      // can just do an empty query. Else need to throw
+      return callback(createError(IDB_ERROR,
+        keyRangeError.name, keyRangeError.message));
     }
 
     var stores = [DOC_STORE, BY_SEQ_STORE];
@@ -84,12 +79,20 @@ function idbAllDocs(opts, api, idb, callback) {
     var txn = txnResult.txn;
     var docStore = txn.objectStore(DOC_STORE);
     var seqStore = txn.objectStore(BY_SEQ_STORE);
-    var cursor = descending ?
-      docStore.openCursor(keyRange, descending) :
-      docStore.openCursor(keyRange);
+    var cursorReq;
+    if (!keyRangeError && limit !== 0) {
+      // don't bother doing the cursor if start > end or limit === 0
+      cursorReq = descending ?
+        docStore.openCursor(keyRange, descending) :
+        docStore.openCursor(keyRange);
+    }
     var docIdRevIndex = seqStore.index('_doc_id_rev');
     var results = [];
-    var docCount = 0;
+    var docCount;
+
+    countDocs(txn, function (thisDocCount) {
+      docCount = thisDocCount;
+    });
 
     // if the user specifies include_docs=true, then we don't
     // want to block the main cursor while we're fetching the doc
@@ -138,7 +141,6 @@ function idbAllDocs(opts, api, idb, callback) {
     }
 
     function onGetCursor(e) {
-      docCount = api._meta.docCount; // do this within the txn for consistency
       var cursor = e.target.result;
       if (!cursor) {
         return;
@@ -166,22 +168,12 @@ function idbAllDocs(opts, api, idb, callback) {
     }
 
     txn.oncomplete = onTxnComplete;
-    cursor.onsuccess = onGetCursor;
-  }
-
-  function allDocs(opts, callback) {
-
-    if (opts.limit === 0) {
-      return callback(null, {
-        total_rows: api._meta.docCount,
-        offset: opts.skip,
-        rows: []
-      });
+    if (cursorReq) {
+      cursorReq.onsuccess = onGetCursor;
     }
-    allDocsQuery(opts, callback);
   }
 
-  allDocs(opts, callback);
+  allDocsQuery(opts, callback);
 }
 
 export default idbAllDocs;

--- a/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
@@ -37,7 +37,6 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
   var attachStore;
   var attachAndSeqStore;
   var docInfoError;
-  var docCountDelta = 0;
 
   for (var i = 0, len = docInfos.length; i < len; i++) {
     var doc = docInfos[i];
@@ -140,7 +139,6 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
     }
 
     changesHandler.notify(api._meta.name);
-    api._meta.docCount += docCountDelta;
     callback(null, results);
   }
 
@@ -197,8 +195,6 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
 
   function writeDoc(docInfo, winningRev, winningRevIsDeleted, newRevIsDeleted,
                     isUpdate, delta, resultsIdx, callback) {
-
-    docCountDelta += delta;
 
     docInfo.metadata.winningRev = winningRev;
     docInfo.metadata.deleted = winningRevIsDeleted;

--- a/packages/node_modules/pouchdb-adapter-idb/src/countDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/countDocs.js
@@ -1,0 +1,10 @@
+import { DOC_STORE } from './constants';
+
+function countDocs(txn, cb) {
+  var index = txn.objectStore(DOC_STORE).index('deletedOrLocal');
+  index.count(IDBKeyRange.only('0')).onsuccess = function (e) {
+    cb(e.target.result);
+  };
+}
+
+export default countDocs;

--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -17,10 +17,10 @@ import { Map } from 'pouchdb-collections';
 import idbBulkDocs from './bulkDocs';
 import idbAllDocs from './allDocs';
 import checkBlobSupport from './blobSupport';
+import countDocs from './countDocs';
 import {
   MISSING_DOC,
   REV_CONFLICT,
-  NOT_OPEN,
   IDB_ERROR,
   createError
 } from 'pouchdb-errors';
@@ -387,26 +387,21 @@ function init(api, opts, callback) {
   };
 
   api._info = function idb_info(callback) {
-
-    if (idb === null || !cachedDBs.has(dbName)) {
-      var error = new Error('db isn\'t open');
-      error.id = 'idbNull';
-      return callback(error);
-    }
     var updateSeq;
     var docCount;
 
-    var txnResult = openTransactionSafely(idb, [BY_SEQ_STORE], 'readonly');
+    var txnResult = openTransactionSafely(idb, [DOC_STORE, BY_SEQ_STORE], 'readonly');
     if (txnResult.error) {
       return callback(txnResult.error);
     }
     var txn = txnResult.txn;
+    countDocs(txn, function (thisDocCount) {
+      docCount = thisDocCount;
+    });
     var cursor = txn.objectStore(BY_SEQ_STORE).openCursor(null, 'prev');
     cursor.onsuccess = function (event) {
       var cursor = event.target.result;
       updateSeq = cursor ? cursor.key : 0;
-      // count within the same txn for consistency
-      docCount = api._meta.docCount;
     };
 
     txn.oncomplete = function () {
@@ -420,7 +415,7 @@ function init(api, opts, callback) {
   };
 
   api._allDocs = function idb_allDocs(opts, callback) {
-    idbAllDocs(opts, api, idb, callback);
+    idbAllDocs(opts, idb, callback);
   };
 
   api._changes = function idbChanges(opts) {
@@ -428,15 +423,10 @@ function init(api, opts, callback) {
   };
 
   api._close = function (callback) {
-    if (idb === null) {
-      return callback(createError(NOT_OPEN));
-    }
-
     // https://developer.mozilla.org/en-US/docs/IndexedDB/IDBDatabase#close
     // "Returns immediately and closes the connection in a separate thread..."
     idb.close();
     cachedDBs.delete(dbName);
-    idb = null;
     callback();
   };
 
@@ -721,24 +711,20 @@ function init(api, opts, callback) {
       DOC_STORE
     ], 'readwrite');
 
-    var req = txn.objectStore(META_STORE).get(META_STORE);
+    var getMetaReq = txn.objectStore(META_STORE).get(META_STORE);
 
     var blobSupport = null;
-    var docCount = null;
     var instanceId = null;
 
-    req.onsuccess = function (e) {
-
-      var checkSetupComplete = function () {
-        if (blobSupport === null || docCount === null ||
-            instanceId === null) {
-          return;
-        } else {
+    getMetaReq.onsuccess = function (e) {
+      var complete = false;
+      function checkSetupComplete() {
+        if (blobSupport !== null && instanceId !== null && !complete) {
+          complete = true;
           api._meta = {
             name: dbName,
             instanceId: instanceId,
-            blobSupport: blobSupport,
-            docCount: docCount
+            blobSupport: blobSupport
           };
 
           cachedDBs.set(dbName, {
@@ -747,7 +733,7 @@ function init(api, opts, callback) {
           });
           callback(null, api);
         }
-      };
+      }
 
       //
       // fetch/store the id
@@ -778,17 +764,6 @@ function init(api, opts, callback) {
         blobSupport = val;
         checkSetupComplete();
       });
-
-      //
-      // count docs
-      //
-
-      var index = txn.objectStore(DOC_STORE).index('deletedOrLocal');
-      index.count(IDBKeyRange.only('0')).onsuccess = function (e) {
-        docCount = e.target.result;
-        checkSetupComplete();
-      };
-
     };
   };
 

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -1062,6 +1062,33 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('test info() after db close', function () {
+      var db = new PouchDB(dbs.name);
+      return db.close().then(function () {
+        return db.info().catch(function (err) {
+          err.message.should.equal('database is closed');
+        });
+      });
+    });
+
+    it('test get() after db close', function () {
+      var db = new PouchDB(dbs.name);
+      return db.close().then(function () {
+        return db.get('foo').catch(function (err) {
+          err.message.should.equal('database is closed');
+        });
+      });
+    });
+
+    it('test close() after db close', function () {
+      var db = new PouchDB(dbs.name);
+      return db.close().then(function () {
+        return db.close().catch(function (err) {
+          err.message.should.equal('database is closed');
+        });
+      });
+    });
+
     if (adapter === 'local') {
       // TODO: this test fails in the http adapter in Chrome
       it('should allow unicode doc ids', function (done) {

--- a/tests/integration/worker.js
+++ b/tests/integration/worker.js
@@ -21,7 +21,7 @@ function bigTest(name) {
   }).catch(onError);
 }
 
-function allDocs(name) {
+function postAttachmentThenAllDocs(name) {
   var db = new PouchDB(name);
   db.post({
     _id: 'blah',
@@ -52,6 +52,13 @@ function putAttachment(name, docId, attId, att, type) {
   }).catch(onError);
 }
 
+function allDocs(name) {
+  var db = new PouchDB(name);
+  db.allDocs().then(function (res) {
+    self.postMessage(res);
+  }).catch(onError);
+}
+
 self.addEventListener('message', function (e) {
   if (Array.isArray(e.data) && e.data[0] === 'source') {
     importScripts(e.data[1]);
@@ -61,10 +68,12 @@ self.addEventListener('message', function (e) {
     self.postMessage(PouchDB.version);
   } else if (Array.isArray(e.data) && e.data[0] === 'create') {
     bigTest(e.data[1]);
-  } else if (Array.isArray(e.data) && e.data[0] === 'allDocs') {
-    allDocs(e.data[1]);
+  } else if (Array.isArray(e.data) && e.data[0] === 'postAttachmentThenAllDocs') {
+    postAttachmentThenAllDocs(e.data[1]);
   } else if (Array.isArray(e.data) && e.data[0] === 'putAttachment') {
     putAttachment(e.data[1], e.data[2], e.data[3], e.data[4], e.data[5]);
+  } else if (Array.isArray(e.data) && e.data[0] === 'allDocs') {
+    allDocs(e.data[1]);
   } else {
     onError(new Error('unknown message: ' + JSON.stringify(e.data)));
   }


### PR DESCRIPTION
Adds a new test to `browser.worker.js`. The test fails before the fix but succeeds after, demonstrating the issue with `docCount`.

I'll need to run some perf tests to see what kind of impact this has, but I believe that since we can now use `getAll()`-based cursors for `allDocs()`, we can offset whatever perf regression this causes. Also it's the right thing to do because it's more correct.

I will have to implement the same fix for WebSQL (due to the cross-tab issue) but I'll do that in another PR. The worker test does not run for WebSQL because no modern browser supports WebSQL in a worker.