### PR TITLE
Update serviceWorker.js to use https

### DIFF
--- a/docs/serviceWorker.js
+++ b/docs/serviceWorker.js
@@ -34,9 +34,9 @@ var nonCriticalAssets =
   [
     '/static/favicon.ico',
     '/static/js/code.min.js',
-    'http://code.jquery.com/jquery.min.js',
-    'http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js',
-    'http://cdn.jsdelivr.net/pouchdb/latest/pouchdb.min.js',
+    'https://code.jquery.com/jquery.min.js',
+    'https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js',
+    'https://cdn.jsdelivr.net/pouchdb/latest/pouchdb.min.js',
   ]
   .concat(pages)
   .filter(function(file) {


### PR DESCRIPTION
In the console there are these se errors because the website is under https

Mixed Content: The page at 'https://pouchdb.com/serviceWorker.js' was loaded over HTTPS, but requested an insecure resource 'http://code.jquery.com/jquery.min.js'. This request has been blocked; the content must be served over HTTPS.
serviceWorker.js:1 Mixed Content: The page at 'https://pouchdb.com/serviceWorker.js' was loaded over HTTPS, but requested an insecure resource 'http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js'. This request has been blocked; the content must be served over HTTPS.
serviceWorker.js:1 Mixed Content: The page at 'https://pouchdb.com/serviceWorker.js' was loaded over HTTPS, but requested an insecure resource 'http://cdn.jsdelivr.net/pouchdb/latest/pouchdb.min.js'. This request has been blocked; the content must be served over HTTPS.