### PR TITLE
(#6121) - remove nightly build references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,16 @@ The PouchDB community is active [on Freenode IRC](https://www.irccloud.com/invit
 
 If you think you've found a bug in PouchDB, please write a reproducible test case and file [a Github issue](https://github.com/pouchdb/pouchdb/issues). We recommend [bl.ocks.org](http://bl.ocks.org/) for code snippets, because some iframe-based services like JSFiddle and JSBin do not support IndexedDB in all browsers. You can start with [this template](https://gist.github.com/nolanlawson/816f138a51b86785d3e6).
 
-Nightly Build
+Prerelease builds
 ----
 
-If you like to live on the bleeding edge, you can find the PouchDB nightly builds at [pouchtest.com/nightly](http://pouchtest.com/nightly).
+If you like to live on the bleeding edge, you can build PouchDB from source using these steps:
+
+    git clone https://github.com/pouchdb/pouchdb.git
+    cd pouchdb
+    npm install
+
+After running these steps, the browser build can be found in `packages/node_modules/pouchdb/dist/pouchdb.js`.
 
 Changelog
 ----


### PR DESCRIPTION
I've decided to retire pouchtest.com because it was costing me too much money. :sweat_smile: If someone would like to contribute a new nightly build, I'd be happy to mention it here. Else it's fairly simple to build from source.