### PR TITLE
(#6132) - merge user-specified and default headers

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -169,6 +169,9 @@ function HttpPouch(opts, callback) {
   function ajax(userOpts, options, callback) {
     var reqAjax = userOpts.ajax || {};
     var reqOpts = assign(clone(ajaxOpts), reqAjax, options);
+    var defaultHeaders = clone(ajaxOpts.headers || {});
+    reqOpts.headers = assign(defaultHeaders, reqAjax.headers,
+      options.headers || {});
     log(reqOpts.method + ' ' + reqOpts.url);
     return api._ajax(reqOpts, callback);
   }


### PR DESCRIPTION
b325846 changed the behaviour of the HTTP adapter so that a
headers object supplied in requets options would overwrite the
default request headers. This results in authentication headers
not being added for certain PouchDB operations (e.g. put attachents)
and breaks instances where users provide custom headers.

Rather than re-introducing deep object extension across the library,
treat the headers object as a special case and explicitly merge default
and request-specific headers when construction the request options.

Fixes #6132, refs #6012