### PR TITLE
Include doc ID in 404 (not_found) errors for IDB adapter

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -498,7 +498,10 @@ function HttpPouch(opts, callback) {
       }).then(function () {
         callback(null, res);
       });
-    }).catch(callback);
+    }).catch(function(e) {
+      e.requestedDocId = id;
+      callback(e)
+    });
   });
 
   // Delete the document given by doc from the database given by host.

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -498,9 +498,9 @@ function HttpPouch(opts, callback) {
       }).then(function () {
         callback(null, res);
       });
-    }).catch(function(e) {
+    }).catch(function (e) {
       e.requestedDocId = id;
-      callback(e)
+      callback(e);
     });
   });
 

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -605,6 +605,7 @@ AbstractPouchDB.prototype.get = adapterFun('get', function (id, opts, cb) {
 
   return this._get(id, opts, function (err, result) {
     if (err) {
+      err.requestedDocId = id;
       return cb(err);
     }
 

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -104,6 +104,16 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('Missing doc should contain ID in error object', function () {
+      var db = new PouchDB(dbs.name);
+      return db.get('abc-123').then(function () {
+        throw 'should not be here';
+      }).catch(function (err) {
+        should.exist(err);
+        err.requestedDocId.should.equal('abc-123');
+      });
+    });
+
     it('Add a doc with a promise', function (done) {
       var db = new PouchDB(dbs.name);
       db.post({test: 'somestuff'}).then(function () {


### PR DESCRIPTION
Adds a property `docId` to not_found error when trying to get an individual doc in the IDB adapter.

As posted on the issue:

> It doesn't really feel like the correct place to be fixing this, so if anyone's got any guidance it would be appreciated. This patch took me less time to write than I spent debugging an app to find the ID of a missing doc, so I'm very interested in getting this issue closed.

Issue: #5490