### PR TITLE
(#6106) deprecate .type() in favor of ._remote

### DIFF
--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -1,7 +1,8 @@
 import {
   flatten,
   guardedConsole,
-  nextTick
+  nextTick,
+  isRemote
 } from 'pouchdb-utils';
 
 import {
@@ -811,13 +812,12 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
   }
 
   function queryPromised(db, fun, opts) {
-    if (db.type() === 'http') {
-      return httpQuery(db, fun, opts);
-    }
-
     /* istanbul ignore next */
     if (typeof db._query === 'function') {
       return customQuery(db, fun, opts);
+    }
+    if (isRemote(db)) {
+      return httpQuery(db, fun, opts);
     }
 
     if (typeof fun !== 'string') {
@@ -905,12 +905,12 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
 
   var abstractViewCleanup = callbackify(function () {
     var db = this;
-    if (db.type() === 'http') {
-      return httpViewCleanup(db);
-    }
     /* istanbul ignore next */
     if (typeof db._viewCleanup === 'function') {
       return customViewCleanup(db);
+    }
+    if (isRemote(db)) {
+      return httpViewCleanup(db);
     }
     return localViewCleanup(db);
   });

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -243,6 +243,8 @@ function HttpPouch(opts, callback) {
     callback(null, api);
   });
 
+  api._remote = true;
+  /* istanbul ignore next */
   api.type = function () {
     return 'http';
   };

--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -289,6 +289,7 @@ function init(api, opts, callback) {
 
   }
 
+  api._remote = false;
   api.type = function () {
     return 'idb';
   };

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
@@ -42,6 +42,7 @@ function IdbPouch(dbOpts, callback) {
     };
   };
 
+  api._remote = false;
   api.type = function () { return ADAPTER_NAME; };
 
   api._id = $(function (idb, cb) {

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -235,6 +235,8 @@ function LevelPouch(opts, callback) {
     return callback(null, db._docCount); // use cached value
   }
 
+  api._remote = false;
+  /* istanbul ignore next */
   api.type = function () {
     return 'leveldb';
   };

--- a/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-websql-core/src/index.js
@@ -552,6 +552,7 @@ function WebSqlPouch(opts, callback) {
     });
   }
 
+  api._remote = false;
   api.type = function () {
     return 'websql';
   };

--- a/packages/node_modules/pouchdb-checkpointer/src/index.js
+++ b/packages/node_modules/pouchdb-checkpointer/src/index.js
@@ -16,7 +16,7 @@ var LOWEST_SEQ = 0;
 function updateCheckpoint(db, id, checkpoint, session, returnValue) {
   return db.get(id).catch(function (err) {
     if (err.status === 404) {
-      if (db.type() === 'http') {
+      if (db.adapter === 'http' || db.adapter === 'https') {
         explainError(
           404, 'PouchDB is just checking if a remote checkpoint exists.'
         );

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -1,5 +1,6 @@
 import {
-    guardedConsole
+  guardedConsole,
+  isRemote
 } from 'pouchdb-utils';
 import { EventEmitter } from 'events';
 import inherits from 'inherits';
@@ -729,7 +730,7 @@ AbstractPouchDB.prototype.allDocs =
       ));
       return;
     }
-    if (this.type() !== 'http') {
+    if (!isRemote(this)) {
       return allDocsKeysQuery(this, opts, callback);
     }
   }
@@ -759,8 +760,8 @@ AbstractPouchDB.prototype.info = adapterFun('info', function (callback) {
     }
     // assume we know better than the adapter, unless it informs us
     info.db_name = info.db_name || self.name;
-    info.auto_compaction = !!(self.auto_compaction && self.type() !== 'http');
-    info.adapter = self.type();
+    info.auto_compaction = !!(self.auto_compaction && !isRemote(self));
+    info.adapter = self.adapter;
     callback(null, info);
   });
 });
@@ -824,7 +825,7 @@ AbstractPouchDB.prototype.bulkDocs =
   }
 
   var adapter = this;
