### PR TITLE
(#6170) - don't expose src directory to npm

### DIFF
--- a/bin/build-module.js
+++ b/bin/build-module.js
@@ -44,11 +44,6 @@ function buildModule(filepath) {
     depsToSkip = depsToSkip.concat(pouchdbPackages);
   }
 
-  if (pkg.browser && pkg.browser['./lib/index.js'] !== './lib/index-browser.js') {
-    return Promise.reject(new Error(pkg.name +
-      ' is missing a "lib/index.js" entry in the browser field'));
-  }
-
   // browser & node vs one single vanilla version
   var versions = pkg.browser ? [false, true] : [false];
 
@@ -79,12 +74,7 @@ function buildModule(filepath) {
           })
         ]
       }).then(function (bundle) {
-        var formats = ['cjs'];
-        if (bundledPkgs.indexOf(pkg.name) !== -1) {
-          // any packages that are aggressively bundled will also have their
-          // npm deps inlined. This means that we need a separate jsnext:main build.
-          formats.push('es');
-        }
+        var formats = ['cjs', 'es'];
         return Promise.all(formats.map(function (format) {
           var dest = (isBrowser ? 'lib/index-browser' : 'lib/index') +
             (format === 'es' ? '.es.js' : '.js');

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -21,7 +21,7 @@ BUILD_DIR=build_"${RANDOM}"
 git checkout -b $BUILD_DIR
 
 # Update dependency versions inside each package.json (replace the "*")
-node bin/update-dependencies.js
+node bin/update-package-json-for-publish.js
 
 # Publish all modules with Lerna
 for pkg in $(ls packages/node_modules); do

--- a/bin/test-webpack.sh
+++ b/bin/test-webpack.sh
@@ -8,6 +8,7 @@
 
 npm run build
 npm install webpack@1.13.1 # do this on-demand to avoid slow installs
+node bin/update-package-json-for-publish.js
 ./node_modules/.bin/webpack \
   --output-library PouchDB --output-library-target umd \
   ./packages/node_modules/pouchdb pouchdb-webpack.js

--- a/bin/update-package-json-for-publish.js
+++ b/bin/update-package-json-for-publish.js
@@ -4,6 +4,8 @@
 // to reflect the true dependencies (automatically determined by require())
 // and update the version numbers to reflect the version from the top-level
 // dependencies list. Also throw an error if a dep is not declared top-level.
+// Also add necessary "browser" switches to each package.json, as well as
+// other fields like "jsnext:main" and "files".
 
 var fs = require('fs');
 var path = require('path');
@@ -47,6 +49,19 @@ modules.forEach(function (mod) {
       throw new Error('Unknown dependency ' + dep);
     }
   });
+
+  // add "browser" switches for both CJS and ES modules
+  if (pkg.browser) {
+    pkg.browser = {
+      './lib/index.js': './lib/index-browser.js',
+      './lib/index.es.js': './lib/index-browser.es.js',
+    };
+  }
+  // update jsnext:main to point to lib/ rather than src/. src/ is only
+  // used for building, not publishing
+  pkg['jsnext:main'] = './lib/index.es.js';
+  // whitelist the files we'll actually publish
+  pkg.files = ['lib', 'dist', 'tonic-example.js'];
 
   var jsonString = JSON.stringify(pkg, null, '  ') + '\n';
   fs.writeFileSync(pkgPath, jsonString, 'utf8');

--- a/packages/node_modules/pouchdb-abstract-mapreduce/package.json
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/package.json
@@ -8,11 +8,6 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
   "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ],
   "browser": {
-    "./lib/index.js": "./lib/index-browser.js"
   }
 }

--- a/packages/node_modules/pouchdb-adapter-fruitdown/package.json
+++ b/packages/node_modules/pouchdb-adapter-fruitdown/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-adapter-http/package.json
+++ b/packages/node_modules/pouchdb-adapter-http/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-adapter-idb/package.json
+++ b/packages/node_modules/pouchdb-adapter-idb/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-adapter-indexeddb/package.json
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/package.json
@@ -8,9 +8,5 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
   "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ],
   "private": true
 }

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/package.json
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/package.json
@@ -8,12 +8,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
   "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ],
   "browser": {
-    "./lib/index.js": "./lib/index-browser.js",
     "./src/createEmptyBlobOrBuffer.js": "./src/createEmptyBlobOrBuffer-browser.js",
     "./src/prepareAttachmentForStorage.js": "./src/prepareAttachmentForStorage-browser.js",
     "./src/readAsBlobOrBuffer.js": "./src/readAsBlobOrBuffer-browser.js"

--- a/packages/node_modules/pouchdb-adapter-leveldb/package.json
+++ b/packages/node_modules/pouchdb-adapter-leveldb/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-adapter-localstorage/package.json
+++ b/packages/node_modules/pouchdb-adapter-localstorage/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-adapter-memory/package.json
+++ b/packages/node_modules/pouchdb-adapter-memory/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-adapter-node-websql/package.json
+++ b/packages/node_modules/pouchdb-adapter-node-websql/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-adapter-utils/package.json
+++ b/packages/node_modules/pouchdb-adapter-utils/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-adapter-websql-core/package.json
+++ b/packages/node_modules/pouchdb-adapter-websql-core/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-adapter-websql/package.json
+++ b/packages/node_modules/pouchdb-adapter-websql/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-ajax/package.json
+++ b/packages/node_modules/pouchdb-ajax/package.json
@@ -8,12 +8,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
   "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ],
   "browser": {
-    "./lib/index.js": "./lib/index-browser.js",
     "./src/applyTypeToBuffer": "./src/applyTypeToBuffer-browser",
     "./src/createBlobOrBufferFromParts": "./src/createBlobOrBufferFromParts-browser",
     "./src/createMultipartPart": "./src/createMultipartPart-browser",

--- a/packages/node_modules/pouchdb-binary-utils/package.json
+++ b/packages/node_modules/pouchdb-binary-utils/package.json
@@ -8,12 +8,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
   "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ],
   "browser": {
-    "./lib/index.js": "./lib/index-browser.js",
     "./src/base64.js": "./src/base64-browser.js",
     "./src/base64StringToBlobOrBuffer.js": "./src/base64StringToBlobOrBuffer-browser.js",
     "./src/blob.js": "./src/blob-browser.js",

--- a/packages/node_modules/pouchdb-browser/package.json
+++ b/packages/node_modules/pouchdb-browser/package.json
@@ -6,9 +6,5 @@
   "jsnext:main": "./lib/index.es.js",
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
-  "repository": "https://github.com/pouchdb/pouchdb",
-  "files": [
-    "src",
-    "lib"
-  ]
+  "repository": "https://github.com/pouchdb/pouchdb"
 }

--- a/packages/node_modules/pouchdb-checkpointer/package.json
+++ b/packages/node_modules/pouchdb-checkpointer/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-collate/package.json
+++ b/packages/node_modules/pouchdb-collate/package.json
@@ -10,9 +10,5 @@
     "couchdb"
   ],
   "license": "Apache-2.0",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-collections/package.json
+++ b/packages/node_modules/pouchdb-collections/package.json
@@ -12,10 +12,6 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
   "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ],
   "contributors": [
     {
       "name": "Calvin Metcalf",

--- a/packages/node_modules/pouchdb-core/package.json
+++ b/packages/node_modules/pouchdb-core/package.json
@@ -8,12 +8,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
   "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ],
   "browser": {
-    "./lib/index.js": "./lib/index-browser.js",
     "./src/evalFilter.js": "./src/evalFilter-browser.js",
     "./src/evalView.js": "./src/evalView-browser.js"
   }

--- a/packages/node_modules/pouchdb-errors/package.json
+++ b/packages/node_modules/pouchdb-errors/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-generate-replication-id/package.json
+++ b/packages/node_modules/pouchdb-generate-replication-id/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-json/package.json
+++ b/packages/node_modules/pouchdb-json/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-mapreduce-utils/package.json
+++ b/packages/node_modules/pouchdb-mapreduce-utils/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-mapreduce/package.json
+++ b/packages/node_modules/pouchdb-mapreduce/package.json
@@ -8,12 +8,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
   "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ],
   "browser": {
-    "./src/evalFunction.js": "./src/evalFunction-browser.js",
-    "./lib/index.js": "./lib/index-browser.js"
+    "./src/evalFunction.js": "./src/evalFunction-browser.js"
   }
 }

--- a/packages/node_modules/pouchdb-md5/package.json
+++ b/packages/node_modules/pouchdb-md5/package.json
@@ -8,12 +8,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
   "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ],
   "browser": {
-    "./lib/index.js": "./lib/index-browser.js",
     "./src/binaryMd5.js": "./src/binaryMd5-browser.js",
     "./src/stringMd5.js": "./src/stringMd5-browser.js"
   }

--- a/packages/node_modules/pouchdb-merge/package.json
+++ b/packages/node_modules/pouchdb-merge/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-node/package.json
+++ b/packages/node_modules/pouchdb-node/package.json
@@ -6,9 +6,5 @@
   "jsnext:main": "./lib/index.es.js",
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
-  "repository": "https://github.com/pouchdb/pouchdb",
-  "files": [
-    "src",
-    "lib"
-  ]
+  "repository": "https://github.com/pouchdb/pouchdb"
 }

--- a/packages/node_modules/pouchdb-promise/package.json
+++ b/packages/node_modules/pouchdb-promise/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-replication/package.json
+++ b/packages/node_modules/pouchdb-replication/package.json
@@ -7,9 +7,5 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ]
+  "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-utils/package.json
+++ b/packages/node_modules/pouchdb-utils/package.json
@@ -8,12 +8,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
   "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ],
   "browser": {
-    "./lib/index.js": "./lib/index-browser.js",
     "./src/cloneBinaryObject.js": "./src/cloneBinaryObject-browser.js",
     "./src/env/hasLocalStorage.js": "./src/env/hasLocalStorage-browser.js",
     "./src/env/isChromeApp.js": "./src/env/isChromeApp-browser.js",

--- a/packages/node_modules/pouchdb/package.json
+++ b/packages/node_modules/pouchdb/package.json
@@ -7,16 +7,7 @@
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
-  "files": [
-    "src",
-    "lib",
-    "tonic-example.js",
-    "dist",
-    "extras"
-  ],
   "browser": {
-    "./lib/index.js": "./lib/index-browser.js",
-    "./lib/index.es.js": "./lib/index-browser.es.js",
     "./src/pouchdb.js": "./src/pouchdb-browser.js"
   },
   "jspm": {

--- a/packages/node_modules/sublevel-pouchdb/package.json
+++ b/packages/node_modules/sublevel-pouchdb/package.json
@@ -8,10 +8,6 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",
   "jsnext:main": "./src/index.js",
-  "files": [
-    "lib",
-    "src"
-  ],
   "contributors": [
     {
       "name": "Dominic Tarr",


### PR DESCRIPTION
This ensures that we don't expose any `src` directories to npm, and that we build standard ES module bundles as well as CJS bundles to the `lib` directory, which are then exposed.

### Changes in this PR

- build `lib/index.es.js` for all packages, `lib/index-browser.es.js` where there's a `"browser"` field
- when we publish to npm, automatically overwrite the `"jsnext:main"` and `"browser"` fields
- remove the warning for missing `lib/index-browser.js` in `"browser"`, since we just generate this automatically when we `npm publish` now
 - remove `"src"` from package.json `"files"` so the files don't even get published

### Notes

I didn't notice build times slowing down at all due to the extra `es` module generation target, probably due to the fact that the Rollup build script is re-using the existing "bundle" object.

One slightly weird thing is that we are using `"jsnext:main":"src/index.js"` during development and then `"jsnext:main":"lib/index.es.js"` in the published package, but I couldn't think of any more elegant solution since we need Rollup to operate on the `src` files.

### Remaining TODOs

1. Remove `*-browser.js` files entirely and use the trick from [my blog post](https://nolanlawson.com/2017/01/09/how-to-write-a-javascript-package-for-both-node-and-the-browser/) instead, which will make for much cleaner code. We can still keep an empty `"browser"` field in `package.json` to signal that the package requires building two versions, though.
2. Expose `"module"` as well as `"jsnext:main"`, seems it's becoming more commonplace although I'm worried that it's too early to squat on the `"module"` field name.