### PR TITLE
Updating hightler for Jekyll 3.x for correctly building the documentation

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -5,7 +5,6 @@ gem 'jekyll'
 group :jekyll_plugins do
   gem 'jekyll-paginate'
   gem 'redcarpet'
-  gem 'pygments.rb'
 end
 
 gem 'json'

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,6 @@
 name: PouchDB
 description: PouchDB, the JavaScript Database that Syncs!
 url: http://pouchdb.com
-highlighter: pygments
 markdown: redcarpet
 baseurl:
 version: 6.1.2


### PR DESCRIPTION
Fixes #6561 