### PR TITLE
Fix typo in test

### DIFF
--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -98,7 +98,7 @@ adapters.forEach(function (adapter) {
     it('Get invalid id', function () {
       var db = new PouchDB(dbs.name);
       return db.get(1234).then(function () {
-        throw 'show not be here';
+        throw new Error('should not be here');
       }).catch(function (err) {
         should.exist(err);
       });


### PR DESCRIPTION
Fixes a typo (`show` -> `should`), and also throws `Error` instead of a string.