### PR TITLE
(#6059) - use batch cursor in allDocs()

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/allDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/allDocs.js
@@ -1,20 +1,20 @@
 import { createError, IDB_ERROR } from 'pouchdb-errors';
 import { collectConflicts } from 'pouchdb-merge';
-
 import {
   ATTACH_STORE,
   BY_SEQ_STORE,
   DOC_STORE
 } from './constants';
-
 import {
   decodeDoc,
   decodeMetadata,
   fetchAttachmentsIfNecessary,
   postProcessAttachments,
-  openTransactionSafely
+  openTransactionSafely,
+  idbError
 } from './utils';
-
+import runBatchedCursor from './runBatchedCursor';
+import getAll from './getAll';
 import countDocs from './countDocs';
 
 function createKeyRange(start, end, inclusiveEnd, key, descending) {
@@ -47,133 +47,143 @@ function createKeyRange(start, end, inclusiveEnd, key, descending) {
 }
 
 function idbAllDocs(opts, idb, callback) {
+  var start = 'startkey' in opts ? opts.startkey : false;
+  var end = 'endkey' in opts ? opts.endkey : false;
+  var key = 'key' in opts ? opts.key : false;
+  var skip = opts.skip || 0;
+  var limit = typeof opts.limit === 'number' ? opts.limit : -1;
+  var inclusiveEnd = opts.inclusive_end !== false;
 
-  function allDocsQuery(opts, callback) {
-    var start = 'startkey' in opts ? opts.startkey : false;
-    var end = 'endkey' in opts ? opts.endkey : false;
-    var key = 'key' in opts ? opts.key : false;
-    var skip = opts.skip || 0;
-    var limit = typeof opts.limit === 'number' ? opts.limit : -1;
-    var inclusiveEnd = opts.inclusive_end !== false;
-    var descending = 'descending' in opts && opts.descending ? 'prev' : null;
+  var keyRange = createKeyRange(start, end, inclusiveEnd, key, opts.descending);
+  var keyRangeError = keyRange && keyRange.error;
+  if (keyRangeError && !(keyRangeError.name === "DataError" &&
+      keyRangeError.code === 0)) {
+    // DataError with error code 0 indicates start is less than end, so
+    // can just do an empty query. Else need to throw
+    return callback(createError(IDB_ERROR,
+      keyRangeError.name, keyRangeError.message));
+  }
 
-    var keyRange = createKeyRange(start, end, inclusiveEnd, key, descending);
-    var keyRangeError = keyRange && keyRange.error;
-    if (keyRangeError && !(keyRangeError.name === "DataError" &&
-        keyRangeError.code === 0)) {
-      // DataError with error code 0 indicates start is less than end, so
-      // can just do an empty query. Else need to throw
-      return callback(createError(IDB_ERROR,
-        keyRangeError.name, keyRangeError.message));
-    }
+  var stores = [DOC_STORE, BY_SEQ_STORE];
 
-    var stores = [DOC_STORE, BY_SEQ_STORE];
+  if (opts.attachments) {
+    stores.push(ATTACH_STORE);
+  }
+  var txnResult = openTransactionSafely(idb, stores, 'readonly');
+  if (txnResult.error) {
+    return callback(txnResult.error);
+  }
+  var txn = txnResult.txn;
+  txn.oncomplete = onTxnComplete;
+  txn.onabort = idbError(callback);
+  var docStore = txn.objectStore(DOC_STORE);
+  var seqStore = txn.objectStore(BY_SEQ_STORE);
+  var docIdRevIndex = seqStore.index('_doc_id_rev');
+  var results = [];
+  var docCount;
 
-    if (opts.attachments) {
-      stores.push(ATTACH_STORE);
-    }
-    var txnResult = openTransactionSafely(idb, stores, 'readonly');
-    if (txnResult.error) {
-      return callback(txnResult.error);
-    }
-    var txn = txnResult.txn;
-    var docStore = txn.objectStore(DOC_STORE);
-    var seqStore = txn.objectStore(BY_SEQ_STORE);
-    var cursorReq;
-    if (!keyRangeError && limit !== 0) {
-      // don't bother doing the cursor if start > end or limit === 0
-      cursorReq = descending ?
-        docStore.openCursor(keyRange, descending) :
-        docStore.openCursor(keyRange);
-    }
-    var docIdRevIndex = seqStore.index('_doc_id_rev');
-    var results = [];
-    var docCount;
+  countDocs(txn, function (thisDocCount) {
+    docCount = thisDocCount;
+  });
 
-    countDocs(txn, function (thisDocCount) {
-      docCount = thisDocCount;
-    });
-
-    // if the user specifies include_docs=true, then we don't
-    // want to block the main cursor while we're fetching the doc
-    function fetchDocAsynchronously(metadata, row, winningRev) {
-      var key = metadata.id + "::" + winningRev;
-      docIdRevIndex.get(key).onsuccess =  function onGetDoc(e) {
-        row.doc = decodeDoc(e.target.result);
-        if (opts.conflicts) {
-          var conflicts = collectConflicts(metadata);
-          if (conflicts.length) {
-            row.doc._conflicts = conflicts;
-          }
-        }
-        fetchAttachmentsIfNecessary(row.doc, opts, txn);
-      };
-    }
-
-    function allDocsInner(cursor, winningRev, metadata) {
-      var row = {
-        id: metadata.id,
-        key: metadata.id,
-        value: {
-          rev: winningRev
-        }
-      };
-      var deleted = metadata.deleted;
-      if (opts.deleted === 'ok') {
-        results.push(row);
-        // deleted docs are okay with "keys" requests
-        if (deleted) {
-          row.value.deleted = true;
-          row.doc = null;
-        } else if (opts.include_docs) {
-          fetchDocAsynchronously(metadata, row, winningRev);
-        }
-      } else if (!deleted && skip-- <= 0) {
-        results.push(row);
-        if (opts.include_docs) {
-          fetchDocAsynchronously(metadata, row, winningRev);
-        }
-        if (--limit === 0) {
-          return;
+  // if the user specifies include_docs=true, then we don't
+  // want to block the main cursor while we're fetching the doc
+  function fetchDocAsynchronously(metadata, row, winningRev) {
+    var key = metadata.id + "::" + winningRev;
+    docIdRevIndex.get(key).onsuccess =  function onGetDoc(e) {
+      row.doc = decodeDoc(e.target.result);
+      if (opts.conflicts) {
+        var conflicts = collectConflicts(metadata);
+        if (conflicts.length) {
+          row.doc._conflicts = conflicts;
         }
       }
-      cursor.continue();
-    }
+      fetchAttachmentsIfNecessary(row.doc, opts, txn);
+    };
+  }
 
-    function onGetCursor(e) {
-      var cursor = e.target.result;
-      if (!cursor) {
-        return;
+  function allDocsInner(winningRev, metadata) {
+    var row = {
+      id: metadata.id,
+      key: metadata.id,
+      value: {
+        rev: winningRev
       }
-      var metadata = decodeMetadata(cursor.value);
-      var winningRev = metadata.winningRev;
-
-      allDocsInner(cursor, winningRev, metadata);
-    }
-
-    function onResultsReady() {
-      callback(null, {
-        total_rows: docCount,
-        offset: opts.skip,
-        rows: results
-      });
-    }
-
-    function onTxnComplete() {
-      if (opts.attachments) {
-        postProcessAttachments(results, opts.binary).then(onResultsReady);
-      } else {
-        onResultsReady();
+    };
+    var deleted = metadata.deleted;
+    if (opts.deleted === 'ok') {
+      results.push(row);
+      // deleted docs are okay with "keys" requests
+      if (deleted) {
+        row.value.deleted = true;
+        row.doc = null;
+      } else if (opts.include_docs) {
+        fetchDocAsynchronously(metadata, row, winningRev);
       }
-    }
-
-    txn.oncomplete = onTxnComplete;
-    if (cursorReq) {
-      cursorReq.onsuccess = onGetCursor;
+    } else if (!deleted && skip-- <= 0) {
+      results.push(row);
+      if (opts.include_docs) {
+        fetchDocAsynchronously(metadata, row, winningRev);
+      }
     }
   }
 
-  allDocsQuery(opts, callback);
+  function processBatch(batchValues) {
+    for (var i = 0, len = batchValues.length; i < len; i++) {
+      if (results.length === limit) {
+        break;
+      }
+      var batchValue = batchValues[i];
+      var metadata = decodeMetadata(batchValue);
+      var winningRev = metadata.winningRev;
+      allDocsInner(winningRev, metadata);
+    }
+  }
+
+  function onBatch(batchKeys, batchValues, cursor) {
+    if (!cursor) {
+      return;
+    }
+    processBatch(batchValues);
+    if (results.length < limit) {
+      cursor.continue();
+    }
+  }
+
+  function onGetAll(e) {
+    var values = e.target.result;
+    if (opts.descending) {
+      values = values.reverse();
+    }
+    processBatch(values);
+  }
+
+  function onResultsReady() {
+    callback(null, {
+      total_rows: docCount,
+      offset: opts.skip,
+      rows: results
+    });
+  }
+
+  function onTxnComplete() {
+    if (opts.attachments) {
+      postProcessAttachments(results, opts.binary).then(onResultsReady);
+    } else {
+      onResultsReady();
+    }
+  }
+
+  // don't bother doing any requests if start > end or limit === 0
+  if (keyRangeError || limit === 0) {
+    return;
+  }
+  if (limit === -1) { // just fetch everything
+    return getAll(docStore, keyRange, onGetAll);
+  }
+  // else do a cursor
+  // choose a batch size based on the skip, since we'll need to skip that many
+  runBatchedCursor(docStore, keyRange, opts.descending, limit + skip, onBatch);
 }
 
 export default idbAllDocs;

--- a/packages/node_modules/pouchdb-adapter-idb/src/changes.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/changes.js
@@ -206,7 +206,10 @@ function changes(opts, api, dbName, idb) {
   docStore = txn.objectStore(DOC_STORE);
   docIdRevIndex = bySeqStore.index('_doc_id_rev');
 
-  runBatchedCursor(bySeqStore, opts.since, opts.descending, limit, onBatch);
+  var keyRange = (opts.since && !opts.descending) ?
+    IDBKeyRange.lowerBound(opts.since, true) : null;
+
+  runBatchedCursor(bySeqStore, keyRange, opts.descending, limit, onBatch);
 }
 
 export default changes;

--- a/packages/node_modules/pouchdb-adapter-idb/src/getAll.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/getAll.js
@@ -1,0 +1,28 @@
+// simple shim for objectStore.getAll(), falling back to IDBCursor
+function getAll(objectStore, keyRange, onSuccess) {
+  if (typeof objectStore.getAll === 'function') {
+    // use native getAll
+    objectStore.getAll(keyRange).onsuccess = onSuccess;
+    return;
+  }
+  // fall back to cursors
+  var values = [];
+
+  function onCursor(e) {
+    var cursor = e.target.result;
+    if (cursor) {
+      values.push(cursor.value);
+      cursor.continue();
+    } else {
+      onSuccess({
+        target: {
+          result: values
+        }
+      });
+    }
+  }
+
+  objectStore.openCursor(keyRange).onsuccess = onCursor;
+}
+
+export default getAll;

--- a/packages/node_modules/pouchdb-adapter-idb/src/runBatchedCursor.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/runBatchedCursor.js
@@ -2,16 +2,18 @@
 // while falling back to a normal IDBCursor operation on browsers that don't support getAll() or
 // getAllKeys(). This allows for a much faster implementation than just straight-up cursors, because
 // we're not processing each document one-at-a-time.
-function runBatchedCursor(objectStore, startKey, descending, batchSize, onBatch) {
+function runBatchedCursor(objectStore, keyRange, descending, batchSize, onBatch) {
 
   // Bail out of getAll()/getAllKeys() in the following cases:
-  // 1) either method is unsupported (we need both)
+  // 1) either method is unsupported - we need both
   // 2) batchSize is 1 (might as well use IDBCursor), or batchSize is -1 (i.e. batchSize unlimited,
   //    not really clear the user wants a batched approach where the entire DB is read into memory,
   //    perhaps they are filtering on a per-doc basis)
   // 3) descending – no real way to do this via getAll()/getAllKeys()
+
   var useGetAll = typeof objectStore.getAll === 'function' &&
-    typeof objectStore.getAllKeys === 'function' && batchSize > 1 && !descending;
+    typeof objectStore.getAllKeys === 'function' &&
+    batchSize > 1 && !descending;
 
   var keysBatch;
   var valuesBatch;
@@ -36,11 +38,25 @@ function runBatchedCursor(objectStore, startKey, descending, batchSize, onBatch)
       return onBatch();
     }
     // fetch next batch, exclusive start
-    range = IDBKeyRange.lowerBound(keysBatch[keysBatch.length - 1], true);
+    var lastKey = keysBatch[keysBatch.length - 1];
+    var newKeyRange;
+    if (keyRange && keyRange.upper) {
+      try {
+        newKeyRange = IDBKeyRange.bound(lastKey, keyRange.upper,
+          true, keyRange.upperOpen);
+      } catch (e) {
+        if (e.name === "DataError" && e.code === 0) {
+          return onBatch(); // we're done, startkey and endkey are equal
+        }
+      }
+    } else {
+      newKeyRange = IDBKeyRange.lowerBound(lastKey, true);
+    }
+    keyRange = newKeyRange;
     keysBatch = null;
     valuesBatch = null;
-    objectStore.getAll(range, batchSize).onsuccess = onGetAll;
-    objectStore.getAllKeys(range, batchSize).onsuccess = onGetAllKeys;
+    objectStore.getAll(keyRange, batchSize).onsuccess = onGetAll;
+    objectStore.getAllKeys(keyRange, batchSize).onsuccess = onGetAllKeys;
   }
 
   function onCursor(e) {
@@ -52,16 +68,14 @@ function runBatchedCursor(objectStore, startKey, descending, batchSize, onBatch)
     onBatch([cursor.key], [cursor.value], cursor);
   }
 
-  var range = (startKey && !descending) ? IDBKeyRange.lowerBound(startKey, true) : null;
-
   if (useGetAll) {
     pseudoCursor = {"continue": continuePseudoCursor};
-    objectStore.getAll(range, batchSize).onsuccess = onGetAll;
-    objectStore.getAllKeys(range, batchSize).onsuccess = onGetAllKeys;
+    objectStore.getAll(keyRange, batchSize).onsuccess = onGetAll;
+    objectStore.getAllKeys(keyRange, batchSize).onsuccess = onGetAllKeys;
   } else if (descending) {
-    objectStore.openCursor(range, 'prev').onsuccess = onCursor;
+    objectStore.openCursor(keyRange, 'prev').onsuccess = onCursor;
   } else {
-    objectStore.openCursor(range).onsuccess = onCursor;
+    objectStore.openCursor(keyRange).onsuccess = onCursor;
   }
 }
 

--- a/tests/integration/test.all_docs.js
+++ b/tests/integration/test.all_docs.js
@@ -603,6 +603,54 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('test descending with startkey/endkey', function () {
+      var db = new PouchDB(dbs.name);
+      return db.bulkDocs([
+        {_id: 'a'},
+        {_id: 'b'},
+        {_id: 'c'},
+        {_id: 'd'},
+        {_id: 'e'}
+      ]).then(function () {
+        return db.allDocs({
+          descending: true,
+          startkey: 'd',
+          endkey: 'b'
+        });
+      }).then(function (res) {
+        var ids = res.rows.map(function (x) { return x.id; });
+        ids.should.deep.equal(['d', 'c', 'b']);
+        return db.allDocs({
+          descending: true,
+          startkey: 'd',
+          endkey: 'b',
+          inclusive_end: false
+        });
+      }).then(function (res) {
+        var ids = res.rows.map(function (x) { return x.id; });
+        ids.should.deep.equal(['d', 'c']);
+        return db.allDocs({
+          descending: true,
+          startkey: 'd',
+          endkey: 'a',
+          skip: 1,
+          limit: 2
+        });
+      }).then(function (res) {
+        var ids = res.rows.map(function (x) { return x.id; });
+        ids.should.deep.equal(['c', 'b']);
+        return db.allDocs({
+          descending: true,
+          startkey: 'd',
+          endkey: 'a',
+          skip: 1
+        });
+      }).then(function (res) {
+        var ids = res.rows.map(function (x) { return x.id; });
+        ids.should.deep.equal(['c', 'b', 'a']);
+      });
+    });
+
     it('#3082 test wrong num results returned', function () {
       var db = new PouchDB(dbs.name);
       var docs = [];


### PR DESCRIPTION
I rebased this on #6056 to avoid bitrotting myself.

This extends our use of `getAll()`/`getAllKeys()` to `allDocs()`, in addition to the work already done to use it in `changes()`. ~~This was a bit trickier because the two have slightly different use cases, but this is documented in the code comments for `runBatchedCursor.js`.~~

~~There is an additional optimization we can do here where we avoid `getAllKeys()` entirely for `allDocs()` (it's not necessary, since unlike the `by-seq-store` for the `doc-store` we can derive the key from the value; it's not an autoincrementing key). However I'll save that for a future PR.~~

_**edit:** I have a new implementation using batched cursors or a regular `getAll` depending on the scenario._

Benchmarks are TBD but in principle this is faster with no increased memory costs since we're still keeping the batch size limited based on `limit`.