### PR TITLE
(#6378) - remove scope-eval dep, use our own

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "memdown": "1.2.4",
     "readable-stream": "1.0.33",
     "request": "2.80.0",
-    "scope-eval": "0.0.3",
     "spark-md5": "3.0.0",
     "through2": "2.0.3",
     "vuvuzela": "1.0.3",
@@ -118,7 +117,6 @@
     "// immediate is pinned to use the same version as lie for a smaller bundle",
     "// leveldown is pinned because something broke in >1.5.0: https://git.io/vy5Xv",
     "// readable-stream has breaking changes in 2.0.0",
-    "// scope-eval is pinned because of breaking changes in 1.0.0",
     "// stream-to-promise is pinned because there's a breaking change in 2.0.0"
   ],
   "greenkeeper": {
@@ -127,7 +125,6 @@
       "immediate",
       "leveldown",
       "readable-stream",
-      "scope-eval",
       "stream-to-promise"
     ]
   }

--- a/packages/node_modules/pouchdb-core/src/evalFilter-browser.js
+++ b/packages/node_modules/pouchdb-core/src/evalFilter-browser.js
@@ -1,7 +1,7 @@
-import scopedEval from 'scope-eval';
+import { scopeEval } from 'pouchdb-utils';
 
 function evalFilter(input) {
-  return scopedEval('"use strict";\nreturn ' + input + ';', {});
+  return scopeEval('"use strict";\nreturn ' + input + ';', {});
 }
 
 export default evalFilter;

--- a/packages/node_modules/pouchdb-core/src/evalView-browser.js
+++ b/packages/node_modules/pouchdb-core/src/evalView-browser.js
@@ -1,4 +1,4 @@
-import scopedEval from 'scope-eval';
+import { scopeEval } from 'pouchdb-utils';
 
 function evalView(input) {
   var code = [
@@ -16,7 +16,7 @@ function evalView(input) {
     '};'
   ].join('\n');
 
-  return scopedEval(code, {});
+  return scopeEval(code, {});
 }
 
 export default evalView;

--- a/packages/node_modules/pouchdb-mapreduce/src/evalFunctionWithEval.js
+++ b/packages/node_modules/pouchdb-mapreduce/src/evalFunctionWithEval.js
@@ -1,5 +1,4 @@
-import scopedEval from 'scope-eval';
-import { guardedConsole } from 'pouchdb-utils';
+import { guardedConsole, scopeEval } from 'pouchdb-utils';
 import sum from './sum';
 
 var log = guardedConsole.bind(null, 'log');
@@ -7,7 +6,7 @@ var isArray = Array.isArray;
 var toJSON = JSON.parse;
 
 function evalFunctionWithEval(func, emit) {
-  return scopedEval(
+  return scopeEval(
     "return (" + func.replace(/;\s*$/, "") + ");",
     {
       emit: emit,

--- a/packages/node_modules/pouchdb-utils/src/index.js
+++ b/packages/node_modules/pouchdb-utils/src/index.js
@@ -20,6 +20,7 @@ import once from './once';
 import parseDdocFunctionName from './parseDdocFunctionName';
 import parseUri from './parseUri';
 import pick from './pick';
+import scopeEval from './scopeEval';
 import toPromise from './toPromise';
 import upsert from './upsert';
 import uuid from './uuid';
@@ -47,6 +48,7 @@ export {
   parseDdocFunctionName,
   parseUri,
   pick,
+  scopeEval,
   toPromise,
   upsert,
   uuid

--- a/packages/node_modules/pouchdb-utils/src/scopeEval.js
+++ b/packages/node_modules/pouchdb-utils/src/scopeEval.js
@@ -1,0 +1,18 @@
+// Based on https://github.com/alexdavid/scope-eval v0.0.3
+// (source: https://unpkg.com/scope-eval@0.0.3/scope_eval.js)
+// This is basically just a wrapper around new Function()
+
+function scopeEval(source, scope) {
+  var keys = [];
+  var values = [];
+  for (var key in scope) {
+    if (scope.hasOwnProperty(key)) {
+      keys.push(key);
+      values.push(scope[key]);
+    }
+  }
+  keys.push(source);
+  return Function.apply(null, keys).apply(null, values);
+}
+
+export default scopeEval;


### PR DESCRIPTION
I'm tired of seeing warnings in our build about this dependency (something about using a non-standard CommonJS export), and we can do it smaller if we just bring it into `pouchdb-utils`. That's what this PR does.

I've checked and it seems that this technique prevents Uglify from not mangling variables, so it should still result in a small `pouchdb.min.js` but it's worth double-checking once this is green.