### PR TITLE
6209 eslint fixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,6 +36,8 @@
     "semi": ["error", "always"],
     "curly": ["error", "all"],
     "space-unary-ops": ["error", {"words": true}],
-    "space-before-function-paren": ["error", {"anonymous": "always", "named": "never"}]
+    "space-before-function-paren": ["error", {"anonymous": "always", "named": "never"}],
+    "max-len": ["error", 100, {"ignoreComments": true, "ignoreStrings": true, "ignoreRegExpLiterals": true}]
+   
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,6 +38,7 @@
     "space-unary-ops": ["error", {"words": true}],
     "space-before-function-paren": ["error", {"anonymous": "always", "named": "never"}],
     "max-len": ["error", 100, {"ignoreComments": true, "ignoreStrings": true, "ignoreRegExpLiterals": true}],
-    "curly": ["error"]  
+    "curly": ["error"],
+    "keyword-spacing": ["error"]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,6 +39,7 @@
     "space-before-function-paren": ["error", {"anonymous": "always", "named": "never"}],
     "max-len": ["error", 100, {"ignoreComments": true, "ignoreStrings": true, "ignoreRegExpLiterals": true}],
     "curly": ["error"],
-    "keyword-spacing": ["error"]
+    "keyword-spacing": ["error"],
+    "space-before-blocks": ["error"]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,7 +37,7 @@
     "curly": ["error", "all"],
     "space-unary-ops": ["error", {"words": true}],
     "space-before-function-paren": ["error", {"anonymous": "always", "named": "never"}],
-    "max-len": ["error", 100, {"ignoreComments": true, "ignoreStrings": true, "ignoreRegExpLiterals": true}]
-   
+    "max-len": ["error", 100, {"ignoreComments": true, "ignoreStrings": true, "ignoreRegExpLiterals": true}],
+    "curly": ["error"]  
   }
 }

--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -334,7 +334,7 @@ function init(api, opts, callback) {
       }
 
       var rev;
