### PR TITLE
(#6101) - add perf test for building secondary indexes

### DIFF
--- a/tests/performance/perf.views.js
+++ b/tests/performance/perf.views.js
@@ -56,6 +56,36 @@ module.exports = function (PouchDB, opts) {
       }
     },
     {
+      name: 'build-secondary-index',
+      assertions: 1,
+      iterations: 1,
+      setup: function (db, callback) {
+        var docs = [];
+        for (var i = 0; i < 1000; i++) {
+          docs.push({});
+        }
+        db.bulkDocs(docs).then(function () {
+          return db.put({
+            _id : '_design/myview',
+            views : {
+              myview : {
+                map : function (doc) {
+                  emit(doc._id);
+                }.toString()
+              }
+            }
+          });
+        }).then(function () {
+          callback();
+        }, callback);
+      },
+      test: function (db, itr, doc, done) {
+        db.query('myview/myview', {limit: 0}).then(function () {
+          done();
+        }, done);
+      }
+    },
+    {
       name: 'persisted-views',
       assertions: 1,
       iterations: 10,


### PR DESCRIPTION
I wanted a perf test that would capture *just* the cost of building secondary indexes. So I wrote this one.

As a side note, I have been spending a lot of time perf-profiling secondary indexes, and I think I may have reached the limit (or close to it) of how fast it can get with the existing architecture. It's probably a good time to shift focus to `idb-next`. :sweat_smile: