### PR TITLE
Prevent GitHub from suppressing diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/packages/node_modules/** linguist-generated=false


### PR DESCRIPTION
GitHub by default suppresses diffs in node_modules directories.
This PR excludes `/packages/node_modules` from that behaviour.
Works for [Cerebral](https://github.com/cerebral/cerebral).