### PR TITLE
(#6458) - consistent error handling for mapreduce

### DIFF
--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -285,7 +285,19 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
         method: method,
         url: '_design/' + parts[0] + '/_view/' + parts[1] + params,
         body: body
-      }).then(postprocessAttachments(opts));
+      }).then(
+      /* istanbul ignore next */
+      function (result) {
+        // fail the entire request if the result contains an error
+        var reduceError = result.rows.find(function (row) {
+          return row.value && row.value.error && row.value.error === "builtin_reduce_error";
+        });
+        if (reduceError) {
+          throw new Error(reduceError.reason);
+        }
+        return result;
+      })
+      .then(postprocessAttachments(opts));
     }
 
     // We are using a temporary view, terrible for performance, good for testing


### PR DESCRIPTION
CouchDB 2 improves mapreduce error reporting in the face of invalid
values being passed to a built-in reduce function.

Previously, a query to a view that couldn't be reduced would result
in a 500 error. In 2.x, CouchDB returns a 200 response and contains
details of the error in the row.

This patch detects the presence of this error message and converts it
into a client-side error, emulating the CouchDB 1.x behaviour.