### PR TITLE
(#5717) - Support selector filter for replication

### DIFF
--- a/docs/_includes/api/replication.html
+++ b/docs/_includes/api/replication.html
@@ -21,6 +21,7 @@ All options default to `false` unless otherwise specified.
 * `options.doc_ids`: Only show changes for docs with these ids (array of strings).
 * `options.query_params`: Object containing properties that are passed to the filter function, e.g. `{"foo":"bar"}`, where `"bar"` will be available in the filter function as `params.query.foo`. To access the `params`, define your filter function like `function (doc, params) {/* ... */}`.
 * `options.view`: Specify a view function (e.g. `'design_doc_name/view_name'` or `'view_name'` as shorthand for `'view_name/view_name'`) to act as a filter. Documents counted as "passed" for a view filter if a map function emits at least one record for them. **Note**: `options.filter` must be set to `'_view'` for this option to work.
+* `options.selector`: Filter using a query/pouchdb-find [selector](http://docs.couchdb.org/en/2.0.0/api/database/find.html#selector-syntax). **Note**: Selectors are not supported in CouchDB 1.x.
 
 **Advanced Options:**
 

--- a/packages/node_modules/pouchdb-generate-replication-id/src/index.js
+++ b/packages/node_modules/pouchdb-generate-replication-id/src/index.js
@@ -15,6 +15,14 @@ function generateReplicationId(src, target, opts) {
   var filterFun = opts.filter ? opts.filter.toString() : '';
   var queryParams = '';
   var filterViewName =  '';
+  var selector = '';
+
+  // possibility for checkpoints to be lost here as behaviour of
+  // JSON.stringify is not stable (see #6226)
+  /* istanbul ignore if */
+  if (opts.selector) {
+    selector = JSON.stringify(opts.selector);
+  }
 
   if (opts.filter && opts.query_params) {
     queryParams = JSON.stringify(sortObjectPropertiesByKey(opts.query_params));
@@ -26,7 +34,7 @@ function generateReplicationId(src, target, opts) {
 
   return Promise.all([src.id(), target.id()]).then(function (res) {
     var queryData = res[0] + res[1] + filterFun + filterViewName +
-      queryParams + docIds;
+      queryParams + docIds + selector;
     return new Promise(function (resolve) {
       binaryMd5(queryData, resolve);
     });

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -21,6 +21,7 @@ function replicate(src, target, opts, returnValue, result) {
   var batches_limit = opts.batches_limit || 10;
   var changesPending = false;     // true while src.changes is running
   var doc_ids = opts.doc_ids;
+  var selector = opts.selector;
   var repId;
   var checkpointer;
   var changedDocs = [];
@@ -382,6 +383,7 @@ function replicate(src, target, opts, returnValue, result) {
           batch_size: batch_size,
           style: 'all_docs',
           doc_ids: doc_ids,
+          selector: selector,
           return_docs: true // required so we know when we're done
         };
         if (opts.filter) {

--- a/packages/node_modules/pouchdb-selector-core/src/matches-selector.js
+++ b/packages/node_modules/pouchdb-selector-core/src/matches-selector.js
@@ -3,6 +3,12 @@ import { filterInMemoryFields } from './in-memory-filter';
 
 // return true if the given doc matches the supplied selector
 function matchesSelector(doc, selector) {
+  /* istanbul ignore if */
+  if (typeof selector !== 'object') {
+    // match the CouchDB error message
+    throw 'Selector error: expected a JSON object';
+  }
+
   selector = massageSelector(selector);
   var row = {
     'doc': doc


### PR DESCRIPTION
Building on the _changes support for selector, this allows a selector filter to be specified during replication.

Checkpoint behaviour has been updated to account for selectors, accepting that depending on JSON.stringify may be unreliable due to instability in the implementation.