### PR TITLE
Throw Errors, not Strings

### DIFF
--- a/packages/node_modules/pouchdb-selector-core/src/matches-selector.js
+++ b/packages/node_modules/pouchdb-selector-core/src/matches-selector.js
@@ -6,7 +6,7 @@ function matchesSelector(doc, selector) {
   /* istanbul ignore if */
   if (typeof selector !== 'object') {
     // match the CouchDB error message
-    throw 'Selector error: expected a JSON object';
+    throw new Error('Selector error: expected a JSON object');
   }
 
   selector = massageSelector(selector);

--- a/tests/integration/test.all_docs.js
+++ b/tests/integration/test.all_docs.js
@@ -146,7 +146,7 @@ adapters.forEach(function (adapter) {
     it('Testing allDocs invalid opts.keys', function () {
       var db = new PouchDB(dbs.name);
       return db.allDocs({keys: 1234}).then(function () {
-        throw 'should not be here';
+        throw new Error('should not be here');
       }).catch(function (err) {
         should.exist(err);
       });

--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -94,7 +94,7 @@ adapters.forEach(function (adapter) {
         }
       }};
       return db.put(doc).then(function () {
-        throw 'Should not succeed';
+        throw new Error('Should not succeed');
       }).catch(function (err) {
         err.name.should.equal('bad_request');
       });

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -107,7 +107,7 @@ adapters.forEach(function (adapter) {
     it('Missing doc should contain ID in error object', function () {
       var db = new PouchDB(dbs.name);
       return db.get('abc-123').then(function () {
-        throw 'should not be here';
+        throw new Error('should not be here');
       }).catch(function (err) {
         should.exist(err);
         err.requestedDocId.should.equal('abc-123');


### PR DESCRIPTION
No idea if this is welcome, but the general convention in pouch seems to be to throw proper `Error` objects.