### PR TITLE
Update to leveldown@1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "inherits": "2.0.3",
     "level-codec": "7.0.0",
     "level-write-stream": "1.0.0",
-    "leveldown": "1.5.0",
+    "leveldown": "1.5.1",
     "levelup": "1.3.5",
     "lie": "3.1.1",
     "localstorage-down": "0.6.7",


### PR DESCRIPTION
leveldown v1.5.1 [includes a change](https://github.com/Level/leveldown/issues/330) that allows prebuild to work when yarn is used as the package manager. This greatly speeds up installation of leveldown and therefore pouchDB.

This should also make using yarn for pouchdb's own CI tests much faster (see https://github.com/pouchdb/pouchdb/pull/5931).