### PR TITLE
(#6366) - fix $or/$nor without explicit $eq

### DIFF
--- a/packages/node_modules/pouchdb-selector-core/src/utils.js
+++ b/packages/node_modules/pouchdb-selector-core/src/utils.js
@@ -208,6 +208,23 @@ function massageSelector(input) {
     wasAnded = true;
   }
 
+  ['$or', '$nor'].forEach(function (orOrNor) {
+    if (orOrNor in result) {
+      // message each individual selector
+      // e.g. {foo: 'bar'} becomes {foo: {$eq: 'bar'}}
+      result[orOrNor].forEach(function (subSelector) {
+        var fields = Object.keys(subSelector);
+        for (var i = 0; i < fields.length; i++) {
+          var field = fields[i];
+          var matcher = subSelector[field];
+          if (typeof matcher !== 'object' || matcher === null) {
+            subSelector[field] = {$eq: matcher};
+          }
+        }
+      });
+    }
+  });
+
   if ('$not' in result) {
     //This feels a little like forcing, but it will work for now,
     //I would like to come back to this and make the merging of selectors a little more generic

--- a/tests/find/index.html
+++ b/tests/find/index.html
@@ -42,7 +42,9 @@
     <script src='./test-suite-1/test.matching-indexes.js'></script>
     <script src='./test-suite-1/test.mod.js'></script>
     <script src='./test-suite-1/test.ne.js'></script>
+    <script src='./test-suite-1/test.nor.js'></script>
     <script src='./test-suite-1/test.not.js'></script>
+    <script src='./test-suite-1/test.or.js'></script>
     <script src='./test-suite-1/test.pick-fields.js'></script>
     <script src='./test-suite-1/test.regex.js'></script>
     <script src='./test-suite-1/test.set-operations.js'></script>

--- a/tests/find/test-suite-1/test.nor.js
+++ b/tests/find/test-suite-1/test.nor.js
@@ -1,0 +1,62 @@
+'use strict';
+
+testCases.push(function (dbType, context) {
+  describe(dbType + ': test.nor.js', function () {
+
+    beforeEach(function () {
+      return context.db.bulkDocs([
+        { name: 'Mario', _id: 'mario', rank: 5, series: 'Mario', debut: 1981, awesome: true },
+        { name: 'Jigglypuff', _id: 'puff', rank: 8, series: 'Pokemon', debut: 1996,
+          awesome: false },
+        { name: 'Link', rank: 10, _id: 'link', series: 'Zelda', debut: 1986, awesome: true },
+        { name: 'Donkey Kong', rank: 7, _id: 'dk', series: 'Mario', debut: 1981, awesome: false },
+        { name: 'Pikachu', series: 'Pokemon', _id: 'pikachu', rank: 1, debut: 1996, awesome: true },
+        { name: 'Luigi', rank: 11, _id: 'luigi', series: 'Mario', debut: 1983, awesome: false },
+        { name: 'Yoshi', _id: 'yoshi', rank: 6, series: 'Mario', debut: 1990, awesome: true }
+      ]);
+    });
+
+    it('#6366 should do a basic $nor', function () {
+      var db = context.db;
+      return db.find({
+        selector: {
+          "$nor": [
+            { "series": "Mario" },
+            { "series": "Pokemon" }
+          ]
+        }
+      }).then(function (res) {
+        var docs = res.docs.map(function (doc) {
+          return {
+            _id: doc._id
+          };
+        });
+        docs.should.deep.equal([
+          {'_id': 'link'}
+        ]);
+      });
+    });
+
+    it('#6366 should do a basic $nor, with explicit $eq', function () {
+      var db = context.db;
+      return db.find({
+        selector: {
+          "$nor": [
+            { "series": {$eq: "Mario"} },
+            { "series": {$eq: "Pokemon"} }
+          ]
+        }
+      }).then(function (res) {
+        var docs = res.docs.map(function (doc) {
+          return {
+            _id: doc._id
+          };
+        });
+        docs.should.deep.equal([
+          {'_id': 'link'}
+        ]);
+      });
+    });
+
+  });
+});

--- a/tests/find/test-suite-1/test.or.js
+++ b/tests/find/test-suite-1/test.or.js
@@ -1,0 +1,72 @@
+'use strict';
+
+testCases.push(function (dbType, context) {
+  describe(dbType + ': test.or.js', function () {
+
+    beforeEach(function () {
+      return context.db.bulkDocs([
+        { name: 'Mario', _id: 'mario', rank: 5, series: 'Mario', debut: 1981, awesome: true },
+        { name: 'Jigglypuff', _id: 'puff', rank: 8, series: 'Pokemon', debut: 1996,
+          awesome: false },
+        { name: 'Link', rank: 10, _id: 'link', series: 'Zelda', debut: 1986, awesome: true },
+        { name: 'Donkey Kong', rank: 7, _id: 'dk', series: 'Mario', debut: 1981, awesome: false },
+        { name: 'Pikachu', series: 'Pokemon', _id: 'pikachu', rank: 1, debut: 1996, awesome: true },
+        { name: 'Captain Falcon', _id: 'falcon', rank: 4, series: 'F-Zero', debut: 1990,
+          awesome: true },
+        { name: 'Luigi', rank: 11, _id: 'luigi', series: 'Mario', debut: 1983, awesome: false },
+        { name: 'Fox', _id: 'fox', rank: 3, series: 'Star Fox', debut: 1993, awesome: true },
+        { name: 'Ness', rank: 9, _id: 'ness', series: 'Earthbound', debut: 1994, awesome: true },
+        { name: 'Samus', rank: 12, _id: 'samus', series: 'Metroid', debut: 1986, awesome: true },
+        { name: 'Yoshi', _id: 'yoshi', rank: 6, series: 'Mario', debut: 1990, awesome: true },
+        { name: 'Kirby', _id: 'kirby', series: 'Kirby', rank: 2, debut: 1992, awesome: true },
+        { name: 'Master Hand', _id: 'master_hand', series: 'Smash Bros', rank: 0, debut: 1999,
+          awesome: false }
+      ]);
+    });
+
+    it('#6366 should do a basic $or', function () {
+      var db = context.db;
+      return db.find({
+        selector: {
+          "$or": [
+            { "name": "Link" },
+            { "name": "Mario" }
+          ]
+        }
+      }).then(function (res) {
+        var docs = res.docs.map(function (doc) {
+          return {
+            _id: doc._id
+          };
+        });
+        docs.should.deep.equal([
+          {'_id': 'link'},
+          {'_id': 'mario'},
+        ]);
+      });
+    });
+
+    it('#6366 should do a basic $or, with explicit $eq', function () {
+      var db = context.db;
+      return db.find({
+        selector: {
+          "$or": [
+            { "name": {$eq: "Link"} },
+            { "name": {$eq: "Mario"} }
+          ]
+        }
+      }).then(function (res) {
+        var docs = res.docs.map(function (doc) {
+          return {
+            _id: doc._id
+          };
+        });
+        docs.should.deep.equal([
+          {'_id': 'link'},
+          {'_id': 'mario'},
+        ]);
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
Adds a new test case for #6366 and fixes it.

In cases where the user uses $or or $nor and the sub-selector don't have an explicit $eq, we were failing to massage the selector into its normal $eq form, which is what was causing the bug.