### PR TITLE
(#6347) - fix build process, put pouchdb-find dist/ in pouchdb pkg

### DIFF
--- a/bin/build-pouchdb.js
+++ b/bin/build-pouchdb.js
@@ -32,7 +32,7 @@ var builtInModules = require('builtin-modules');
 var external = Object.keys(require('../package.json').dependencies)
   .concat(builtInModules);
 
-var plugins = ['fruitdown', 'localstorage', 'memory'];
+var plugins = ['fruitdown', 'localstorage', 'memory', 'find'];
 
 var currentYear = new Date().getFullYear();
 
@@ -65,6 +65,15 @@ var comments = {
 
   'fruitdown': '// PouchDB fruitdown plugin ' + version +
   '\n// Based on FruitDOWN: https://github.com/nolanlawson/fruitdown' +
+  '\n// ' +
+  '\n// (c) 2012-' + currentYear + ' Dale Harvey and the PouchDB team' +
+  '\n// PouchDB may be freely distributed under the Apache license, ' +
+  'version 2.0.' +
+  '\n// For all details and documentation:' +
+  '\n// http://pouchdb.com\n',
+
+  'find': '// pouchdb-find plugin ' + version +
+  '\n// Based on Mango: https://github.com/cloudant/mango' +
   '\n// ' +
   '\n// (c) 2012-' + currentYear + ' Dale Harvey and the PouchDB team' +
   '\n// PouchDB may be freely distributed under the Apache license, ' +
@@ -151,7 +160,11 @@ function buildPluginsForBrowser() {
 }
 
 function buildPouchDBNext() {
-  return doBrowserify('pouchdb', 'src/next.js', {standalone: 'PouchDB'}).then(function (code) {
+  return doRollup('src/next.js', true, {
+    cjs: 'lib/next.js'
+  }).then(function () {
+    return doBrowserify('pouchdb', 'lib/next.js', {standalone: 'PouchDB'});
+  }).then(function (code) {
     return writeFile('packages/node_modules/pouchdb/dist/pouchdb-next.js', code);
   });
 }

--- a/packages/node_modules/pouchdb-find/src/index.js
+++ b/packages/node_modules/pouchdb-find/src/index.js
@@ -47,8 +47,3 @@ plugin.deleteIndex = toPromise(function (indexDef, callback) {
 });
 
 export default plugin;
-
-/* istanbul ignore next */
-if (typeof window !== 'undefined' && window.PouchDB) {
-  window.PouchDB.plugin(plugin);
-}

--- a/packages/node_modules/pouchdb/src/next.js
+++ b/packages/node_modules/pouchdb/src/next.js
@@ -1,4 +1,9 @@
-module.exports = require('pouchdb-core')
-  .plugin(require('pouchdb-adapter-indexeddb'))
-  .plugin(require('pouchdb-adapter-http'))
-  .plugin(require('pouchdb-replication'));
+import PouchDB from 'pouchdb-core';
+import idbPouch from 'pouchdb-adapter-indexeddb';
+import httpPouch from 'pouchdb-adapter-http';
+import replication from 'pouchdb-replication';
+
+export default PouchDB
+  .plugin(idbPouch)
+  .plugin(httpPouch)
+  .plugin(replication);

--- a/packages/node_modules/pouchdb/src/plugins/find.js
+++ b/packages/node_modules/pouchdb/src/plugins/find.js
@@ -2,13 +2,13 @@
 
 // this code only runs in the browser, as its own dist/ script
 
-import FruitdownPouchPlugin from 'pouchdb-adapter-fruitdown';
+import FindPlugin from 'pouchdb-find';
 import { guardedConsole } from 'pouchdb-utils';
 
 if (typeof PouchDB === 'undefined') {
-  guardedConsole('error', 'fruitdown adapter plugin error: ' +
+  guardedConsole('error', 'pouchdb-find plugin error: ' +
     'Cannot find global "PouchDB" object! ' +
     'Did you remember to include pouchdb.js?');
 } else {
-  PouchDB.plugin(FruitdownPouchPlugin);
+  PouchDB.plugin(FindPlugin);
 }

--- a/packages/node_modules/pouchdb/src/plugins/localstorage.js
+++ b/packages/node_modules/pouchdb/src/plugins/localstorage.js
@@ -1,13 +1,14 @@
 /* global PouchDB */
 
+// this code only runs in the browser, as its own dist/ script
+
 import LocalStoragePouchPlugin from 'pouchdb-adapter-localstorage';
 import { guardedConsole } from 'pouchdb-utils';
 
-var PDB = (typeof PouchDB !== 'undefined') ? PouchDB : require('pouchdb');
-if (!PDB) {
+if (typeof PouchDB === 'undefined') {
   guardedConsole('error', 'localstorage adapter plugin error: ' +
     'Cannot find global "PouchDB" object! ' +
     'Did you remember to include pouchdb.js?');
 } else {
-  LocalStoragePouchPlugin(PDB);
+  PouchDB.plugin(LocalStoragePouchPlugin);
 }

--- a/packages/node_modules/pouchdb/src/plugins/memory.js
+++ b/packages/node_modules/pouchdb/src/plugins/memory.js
@@ -1,13 +1,14 @@
 /* global PouchDB */
 
+// this code only runs in the browser, as its own dist/ script
+
 import MemoryPouchPlugin from 'pouchdb-adapter-memory';
 import { guardedConsole } from 'pouchdb-utils';
 
-var PDB = (typeof PouchDB !== 'undefined') ? PouchDB : require('pouchdb');
-if (!PDB) {
+if (typeof PouchDB === 'undefined') {
   guardedConsole('error', 'memory adapter plugin error: ' +
     'Cannot find global "PouchDB" object! ' +
     'Did you remember to include pouchdb.js?');
 } else {
-  MemoryPouchPlugin(PDB);
+  PouchDB.plugin(MemoryPouchPlugin);
 }

--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -24,8 +24,9 @@
   }
   if (plugins) {
     plugins[1].split(',').forEach(function (plugin) {
+      plugin = plugin.replace(/^pouchdb-/, '');
       scriptsToLoad.push(
-        '../../packages/node_modules/' + plugin + '/dist/pouchdb.' + plugin + '.js');
+        '../../packages/node_modules/pouchdb/dist/pouchdb.' + plugin + '.js');
     });
   }
 


### PR DESCRIPTION
While writing #6346 I discovered several problems in our build process. This fixes them.

- `pouchdb-next` should be built as a Rollup ES6 project and then as a Browserify bundle, exactly like everything else in the project. Otherwise it may look for CJS packages that don't exist yet.
- `pouchdb-find` should put its `dist/` folder in the `pouchdb` package. I thought about this for awhile and decided it makes more sense, because it fits in with our existing build process and is much simpler (less build code required). Anybody who wants to use the `dist/` plugins can just get 'em from bower or from the pouchdb npm package. Anybody using separate npm pacakges is probably an advanced user who is capable of using Browserify/Webpack/Rollup/etc. to build from CJS modules.