### PR TITLE
pouchdb-find: don't emit missing fields

### DIFF
--- a/packages/node_modules/pouchdb-find/src/adapters/local/abstract-mapper.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/abstract-mapper.js
@@ -23,7 +23,7 @@ function createDeepMultiMapper(fields, emit) {
         var key = parsedField[j];
         value = value[key];
         if (!value) {
-          break;
+          return; // don't emit
         }
       }
       toEmit.push(value);


### PR DESCRIPTION
This will make the local index smaller.
(But might break `'$exists': false` queries)

In our case it shaves of 100MB with 8 indices to produce a 40MB local indexedDb (30k docs).