### PR TITLE
(#6518) - improve createIndex() performance for named indexes

### DIFF
--- a/packages/node_modules/pouchdb-find/src/adapters/local/create-index/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/create-index/index.js
@@ -12,11 +12,16 @@ function createIndex(db, requestDef) {
 
   validateIndex(requestDef.index);
 
-  var md5 = stringMd5(JSON.stringify(requestDef));
+  // calculating md5 is expensive - memoize and only
+  // run if required
+  var md5;
+  function getMd5() {
+    return md5 || (md5 = stringMd5(JSON.stringify(requestDef)));
+  }
 
-  var viewName = requestDef.name || ('idx-' + md5);
+  var viewName = requestDef.name || ('idx-' + getMd5());
 
-  var ddocName = requestDef.ddoc || ('idx-' + md5);
+  var ddocName = requestDef.ddoc || ('idx-' + getMd5());
   var ddocId = '_design/' + ddocName;
 
   var hasInvalidLanguage = false;


### PR DESCRIPTION
createIndex() uses the md5 hash of the index definition to test for duplcates. There's no straightforward way to avoid this, but users can specify their own index/ddoc name. In this case, we should skip the md5 calculation to improve performance.