### PR TITLE
(#6502) http adapter - changes() return_docs defaults false

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -777,7 +777,8 @@ function HttpPouch(opts, callback) {
       // TODO: Remove 'returnDocs' in favor of 'return_docs' in a future release
       returnDocs = opts.returnDocs;
     } else {
-      returnDocs = true;
+      // should default to false for http based adapters
+      returnDocs = false;
     }
     //
     var leftToFetch = limit;


### PR DESCRIPTION
* resolves (#6502) and aligns with documentation by making return_docs
default false for the http adapter