-  if (!opts.new_edits && adapter.type() !== 'http') {
+  if (!opts.new_edits && !isRemote(adapter)) {
     // ensure revisions of the same doc are sorted, so that
     // the local adapter processes them correctly (#2935)
     req.docs.sort(compareByIdThenRev);
@@ -850,7 +851,7 @@ AbstractPouchDB.prototype.bulkDocs =
       });
     }
     // add ids for error/conflict responses (not required for CouchDB)
-    if (adapter.type() !== 'http') {
+    if (!isRemote(adapter)) {
       for (var i = 0, l = res.length; i < l; i++) {
         res[i].id = res[i].id || ids[i];
       }
@@ -902,7 +903,7 @@ AbstractPouchDB.prototype.destroy =
     });
   }
 
-  if (self.type() === 'http') {
+  if (isRemote(self)) {
     // no need to check for dependent DBs if it's a remote DB
     return destroyDb();
   }

--- a/packages/node_modules/pouchdb-core/src/changes.js
+++ b/packages/node_modules/pouchdb-core/src/changes.js
@@ -5,7 +5,8 @@ import {
   once,
   parseDdocFunctionName,
   normalizeDdocFunctionName,
-  guardedConsole
+  guardedConsole,
+  isRemote
 } from 'pouchdb-utils';
 import {
   isDeleted,
@@ -197,7 +198,7 @@ Changes.prototype.doChanges = function (opts) {
       opts.filter = normalizeDdocFunctionName(opts.filter);
     }
 
-    if (this.db.type() !== 'http' && !opts.doc_ids) {
+    if (!isRemote(this.db) && !opts.doc_ids) {
       return this.filterChanges(opts);
     }
   }

--- a/packages/node_modules/pouchdb-find/src/index.js
+++ b/packages/node_modules/pouchdb-find/src/index.js
@@ -1,4 +1,4 @@
-import { toPromise } from 'pouchdb-utils';
+import { toPromise, isRemote } from 'pouchdb-utils';
 import * as http from './adapters/http/index';
 import * as local from './adapters/local/index';
 
@@ -9,7 +9,7 @@ plugin.createIndex = toPromise(function (requestDef, callback) {
     return callback(new Error('you must provide an index to create'));
   }
 
-  var createIndex = this.type() === 'http' ?
+  var createIndex = isRemote(this) ?
     http.createIndex : local.createIndex;
   createIndex(this, requestDef, callback);
 });
@@ -25,13 +25,13 @@ plugin.find = toPromise(function (requestDef, callback) {
     return callback(new Error('you must provide search parameters to find()'));
   }
 
-  var find = this.type() === 'http' ? http.find : local.find;
+  var find = isRemote(this) ? http.find : local.find;
   find(this, requestDef, callback);
 });
 
 plugin.getIndexes = toPromise(function (callback) {
 
-  var getIndexes = this.type() === 'http' ? http.getIndexes : local.getIndexes;
+  var getIndexes = isRemote(this) ? http.getIndexes : local.getIndexes;
   getIndexes(this, callback);
 });
 
@@ -41,7 +41,7 @@ plugin.deleteIndex = toPromise(function (indexDef, callback) {
     return callback(new Error('you must provide an index to delete'));
   }
 
-  var deleteIndex = this.type() === 'http' ?
+  var deleteIndex = isRemote(this) ?
     http.deleteIndex : local.deleteIndex;
   deleteIndex(this, indexDef, callback);
 });

