### PR TITLE
Revert to uglify 2.x from 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "tape": "4.6.3",
     "throw-max-listeners-error": "1.0.1",
     "ua-parser-js": "0.7.12",
-    "uglify-js": "3.0.15",
+    "uglify-js": "2.8.21",
     "watch-glob": "0.1.3",
     "wd": "1.2.0"
   },


### PR DESCRIPTION
Multiple contributors are reporting build errors since we updated to uglify 3.x, even though Travis builds successfully. Reverting to 2.x until we understand the failure.