### PR TITLE
(#6251) - import pouchdb-find API docs, update guide

### DIFF
--- a/docs/_guides/changes.md
+++ b/docs/_guides/changes.md
@@ -139,4 +139,4 @@ Also notice that new documents always have revisions starting with the string `'
 
 {% include anchor.html title="Next" hash="next" %}
 
-Now that we know how to hook our data spigot to the changes feed, let's look into using the very powerful `query()` API.
+Now that we know how to hook our data spigot to the changes feed, let's look into using the very powerful `find()` API.

--- a/docs/_guides/compact-and-destroy.md
+++ b/docs/_guides/compact-and-destroy.md
@@ -1,5 +1,5 @@
 ---
-index: 14
+index: 15
 layout: guide
 title: Compacting and destroying
 sidebar: guides_nav.html

--- a/docs/_guides/local-documents.md
+++ b/docs/_guides/local-documents.md
@@ -1,5 +1,5 @@
 ---
-index: 15
+index: 16
 layout: guide
 title: Local documents
 sidebar: guides_nav.html

--- a/docs/_guides/mango-queries.md
+++ b/docs/_guides/mango-queries.md
@@ -1,0 +1,330 @@
+---
+index: 13
+layout: guide
+title: Mango queries
+sidebar: guides_nav.html
+---
+
+Mango queries, also known as `pouchdb-find` or the `find()` API, are a structured query API that allows you to build _secondary indexes_ beyond the built-in `allDocs()` and `changes()` indexes. 
+
+This API is useful for answering questions like:
+
+- find all documents where the `type` is `'user'`
+- find all users whose `age` is greater than `21`
+- find all Pokémon whose `name` starts with `'pika'`
+- etc.
+
+{% include anchor.html title="Installation" hash="installation" %}
+
+The `find()` API is currently offered as a separate plugin, meaning that you must install it on top of `pouchdb.js`. Here's how to do so:
+
+### Script tags
+
+```html
+<script src="pouchdb.js"></script>
+<script src="pouchdb.find.js"></script>
+```
+
+The `pouchdb.find.js` file is available in the `pouchdb` package in npm/Bower, on [unpkg](unpkg.com/pouchdb/dist/), or [as a GitHub download](https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb.find.js). Note it must be placed after `pouchdb.js`.
+
+### npm
+
+If you are using Node, Browserify, Webpack, Rollup, etc., then you can install it like so:
+
+    npm install --save pouchdb-find
+
+Then in code:
+
+```js
+var PouchDB = require('pouchdb');
+PouchDB.plugin(require('pouchdb-find'));
+```
+
+{% include anchor.html title="Query language" hash="query-language" %}
+
+The [Mango query language](https://github.com/cloudant/mango) is a DSL inspired by MongoDB, which allows you to define an index that is then used for querying. One quick way to understand how this works is to use the [live query demo](https://nolanlawson.github.io/pouchdb-find/).
+
+At a basic level, there are two steps to running a query: `createIndex()` (to define which fields to index) and `find()` (to query the index).
+
+For instance, let's imagine a simple index to look up all documents whose `name` is `"mario"`. First we'll create it:
+
+```js
+db.createIndex({
+  index: {fields: ['name']}
+});
+```
+
+This returns a Promise once the index is created. At this point, we have an index based on the `"name"` field, so we can use it for lookup:
+
+```js
+db.find({
+  selector: {
+    name: 'mario'
+  }
+});
+```
+
+This returns a Promise containing an array of all documents that match this selector. Note that this is equivalent to using the `$eq` (equals) operator:
+
+```js
+db.find({
+  selector: {
+    name: {$eq: 'mario'}
+  }
+});
+```
+
+The important thing to understand is that, for a typical database, `createIndex()` is the expensive operation, because it is looping through all documents in the database and building a [B-tree](https://en.wikipedia.org/wiki/B-tree) based on the `name` value.
+
+Once the B-tree is built up, though, the `find()` is relatively cheap. (If this were _not_ the case, then we would be better off just using `allDocs()` to iterate through the database ourselves!)
+
+Once we have an index on `name`, we can also sort all documents by `name`:
+
+```js
+db.find({
+  selector: {
+    name: {$gte: null}
+  },
+  sort: ['name']
+});
+```
+
+Note that we are specifying that the `name` must be greater than or equal to `null`, which is a workaround for the fact that the Mango query language requires us to have a selector. In [CouchDB collation order](http://docs.couchdb.org/en/2.0.0/couchapp/views/collation.html), `null` is the "lowest" value, and so this will return all documents regardless of their `name` value.
+
+{% include anchor.html title="Pagination" hash="pagination" %}
+
+Reading all documents in the database and sorting them by a particular value is neat, but we could do this ourselves with `allDocs()`, and it would have the same performance impact. Where it gets more interesting is when we use `limit`:
+
+```js
+db.find({
+  selector: {
+    name: {$gte: null}
+  },
+  sort: ['name'],
+  limit: 10
+});
+```
+
+In this case, we only get 10 documents back, but they are the first 10 documents, sorted by name. This means that we have only read 10 documents out of the database into memory, which can be used for [efficient pagination](http://pouchdb.com/2014/04/14/pagination-strategies-with-pouchdb.html).
+
+For instance, if we are displaying the first 10 results on a single page, and the user clicks "next" to see the next page, we can restructure our query based on the last result, to continue the pagination. Let's imagine the first 10 documents' `name`s are:
+
+```js
+[
+  'abby', 'bertrand', 'clarice', 'don', 'emily',
+  'fumiko', 'gunther', 'horatio', 'ike', 'joy'
+]
+```
+
+For our next 10 pages of results, the query becomes:
+
+```js
+db.find({
+  selector: {
+    name: {$gt: 'joy'}
+  },
+  sort: ['name'],
+  limit: 10
+});
+```
+
+Because we are now specifying that the `name` must be greater than `'joy'`, we are guaranteed to get the next-highest result after `'joy'`, which may (for instance) look like this:
+
+```js
+[
+  'kim', 'lin', 'maria', 'nell', 'oliver',
+  'pat', 'quincy', 'roy', 'sam', 'tanya'
+]
+```
+
+In this way, we can continue paginating by using the last value as our next starting point. At any given point in time, there are only 10 documents stored in memory at once, which is great for performance.
+
+{% include anchor.html title="Indexing on more than one field" hash="more-than-one-field" %}
+
+Sometimes an index is not as simple as "find all documents whose `name` is `"mario"`. Sometimes you want to do something fancy, such as "find all documents whose `name` is `"mario"` and whose `age` is greater than `21`". In those cases, you can index on more than one field:
+
+```js
+db.createIndex({
+  index: {
+    fields: ['name', 'age']
+  }
+}).then(function () {
+  return db.find({
+    selector: {
+      name: 'mario',
+      age: {$gt: 21}
+    }
+  });
+});
+```
+
+One thing to note is that the order of these fields matters when creating your index. For instance, the following would _not_ work:
+
+```js
+/* THIS WON'T WORK! */
+db.createIndex({
+  index: {
+    fields: ['age', 'name']
+  }
+}).then(function () {
+  return db.find({
+    selector: {
+      name: 'mario',
+      age: {$gt: 21}
+    }
+  });
+});
+```
+
+The reason for this is easy to understand if we imagine how this index would sort a hypothetical database:
+
+<div class="table-responsive">
+<table class="table">
+<tr>
+  <th>name</th>
+  <th>age</th>
+</tr>
+<tr>
+  <td>Luigi</td>
+  <td>17</td>
+</tr>
+<tr>
+  <td>Luigi</td>
+  <td>28</td>
+</tr>
+<tr>
+  <td>Mario</td>
+  <td>18</td>
+</tr>
+<tr>
+  <td>Mario</td>
+  <td>21</td>
+</tr>
+<tr>
+  <td>Mario</td>
+  <td>22</td>
+</tr>
+<tr>
+  <td>Mario</td>
+  <td>26</td>
+</tr>
+<tr>
+  <td>Peach</td>
+  <td>17</td>
+</tr>
+<tr>
+  <td>Peach</td>
+  <td>21</td>
+</tr>
+<tr>
+  <td>Peach</td>
+  <td>25</td>
+</tr>
+</table>
+</div>
+
+In the above table, the documents are sorted by `['name', 'age']`, and our "Marios above the age of 21" are very clearly grouped together.
+
+However, if we were to change the order, and sort them by `['age', 'name']`, it would look instead like this:
+ 
+<div class="table-responsive">
+<table class="table">
+<tr>
+  <th>age</th>
+  <th>name</th>
+</tr>
+<tr>
+  <td>17</td>
+  <td>Luigi</td>
+</tr>
+<tr>
+  <td>17</td>
+  <td>Peach</td>
+</tr>
+<tr>
+  <td>18</td>
+  <td>Mario</td>
+</tr>
+<tr>
+  <td>21</td>
+  <td>Mario</td>
+</tr>
+<tr>
+  <td>21</td>
+  <td>Peach</td>
+</tr>
+<tr>
+  <td>22</td>
+  <td>Mario</td>
+</tr>
+<tr>
+  <td>25</td>
+  <td>Peach</td>
+</tr>
+<tr>
+  <td>26</td>
+  <td>Mario</td>
+</tr>
+<tr>
+  <td>28</td>
+  <td>Luigi</td>
+</tr>
+</table>
+</div>
+
+If we imagine our `find()` query as a "slice" of the data, it's obvious that there's no slice that corresponds to "all Marios whose age is greater than 21." Instead, our documents are sorted by `age`, and then documents with the same `age` are sorted by `name`.
+
+This index may be good for answering questions like "find all 17-year-olds whose name starts with letters N-Z", but it's not very good for answering questions like "find all people with a certain name, older than a certain age."
+
+This shows that it's important to carefully design an index before creating a query to use that index. Otherwise, the query planner may fall back to in-memory querying, which can be expensive.
+
+{% include anchor.html title="Performance notes" hash="performance-notes" %}
+
+The Mango query language is generally very permissive, and allows you to write queries that may not perform very well, but will run regardless. For instance, you may create an index with `createIndex()`, but then write a `find()` query that doesn't actually use that index. In general, the query planner tries to find the most appropriate index, but it may fall back to in-memory querying.
+
+As a straightforward example, if you query using the `_id` field, then the query planner will automatically map that directly to an `allDocs()` query. However, if you query for a field that isn't yet indexed, then it will simply use `allDocs()` to read in all documents from the database (!) and then filter in-memory. This can lead to poor performance, especially if your database is large.
+
+If you're ever wondering how the query planner is interpreting your query, you can enable debugging like so:
+
+```js
+PouchDB.debug.enable('pouchdb:find');
+```
+
+In the console, the query planner will show a detailed explanation of how it has interpreted the query, whether it uses any indexes, and whether any parts of the query need to be executed in-memory.
+
+You may also want to pay attention to the `"warning"` value included in your results set, indicating that there was no index that matched the given query. For instance, the warning may look like this:
+
+```js
+{
+  "docs": [ /* ... */ ],
+  "warning": "no matching index found, create an index to optimize query time"
+}
+```
+
+{% include anchor.html title="Further reading" hash="further-reading" %}
+
+The Mango query language is quite large and supports many options. Some of the more common ones include:
+
+* `$eq`: equals
+* `$gt`: greater than
+* `$gte`: greater than or equal to
+* `$lt`: less than
+* `$lte`: less than or equal to
+
+There are many more options besides these, although note that not all of them can take advantage of indexes. For instance, `$regex`, `$ne`, and `$not` cannot use on-disk indexes, and must use in-memory filtering instead.
+
+The most complete documentation for selector options can be found at [Cloudant Query Language](https://docs.cloudant.com/cloudant_query.html) (which is the same thing as Mango). Any differences between this specification and PouchDB's implementation should be considered a bug; they are designed to be identical!
+
+It should be noted that, over HTTP, this API currently works with CouchDB 2.0+, Cloudant, and PouchDB Server.
+CouchDB 2.0 is the reference implementation, so the API should be the same. CouchDB 1.6.1 and below is not supported.
+
+{% include anchor.html title="Related API documentation" hash="related-api-documentation" %}
+
+* [createIndex()](/api.html#create_index)
+* [find()](/api.html#query_index)
+* [getIndexes()](/api.html#list_indexes)
+* [deleteIndex()](/api.html#delete_index)
+
+{% include anchor.html title="Next" hash="next" %}
+
+Now that we've learned how to do structured Mango queries, let's try some more advanced queries, using _map/reduce_.

--- a/docs/_guides/mango-queries.md
+++ b/docs/_guides/mango-queries.md
@@ -313,7 +313,7 @@ The Mango query language is quite large and supports many options. Some of the m
 
 There are many more options besides these, although note that not all of them can take advantage of indexes. For instance, `$regex`, `$ne`, and `$not` cannot use on-disk indexes, and must use in-memory filtering instead.
 
-The most complete documentation for selector options can be found at [Cloudant Query Language](https://docs.cloudant.com/cloudant_query.html) (which is the same thing as Mango). Any differences between this specification and PouchDB's implementation should be considered a bug; they are designed to be identical!
+The most complete documentation for selector options can be found in the [CouchDB `_find` documentation](http://docs.couchdb.org/en/2.0.0/api/database/find.html). You might also look at the [Cloudant Query Language](https://docs.cloudant.com/cloudant_query.html) documentation (which is nearly identical to Mango, other than `text` and other Cloudant-specific features). PouchDB uses CouchDB as the reference implementation; they ought to be functionally identical.
 
 It should be noted that, over HTTP, this API currently works with CouchDB 2.0+, Cloudant, and PouchDB Server.
 CouchDB 2.0 is the reference implementation, so the API should be the same. CouchDB 1.6.1 and below is not supported.

--- a/docs/_guides/queries.md
+++ b/docs/_guides/queries.md
@@ -1,19 +1,19 @@
 ---
-index: 13
+index: 14
 layout: guide
 title: Map/reduce queries
 sidebar: guides_nav.html
 ---
 
-Map/reduce queries, also known as *secondary indexes*, are one of the most powerful features in PouchDB. However, they can be quite tricky to use, so this guide is designed to dispell some of the mysteries around them.
+Map/reduce queries, also known as the `query()` API, are one of the most powerful features in PouchDB. However, they can be quite tricky to use, and so this guide is designed to dispell some of the mysteries around them.
 
-{% include alert/start.html variant="warning" %}
+The first thing to understand is that you don't need map/reduce queries if you merely want to look up documents by `_id` or sort them by `_id`. The `allDocs()` API already does this, using an efficient built-in index (see ["bulk operations"](bulk-operations.html) for details).
 
-Many developers make the mistake of using the <code>query()</code> API when the more performant <code>allDocs()</code> API would be a better fit.
-<p/>&nbsp;<p/>
-Before you solve a problem with secondary indexes, you should ask yourself: can I solve this with the <em>primary index</em> (<code>_id</code>) instead?
+The second thing to know is that map/reduce is also unnecessary if you want to sort documents by their update time &ndash; this is exactly what the [changes feed](changes.html) does! Again, this is a built-in index that you get for free.
 
-{% include alert/end.html %}
+Finally, it's important to understand that [Mango queries](mango-queries.html) are much easier to use than map/reduce queries, and they can usually satisfy 99% of use cases. The point of map/reduce is to provide an _extremely advanced_ API for building secondary indexes, suitable for those with specific querying needs.
+ 
+So now that you've read the fine print, let's talk about how map/reduce queries actually work!
 
 {% include anchor.html title="Mappin' and reducin'" hash="mappin-and-reducin" %}
 
@@ -221,21 +221,14 @@ pouch.query(myMapReduceFun, {
 
 If you're adventurous, though, you should check out the [CouchDB documentation](http://couchdb.readthedocs.org/en/latest/couchapp/views/intro.html) or the [PouchDB documentation](http://pouchdb.com/api.html#query_database) for details on reduce functions.
 
-{% include anchor.html title="PouchDB Find" hash="pouchdb-find" %}
+{% include anchor.html title="Avoiding map/reduce" hash="avoiding-map-reduce" %}
 
-The map/reduce API is complex. Part of this problem will be resolved when the more developer-friendly [Cloudant query language](http://docs.cloudant.com/api/cloudant-query.html) is released in CouchDB 2.0, and the equivalent [pouchdb-find plugin](https://github.com/nolanlawson/pouchdb-find) is finished.
+The map/reduce API is complex, and it can be computationally expensive because it requires building up an entirely new index. Therefore, it's good to know some tricks for avoiding the map/reduce API when you don't need it:
 
-{% include alert/start.html variant="warning" %}
-{% markdown %}
-pouchdb-find is in beta, but you may find it is already sufficient for simple queries. Eventually it will replace map/reduce as PouchDB's "flagship" query engine.
-{% endmarkdown %}
-{% include alert/end.html %}
-
-In the meantime, there are a few tricks you can use to avoid unnecessarily complicating your codebase:
-
-1. Avoid the `query()` API altogether if you can. You'd be amazed how much you can do with just `allDocs()`. (In fact, under the hood, the `query()` API is simply implemented on top of `allDocs()`!)
-2. If your data is highly relational, try the [relational-pouch](https://github.com/nolanlawson/relational-pouch) plugin.
-1. Read the [12 tips for better code with PouchDB](/2014/06/17/12-pro-tips-for-better-code-with-pouchdb.html).
+1. If you can use `allDocs()` or `changes()` instead of the `query()` API, do it!
+2. If your query is simple enough that you can use `find()`, use that instead.
+3. Read the [12 tips for better code with PouchDB](/2014/06/17/12-pro-tips-for-better-code-with-pouchdb.html), especially the tip to "use and abuse your doc <code>_id</code>s."
+4. If your data is highly relational, try the [relational-pouch](https://github.com/nolanlawson/relational-pouch) plugin, which follows this advice, and only uses `_id` and `allDocs()` under the hood.
 
 {% include anchor.html title="Related API documentation" hash="related-api-documentation" %}
 

--- a/docs/_includes/api.html
+++ b/docs/_includes/api.html
@@ -12,7 +12,11 @@
 <li><a href="#save_attachment">Save attachment</a></li>
 <li><a href="#get_attachment">Get attachment</a></li>
 <li><a href="#delete_attachment">Delete attachment</a></li>
-<li><a href="#query_database">Query database</a></li>
+<li><a href="#create_index">Create index</a></li>
+<li><a href="#query_index">Query index</a></li>
+<li><a href="#list_indexes">List indexes</a></li>
+<li><a href="#delete_index">Delete index</a></li>
+<li><a href="#query_database">Map/reduce query</a></li>
 <li><a href="#view_cleanup">View cleanup</a></li>
 <li><a href="#database_information">Database info</a></li>
 <li><a href="#compaction">Compaction</a></li>

--- a/docs/_includes/api/create_index.html
+++ b/docs/_includes/api/create_index.html
@@ -1,0 +1,218 @@
+{% include anchor.html edit="true" title="Create index" hash="create_index" %}
+
+{% highlight js %}
+db.createIndex(index [, callback])
+{% endhighlight %}
+
+Create an index if it doesn't exist, or do nothing if it already exists.
+
+{% include alert/start.html variant="info"%}
+{% markdown %}
+
+**pouchdb-find plugin needed:** This API requires the `pouchdb-find` plugin. See
+[Mango queries](/guides/mango-queries.html) for installation instructions.
+
+{% endmarkdown %}
+{% include alert/end.html%}
+
+#### Example Usage:
+
+{% include code/start.html id="create_idx" type="callback" %}
+{% highlight js %}
+db.createIndex({
+  index: {
+    fields: ['foo']
+  }
+}, function (err, result) {
+  if (err) { return console.log(err); }
+  // handle result
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="create_idx" type="async" %}
+{% highlight js %}
+try {
+  var result = await db.createIndex({
+    index: {
+      fields: ['foo']
+    }
+  });
+} catch (err) {
+  console.log(err);
+}
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="create_idx" type="promise" %}
+{% highlight js %}
+db.createIndex({
+  index: {
+    fields: ['foo']
+  }
+}).then(function (result) {
+  // handle result
+}).catch(function (err) {
+  console.log(err);
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+#### Example Response:
+
+If the index was created, you'll see:
+
+{% highlight js %}
+{ "result": "created" }
+{% endhighlight %}
+
+Or if the index already exists:
+
+{% highlight js %}
+{ "result": "exists" }
+{% endhighlight %}
+
+You can also create an index on multiple fields:
+
+{% include code/start.html id="create_idx2" type="callback" %}
+{% highlight js %}
+db.createIndex({
+  index: {
+    fields: ['foo', 'bar', 'baz']
+  }
+}, function (err, result) {
+  if (err) { return console.log(err); }
+  // handle result
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="create_idx2" type="async" %}
+{% highlight js %}
+try {
+  var result = await db.createIndex({
+    index: {
+      fields: ['foo', 'bar', 'baz']
+    }
+  });
+} catch (err) {
+  console.log(err);
+}
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="create_idx2" type="promise" %}
+{% highlight js %}
+db.createIndex({
+  index: {
+    fields: ['foo', 'bar', 'baz']
+  }
+}).then(function (result) {
+  // handle result
+}).catch(function (err) {
+  console.log(err);
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+Or an index on deep fields:
+
+{% include code/start.html id="create_idx3" type="callback" %}
+{% highlight js %}
+db.createIndex({
+  index: {
+    fields: ['person.address.zipcode']
+  }
+}, function (err, result) {
+  if (err) { return console.log(err); }
+  // handle result
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="create_idx3" type="async" %}
+{% highlight js %}
+try {
+  var result = await db.createIndex({
+    index: {
+      fields: ['person.address.zipcode']
+    }
+  });
+} catch (err) {
+  console.log(err);
+}
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="create_idx3" type="promise" %}
+{% highlight js %}
+db.createIndex({
+  index: {
+    fields: ['person.address.zipcode']
+  }
+}).then(function (result) {
+  // handle result
+}).catch(function (err) {
+  console.log(err);
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+You can also specify additional options, if you want more control over how your index is created:
+
+{% include code/start.html id="create_idx4" type="callback" %}
+{% highlight js %}
+db.createIndex({
+  index: {
+    fields: ['foo', 'bar'],
+    name: 'myindex',
+    ddoc: 'mydesigndoc'
+    type: 'json',
+  }
+}, function (err, result) {
+  if (err) { return console.log(err); }
+  // handle result
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="create_idx4" type="async" %}
+{% highlight js %}
+try {
+  var result = await db.createIndex({
+    index: {
+      fields: ['foo', 'bar'],
+      name: 'myindex',
+      ddoc: 'mydesigndoc'
+      type: 'json',
+    }
+  });
+} catch (err) {
+  console.log(err);
+}
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="create_idx4" type="promise" %}
+{% highlight js %}
+db.createIndex({
+  index: {
+    fields: ['foo', 'bar'],
+    name: 'myindex',
+    ddoc: 'mydesigndoc'
+    type: 'json',
+  }
+}).then(function (result) {
+  // handle result
+}).catch(function (err) {
+  console.log(err);
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+### Options
+
+* `fields`: a list of fields to index
+* `name` (optional): name of the index, auto-generated if you don't include it
+* `ddoc` (optional): design document name (i.e. the part after `'_design/'`), auto-generated if you don't include it
+* `type` (optional): only supports `'json'`, which is also the default

--- a/docs/_includes/api/delete_index.html
+++ b/docs/_includes/api/delete_index.html
@@ -1,0 +1,129 @@
+{% include anchor.html edit="true" title="Delete index" hash="delete_index" %}
+
+{% highlight js %}
+db.deleteIndex(index [, callback])
+{% endhighlight %}
+
+Delete an index, remove any orphaned design documents, and clean up any leftover data on disk.
+
+{% include alert/start.html variant="info"%}
+{% markdown %}
+
+**pouchdb-find plugin needed:** This API requires the `pouchdb-find` plugin. See
+[Mango queries](/guides/mango-queries.html) for installation instructions.
+
+{% endmarkdown %}
+{% include alert/end.html%}
+
+
+#### Example Usage:
+
+{% include code/start.html id="delete_idx" type="callback" %}
+{% highlight js %}
+db.deleteIndex({
+  "ddoc": "_design/idx-0f3a6f73110868266fa5c688caf8acd3",
+  "name": "idx-0f3a6f73110868266fa5c688caf8acd3",
+  "type": "json",
+  "def": {
+    "fields": [
+      { "foo": "asc" },
+      { "bar": "asc" }
+    ]
+  }
+}, function (err, result) {
+  if (err) { return console.log(err); }
+  // handle result
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="delete_idx" type="async" %}
+{% highlight js %}
+try {
+  var result = await db.deleteIndex({
+    "ddoc": "_design/idx-0f3a6f73110868266fa5c688caf8acd3",
+    "name": "idx-0f3a6f73110868266fa5c688caf8acd3",
+    "type": "json",
+    "def": {
+      "fields": [
+        { "foo": "asc" },
+        { "bar": "asc" }
+      ]
+    }
+  });
+} catch (err) {
+  console.log(err);
+}
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="delete_idx" type="promise" %}
+{% highlight js %}
+db.deleteIndex({
+  "ddoc": "_design/idx-0f3a6f73110868266fa5c688caf8acd3",
+  "name": "idx-0f3a6f73110868266fa5c688caf8acd3",
+  "type": "json",
+  "def": {
+    "fields": [
+      { "foo": "asc" },
+      { "bar": "asc" }
+    ]
+  }
+}).then(function (result) {
+  // handle result
+}).catch(function (err) {
+  console.log(err);
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+#### Example Response:
+
+{% highlight js %}
+{ "ok": true }
+{% endhighlight %}
+
+Note that the easiest way to do this is to locate the index you want to delete using [`getIndexes()`](#list_indexes).
+For instance, here is how you would delete the second index from that list (which should be the
+one after the built-in `_all_docs` index):
+
+{% include code/start.html id="delete_idx2" type="callback" %}
+{% highlight js %}
+db.findIndexes(function (err, indexesResult) {
+  if (err) { return console.log(err); }
+  db.deleteIndex(indexesResult.indexes[1], function (err, result) {
+    if (err) { return console.log(err); }
+    // handle result
+  });
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="delete_idx2" type="async" %}
+{% highlight js %}
+try {
+  var indexesResult = await db.findIndexes();
+  var result = await db.deleteIndex(indexesResult.indexes[1]);
+} catch (err) {
+  console.log(err);
+}
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="delete_idx2" type="promise" %}
+{% highlight js %}
+db.findIndexes().then(function (indexesResult) {
+  return db.deleteIndex(indexesResult.indexes[1]);
+}).then(function (result) {
+  // handle result
+}).catch(function (err) {
+  console.log(err);
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+**Notes:**
+
+* You don't need to provide a `_rev` when deleting an index.
+* The associated design doc is automatically deleted, assuming it only contains one index.
+* There is no need to call [`viewCleanup`](#view_cleanup) to clean up any leftover data. `deleteIndex()` does this automatically for you.

--- a/docs/_includes/api/list_indexes.html
+++ b/docs/_includes/api/list_indexes.html
@@ -1,0 +1,84 @@
+{% include anchor.html edit="true" title="List indexes" hash="list_indexes" %}
+
+{% highlight js %}
+db.getIndexes([callback])
+{% endhighlight %}
+
+Get a list of all the indexes you've created. Also tells you about the
+special `_all_docs` index, i.e. the default index on the `_id` field.
+
+{% include alert/start.html variant="info"%}
+{% markdown %}
+
+**pouchdb-find plugin needed:** This API requires the `pouchdb-find` plugin. See
+[Mango queries](/guides/mango-queries.html) for installation instructions.
+
+{% endmarkdown %}
+{% include alert/end.html%}
+
+#### Example Usage:
+
+{% include code/start.html id="get_idxs" type="callback" %}
+{% highlight js %}
+db.getIndexes(function (err, result) {
+  if (err) { return console.log(err); }
+  // handle result
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="get_idxs" type="async" %}
+{% highlight js %}
+try {
+  var result = await db.getIndexes();
+} catch (err) {
+  console.log(err);
+}
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="get_idxs" type="promise" %}
+{% highlight js %}
+db.getIndexes().then(function (result) {
+  // handle result
+}).catch(function (err) {
+  console.log(err);
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+#### Example Response:
+
+{% highlight js %}
+{
+  "indexes": [
+    {
+      "ddoc": null,
+      "name": "_all_docs",
+      "type": "special",
+      "def": {
+        "fields": [
+          {
+            "_id": "asc"
+          }
+        ]
+      }
+    },
+    {
+      "ddoc": "_design/idx-0f3a6f73110868266fa5c688caf8acd3",
+      "name": "idx-0f3a6f73110868266fa5c688caf8acd3",
+      "type": "json",
+      "def": {
+        "fields": [
+          {
+            "foo": "asc"
+          },
+          {
+            "bar": "asc"
+          }
+        ]
+      }
+    }
+  ]
+}
+{% endhighlight %}

--- a/docs/_includes/api/query_database.html
+++ b/docs/_includes/api/query_database.html
@@ -1,21 +1,22 @@
-{% include anchor.html edit="true" title="Query the database" hash="query_database" %}
+{% include anchor.html edit="true" title="Map/reduce queries" hash="query_database" %}
 
 {% highlight js %}
 db.query(fun, [options], [callback])
 {% endhighlight %}
 
-Invoke a map/reduce function, which allows you to perform more complex queries on PouchDB than what you get with [allDocs()](#batch_fetch). The [CouchDB documentation for map/reduce](http://docs.couchdb.org/en/latest/couchapp/views/intro.html) applies to PouchDB.
+Invoke a map/reduce function, which allows you to perform more complex queries on PouchDB than what you get with [allDocs()](#batch_fetch), [changes()](#changes), or [find()](#query_index). The [CouchDB documentation for map/reduce](http://docs.couchdb.org/en/latest/couchapp/views/intro.html) applies to PouchDB.
 
 Since views perform a full scan of all documents, this method may be slow, unless you first save your view in a design document. Read the [query guide](/guides/queries.html) for a good tutorial.
 
-{% include alert/start.html variant="info"%}
-
+{% include alert/start.html variant="warning"%}
 {% markdown %}
 
-**Heads up:** eventually the `query()` API will be deprecated in favor of the much simpler  [pouchdb-find plugin](https://github.com/nolanlawson/pouchdb-find). You will still be able to use `query()`, but it will be distributed as [a separate plugin](https://github.com/pouchdb/mapreduce).
+**Warning: advanced API.** The map/reduce API is designed for cases that are too complex for Mango queries, which are described in
+[createIndex()](#create_index), [find()](#query_index), [listIndexes()](#list_indexes), and [deleteIndex()](#delete_index).
+
+Under the hood, Mango indexes are the same as map/reduce indexes. The Mango API is just a simplified user-facing API on top of map/reduce.
 
 {% endmarkdown %}
-
 {% include alert/end.html%}
 
 ### Options

--- a/docs/_includes/api/query_index.html
+++ b/docs/_includes/api/query_index.html
@@ -1,0 +1,340 @@
+{% include anchor.html edit="true" title="Query index" hash="query_index" %}
+
+{% highlight js %}
+db.find(request [, callback])
+{% endhighlight %}
+
+Query an index and return the list of documents that match the request.
+
+{% include alert/start.html variant="info"%}
+{% markdown %}
+
+**pouchdb-find plugin needed:** This API requires the `pouchdb-find` plugin. See
+[Mango queries](/guides/mango-queries.html) for installation instructions.
+
+{% endmarkdown %}
+{% include alert/end.html%}
+
+#### Example Usage:
+
+{% include code/start.html id="query_idx" type="callback" %}
+{% highlight js %}
+db.find({
+  selector: {name: 'Mario'},
+  fields: ['_id', 'name'],
+  sort: ['name']
+}, function (err, result) {
+  if (err) { return console.log(err); }
+  // handle result
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="query_idx" type="async" %}
+{% highlight js %}
+try {
+  var result = await db.find({
+    selector: {name: 'Mario'},
+    fields: ['_id', 'name'],
+    sort: ['name']
+  });
+} catch (err) {
+  console.log(err);
+}
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="query_idx" type="promise" %}
+{% highlight js %}
+db.find({
+  selector: {name: 'Mario'},
+  fields: ['_id', 'name'],
+  sort: ['name']
+}).then(function (result) {
+  // handle result
+}).catch(function (err) {
+  console.log(err);
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+#### Example Response:
+
+{% highlight js %}
+{
+  "docs": [
+    {
+      "_id": "mario",
+      "name": "Mario"
+    }
+  ]
+}
+{% endhighlight %}
+
+The above is a simple example. For an in-depth tutorial, please refer to
+[the Mango guide](/guides/mango-queries.html).
+
+### Options
+
+* `selector` Defines a selector to filter the results. Required.
+  * `$lt` Match fields "less than" this one.
+  * `$gt` Match fields "greater than" this one.
+  * `$lte` Match fields "less than or equal to" this one.
+  * `$gte` Match fields "greater than or equal to" this one.
+  * `$eq` Match fields equal to this one.
+  * `$ne` Match fields not equal to this one.
+  * `$exists` True if the field should exist, false otherwise.
+  * `$type` One of: "null", "boolean", "number", "string", "array", or "object".
+  * `$in` Matches if all the selectors in the array match.
+  * `$and` Matches if all the selectors in the array match.
+  * `$nin` The document field must not exist in the list provided.
+  * `$all` Matches an array value if it contains all the elements of the argument array.
+  * `$size` Special condition to match the length of an array field in a document.
+  * `$or` Matches if any of the selectors in the array match. All selectors must use the same index.
+  * `$nor` Matches if none of the selectors in the array match.
+  * `$not` Matches if the given selector does not match.
+  * `$mod` Matches documents where (field % Divisor == Remainder) is true, and only when the document field is an integer.
+  * `$regex` A regular expression pattern to match against the document field.
+  * `$elemMatch` Matches all documents that contain an array field with at least one element that matches all the specified query criteria.
+* `fields` (Optional) Defines a list of fields that you want to receive. If omitted, you get the full documents.
+* `sort` (Optional) Defines a list of fields defining how you want to sort. Note that sorted fields also have to be selected in the `selector`.
+* `limit` (Optional) Maximum number of documents to return.
+* `skip` (Optional) Number of docs to skip before returning.
+
+If there's no index that matches your `selector`/`sort`, then this method will issue a warning:
+
+{% highlight js %}
+{
+  "docs": [ /* ... */ ],
+  "warning": "no matching index found, create an index to optimize query time"
+}
+{% endhighlight %}
+
+The best index will be chosen automatically. If you want to see the query plan for your query, then turn on debugging:
+
+{% highlight js %}
+PouchDB.debug.enable('pouchdb:find');
+{% endhighlight %}
+
+See [the Cloudant Query Language documentation](https://docs.cloudant.com/cloudant_query.html) and [the CouchDB Mango repo](https://github.com/cloudant/mango) for more details.
+
+### More examples
+
+Use `$eq` for "equals":
+
+{% include code/start.html id="query_idx2" type="callback" %}
+{% highlight js %}
+db.find({
+  selector: {name: {$eq: 'Mario'}}
+}, function (err, result) {
+  if (err) { return console.log(err); }
+  // handle result
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="query_idx2" type="async" %}
+{% highlight js %}
+try {
+  var result = await db.find({
+    selector: {name: {$eq: 'Mario'}}
+  });
+} catch (err) {
+  console.log(err);
+}
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="query_idx2" type="promise" %}
+{% highlight js %}
+db.find({
+  selector: {name: {$eq: 'Mario'}}
+}).then(function (result) {
+  // handle result
+}).catch(function (err) {
+  console.log(err);
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+This is equivalent to:
+
+{% include code/start.html id="query_idx3" type="callback" %}
+{% highlight js %}
+db.find({
+  selector: {name: 'Mario'}
+}, function (err, result) {
+  if (err) { return console.log(err); }
+  // handle result
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="query_idx3" type="async" %}
+{% highlight js %}
+try {
+  var result = await db.find({
+    selector: {name: 'Mario'}
+  });
+} catch (err) {
+  console.log(err);
+}
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="query_idx3" type="promise" %}
+{% highlight js %}
+db.find({
+  selector: {name: 'Mario'}
+}).then(function (result) {
+  // handle result
+}).catch(function (err) {
+  console.log(err);
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+You can also do selections on multiple fields. For instance, to
+find all docs where `series` is `'Mario'` and `debut` is greater than `1990`:
+
+{% include code/start.html id="query_idx4" type="callback" %}
+{% highlight js %}
+db.find({
+  selector: {
+    series: 'Mario',
+    debut: { $gt: 1990 }
+  }
+}, function (err, result) {
+  if (err) { return console.log(err); }
+  // handle result
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="query_idx4" type="async" %}
+{% highlight js %}
+try {
+  var result = await db.find({
+    selector: {
+      series: 'Mario',
+      debut: { $gt: 1990 }
+    }
+  });
+} catch (err) {
+  console.log(err);
+}
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="query_idx4" type="promise" %}
+{% highlight js %}
+db.find({
+  selector: {
+    series: 'Mario',
+    debut: { $gt: 1990 }
+  }
+}).then(function (result) {
+  // handle result
+}).catch(function (err) {
+  console.log(err);
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+This is equivalent to:
+
+{% include code/start.html id="query_idx5" type="callback" %}
+{% highlight js %}
+db.find({
+  selector: {
+    $and: [
+      { series: 'Mario' },
+      { debut: { $gt: 1990 } }
+    ]
+  }
+}, function (err, result) {
+  if (err) { return console.log(err); }
+  // handle result
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="query_idx5" type="async" %}
+{% highlight js %}
+try {
+  var result = await db.find({
+    selector: {
+      $and: [
+        { series: 'Mario' },
+        { debut: { $gt: 1990 } }
+      ]
+    }
+  });
+} catch (err) {
+  console.log(err);
+}
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="query_idx5" type="promise" %}
+{% highlight js %}
+db.find({
+  selector: {
+    $and: [
+      { series: 'Mario' },
+      { debut: { $gt: 1990 } }
+    ]
+  }
+}).then(function (result) {
+  // handle result
+}).catch(function (err) {
+  console.log(err);
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+You can also sort the returned documents. For instance, to find all docs sorted by `debut` descending:
+
+{% include code/start.html id="query_idx6" type="callback" %}
+{% highlight js %}
+db.find({
+  selector: {
+    debut: {'$gte': null}
+  },
+  sort: [{debut: 'desc'}]
+}, function (err, result) {
+  if (err) { return console.log(err); }
+  // handle result
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="query_idx6" type="async" %}
+{% highlight js %}
+try {
+  var result = await db.find({
+    selector: {
+      debut: {'$gte': null}
+    },
+    sort: [{debut: 'desc'}]
+  });
+} catch (err) {
+  console.log(err);
+}
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="query_idx6" type="promise" %}
+{% highlight js %}
+db.find({
+  selector: {
+    debut: {'$gte': null}
+  },
+  sort: [{debut: 'desc'}]
+}).then(function (result) {
+  // handle result
+}).catch(function (err) {
+  console.log(err);
+});
+{% endhighlight %}
+{% include code/end.html %}

--- a/docs/_includes/api/query_index.html
+++ b/docs/_includes/api/query_index.html
@@ -116,7 +116,8 @@ The best index will be chosen automatically. If you want to see the query plan f
 PouchDB.debug.enable('pouchdb:find');
 {% endhighlight %}
 
-See [the Cloudant Query Language documentation](https://docs.cloudant.com/cloudant_query.html) and [the CouchDB Mango repo](https://github.com/cloudant/mango) for more details.
+See the [CouchDB `_find` documentation](http://docs.couchdb.org/en/2.0.0/api/database/find.html) for more details on
+selectors and the Mango query language.
 
 ### More examples
 

--- a/docs/api.html
+++ b/docs/api.html
@@ -21,6 +21,10 @@ edit: false
 {% include api/save_attachment.html %}
 {% include api/get_attachment.html %}
 {% include api/delete_attachment.html %}
+{% include api/create_index.html %}
+{% include api/query_index.html %}
+{% include api/list_indexes.html %}
+{% include api/delete_index.html %}
 {% include api/query_database.html %}
 {% include api/view_cleanup.html %}
 {% include api/database_information.html %}

--- a/docs/custom.md
+++ b/docs/custom.md
@@ -278,6 +278,46 @@ var db = new PouchDB('mydb', {adapter: 'websql'});
 console.log(db.adapter); // 'websql'
 ```
 
+### pouchdb-adapter-indexeddb
+
+{% include alert/start.html variant="warning"%}
+{% markdown %}
+
+**Warning: experimental.** You probably don't want to use this yet. &#x1F609;
+
+{% endmarkdown %}
+{% include alert/end.html%}
+
+An experimental next-generation IndexedDB adapter, also known as "idb-next". Currently not shipped as part of PouchDB. The adapter name is `'indexeddb'`.
+
+#### Example usage
+
+```bash
+npm install pouchdb-adapter-indexeddb
+```
+
+```js
+PouchDB.plugin(require('pouchdb-adapter-indexeddb'));
+var db = new PouchDB('mydb', {adapter: 'indexeddb'});
+console.log(db.adapter); // 'indexeddb'
+```
+
+### pouchdb-find
+
+PouchDB's "Mango" query API, exposed via the `find()`, `listIndexes(), `createIndex()`, and `deleteIndex()` methods. Not shipped by default in PouchDB.
+
+#### Example usage
+
+```bash
+npm install pouchdb-find
+```
+
+```js
+PouchDB.plugin(require('pouchdb-find'));
+var db = new PouchDB('mydb');
+db.find(/* see API docs for full info */);
+```
+
 ### pouchdb-mapreduce
 
 PouchDB's map/reduce API, exposed via the `query()` and `viewCleanup()` methods. Ships by default in PouchDB.
@@ -330,6 +370,16 @@ without warning. You are strongly recommended to **use exact versions** when ins
 
 {% endmarkdown %}
 {% include alert/end.html%}
+
+### pouchdb-abstract-mapreduce
+
+The underlying logic for secondary indexes, as expressed in both `pouchdb-mapreduce` and `pouchdb-find`. Both packages use this package under the hood.
+
+#### Example usage
+
+```bash
+npm install --save-exact pouchdb-abstract-mapreduce
+```
 
 ### pouchdb-adapter-utils
 
@@ -389,6 +439,16 @@ ES6 shims for Map and Set as used in PouchDB.
 
 ```bash
 npm install --save-exact pouchdb-collections
+```
+
+### pouchdb-debug
+
+The `PouchDB.debug()` API, expressed as a separate plugin. May eventually be removed from PouchDB core.
+
+#### Example usage
+
+```bash
+npm install --save-exact pouchdb-debug
 ```
 
 ### pouchdb-errors
@@ -459,6 +519,16 @@ A `Promise` object, polyfilled using `lie` if Promises aren't available globally
 
 ```bash
 npm install --save-exact pouchdb-promise
+```
+
+### pouchdb-selector-core
+
+The core Mango selector logic, which allows the selector to be used both by `pouchdb-find` and for filtering/replication.
+
+#### Example usage
+
+```bash
+npm install --save-exact pouchdb-selector-core
 ```
 
 ### pouchdb-utils

--- a/docs/external.md
+++ b/docs/external.md
@@ -20,10 +20,6 @@ Plugin for CouchDB's authentication system.
 
 Allows decentralized authentication and access control per document, using asymmetric encryption.
 
-#### [PouchDB Collate](https://github.com/pouchdb/collate)
-
-Collation utilities, so you can use complex keys as doc IDs.
-
 #### [Crypto Pouch](https://github.com/calvinmetcalf/crypto-pouch)
 
 Encrypt a PouchDB/CouchDB database.
@@ -47,10 +43,6 @@ Implements the handy "every document is a delta" pattern, so you don't have to d
 #### [PouchDB Erase](https://github.com/marten-de-vries/pouchdb-erase)
 
 A replicating `db.destroy()` alternative.
-
-#### [PouchDB Find](https://github.com/nolanlawson/pouchdb-find)
-
-MongoDB-like query language, based on CouchDB 2.0. ([Live demo](http://nolanlawson.github.io/pouchdb-find/))
 
 #### [PouchDB Full Sync](https://github.com/nolanlawson/pouchdb-full-sync)
 


### PR DESCRIPTION
This imports the `pouchdb-find` docs (mostly from the `README`) into our own API docs. I also wrote a new section in the Guide to describe how to use `pouchdb-find`.

The trickiest part I found is that we are adding a whole new querying API, with lots of confusing names like "Mango," "Cloudant Query Language," "pouchdb-find", etc. So I tried to strike a nice balance by making it clear which parts of the API correspond to pouchdb-find and which correspond to map/reduce, while also promoting pouchdb-find over map/reduce. (For instance, it comes up first in both the API docs and the guide now.)

pouchdb-find is still an external plugin, but the UMD builds (`pouchdb.find.js`, `pouchdb.find.min.js`) will be in the npm/bower package and hosted in GitHub (assuming #6347 gets merged), so I was also careful to include instructions for installing it.