### PR TITLE
Angular Branding Guidelines

### DIFF
--- a/docs/_includes/api/overview.html
+++ b/docs/_includes/api/overview.html
@@ -28,7 +28,7 @@ If you don't specify a `callback`, then the API returns a [promise][]. In [suppo
 {% include alert/start.html variant="info"%}
 {% markdown %}
 
-**Using Ionic/Angular?**  You can wrap PouchDB promises in [`$q.when()`](https://docs.angularjs.org/api/ng/service/$q#when). This will notify Angular to update the UI when the PouchDB promise has resolved.
+**Using Ionic/AngularJS?**  You can wrap PouchDB promises in [`$q.when()`](https://docs.angularjs.org/api/ng/service/$q#when). This will notify AngularJS to update the UI when the PouchDB promise has resolved.
 
 {% endmarkdown %}
 {% include alert/end.html%}


### PR DESCRIPTION
The Angular team released naming conventions regarding the various versions of Angular.
As this part of the docs are targeted to 1.x versions, the convention is to use AngularJS and not refer to it as Angular.
This fix helps avoid confusion between the two libraries.

http://angularjs.blogspot.co.ke/2016/12/ok-let-me-explain-its-going-to-be.html#Naming_guidelines_48
http://angularjs.blogspot.co.ke/2017/01/branding-guidelines-for-angular-and.html