### PR TITLE
(#6055) - remove docCount optimization from WebSQL

### DIFF
--- a/packages/node_modules/pouchdb-adapter-websql-core/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-websql-core/src/bulkDocs.js
@@ -62,7 +62,6 @@ function websqlBulkDocs(dbOpts, req, opts, api, db, websqlChanges, callback) {
       return callback(preconditionErrored);
     }
     websqlChanges.notify(api._name);
-    api._docCount = -1; // invalidate
     callback(null, results);
   }
 

--- a/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
@@ -130,7 +130,6 @@ function WebSqlPouch(opts, callback) {
   var idRequests = [];
   var encoding;
 
-  api._docCount = -1; // cache sqlite count(*) for performance
   api._name = opts.name;
 
   // extend the options here, because sqlite plugin has a ton of options
@@ -532,6 +531,27 @@ function WebSqlPouch(opts, callback) {
 
   setup();
 
+  function getMaxSeq(tx, callback) {
+    var sql = 'SELECT MAX(seq) AS seq FROM ' + BY_SEQ_STORE;
+    tx.executeSql(sql, [], function (tx, res) {
+      var updateSeq = res.rows.item(0).seq || 0;
+      callback(updateSeq);
+    });
+  }
+
+  function countDocs(tx, callback) {
+    // count the total rows
+    var sql = select(
+      'COUNT(' + DOC_STORE + '.id) AS \'num\'',
+      [DOC_STORE, BY_SEQ_STORE],
+      DOC_STORE_AND_BY_SEQ_JOINER,
+      BY_SEQ_STORE + '.deleted=0');
+
+    tx.executeSql(sql, [], function (tx, result) {
+      callback(result.rows.item(0).num);
+    });
+  }
+
   api.type = function () {
     return 'websql';
   };
@@ -541,19 +561,22 @@ function WebSqlPouch(opts, callback) {
   });
 
   api._info = function (callback) {
+    var seq;
+    var docCount;
     db.readTransaction(function (tx) {
-      countDocs(tx, function (docCount) {
-        var sql = 'SELECT MAX(seq) AS seq FROM ' + BY_SEQ_STORE;
-        tx.executeSql(sql, [], function (tx, res) {
-          var updateSeq = res.rows.item(0).seq || 0;
-          callback(null, {
-            doc_count: docCount,
-            update_seq: updateSeq,
-            websql_encoding: encoding
-          });
-        });
+      getMaxSeq(tx, function (theSeq) {
+        seq = theSeq;
       });
-    }, websqlError(callback));
+      countDocs(tx, function (theDocCount) {
+        docCount = theDocCount;
+      });
+    }, websqlError(callback), function () {
+      callback(null, {
+        doc_count: docCount,
+        update_seq: seq,
+        websql_encoding: encoding
+      });
+    });
   };
 
   api._bulkDocs = function (req, reqOpts, callback) {
@@ -635,25 +658,6 @@ function WebSqlPouch(opts, callback) {
     });
   };
 
-  function countDocs(tx, callback) {
-
-    if (api._docCount !== -1) {
-      return callback(api._docCount);
-    }
-
-    // count the total rows
-    var sql = select(
-      'COUNT(' + DOC_STORE + '.id) AS \'num\'',
-      [DOC_STORE, BY_SEQ_STORE],
-      DOC_STORE_AND_BY_SEQ_JOINER,
-      BY_SEQ_STORE + '.deleted=0');
-
-    tx.executeSql(sql, [], function (tx, result) {
-      api._docCount = result.rows.item(0).num;
-      callback(api._docCount);
-    });
-  }
-
   api._allDocs = function (opts, callback) {
     var results = [];
     var totalRows;
@@ -697,59 +701,58 @@ function WebSqlPouch(opts, callback) {
     }
 
     db.readTransaction(function (tx) {
+      // count the docs in parallel to other operations
+      countDocs(tx, function (docCount) {
+        totalRows = docCount;
+      });
 
-      // first count up the total rows
-      countDocs(tx, function (count) {
-        totalRows = count;
+      if (limit === 0) {
+        return;
+      }
 
-        if (limit === 0) {
-          return;
-        }
+      // do a single query to fetch the documents
+      var sql = select(
+        SELECT_DOCS,
+        [DOC_STORE, BY_SEQ_STORE],
+        DOC_STORE_AND_BY_SEQ_JOINER,
+        criteria,
+        DOC_STORE + '.id ' + (descending ? 'DESC' : 'ASC')
+        );
+      sql += ' LIMIT ' + limit + ' OFFSET ' + offset;
 
-        // then actually fetch the documents
-        var sql = select(
-          SELECT_DOCS,
-          [DOC_STORE, BY_SEQ_STORE],
-          DOC_STORE_AND_BY_SEQ_JOINER,
-          criteria,
-          DOC_STORE + '.id ' + (descending ? 'DESC' : 'ASC')
-          );
-        sql += ' LIMIT ' + limit + ' OFFSET ' + offset;
-
-        tx.executeSql(sql, sqlArgs, function (tx, result) {
-          for (var i = 0, l = result.rows.length; i < l; i++) {
-            var item = result.rows.item(i);
-            var metadata = safeJsonParse(item.metadata);
-            var id = metadata.id;
-            var data = unstringifyDoc(item.data, id, item.rev);
-            var winningRev = data._rev;
-            var doc = {
-              id: id,
-              key: id,
-              value: {rev: winningRev}
-            };
-            if (opts.include_docs) {
-              doc.doc = data;
-              doc.doc._rev = winningRev;
-              if (opts.conflicts) {
-                var conflicts = collectConflicts(metadata);
-                if (conflicts.length) {
-                  doc.doc._conflicts = conflicts;
-                }
-              }
-              fetchAttachmentsIfNecessary(doc.doc, opts, api, tx);
-            }
-            if (item.deleted) {
-              if (opts.deleted === 'ok') {
-                doc.value.deleted = true;
-                doc.doc = null;
-              } else {
-                continue;
+      tx.executeSql(sql, sqlArgs, function (tx, result) {
+        for (var i = 0, l = result.rows.length; i < l; i++) {
+          var item = result.rows.item(i);
+          var metadata = safeJsonParse(item.metadata);
+          var id = metadata.id;
+          var data = unstringifyDoc(item.data, id, item.rev);
+          var winningRev = data._rev;
+          var doc = {
+            id: id,
+            key: id,
+            value: {rev: winningRev}
+          };
+          if (opts.include_docs) {
+            doc.doc = data;
+            doc.doc._rev = winningRev;
+            if (opts.conflicts) {
+              var conflicts = collectConflicts(metadata);
+              if (conflicts.length) {
+                doc.doc._conflicts = conflicts;
               }
             }
-            results.push(doc);
+            fetchAttachmentsIfNecessary(doc.doc, opts, api, tx);
           }
-        });
+          if (item.deleted) {
+            if (opts.deleted === 'ok') {
+              doc.value.deleted = true;
+              doc.doc = null;
+            } else {
+              continue;
+            }
+          }
+          results.push(doc);
+        }
       });
     }, websqlError(callback), function () {
       callback(null, {


### PR DESCRIPTION
Unlike #6056 I don't believe there's any way to test this, since modern browsers don't support WebSQL in a worker. Or rather, to test it we'd have to open up two browser tabs and see the result between the two, which is way too complex given our current test infrastructure, so I'm just proposing the change without tests.