### PR TITLE
(#6350) - fix read-only error.result in Firefox

### DIFF
--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -3,6 +3,7 @@ import getDocs from './getDocs';
 import Checkpointer from 'pouchdb-checkpointer';
 import backOff from './backoff';
 import generateReplicationId from 'pouchdb-generate-replication-id';
+import { createError } from 'pouchdb-errors';
 
 function replicate(src, target, opts, returnValue, result) {
   var batches = [];               // list of batches to be processed
@@ -248,6 +249,8 @@ function replicate(src, target, opts, returnValue, result) {
     replicationCompleted = true;
 
     if (fatalError) {
+      // need to extend the error because Firefox considers ".result" read-only
+      fatalError = createError(fatalError);
       fatalError.result = result;
 
       if (fatalError.name === 'unauthorized' || fatalError.name === 'forbidden') {


### PR DESCRIPTION
Firefox 52 seems to have decided that this error object's `.result` property is read-only, which causes our tests to fail. This fixes that.