### PR TITLE
(#6510) - respect ajax timeout when fetching _changes

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -1,5 +1,7 @@
 var CHANGES_BATCH_SIZE = 25;
 var MAX_SIMULTANEOUS_REVS = 50;
+var CHANGES_TIMEOUT_BUFFER = 5000;
+var DEFAULT_HEARTBEAT = 10000;
 
 var supportsBulkGetMap = {};
 
@@ -762,13 +764,31 @@ function HttpPouch(opts, callback) {
     var batchSize = 'batch_size' in opts ? opts.batch_size : CHANGES_BATCH_SIZE;
 
     opts = clone(opts);
-    opts.timeout = ('timeout' in opts) ? opts.timeout :
+
+    if (opts.continuous && !('heartbeat' in opts)) {
+      opts.heartbeat = DEFAULT_HEARTBEAT;
+    }
+
+    var requestTimeout = ('timeout' in opts) ? opts.timeout :
       ('timeout' in ajaxOpts) ? ajaxOpts.timeout :
       30 * 1000;
 
-    // We give a 5 second buffer for CouchDB changes to respond with
-    // an ok timeout (if a timeout it set)
-    var params = opts.timeout ? {timeout: opts.timeout - (5 * 1000)} : {};
+    // ensure CHANGES_TIMEOUT_BUFFER applies
+    if ('timeout' in opts && opts.timeout &&
+      (requestTimeout - opts.timeout) < CHANGES_TIMEOUT_BUFFER) {
+        requestTimeout = opts.timeout + CHANGES_TIMEOUT_BUFFER;
+    }
+
+    if ('heartbeat' in opts && opts.heartbeat &&
+       (requestTimeout - opts.heartbeat) < CHANGES_TIMEOUT_BUFFER) {
+        requestTimeout = opts.heartbeat + CHANGES_TIMEOUT_BUFFER;
+    }
+
+    var params = {};
+    if ('timeout' in opts && opts.timeout) {
+      params.timeout = opts.timeout;
+    }
+
     var limit = (typeof opts.limit !== 'undefined') ? opts.limit : false;
     var returnDocs;
     if ('return_docs' in opts) {
@@ -811,9 +831,6 @@ function HttpPouch(opts, callback) {
       if (opts.heartbeat) {
         params.heartbeat = opts.heartbeat;
       }
-    } else if (opts.continuous) {
-      // Default heartbeat to 10 seconds
-      params.heartbeat = 10000;
     }
 
     if (opts.filter && typeof opts.filter === 'string') {
@@ -883,7 +900,7 @@ function HttpPouch(opts, callback) {
       var xhrOpts = {
         method: method,
         url: genDBUrl(host, '_changes' + paramsToStr(params)),
-        timeout: opts.timeout,
+        timeout: requestTimeout,
         body: body
       };
       lastFetchedSeq = since;

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -4038,7 +4038,7 @@ adapters.forEach(function (adapters) {
       var ajax = remote._ajax;
       remote._ajax = function (opts) {
         // the http adapter takes 5s off the provided timeout
-        if (/timeout=15000/.test(opts.url)) {
+        if (/timeout=20000/.test(opts.url)) {
           seenTimeout = true;
         }
         ajax.apply(this, arguments);

--- a/tests/integration/test.replicationBackoff.js
+++ b/tests/integration/test.replicationBackoff.js
@@ -26,6 +26,11 @@ adapters.forEach(function (adapters) {
       var db = new PouchDB(dbs.name);
       var backOffCount = 0;
       var numberOfActiveListeners = 0;
+
+      remote._ajax = function (opts, cb) {
+        cb(new Error('flunking you'));
+      };
+
       var replication = db.sync(remote, {
         live: true,
         retry: true,


### PR DESCRIPTION
PouchDB already has logic to create a buffer between the server side
timeout and the client timeout, providing a 5 second grace period
for the server to respond before the client will timeout. However, there
are some situations where this causes _changes to fail with a client
timeout. Specifically:

1. If the timeout is less than 5 seconds. Given the logic to add a 5
second grace period, we need the client request timeout to be at least
this.
2. If the heartbeat is specified that is greater than the client timeout.
If a heartbeat parameter is specified, Couch ignores any timeout parameter.

To handle (1), this commit adjusts the client side timeout to be at least 5
seconds. To handle (2), we make the client side timeout at least the heartbeat
value.