-      if(!opts.rev) {
+      if (!opts.rev) {
         rev = metadata.winningRev;
         var deleted = isDeleted(metadata);
         if (deleted) {
@@ -818,7 +818,7 @@ function tryStorageOption(dbName, storage) {
       version: ADAPTER_VERSION,
       storage: storage
     });
-  } catch(err) {
+  } catch (err) {
       return indexedDB.open(dbName, ADAPTER_VERSION);
   }
 }

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/get.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/get.js
@@ -17,7 +17,7 @@ export default function (db, id, opts, callback) {
 
     var doc = e.target.result;
     var rev;
-    if(!opts.rev) {
+    if (!opts.rev) {
       rev = (doc && doc.rev);
     } else {
       rev = opts.latest ? getLatest(opts.rev, doc.metadata) : opts.rev;

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -373,7 +373,7 @@ function LevelPouch(opts, callback) {
       }
 
       var rev;
-      if(!opts.rev) {
+      if (!opts.rev) {
         rev = getWinningRev(metadata);
         var deleted = getIsDeleted(metadata, rev);
         if (deleted) {

--- a/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
@@ -619,7 +619,7 @@ function WebSqlPouch(opts, callback) {
     var sql;
     var sqlArgs;
 
-    if(!opts.rev) {
+    if (!opts.rev) {
       sql = select(
         SELECT_DOCS,
         [DOC_STORE, BY_SEQ_STORE],

--- a/packages/node_modules/pouchdb-ajax/src/request-browser.js
+++ b/packages/node_modules/pouchdb-ajax/src/request-browser.js
@@ -180,7 +180,7 @@ function xhRequest(options, callback) {
     timer = setTimeout(timeoutReq, options.timeout);
     xhr.onprogress = function () {
       clearTimeout(timer);
-      if(xhr.readyState !== 4) {
+      if (xhr.readyState !== 4) {
         timer = setTimeout(timeoutReq, options.timeout);
       }
     };
@@ -216,7 +216,7 @@ function xhRequest(options, callback) {
       } else if (typeof xhr.response === 'string') {
         try {
           err = JSON.parse(xhr.response);
-        } catch(e) {}
+        } catch (e) {}
       }
       err.status = xhr.status;
       callback(err);

--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -44,7 +44,7 @@ PouchDB.adapter = function (id, obj, addToPreferredAdapters) {
 PouchDB.plugin = function (obj) {
   if (typeof obj === 'function') { // function style for plugins
     obj(PouchDB);
-  } else if (typeof obj !== 'object' || Object.keys(obj).length === 0){
+  } else if (typeof obj !== 'object' || Object.keys(obj).length === 0) {
     throw new Error('Invalid plugin: got \"' + obj + '\", expected an object or a function');
   } else {
     Object.keys(obj).forEach(function (id) { // object style for plugins

--- a/packages/node_modules/pouchdb-replication/src/getDocs.js
+++ b/packages/node_modules/pouchdb-replication/src/getDocs.js
@@ -101,17 +101,19 @@ function getDocs(src, target, diffs, state) {
             return remoteDoc;
           }
 
-          return getDocAttachmentsFromTargetOrSource(target, src, remoteDoc).then(function (attachments) {
-            var filenames = Object.keys(remoteDoc._attachments);
-            attachments.forEach(function (attachment, i) {
-              var att = remoteDoc._attachments[filenames[i]];
-              delete att.stub;
-              delete att.length;
-              att.data = attachment;
-            });
+          return getDocAttachmentsFromTargetOrSource(target, src, remoteDoc)
+                   .then(function (attachments) {
+                           var filenames = Object.keys(remoteDoc._attachments);
+                           attachments
+                             .forEach(function (attachment, i) {
+                                        var att = remoteDoc._attachments[filenames[i]];
+                                        delete att.stub;
+                                        delete att.length;
+                                        att.data = attachment;
+                                      });
 
-            return remoteDoc;
-          });
+                                      return remoteDoc;
+                                    });
         }));
       }))
 

--- a/packages/node_modules/pouchdb-utils/src/defaultBackOff.js
+++ b/packages/node_modules/pouchdb-utils/src/defaultBackOff.js
@@ -8,7 +8,7 @@ function randomNumber(min, max) {
     max = max + 1;
   }
   // In order to not exceed maxTimeout, pick a random value between half of maxTimeout and maxTimeout
-  if(max > maxTimeout) {
+  if (max > maxTimeout) {
     min = maxTimeout >> 1; // divide by two
     max = maxTimeout;
   }

--- a/packages/node_modules/sublevel-pouchdb/src/nut.js
+++ b/packages/node_modules/sublevel-pouchdb/src/nut.js
@@ -13,7 +13,7 @@ function getPrefix(db) {
 
 function clone(_obj) {
   var obj = {};
-  for(var k in _obj) {
+  for (var k in _obj) {
     obj[k] = _obj[k];
   }
   return obj;
@@ -25,7 +25,7 @@ function nut(db, precodec, codec) {
   }
 
   function addEncodings(op, prefix) {
-    if(prefix && prefix.options) {
+    if (prefix && prefix.options) {
       op.keyEncoding =
         op.keyEncoding || prefix.options.keyEncoding;
       op.valueEncoding =

--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -3867,7 +3867,7 @@ repl_adapters.forEach(function (adapters) {
 
       db.put(doc).then(function () {
         return db.get('x');
-      }).then(function (doc){
+      }).then(function (doc) {
         var digests = Object.keys(doc._attachments).map(function (a) {
           return doc._attachments[a].digest;
         });

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -73,7 +73,7 @@ adapters.forEach(function (adapter) {
       });
     });
 
-    it('[4595] should reject xhr errors', function (done){
+    it('[4595] should reject xhr errors', function (done) {
       var invalidUrl = 'http:///';
       new PouchDB(dbs.name).replicate.to(invalidUrl, {}).catch(function () {
         done();
@@ -81,7 +81,7 @@ adapters.forEach(function (adapter) {
 
     });
 
-    it('[4595] should emit error event on xhr error', function (done){
+    it('[4595] should emit error event on xhr error', function (done) {
       var invalidUrl = 'http:///';
       new PouchDB(dbs.name).replicate.to(invalidUrl,{})
         .on('error', function () { done(); });

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -64,7 +64,7 @@ adapters.forEach(function (adapters) {
       }
       // CSG will send a change event when just the ACL changed
       if (testUtils.isSyncGateway()) {
-        changes = changes.filter(function (change){
+        changes = changes.filter(function (change) {
           return change.id !== "_user/";
         });
       }
@@ -307,7 +307,7 @@ adapters.forEach(function (adapters) {
         return db.allDocs({keys: ['foo']});
       }).then(function (res) {
         if (testUtils.isSyncGateway() && !res.rows[0].value) {
-          return remote.get('foo', {open_revs:'all'}).then(function (doc){
+          return remote.get('foo', {open_revs:'all'}).then(function (doc) {
             return db.put({_id: 'foo', _rev: doc[0].ok._rev});
           });
         } else {
@@ -3892,7 +3892,7 @@ adapters.forEach(function (adapters) {
         return db.allDocs();
       }).then(function (res) {
         res.rows.should.have.length(2);
-      }).then(function (){
+      }).then(function () {
         return remote.get('a');
       }).then(function (doc) {
         return remote.remove(doc);
@@ -4094,7 +4094,7 @@ adapters.forEach(function (adapters) {
 
 // This test only needs to run for one configuration, and it slows stuff
 // down
-downAdapters.map(function (){
+downAdapters.map(function () {
 
   describe('suite2 test.replication.js-down-test', function () {
 

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -2393,7 +2393,7 @@ adapters.forEach(function (adapters) {
       // place in the 'changes' function
       var changes = source.changes;
       source.changes = function (opts) {
-        if(mismatch) {
+        if (mismatch) {
           // We expect this replication to start over,
           // so the correct value of since is 0
           // if it's higher, the replication read the checkpoint
@@ -2477,7 +2477,7 @@ adapters.forEach(function (adapters) {
       var changes = source.changes;
 
       source.changes = function (opts) {
-        if(mismatch) {
+        if (mismatch) {
           // If we resolve to 0, the checkpoint resolver has not
           // been going through the sessions
           opts.since.should.not.equal(0);

--- a/tests/integration/test.replicationBackoff.js
+++ b/tests/integration/test.replicationBackoff.js
@@ -41,7 +41,7 @@ adapters.forEach(function (adapters) {
         }
       });
 
-      replication.on("complete", function (){
+      replication.on("complete", function () {
         if (numberOfActiveListeners > 3) {
           done(new Error("Number of 'active' listeners shouldn't grow larger than one.  Currently at " + numberOfActiveListeners));
         } else {

--- a/tests/integration/test.retry.js
+++ b/tests/integration/test.retry.js
@@ -363,7 +363,7 @@ adapters.forEach(function (adapters) {
                 if (typeof originalNumListeners !== 'number') {
                   originalNumListeners = numListeners;
                 } else {
-                  if(event === "paused") {
+                  if (event === "paused") {
                     Math.abs(numListeners -  originalNumListeners).should.be.at.most(1);
                   } else {
                     Math.abs(numListeners -  originalNumListeners).should.be.eql(0);

--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -82,7 +82,7 @@ function startTests() {
     // Capture logs for selenium output
     var logs = [];
 
-    (function (){
+    (function () {
 
       var oldLog = console.log;
       console.log = function () {

--- a/tests/unit/test.backoff.js
+++ b/tests/unit/test.backoff.js
@@ -10,7 +10,7 @@ describe('test.backoff.js', function () {
     var limit = 600000;
     var delay = 0;
     var values = [];
-    for(var i=0; i<100; i++) {
+    for (var i=0; i<100; i++) {
       delay = defaultBackOff(delay);
       values.push(delay);
     }


### PR DESCRIPTION
Changes to `.eslintrc` incl.
- Max line length of 100 excluding comments, strings and regex literals

- Enforced curly brackets on all blocks, no more `if (true) return 1;`

- Added spacing before and after keywords `if()` no longer allowed, must be `if ()`

- Added spacing before blocks `if (){` no longer allowed, must be `if () {`