### PR TITLE
(#6369) - pouchdb-find debugs correctly

### DIFF
--- a/packages/node_modules/pouchdb-find/src/adapters/local/create-index/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/create-index/index.js
@@ -48,7 +48,7 @@ function createIndex(db, requestDef) {
     return doc;
   }
 
-  db.constructor.emit('debug' ['find', 'creating index', ddocId]);
+  db.constructor.emit('debug', ['find', 'creating index', ddocId]);
 
   return upsert(db, ddocId, updateDdoc).then(function () {
     if (hasInvalidLanguage) {

--- a/packages/node_modules/pouchdb-find/src/adapters/local/find/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/find/index.js
@@ -62,9 +62,9 @@ function find(db, requestDef) {
 
   return getIndexes(db).then(function (getIndexesRes) {
 
-    db.constructor.emit('debug' ['find', 'planning query', requestDef]);
+    db.constructor.emit('debug', ['find', 'planning query', requestDef]);
     var queryPlan = planQuery(requestDef, getIndexesRes.indexes);
-    db.constructor.emit('debug' ['find', 'query plan', queryPlan]);
+    db.constructor.emit('debug', ['find', 'query plan', queryPlan]);
 
     var indexToUse = queryPlan.index;
 


### PR DESCRIPTION
I'm not sure how this bug slipped through, but pouchdb-find's debugging wasn't working correctly because of a syntax error. This fixes it.