### PR TITLE
(#6162) - make polyfills extractable

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,13 +14,14 @@
   },
 
   "globals": {
+    "Map": true,
+    "Set": true,
     "chrome": true,
     "Promise": true,
     "Uint8Array": true,
     "ArrayBuffer": true,
     "FileReaderSync": true,
     "sqlitePlugin": true,
-
     "emit": true,
     "PouchDB": true,
     "should": true,

--- a/bin/build-module.js
+++ b/bin/build-module.js
@@ -10,8 +10,7 @@
 'use strict';
 
 var rollup = require('rollup').rollup;
-var nodeResolve = require('rollup-plugin-node-resolve');
-var replace = require('rollup-plugin-replace');
+var rollupPlugins = require('./rollupPlugins');
 
 var path = require('path');
 var lie = require('lie');
@@ -65,19 +64,11 @@ function buildModule(filepath) {
       return rollup({
         entry: path.resolve(filepath, './src/index.js'),
         external: depsToSkip,
-        plugins: [
-          nodeResolve({
-            skip: depsToSkip,
-            jsnext: true,
-            browser: isBrowser || forceBrowser
-          }),
-          replace({
-            // we have switches for coverage; don't ship this to consumers
-            'process.env.COVERAGE': JSON.stringify(!!process.env.COVERAGE),
-            // test for fetch vs xhr
-            'process.env.FETCH': JSON.stringify(!!process.env.FETCH)
-          })
-        ]
+        plugins: rollupPlugins({
+          skip: depsToSkip,
+          jsnext: true,
+          browser: isBrowser || forceBrowser
+        })
       }).then(function (bundle) {
         var formats = ['cjs'];
         if (bundledPkgs.indexOf(pkg.name) !== -1) {

--- a/bin/build-pouchdb.js
+++ b/bin/build-pouchdb.js
@@ -17,8 +17,7 @@ var denodeify = require('denodeify');
 var browserify = require('browserify');
 var browserifyIncremental = require('browserify-incremental');
 var rollup = require('rollup');
-var nodeResolve = require('rollup-plugin-node-resolve');
-var replace = require('rollup-plugin-replace');
+var rollupPlugins = require('./rollupPlugins');
 var derequire = require('derequire');
 var fs = require('fs');
 var writeFileAsync = denodeify(fs.writeFile);
@@ -149,20 +148,12 @@ function doRollup(entry, browser, formatsToFiles) {
   return rollup.rollup({
     entry: addPath(entry),
     external: external,
-    plugins: [
-      nodeResolve({
-        skip: external,
-        jsnext: true,
-        browser: browser,
-        main: false  // don't use "main"s that are CJS
-      }),
-      replace({
-        // we have switches for coverage; don't ship this to consumers
-        'process.env.COVERAGE': JSON.stringify(!!process.env.COVERAGE),
-        // test for fetch vs xhr
-        'process.env.FETCH': JSON.stringify(!!process.env.FETCH)
-      })
-    ]
+    plugins: rollupPlugins({
+      skip: external,
+      jsnext: true,
+      browser: browser,
+      main: false  // don't use "main"s that are CJS
+    })
   }).then(function (bundle) {
     return Promise.all(Object.keys(formatsToFiles).map(function (format) {
       var fileOut = formatsToFiles[format];

--- a/bin/rollupPlugins.js
+++ b/bin/rollupPlugins.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var nodeResolve = require('rollup-plugin-node-resolve');
+var replace = require('rollup-plugin-replace');
+var inject = require('rollup-plugin-inject');
+
+function rollupPlugins(nodeResolveConfig) {
+  return [
+    nodeResolve(nodeResolveConfig),
+    replace({
+      // we have switches for coverage; don't ship this to consumers
+      'process.env.COVERAGE': JSON.stringify(!!process.env.COVERAGE),
+      // test for fetch vs xhr
+      'process.env.FETCH': JSON.stringify(!!process.env.FETCH)
+    }),
+    inject({
+      exclude: [
+        '**/pouchdb-utils/src/assign.js',
+        '**/pouchdb-promise/src/index.js',
+        '**/pouchdb-collections/src/**'
+      ],
+      Map: ['pouchdb-collections', 'Map'],
+      Set: ['pouchdb-collections', 'Set'],
+      'Object.assign': ['pouchdb-utils', 'assign'],
+      Promise: 'pouchdb-promise'
+    })
+  ];
+}
+
+module.exports = rollupPlugins;

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "replace": "0.3.0",
     "rimraf": "2.5.4",
     "rollup": "0.41.4",
+    "rollup-plugin-inject": "2.0.0",
     "rollup-plugin-node-resolve": "2.0.0",
     "rollup-plugin-replace": "1.1.1",
     "sauce-connect-launcher": "1.2.0",

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -28,8 +28,6 @@ import {
   NotFoundError,
   BuiltInError
 } from 'pouchdb-mapreduce-utils';
-import { Map, Set } from 'pouchdb-collections';
-import Promise from 'pouchdb-promise';
 
 var persistentQueues = {};
 var tempViewQueue = new TaskQueue();

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/taskqueue.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/taskqueue.js
@@ -3,7 +3,6 @@
  * callbacks will eventually fire (once).
  */
 
-import Promise from 'pouchdb-promise';
 
 function TaskQueue() {
   this.promise = new Promise(function (fulfill) {fulfill(); });

--- a/packages/node_modules/pouchdb-adapter-fruitdown/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-fruitdown/src/index.js
@@ -1,10 +1,10 @@
 import CoreLevelPouch from 'pouchdb-adapter-leveldb-core';
-import { assign } from 'pouchdb-utils';
+
 
 import fruitdown from 'fruitdown';
 
 function FruitDownPouch(opts, callback) {
-  var _opts = assign({
+  var _opts = Object.assign({
     db: fruitdown
   }, opts);
 

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -3,8 +3,7 @@ var MAX_SIMULTANEOUS_REVS = 50;
 
 var supportsBulkGetMap = {};
 
-import { assign, nextTick } from 'pouchdb-utils';
-import Promise from 'pouchdb-promise';
+import { nextTick } from 'pouchdb-utils';
 import ajaxCore from 'pouchdb-ajax';
 import getArguments from 'argsarray';
 
@@ -168,9 +167,9 @@ function HttpPouch(opts, callback) {
 
   function ajax(userOpts, options, callback) {
     var reqAjax = userOpts.ajax || {};
-    var reqOpts = assign(clone(ajaxOpts), reqAjax, options);
+    var reqOpts = Object.assign(clone(ajaxOpts), reqAjax, options);
     var defaultHeaders = clone(ajaxOpts.headers || {});
-    reqOpts.headers = assign(defaultHeaders, reqAjax.headers,
+    reqOpts.headers = Object.assign(defaultHeaders, reqAjax.headers,
       options.headers || {});
     log(reqOpts.method + ' ' + reqOpts.url);
     return api._ajax(reqOpts, callback);

--- a/packages/node_modules/pouchdb-adapter-http/src/promise-pool.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/promise-pool.js
@@ -1,7 +1,6 @@
 // dead simple promise pool, inspired by https://github.com/timdp/es6-promise-pool
 // but much smaller in code size. limits the number of concurrent promises that are executed
 
-import Promise from 'pouchdb-promise';
 
 function pool(promiseFactories, limit) {
   return new Promise(function (resolve, reject) {

--- a/packages/node_modules/pouchdb-adapter-idb/src/blobSupport.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/blobSupport.js
@@ -1,5 +1,4 @@
 import { blob as createBlob } from 'pouchdb-binary-utils';
-import Promise from 'pouchdb-promise';
 import { DETECT_BLOB_SUPPORT_STORE } from './constants';
 
 //

--- a/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
@@ -1,4 +1,3 @@
-import { Map } from 'pouchdb-collections';
 import { createError, MISSING_STUB } from 'pouchdb-errors';
 import {
   preprocessAttachments,

--- a/packages/node_modules/pouchdb-adapter-idb/src/changes.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/changes.js
@@ -5,10 +5,6 @@ import {
   uuid
 } from 'pouchdb-utils';
 import {
-  Map,
-  Set
-} from 'pouchdb-collections';
-import {
   ATTACH_STORE,
   BY_SEQ_STORE,
   DOC_STORE

--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -13,7 +13,6 @@ import {
   latest as getLatest
 } from 'pouchdb-merge';
 
-import { Map } from 'pouchdb-collections';
 import idbBulkDocs from './bulkDocs';
 import idbAllDocs from './allDocs';
 import checkBlobSupport from './blobSupport';

--- a/packages/node_modules/pouchdb-adapter-idb/src/utils.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/utils.js
@@ -1,5 +1,4 @@
-import { assign } from 'pouchdb-utils';
-import Promise from 'pouchdb-promise';
+
 import { createError, IDB_ERROR } from 'pouchdb-errors';
 import {
   pick
@@ -142,7 +141,7 @@ function postProcessAttachments(results, asBlob) {
         var type = attObj.content_type;
         return new Promise(function (resolve) {
           readBlobData(body, type, asBlob, function (data) {
-            row.doc._attachments[att] = assign(
+            row.doc._attachments[att] = Object.assign(
               pick(attObj, ['digest', 'content_type']),
               {data: data}
             );

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -2,9 +2,7 @@ import levelup from 'levelup';
 import sublevel from 'sublevel-pouchdb';
 import { obj as through } from 'through2';
 import getArguments from 'argsarray';
-import { Map, Set } from 'pouchdb-collections';
 import Deque from 'double-ended-queue';
-import Promise from 'pouchdb-promise';
 import bufferFrom from 'buffer-from'; // ponyfill for Node <6
 import {
   clone,

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/transaction.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/transaction.js
@@ -3,7 +3,6 @@
 // things in-memory and then does a big batch() operation
 // when you're done
 
-import { Map, Set } from 'pouchdb-collections';
 import { nextTick } from 'pouchdb-utils';
 
 function getCacheFor(transaction, store) {

--- a/packages/node_modules/pouchdb-adapter-leveldb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb/src/index.js
@@ -1,5 +1,5 @@
 import CoreLevelPouch from 'pouchdb-adapter-leveldb-core';
-import { assign } from 'pouchdb-utils';
+
 import requireLeveldown from './requireLeveldown';
 import migrate from './migrate';
 
@@ -19,7 +19,7 @@ function LevelDownPouch(opts, callback) {
     }
   }
 
-  var _opts = assign({
+  var _opts = Object.assign({
     db: leveldown,
     migrate: migrate
   }, opts);

--- a/packages/node_modules/pouchdb-adapter-localstorage/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-localstorage/src/index.js
@@ -1,10 +1,10 @@
 import CoreLevelPouch from 'pouchdb-adapter-leveldb-core';
-import { assign } from 'pouchdb-utils';
+
 
 import localstoragedown from 'localstorage-down';
 
 function LocalStoragePouch(opts, callback) {
-  var _opts = assign({
+  var _opts = Object.assign({
     db: localstoragedown
   }, opts);
 

--- a/packages/node_modules/pouchdb-adapter-memory/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-memory/src/index.js
@@ -1,10 +1,10 @@
 import CoreLevelPouch from 'pouchdb-adapter-leveldb-core';
-import { assign } from 'pouchdb-utils';
+
 
 import memdown from 'memdown';
 
 function MemDownPouch(opts, callback) {
-  var _opts = assign({
+  var _opts = Object.assign({
     db: memdown
   }, opts);
 

--- a/packages/node_modules/pouchdb-adapter-node-websql/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-node-websql/src/index.js
@@ -1,9 +1,9 @@
 import WebSqlPouchCore from 'pouchdb-adapter-websql-core';
-import { assign } from 'pouchdb-utils';
+
 import websql from 'websql';
 
 function NodeWebSqlPouch(opts, callback) {
-  var _opts = assign({
+  var _opts = Object.assign({
     websql: websql // pass node-websql in as our "openDatabase" function
   }, opts);
 

--- a/packages/node_modules/pouchdb-adapter-utils/src/processDocs.js
+++ b/packages/node_modules/pouchdb-adapter-utils/src/processDocs.js
@@ -6,7 +6,6 @@ import {
   merge,
   winningRev as calculateWinningRev
 } from 'pouchdb-merge';
-import { Map } from 'pouchdb-collections';
 
 function rootIsMissing(docInfo) {
   return docInfo.metadata.rev_tree[0].ids[1].status === 'missing';

--- a/packages/node_modules/pouchdb-adapter-websql-core/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-websql-core/src/bulkDocs.js
@@ -1,4 +1,3 @@
-import { Map } from 'pouchdb-collections';
 import {
   preprocessAttachments,
   isLocalId,

--- a/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
@@ -1,4 +1,4 @@
-import { assign } from 'pouchdb-utils';
+
 import {
   clone,
   pick,
@@ -77,7 +77,7 @@ function fetchAttachmentsIfNecessary(doc, opts, api, txn, cb) {
     var attObj = doc._attachments[att];
     var attOpts = {binary: opts.binary, ctx: txn};
     api._getAttachment(doc._id, att, attObj, attOpts, function (_, data) {
-      doc._attachments[att] = assign(
+      doc._attachments[att] = Object.assign(
         pick(attObj, ['digest', 'content_type']),
         { data: data }
       );
@@ -134,7 +134,7 @@ function WebSqlPouch(opts, callback) {
 
   // extend the options here, because sqlite plugin has a ton of options
   // and they are constantly changing, so it's more prudent to allow anything
-  var websqlOpts = assign({}, opts, {
+  var websqlOpts = Object.assign({}, opts, {
     version: POUCH_VERSION,
     description: opts.name,
     size: size
@@ -608,7 +608,7 @@ function WebSqlPouch(opts, callback) {
     var tx = opts.ctx;
     if (!tx) {
       return db.readTransaction(function (txn) {
-        api._get(id, assign({ctx: txn}, opts), callback);
+        api._get(id, Object.assign({ctx: txn}, opts), callback);
       });
     }
 

--- a/packages/node_modules/pouchdb-adapter-websql-core/src/openDatabase.js
+++ b/packages/node_modules/pouchdb-adapter-websql-core/src/openDatabase.js
@@ -1,6 +1,5 @@
 'use strict';
 
-import { Map } from 'pouchdb-collections';
 
 var cachedDatabases = new Map();
 

--- a/packages/node_modules/pouchdb-adapter-websql-core/src/utils.js
+++ b/packages/node_modules/pouchdb-adapter-websql-core/src/utils.js
@@ -1,4 +1,3 @@
-import { Set } from 'pouchdb-collections';
 import { createError, WSQ_ERROR } from 'pouchdb-errors';
 import { guardedConsole } from 'pouchdb-utils';
 

--- a/packages/node_modules/pouchdb-adapter-websql/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-websql/src/index.js
@@ -1,5 +1,5 @@
 import WebSqlPouchCore from 'pouchdb-adapter-websql-core';
-import { assign } from 'pouchdb-utils';
+
 import valid from './valid';
 
 function openDB(name, version, description, size) {
@@ -8,7 +8,7 @@ function openDB(name, version, description, size) {
 }
 
 function WebSQLPouch(opts, callback) {
-  var _opts = assign({
+  var _opts = Object.assign({
     websql: openDB
   }, opts);
 

--- a/packages/node_modules/pouchdb-ajax/src/ajaxCore.js
+++ b/packages/node_modules/pouchdb-ajax/src/ajaxCore.js
@@ -1,5 +1,5 @@
 import request from './request';
-import { assign } from 'pouchdb-utils';
+
 import { generateErrorFromResponse } from 'pouchdb-errors';
 import { clone } from 'pouchdb-utils';
 import applyTypeToBuffer from './applyTypeToBuffer';
@@ -18,7 +18,7 @@ function ajaxCore(options, callback) {
     cache: false
   };
 
-  options = assign(defaultOptions, options);
+  options = Object.assign(defaultOptions, options);
 
   function onSuccess(obj, resp, cb) {
     if (!options.binary && options.json && typeof obj === 'string') {

--- a/packages/node_modules/pouchdb-ajax/src/request-browser.js
+++ b/packages/node_modules/pouchdb-ajax/src/request-browser.js
@@ -1,7 +1,6 @@
 /* global fetch */
 /* global Headers */
 import {blob as createBlob, readAsArrayBuffer } from 'pouchdb-binary-utils';
-import Promise from 'pouchdb-promise';
 
 function wrappedFetch() {
   var wrappedPromise = {};

--- a/packages/node_modules/pouchdb-checkpointer/src/index.js
+++ b/packages/node_modules/pouchdb-checkpointer/src/index.js
@@ -1,4 +1,3 @@
-import Promise from 'pouchdb-promise';
 import { explainError } from 'pouchdb-utils';
 import { collate } from 'pouchdb-collate';
 

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -1,9 +1,6 @@
 import {
-    assign,
     guardedConsole
 } from 'pouchdb-utils';
-import Promise from 'pouchdb-promise';
-import { Map } from 'pouchdb-collections';
 import { EventEmitter } from 'events';
 import inherits from 'inherits';
 import Changes from './changes';
@@ -126,7 +123,7 @@ function allDocsKeysQuery(api, opts, callback) {
     offset: opts.skip
   };
   return Promise.all(keys.map(function (key) {
-    var subOpts = assign({key: key, deleted: 'ok'}, opts);
+    var subOpts = Object.assign({key: key, deleted: 'ok'}, opts);
     ['limit', 'skip', 'keys'].forEach(function (optKey) {
       delete subOpts[optKey];
     });

--- a/packages/node_modules/pouchdb-core/src/changes.js
+++ b/packages/node_modules/pouchdb-core/src/changes.js
@@ -1,4 +1,3 @@
-import Promise from 'pouchdb-promise';
 import getArguments from 'argsarray';
 import {
   clone,

--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -1,8 +1,7 @@
-import { assign } from 'pouchdb-utils';
+
 
 import PouchDB from './constructor';
 import inherits from 'inherits';
-import { Map } from 'pouchdb-collections';
 import { EventEmitter as EE } from 'events';
 
 PouchDB.adapters = {};
@@ -69,7 +68,7 @@ PouchDB.defaults = function (defaultOpts) {
       delete opts.name;
     }
 
-    opts = assign({}, PouchAlt.__defaults, opts);
+    opts = Object.assign({}, PouchAlt.__defaults, opts);
     PouchDB.call(this, name, opts);
   }
 
@@ -84,7 +83,7 @@ PouchDB.defaults = function (defaultOpts) {
 
   // make default options transitive
   // https://github.com/pouchdb/pouchdb/issues/5922
-  PouchAlt.__defaults = assign({}, this.__defaults, defaultOpts);
+  PouchAlt.__defaults = Object.assign({}, this.__defaults, defaultOpts);
 
   return PouchAlt;
 };

--- a/packages/node_modules/pouchdb-for-coverage/src/utils.js
+++ b/packages/node_modules/pouchdb-for-coverage/src/utils.js
@@ -16,8 +16,7 @@ import {
   once,
   upsert,
   toPromise,
-  defaultBackOff,
-  assign
+  defaultBackOff
 } from 'pouchdb-utils';
 
 import {
@@ -40,7 +39,6 @@ import {
   promisedCallback
 } from 'pouchdb-mapreduce-utils';
 
-import Promise from 'pouchdb-promise';
 
 import {
   createError,
@@ -72,7 +70,7 @@ export default {
   toPromise: toPromise,
   checkpointer: checkpointer,
   defaultBackOff: defaultBackOff,
-  assign: assign,
+  assign: Object.assign,
   mapReduceUtils: {
     uniq: uniq,
     sequentialize: sequentialize,

--- a/packages/node_modules/pouchdb-generate-replication-id/src/index.js
+++ b/packages/node_modules/pouchdb-generate-replication-id/src/index.js
@@ -1,4 +1,3 @@
-import Promise from 'pouchdb-promise';
 import { binaryMd5 } from 'pouchdb-md5';
 import { collate } from 'pouchdb-collate';
 

--- a/packages/node_modules/pouchdb-mapreduce-utils/src/index.js
+++ b/packages/node_modules/pouchdb-mapreduce-utils/src/index.js
@@ -1,6 +1,5 @@
 import argsarray from 'argsarray';
 import { nextTick } from 'pouchdb-utils';
-import { Set } from 'pouchdb-collections';
 import {
   QueryParseError,
   NotFoundError,

--- a/packages/node_modules/pouchdb-replication/src/getDocs.js
+++ b/packages/node_modules/pouchdb-replication/src/getDocs.js
@@ -1,5 +1,4 @@
 import { clone, flatten } from 'pouchdb-utils';
-import Promise from 'pouchdb-promise';
 
 function isGenOne(rev) {
   return /^1-/.test(rev);

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -1,6 +1,5 @@
 import { clone, filterChange, uuid } from 'pouchdb-utils';
 import getDocs from './getDocs';
-import Promise from 'pouchdb-promise';
 import Checkpointer from 'pouchdb-checkpointer';
 import backOff from './backoff';
 import generateReplicationId from 'pouchdb-generate-replication-id';

--- a/packages/node_modules/pouchdb-replication/src/replication.js
+++ b/packages/node_modules/pouchdb-replication/src/replication.js
@@ -1,5 +1,4 @@
 import { EventEmitter as EE } from 'events';
-import Promise from 'pouchdb-promise';
 import inherits from 'inherits';
 
 // We create a basic promise so the caller can cancel the replication possibly

--- a/packages/node_modules/pouchdb-replication/src/sync.js
+++ b/packages/node_modules/pouchdb-replication/src/sync.js
@@ -1,5 +1,4 @@
-import { assign } from 'pouchdb-utils';
-import Promise from 'pouchdb-promise';
+
 import {
   replicate,
   toPouch
@@ -30,8 +29,8 @@ function Sync(src, target, opts, callback) {
   var self = this;
   this.canceled = false;
 
-  var optsPush = opts.push ? assign({}, opts, opts.push) : opts;
-  var optsPull = opts.pull ? assign({}, opts, opts.pull) : opts;
+  var optsPush = opts.push ? Object.assign({}, opts, opts.push) : opts;
+  var optsPull = opts.pull ? Object.assign({}, opts, opts.pull) : opts;
 
   this.push = replicate(src, target, optsPush);
   this.pull = replicate(target, src, optsPull);

--- a/packages/node_modules/pouchdb-utils/src/adapterFun.js
+++ b/packages/node_modules/pouchdb-utils/src/adapterFun.js
@@ -1,4 +1,3 @@
-import Promise from 'pouchdb-promise';
 import toPromise from './toPromise';
 import getArguments from 'argsarray';
 import debug from 'debug';

--- a/packages/node_modules/pouchdb-utils/src/bulkGetShim.js
+++ b/packages/node_modules/pouchdb-utils/src/bulkGetShim.js
@@ -1,5 +1,4 @@
 import pick from './pick';
-import { Map } from 'pouchdb-collections';
 
 // Most browsers throttle concurrent requests at 6, so it's silly
 // to shim _bulk_get by trying to launch potentially hundreds of requests

--- a/packages/node_modules/pouchdb-utils/src/toPromise.js
+++ b/packages/node_modules/pouchdb-utils/src/toPromise.js
@@ -1,4 +1,3 @@
-import Promise from 'pouchdb-promise';
 import getArguments from 'argsarray';
 import clone from './clone';
 import once from './once';

--- a/packages/node_modules/pouchdb-utils/src/upsert.js
+++ b/packages/node_modules/pouchdb-utils/src/upsert.js
@@ -1,4 +1,3 @@
-import Promise from 'pouchdb-promise';
 
 // this is essentially the "update sugar" function from daleharvey/pouchdb#1388
 // the diffFun tells us what delta to apply to the doc.  it either returns


### PR DESCRIPTION
This doesn't actually have any functional changes. This simply migrates all our code to use base `Object.assign`, `Map`, `Set`, and `Promise` and then uses [rollup-plugin-inject](https://github.com/rollup/rollup-plugin-inject) to automatically transform those into the corresponding PouchDB polyfills at build time.

This puts us in a position where, if we _wanted_ to, we could create a build of PouchDB without these polyfills. We can also add polyfills later (`fetch()`?) as needed.

I inspected the browser output and confirmed that it looks exactly the same, except for some cosmetic differences.