### PR TITLE
(#6345) - fix nextTick ES6 import in pouchdb-utils

### DIFF
--- a/packages/node_modules/pouchdb-utils/src/changesHandler.js
+++ b/packages/node_modules/pouchdb-utils/src/changesHandler.js
@@ -3,7 +3,7 @@ import inherits from 'inherits';
 import isChromeApp from './env/isChromeApp';
 import hasLocalStorage from './env/hasLocalStorage';
 import pick from './pick';
-import { nextTick } from 'pouchdb-utils';
+import nextTick from './nextTick';
 
 inherits(Changes, EventEmitter);
 


### PR DESCRIPTION
Since `nextTick` lives in `pouchdb-utils` itself, it doesn't need to import from `pouchdb-utils`.