### PR TITLE
(#6582) - revert uglify-js to version 2.8.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "tape": "4.7.0",
     "throw-max-listeners-error": "1.0.1",
     "ua-parser-js": "0.7.12",
-    "uglify-js": "3.0.21",
+    "uglify-js": "2.8.21",
     "watch-glob": "0.1.3",
     "wd": "1.3.0"
   },


### PR DESCRIPTION
This reverts commit 3f6f35204d4309ab7bcc644e14fd4db8c2e3c6de. 

Uglify 3.x breaks local builds (unsure why)