### PR TITLE
pouchdb-adapter-idb: fix "possible EventEmitter memory leak detected"

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -418,7 +418,7 @@ function init(api, opts, callback) {
   };
 
   api._changes = function idbChanges(opts) {
-    changes(opts, api, dbName, idb);
+    return changes(opts, api, dbName, idb);
   };
 
   api._close = function (callback) {


### PR DESCRIPTION
### Problem

With the idb adapter (default in Chrome), calling `.changes()` or `.replicate()` with `{live: true}` multiple times results in this error, even when the handler is nicely terminated with `.cancel()`.

    (node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.

Related to #4176, #4141, #4093, #3848, #2667, #2311, #2205, and maybe others.

### How to reproduce the bug?

Run this plunkr: http://plnkr.co/edit/JKCbQ6vwlYClAp6ZSAf4?p=preview

Alternatively, you can create + cancel a `.changes()` feed a few times:

```js
changesHandler = db.changes({live: true});
changesHandler.cancel();
repeat
```

### About this fix

The bug comes from [the `_change()` API call from the idb adapter](https://github.com/pouchdb/pouchdb/blob/49e4945/packages/node_modules/pouchdb-adapter-idb/src/index.js#L420-L422) returning `undefined` instead of the `{cancel: function() {...}}` object [it should return](https://github.com/pouchdb/pouchdb/blob/49e4945/packages/node_modules/pouchdb-adapter-idb/src/changes.js#L29-L33). Because of that, the cleanup function in the core module [doesn't call the adapter's `cancel()` function](https://github.com/pouchdb/pouchdb/blob/49e4945/packages/node_modules/pouchdb-core/src/changes.js#L201-L209), letting a listener into the wild.

This commit fixes that.