### PR TITLE
(#6053) - assign defaults to new pouch db instance in PouchDB.plugin()

### DIFF
--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -52,6 +52,9 @@ PouchDB.plugin = function (obj) {
       PouchDB.prototype[id] = obj[id];
     });
   }
+  if(this.__defaults){
+    PouchDB.__defaults = assign({}, this.__defaults);
+  }
   return PouchDB;
 };
 

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -1134,6 +1134,13 @@ adapters.forEach(function (adapter) {
           });
         });
       });
+
+      it('6053, PouchDB.plugin() resets defaults', function () {
+        var db = PouchDB.defaults({foo: 'bar'});
+        var db2 = db.plugin({foo: function () {}});
+        should.exist(db2.__defaults);
+        db.__defaults.should.deep.equal(db2.__defaults);
+       });
     }
 
     if (typeof process !== 'undefined' && !process.browser) {


### PR DESCRIPTION
Check if the current instance of PouchDB has __defaults, if it has then assign these properties to the new instance as well.