### PR TITLE
Improving UUID generation with better random numbers

### DIFF
--- a/packages/node_modules/pouchdb-utils/package.json
+++ b/packages/node_modules/pouchdb-utils/package.json
@@ -15,6 +15,7 @@
     "./src/env/isChromeApp.js": "./src/env/isChromeApp-browser.js",
     "./src/explainError.js": "./src/explainError-browser.js",
     "./src/isBinaryObject.js": "./src/isBinaryObject-browser.js",
-    "./src/nextTick.js": "./src/nextTick-browser.js"
+    "./src/nextTick.js": "./src/nextTick-browser.js",
+    "./src/random.js": "./src/random-browser.js"
   }
 }

--- a/packages/node_modules/pouchdb-utils/src/random-browser.js
+++ b/packages/node_modules/pouchdb-utils/src/random-browser.js
@@ -1,0 +1,10 @@
+function randomUInt8() {
+  var crypto = global.crypto || global.msCrypto;
+  if (crypto && crypto.getRandomValues) {
+    return crypto.getRandomValues(new Uint8Array(1))[0];
+  } else {
+    return 0 | Math.random() * 256;
+  }
+}
+
+export default randomUInt8;

--- a/packages/node_modules/pouchdb-utils/src/random.js
+++ b/packages/node_modules/pouchdb-utils/src/random.js
@@ -1,0 +1,7 @@
+import { randomBytes } from 'crypto';
+
+function randomUInt8() {
+  return randomBytes(1).readUInt8();
+}
+
+export default randomUInt8;

--- a/packages/node_modules/pouchdb-utils/src/uuid.js
+++ b/packages/node_modules/pouchdb-utils/src/uuid.js
@@ -1,3 +1,5 @@
+import randomUInt8 from './random';
+
 // BEGIN Math.uuid.js
 
 /*!
@@ -39,7 +41,17 @@ var chars = (
   'abcdefghijklmnopqrstuvwxyz'
 ).split('');
 function getValue(radix) {
-  return 0 | Math.random() * radix;
+  // Using maxRandom of 255 will produce an un-even spread of random numbers.
+  // Instead, find the biggest number (within 8-bit range) that is a multiple of
+  // radix.
+  var maxRandom = 255 - (256 % radix);
+
+  var randomValue;
+  do {
+    randomValue = randomUInt8();
+  } while (randomValue > maxRandom);
+
+  return randomValue % radix;
 }
 function uuid(len, radix) {
   radix = radix || chars.length;

--- a/packages/node_modules/pouchdb-utils/src/uuid.js
+++ b/packages/node_modules/pouchdb-utils/src/uuid.js
@@ -41,17 +41,7 @@ var chars = (
   'abcdefghijklmnopqrstuvwxyz'
 ).split('');
 function getValue(radix) {
-  // Using maxRandom of 255 will produce an un-even spread of random numbers.
-  // Instead, find the biggest number (within 8-bit range) that is a multiple of
-  // radix.
-  var maxRandom = 255 - (256 % radix);
-
-  var randomValue;
-  do {
-    randomValue = randomUInt8();
-  } while (randomValue > maxRandom);
-
-  return randomValue % radix;
+  return Math.floor(randomUInt8() / 256 * radix);
 }
 function uuid(len, radix) {
   radix = radix || chars.length;


### PR DESCRIPTION
Replaces Math.random() with the crypto library, if available.

I think it's mostly there. I have a couple of problems with it:
 - According to [node documentation](https://nodejs.org/api/crypto.html#crypto_determining_if_crypto_support_is_unavailable) node can be compiled without crypto support. It's not clear to me how to deal with this. `import … from` gets converted into a `require` for node, and I don't see how I can wrap that generated code in the a `try … catch` block to correctly detect if it's not available.
 - It is getting tested by virtue of [test-uuids.js](https://github.com/pouchdb/pouchdb/blob/master/tests/integration/test.uuids.js) existing, but it isn't specifically testing the `randomUInt8` function 
 - Not sure I'm supposed to [append anything to this copyright notice](https://github.com/pouchdb/pouchdb/compare/master...SCdF:better-random-uuids?expand=1#diff-b31fb7bfa63105b279cfcf023feb9263R10)