### PR TITLE
(#5572) - support IDB in Safari 10.1+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ env:
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome COMMAND=test
   - FETCH=1 CLIENT=selenium:firefox:47.0.2 COMMAND=test
-  - CLIENT=saucelabs:safari:10.1 COMMAND=test
+  - CLIENT=saucelabs:safari:10 COMMAND=test
   - CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
 
   # split up the android+iphone tests as it goes over time

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ env:
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome COMMAND=test
   - FETCH=1 CLIENT=selenium:firefox:47.0.2 COMMAND=test
-  - CLIENT=saucelabs:safari:6 COMMAND=test
+  - CLIENT=saucelabs:safari:10.1 COMMAND=test
   - CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
 
   # split up the android+iphone tests as it goes over time

--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -799,17 +799,20 @@ function init(api, opts, callback) {
 }
 
 IdbPouch.valid = function () {
-  // Issue #2533, we finally gave up on doing bug
-  // detection instead of browser sniffing. Safari brought us
-  // to our knees.
+  /* global fetch */
   var isSafari = typeof openDatabase !== 'undefined' &&
     /(Safari|iPhone|iPad|iPod)/.test(navigator.userAgent) &&
     !/Chrome/.test(navigator.userAgent) &&
     !/BlackBerry/.test(navigator.platform);
+  var hasFetch = typeof fetch === 'function' &&
+    fetch.toString().indexOf('[native code') !== -1;
 
-  // some outdated implementations of IDB that appear on Samsung
-  // and HTC Android devices <4.4 are missing IDBKeyRange
-  return !isSafari && typeof indexedDB !== 'undefined' &&
+  // Safari <10.1 does not meet our requirements for IDB support (#5572)
+  // since Safari 10.1 shipped with fetch, we can use that to detect it
+  return (!isSafari || hasFetch) &&
+    typeof indexedDB !== 'undefined' &&
+    // some outdated implementations of IDB that appear on Samsung
+    // and HTC Android devices <4.4 are missing IDBKeyRange
     typeof IDBKeyRange !== 'undefined';
 };
 


### PR DESCRIPTION
Safari 10.1 [has shipped](https://developer.apple.com/library/prerelease/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_10_1.html), with full and performant support for IndexedDB. There's no reason I'm aware of that we should continue supporting WebSQL.

I think it would be prudent, though, to ensure that our tests are passing in SauceLabs. This PR may fail; I'm not sure if SauceLabs supports 10.1 yet.

WebSQL will still be tested in PhantomJS, which should be good enough until we can gracefully deprecate the WebSQL adapter entirely.