### PR TITLE
(#5490) include doc ID in conflict errors

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -661,6 +661,7 @@ function HttpPouch(opts, callback) {
         body: doc
       }, function (err, result) {
         if (err) {
+          err.docId = doc && doc._id;
           return callback(err);
         }
         callback(null, result);

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -45,10 +45,12 @@ function compare(left, right) {
 
 // Wrapper for functions that call the bulkdocs api with a single doc,
 // if the first result is an error, return an error
-function yankError(callback) {
+function yankError(callback, docId) {
   return function (err, results) {
     if (err || (results[0] && results[0].error)) {
-      callback(err || results[0]);
+      err = err || results[0];
+      err.docId = docId;
+      callback(err);
     } else {
       callback(null, results.length ? results[0]  : results);
     }
@@ -197,7 +199,7 @@ AbstractPouchDB.prototype.post =
   if (typeof doc !== 'object' || Array.isArray(doc)) {
     return callback(createError(NOT_AN_OBJECT));
   }
-  this.bulkDocs({docs: [doc]}, opts, yankError(callback));
+  this.bulkDocs({docs: [doc]}, opts, yankError(callback, doc._id));
 });
 
 AbstractPouchDB.prototype.put = adapterFun('put', function (doc, opts, cb) {
@@ -246,7 +248,7 @@ AbstractPouchDB.prototype.put = adapterFun('put', function (doc, opts, cb) {
     if (typeof self._put === 'function' && opts.new_edits !== false) {
       self._put(doc, opts, next);
     } else {
-      self.bulkDocs({docs: [doc]}, opts, yankError(next));
+      self.bulkDocs({docs: [doc]}, opts, yankError(next, doc._id));
     }
   }
 });
@@ -356,7 +358,7 @@ AbstractPouchDB.prototype.remove =
   if (isLocalId(newDoc._id) && typeof this._removeLocal === 'function') {
     return this._removeLocal(doc, callback);
   }
-  this.bulkDocs({docs: [newDoc]}, opts, yankError(callback));
+  this.bulkDocs({docs: [newDoc]}, opts, yankError(callback, newDoc._id));
 });
 
 AbstractPouchDB.prototype.revsDiff =

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -114,6 +114,38 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('PUTed Conflicted doc should contain ID in error object', function () {
+      var db = new PouchDB(dbs.name);
+      var savedDocId;
+      return db.post({}).then(function (info) {
+        savedDocId = info.id;
+        return db.put({
+          _id: savedDocId,
+        });
+      }).then(function () {
+        throw new Error('should not be here');
+      }).catch(function (err) {
+        err.should.have.property('status', 409);
+        err.docId.should.equal(savedDocId);
+      });
+    });
+
+    it('POSTed Conflicted doc should contain ID in error object', function () {
+      var db = new PouchDB(dbs.name);
+      var savedDocId;
+      return db.post({}).then(function (info) {
+        savedDocId = info.id;
+        return db.post({
+          _id: savedDocId,
+        });
+      }).then(function () {
+        throw new Error('should not be here');
+      }).catch(function (err) {
+        err.should.have.property('status', 409);
+        err.docId.should.equal(savedDocId);
+      });
+    });
+
     it('Add a doc with a promise', function (done) {
       var db = new PouchDB(dbs.name);
       db.post({test: 'somestuff'}).then(function () {


### PR DESCRIPTION
Adds a property `suppliedDocId` to conflict error when trying to put or post an individual doc.