### PR TITLE
(#6089) - Don't add default heartbeat to non-live `_changes` requests

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -801,7 +801,7 @@ function HttpPouch(opts, callback) {
       if (opts.heartbeat) {
         params.heartbeat = opts.heartbeat;
       }
-    } else {
+    } else if (opts.continuous) {
       // Default heartbeat to 10 seconds
       params.heartbeat = 10000;
     }

--- a/tests/component/test.params.js
+++ b/tests/component/test.params.js
@@ -15,8 +15,8 @@ describe('test.params.js', function () {
   before(function (done) {
     server = http.createServer(function (req, res) {
       params = url.parse(req.url,true).query;
-      res.writeHead(200, {'Content-Type': 'text/plain'});
-      res.end('');
+      res.writeHead(200, {'Content-Type': 'application/json'});
+      res.end('{"results":[{"seq":1,"id":"foo","changes":[{"rev":"1-a"}]}], "last_seq":1}');
     });
     server.listen(PORT, done);
   });
@@ -28,6 +28,16 @@ describe('test.params.js', function () {
   it('Test default heartbeat', function () {
     var url = 'http://127.0.0.1:' + PORT;
     return new PouchDB(url).changes().then(function () {
+      should.not.exist(params.heartbeat);
+    });
+  });
+
+  it('Test default heartbeat for live changes', function () {
+    var url = 'http://127.0.0.1:' + PORT;
+    var changes = new PouchDB(url).changes({live: true});
+    changes.on('change', function () {
+      changes.cancel();
+    }).then(function () {
       should.exist(params.heartbeat);
     });
   });


### PR DESCRIPTION
Per [CouchDB documentation](http://docs.couchdb.org/en/2.0.0/api/database/changes.html)
`heartbeat` is not applicable if `feed` isn't `longpoll`, `continuous`
or `eventsource`.