### PR TITLE
(#6099) - use Map/Set in viewCleanup()

### DIFF
--- a/packages/node_modules/pouchdb-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-mapreduce/src/index.js
@@ -771,23 +771,27 @@ function httpViewCleanup(db) {
 
 function localViewCleanup(db) {
   return db.get('_local/mrviews').then(function (metaDoc) {
-    var docsToViews = {};
+    var docsToViews = new Map();
     Object.keys(metaDoc.views).forEach(function (fullViewName) {
       var parts = parseViewName(fullViewName);
       var designDocName = '_design/' + parts[0];
       var viewName = parts[1];
-      docsToViews[designDocName] = docsToViews[designDocName] || {};
-      docsToViews[designDocName][viewName] = true;
+      var views = docsToViews.get(designDocName);
+      if (!views) {
+        views = new Set();
+        docsToViews.set(designDocName, views);
+      }
+      views.add(viewName);
     });
     var opts = {
-      keys : Object.keys(docsToViews),
+      keys : mapToKeysArray(docsToViews),
       include_docs : true
     };
     return db.allDocs(opts).then(function (res) {
       var viewsToStatus = {};
       res.rows.forEach(function (row) {
-        var ddocName = row.key.substring(8);
-        Object.keys(docsToViews[row.key]).forEach(function (viewName) {
+        var ddocName = row.key.substring(8); // cuts off '_design/'
+        docsToViews.get(row.key).forEach(function (viewName) {
           var fullViewName = ddocName + '/' + viewName;
           /* istanbul ignore if */
           if (!metaDoc.views[fullViewName]) {


### PR DESCRIPTION
One more place where we were unsafely mapping docIds using `{}` instead of `Map`/`Set`...

I should probably add a test to do map/reduce with a doc ID like `"constructor"` but haven't gotten around to it yet.