### PR TITLE
(#6352) - add "module" to pkg.json when publishing

### DIFF
--- a/bin/update-package-json-for-publish.js
+++ b/bin/update-package-json-for-publish.js
@@ -57,9 +57,10 @@ modules.forEach(function (mod) {
       './lib/index.es.js': './lib/index-browser.es.js',
     };
   }
-  // update jsnext:main to point to lib/ rather than src/. src/ is only
-  // used for building, not publishing
-  pkg['jsnext:main'] = './lib/index.es.js';
+  // Update "jsnext:main" to point to `lib/` rather than `src/`.
+  // `src/` is only used for building, not publishing.
+  // Also add "module" member: https://github.com/rollup/rollup/wiki/pkg.module
+  pkg['jsnext:main'] = pkg.module = './lib/index.es.js';
   // whitelist the files we'll actually publish
   pkg.files = ['lib', 'dist', 'tonic-example.js'];
 


### PR DESCRIPTION
Based on https://github.com/rollup/rollup/wiki/pkg.module it seems we might as well do this. Webpack 2 and Rollup essentially consider these interchangeable.