### PR TITLE
(#6167) - fix and improve test scripts

### DIFF
--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -24,7 +24,12 @@ if (process.env.POUCHDB_SRC) {
 if (process.env.COUCH_HOST) {
   queryParams.couchHost = process.env.COUCH_HOST;
 }
-
+if (process.env.ADAPTER) {
+  queryParams.adapter = process.env.ADAPTER;
+}
+if (process.env.ITERATIONS) {
+  queryParams.iterations = process.env.ITERATIONS;
+}
 if (process.env.NEXT) {
   queryParams.src = '../../packages/node_modules/pouchdb/dist/pouchdb-next.js';
 }
@@ -35,6 +40,7 @@ function rebuildPouch() {
   rebuildPromise = rebuildPromise.then(buildPouchDB).then(function () {
     console.log('Rebuilt packages/node_modules/pouchdb');
   }).catch(console.error);
+  return rebuildPromise;
 }
 
 function browserifyPromise(src, dest) {
@@ -52,6 +58,7 @@ function rebuildTestUtils() {
   }).then(function () {
     console.log('Rebuilt tests/integration/utils-bundle.js');
   }).catch(console.error);
+  return rebuildPromise;
 }
 
 function rebuildPerf() {
@@ -61,6 +68,7 @@ function rebuildPerf() {
   }).then(function () {
     console.log('Rebuilt tests/performance-bundle.js');
   }).catch(console.error);
+  return rebuildPromise;
 }
 
 function watchAll() {
@@ -84,6 +92,7 @@ Promise.resolve().then(function () {
     rebuildPerf()
   ]);
 }).then(function () {
+  console.log('Rebuilt PouchDB/test/perf JS bundles');
   filesWritten = true;
   checkReady();
 });

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -77,6 +77,12 @@ if (process.env.POUCHDB_SRC) {
 if (process.env.COUCH_HOST) {
   qs.couchHost = process.env.COUCH_HOST;
 }
+if (process.env.ADAPTER) {
+  qs.adapter = process.env.ADAPTER;
+}
+if (process.env.ITERATIONS) {
+  qs.iterations = process.env.ITERATIONS;
+}
 if (process.env.NEXT) {
   qs.NEXT = '1';
 }
@@ -125,7 +131,7 @@ function postResult(result) {
 }
 
 function testComplete(result) {
-  console.log(result);
+  console.log('=>', JSON.stringify(result, null, '  '), '<=');
 
   sauceClient.quit().then(function () {
     if (sauceConnectProcess) {
@@ -204,7 +210,7 @@ function startTest() {
           clearInterval(interval);
           testComplete(results);
         } else {
-          console.log('=> ', results);
+          console.log(results);
         }
       });
     }, 10 * 1000);

--- a/tests/performance/index.js
+++ b/tests/performance/index.js
@@ -3,9 +3,7 @@
 
 var opts = {};
 
-var levelAdapter;
 if (typeof process !== 'undefined' && process.env) {
-  levelAdapter = process.env.LEVEL_ADAPTER;
   if (process.env.ADAPTER) {
     opts.adapter = process.env.ADAPTER;
   }
@@ -16,13 +14,22 @@ function runTestSuites(PouchDB) {
   function runTestsNow() {
     var reporter = require('./perf.reporter');
     reporter.log('Testing PouchDB version ' + PouchDB.version +
-      ((opts.adapter || levelAdapter) ?
-        (', using adapter: ' + (opts.adapter || levelAdapter)) : '') +
+      (opts.adapter ?
+        (', using adapter: ' + opts.adapter) : '') +
       '\n\n');
 
-    require('./perf.basics')(PouchDB, opts);
-    require('./perf.views')(PouchDB, opts);
-    require('./perf.attachments')(PouchDB, opts);
+    var theAdapterUsed;
+    var count = 0;
+    function checkDone(adapterUsed) {
+      theAdapterUsed = theAdapterUsed || adapterUsed;
+      if (++count === 3) { // number of perf.xxxx.js tests
+        reporter.complete(theAdapterUsed);
+      }
+    }
+
+    require('./perf.basics')(PouchDB, opts, checkDone);
+    require('./perf.views')(PouchDB, opts, checkDone);
+    require('./perf.attachments')(PouchDB, opts, checkDone);
   }
 
   if (typeof process === 'undefined' || process.browser) {
@@ -69,6 +76,8 @@ if (startNow) {
     // fails in Node 0.11-0.12 due to sqlite3 being incompatible
     PouchDB.plugin(require('../../packages/node_modules/' +
       'pouchdb-adapter-node-websql'));
+    PouchDB.plugin(require('../../packages/node_modules/' +
+      'pouchdb-adapter-memory'));
   }
   runTestSuites(PouchDB);
 }

--- a/tests/performance/perf.attachments.js
+++ b/tests/performance/perf.attachments.js
@@ -28,7 +28,7 @@ function randomBlob(size) {
   }
 }
 
-module.exports = function (PouchDB, opts) {
+module.exports = function (PouchDB, opts, callback) {
 
   require('lie');
   var utils = require('./utils');
@@ -53,6 +53,6 @@ module.exports = function (PouchDB, opts) {
     }
   ];
 
-  utils.runTests(PouchDB, 'views', testCases, opts);
+  utils.runTests(PouchDB, 'views', testCases, opts, callback);
 
 };

--- a/tests/performance/perf.basics.js
+++ b/tests/performance/perf.basics.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function (PouchDB, opts) {
+module.exports = function (PouchDB, opts, callback) {
 
   var Promise = require('lie');
   var utils = require('./utils');
@@ -61,10 +61,10 @@ module.exports = function (PouchDB, opts) {
     {
       name: 'basic-gets',
       assertions: 1,
-      iterations: 10000,
+      iterations: 1000,
       setup: function (db, callback) {
         var docs = [];
-        for (var i = 0; i < 10000; i++) {
+        for (var i = 0; i < 1000; i++) {
           docs.push({_id : commonUtils.createDocId(i),
             foo : 'bar', baz : 'quux'});
         }
@@ -223,5 +223,5 @@ module.exports = function (PouchDB, opts) {
     }
   ];
 
-  utils.runTests(PouchDB, 'basics', testCases, opts);
+  utils.runTests(PouchDB, 'basics', testCases, opts, callback);
 };

--- a/tests/performance/perf.views.js
+++ b/tests/performance/perf.views.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function (PouchDB, opts) {
+module.exports = function (PouchDB, opts, callback) {
 
   var Promise = require('lie');
   var utils = require('./utils');
@@ -173,6 +173,6 @@ module.exports = function (PouchDB, opts) {
     }
   ];
 
-  utils.runTests(PouchDB, 'views', testCases, opts);
+  utils.runTests(PouchDB, 'views', testCases, opts, callback);
 
 };


### PR DESCRIPTION
I was trying to do some simple performance tests:

    PERF=1 CLIENT=selenium:chrome GREP=temp-views ITERATIONS=5 npm t

And I found that basic stuff was not working. So I fixed several issues with our test scripts, notably:

- `results.completed` being called too early (end of test suite, not end of all test suites)
- not able to test `memory` in Node
- `GREP` not working correctly with marking `results.completed`
- not able to specify number of iterations
- object printed to console too large, too hard to read

Our test scripts could probably use a heck of a lot more refactoring, but for the time being they're at least usable now.