### PR TITLE
(#6370) - fix building of plugins in dev mode

### DIFF
--- a/bin/build-pouchdb.js
+++ b/bin/build-pouchdb.js
@@ -192,12 +192,6 @@ function doBuildNode() {
     .then(buildForNode);
 }
 
-function doBuildDev() {
-  return doAll(buildForNode, buildForBrowserify)()
-    .then(doAll(buildForBrowser, buildPluginsForBrowserify, buildPouchDBNext))
-    .then(buildPluginsForBrowser);
-}
-
 function doBuildAll() {
   return rimrafMkdirp('lib', 'dist', 'lib/plugins')
     .then(doAll(buildForNode, buildForBrowserify))
@@ -208,8 +202,6 @@ function doBuildAll() {
 function doBuild() {
   if (process.env.BUILD_NODE) { // rebuild before "npm test"
     return doBuildNode();
-  } else if (DEV_MODE) { // rebuild during "npm run dev"
-    return doBuildDev();
   } else { // normal, full build
     return doBuildAll();
   }

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -75,7 +75,7 @@ function rebuildPerf() {
 }
 
 function watchAll() {
-  watch(['packages/node_modules/**/src/**/*.js'],
+  watch(['packages/node_modules/*/src/**/*.js'],
     debounce(rebuildPouch, 700, {leading: true}));
   watch(['tests/integration/utils.js'],
     debounce(rebuildTestUtils, 700, {leading: true}));


### PR DESCRIPTION
Plugins like pouchdb-find and pouchdb.memory.js weren't being correctly rebuilt in dev mode, which is a bit annoying. This fixes that.