### PR TITLE
Check if replication is defined

### DIFF
--- a/packages/node_modules/pouchdb-replication/src/index.js
+++ b/packages/node_modules/pouchdb-replication/src/index.js
@@ -5,19 +5,21 @@ function replication(PouchDB) {
   PouchDB.replicate = replicate;
   PouchDB.sync = sync;
 
-  Object.defineProperty(PouchDB.prototype, 'replicate', {
-    get: function () {
-      var self = this;
-      return {
-        from: function (other, opts, callback) {
-          return self.constructor.replicate(other, self, opts, callback);
-        },
-        to: function (other, opts, callback) {
-          return self.constructor.replicate(self, other, opts, callback);
-        }
-      };
-    }
-  });
+  if (!PouchDB.prototype.replicate) {
+    Object.defineProperty(PouchDB.prototype, 'replicate', {
+      get: function () {
+        var self = this;
+        return {
+          from: function (other, opts, callback) {
+            return self.constructor.replicate(other, self, opts, callback);
+          },
+          to: function (other, opts, callback) {
+            return self.constructor.replicate(self, other, opts, callback);
+          }
+        };
+      }
+    });
+  }
 
   PouchDB.prototype.sync = function (dbName, opts, callback) {
     return this.constructor.sync(this, dbName, opts, callback);


### PR DESCRIPTION
Currently when using with https://github.com/zeit/next.js/ (server rendered react) 

I get this error:
```sh
TypeError: Cannot redefine property: replicate
    at Function.defineProperty (<anonymous>)
    at replication (../node_modules/pouchdb-replication/lib/index.js:979:10)
```
I think this is the correct way to fix that? 🤔 

Fixes #6512