--- a/packages/node_modules/pouchdb-replication/src/getDocs.js
+++ b/packages/node_modules/pouchdb-replication/src/getDocs.js
@@ -1,4 +1,4 @@
-import { clone, flatten } from 'pouchdb-utils';
+import { clone, flatten, isRemote } from 'pouchdb-utils';
 
 function isGenOne(rev) {
   return /^1-/.test(rev);
@@ -18,7 +18,7 @@ function getDocAttachments(db, doc) {
 }
 
 function getDocAttachmentsFromTargetOrSource(target, src, doc) {
-  var doCheckForLocalAttachments = src.type() === 'http' && target.type() !== 'http';
+  var doCheckForLocalAttachments = isRemote(src) && !isRemote(target);
   var filenames = Object.keys(doc._attachments);
 
   if (!doCheckForLocalAttachments) {

--- a/packages/node_modules/pouchdb-utils/src/index.js
+++ b/packages/node_modules/pouchdb-utils/src/index.js
@@ -13,6 +13,7 @@ import hasLocalStorage from './env/hasLocalStorage';
 import invalidIdError from './invalidIdError';
 import isChromeApp from './env/isChromeApp';
 import isCordova from './isCordova';
+import isRemote from './isRemote';
 import listenerCount from './listenerCount';
 import nextTick from './nextTick';
 import normalizeDdocFunctionName from './normalizeDdocFunctionName';
@@ -40,6 +41,7 @@ export {
   invalidIdError,
   isChromeApp,
   isCordova,
+  isRemote,
   listenerCount,
   nextTick,
   normalizeDdocFunctionName,

--- a/packages/node_modules/pouchdb-utils/src/isRemote.js
+++ b/packages/node_modules/pouchdb-utils/src/isRemote.js
@@ -1,0 +1,28 @@
+// Checks if a PouchDB object is "remote" or not. This is
+// designed to opt-in to certain optimizations, such as
+// avoiding checks for "dependentDbs" and other things that
+// we know only apply to local databases. In general, "remote"
+// should be true for the http adapter, and for third-party
+// adapters with similar expensive boundaries to cross for
+// every API call, such as socket-pouch and worker-pouch.
+// Previously, this was handled via db.type() === 'http'
+// which is now deprecated.
+
+import guardedConsole from './guardedConsole';
+
+function isRemote(db) {
+  if (typeof db._remote === 'boolean') {
+    return db._remote;
+  }
+  /* istanbul ignore next */
+  if (typeof db.type === 'function') {
+    guardedConsole('warn',
+      'db.type() is deprecated and will be removed in ' +
+      'a future version of PouchDB');
+    return db.type() === 'http';
+  }
+  /* istanbul ignore next */
+  return false;
+}
+
+export default isRemote;

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -804,14 +804,14 @@ adapters.forEach(function (adapter) {
       var db = new PouchDB(dbs.name, { auto_compaction: true});
       return db.info().then(function (info) {
         // http doesn't support auto compaction
-        info.auto_compaction.should.equal(db.type() !== 'http');
+        info.auto_compaction.should.equal(adapter !== 'http');
       });
     });
 
     it('db.info should give adapter name (#3567)', function () {
       var db = new PouchDB(dbs.name);
       return db.info().then(function (info) {
-        info.adapter.should.equal(db.type());
+        info.adapter.should.equal(db.adapter);
       });
     });
 
@@ -987,16 +987,6 @@ adapters.forEach(function (adapter) {
         should.not.exist(doc.foo);
         Object.keys(doc).sort().should.deep.equal(['_id', '_rev', 'foo']);
       });
-    });
-
-    it('db.type() returns a type', function () {
-      var db = new PouchDB(dbs.name);
-      db.type().should.be.a('string');
-    });
-
-    it('#4788 db.type() is synchronous', function () {
-      new PouchDB(dbs.name).type.should.be.a('function');
-      new PouchDB(dbs.name).type.should.be.a('function');
     });
 
     it('replace PouchDB.destroy() (express-pouchdb#203)', function (done) {


### PR DESCRIPTION
My proposed solution to #6106:

- Deprecate `.type()`. It was undocumented and always a bit strange. This PR itself only adds a warning for it, though.
- Add `._remote`, a boolean that each adapter can define which says whether they want to opt-in to certain optimizations for "remote" adapters
- Update our code as much as possible to remove references to `.type()`.

In PouchDB 7.0.0 we can just remove `.type()` entirely. Also, plugins like `socket-pouch` and `worker-pouch` can just add `this._remote = true` and get the fixes they need.