### PR TITLE
(#6076) - slight improvements to perf test runner

### DIFF
--- a/tests/performance/index.js
+++ b/tests/performance/index.js
@@ -12,15 +12,26 @@ if (typeof process !== 'undefined' && process.env) {
 }
 
 function runTestSuites(PouchDB) {
-  var reporter = require('./perf.reporter');
-  reporter.log('Testing PouchDB version ' + PouchDB.version +
-    ((opts.adapter || levelAdapter) ?
-      (', using adapter: ' + (opts.adapter || levelAdapter)) : '') +
-    '\n\n');
 
-  require('./perf.basics')(PouchDB, opts);
-  require('./perf.views')(PouchDB, opts);
-  require('./perf.attachments')(PouchDB, opts);
+  function runTestsNow() {
+    var reporter = require('./perf.reporter');
+    reporter.log('Testing PouchDB version ' + PouchDB.version +
+      ((opts.adapter || levelAdapter) ?
+        (', using adapter: ' + (opts.adapter || levelAdapter)) : '') +
+      '\n\n');
+
+    require('./perf.basics')(PouchDB, opts);
+    require('./perf.views')(PouchDB, opts);
+    require('./perf.attachments')(PouchDB, opts);
+  }
+
+  if (typeof process === 'undefined' || process.browser) {
+    // rendering the initial view has its own costs
+    // that interfere with measurements
+    setTimeout(runTestsNow, 1000);
+  } else {
+    runTestsNow();
+  }
 }
 var startNow = true;
 if (global.window && global.window.location && global.window.location.search) {

--- a/tests/performance/markMeasure.js
+++ b/tests/performance/markMeasure.js
@@ -1,0 +1,11 @@
+function noop() {}
+
+if (typeof performance !== 'undefined' &&
+    performance.mark && performance.measure) {
+  module.exports = performance;
+} else {
+  module.exports = {
+    mark: noop,
+    measure: noop
+  };
+}

--- a/tests/performance/perf.reporter.js
+++ b/tests/performance/perf.reporter.js
@@ -2,13 +2,14 @@
 var isNode = process && !process.browser;
 var UAParser = require('ua-parser-js');
 var ua = !isNode && new UAParser(navigator.userAgent);
+var now = isNode ? Date.now.bind(Date) : performance.now.bind(performance);
 global.results = {};
 
 var pre = !isNode && global.document.getElementById('output');
 
 function log(msg) {
   if (pre) {
-    pre.innerHTML = pre.innerHTML + msg;
+    pre.textContent += msg;
   } else {
     console.log(msg);
   }
@@ -25,14 +26,14 @@ exports.start = function (testCase) {
   log('Starting test: ' + key + ' with ' + testCase.assertions +
     ' assertions and ' + testCase.iterations + ' iterations... ');
   global.results[key] = {
-    start: Date.now()
+    start: now()
   };
 };
 
 exports.end = function (testCase) {
   var key = testCase.name;
   var obj = global.results[key];
-  obj.end = Date.now();
+  obj.end = now();
   obj.duration = obj.end - obj.start;
   log('done in ' + obj.duration + 'ms\n');
 };


### PR DESCRIPTION
This contains some small improvements that I find make it easier to work with our perf tets.

1. Use `performance.now()` instead of `Date.now()` where available; it's more accurate
2. Do a 1000ms initial delay in the browser to avoid first load costs interfering with measurements
3. Add `performance.mark()`/`measure()` where available because it shows better visualizations in Chrome Timeline, Edge F12, and Windows Performance Recorder.
4. Prefer `setTimeout()` to `nextTick` in the browser because the stack traces are easier to follow.