### PR TITLE
DO NOT MERGE - Fixes #6277

### DIFF
--- a/packages/node_modules/pouchdb-find/src/adapters/local/find/query-planner.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/find/query-planner.js
@@ -336,7 +336,7 @@ function getMultiFieldQueryOpts(selector, index) {
 
     var matcher = selector[indexField];
 
-    if (!matcher) { // fewer fields in user query than in index
+    if (!matcher || !Object.keys(matcher).length) { // fewer fields in user query than in index
       finish(i);
       break;
     } else if (i > 0) {


### PR DESCRIPTION
This is a mirror of nolanlawson/pouchdb-find#256 and fixes #6277.

It will break when you pass an empty object to the selector. You can reproduce it like this:

```javascript
db.createIndex({
  index: {
    fields: ['field1', 'field2'],
  },
})
  .then(() => {
    console.log('this will work');
    return db.find({
      selector: { field1: 'xxx', field2: null },
      sort: [ { field1: 'asc' }, { field2: 'desc' }],
    });
  })
  .then(() => {
    console.log('this won\'t');
    return db.find({
      selector: { field1: 'xxx', field2: {} },
      sort: [ { field1: 'asc' }, { field2: 'desc' }],
    });
  });
```

[The `null` value assigned in this line](https://github.com/nolanlawson/pouchdb-find/blob/master/lib/adapters/local/find/query-planner.js#L353) is never converted to an object, so doing `'x' in null` later throws an error.

Other option is to say `var combinedOpts = {};` but we can save some runtime exiting earlier as in the PR.