### PR TITLE
Add export of in-memory-logic

### DIFF
--- a/packages/node_modules/pouchdb-selector-core/src/in-memory-filter.js
+++ b/packages/node_modules/pouchdb-selector-core/src/in-memory-filter.js
@@ -280,4 +280,4 @@ var matchers = {
   }
 };
 
-export { filterInMemoryFields };
+export { filterInMemoryFields, createFieldSorter, rowFilter };

--- a/packages/node_modules/pouchdb-selector-core/src/index.js
+++ b/packages/node_modules/pouchdb-selector-core/src/index.js
@@ -1,5 +1,5 @@
 import { matchesSelector } from './matches-selector';
-import { filterInMemoryFields } from './in-memory-filter';
+import { filterInMemoryFields, createFieldSorter, rowFilter } from './in-memory-filter';
 import {
   massageSelector,
   isCombinationalField,
@@ -15,6 +15,8 @@ export {
   massageSelector,
   matchesSelector,
   filterInMemoryFields,
+  createFieldSorter,
+  rowFilter,
   isCombinationalField,
   getKey,
   getValue,


### PR DESCRIPTION
Sometimes I want to use the sorting and matching-logic of pouch-find without adding a document to the database.

By exporting the functions `createFieldSorter` and `rowFilter`, it is possible to determine if a given document would match a given query, without saving it to the database. Also we could check if a document would be placed before or after another document when sorting.

This PR exports both functions.
