### PR TITLE
Update leveldown to 1.6.0 to resolve installation fail behind proxy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "inherits": "2.0.3",
     "level-codec": "7.0.0",
     "level-write-stream": "1.0.0",
-    "leveldown": "1.5.0",
+    "leveldown": "1.6.0",
     "levelup": "1.3.7",
     "lie": "3.1.1",
     "localstorage-down": "0.6.7",


### PR DESCRIPTION
When using npm i leveldown behind corporate proxy occurs a timeout because leveldown tries to get prebuild binaries from github. The flag --build-from-source avoid this issue by always compiling the source code, but only works with leveldown 1.6.0.