### PR TITLE
(#6607) - Use plain imports for uuid

### DIFF
--- a/packages/node_modules/pouchdb-utils/src/index.js
+++ b/packages/node_modules/pouchdb-utils/src/index.js
@@ -1,3 +1,5 @@
+import uuidV4 from 'uuid';
+
 import adapterFun from './adapterFun';
 import bulkGetShim from './bulkGetShim';
 import changesHandler from './changesHandler';
@@ -24,10 +26,9 @@ import pick from './pick';
 import scopeEval from './scopeEval';
 import toPromise from './toPromise';
 import upsert from './upsert';
-import v4 from 'uuid/v4';
 import rev from './rev';
 
-var uuid = v4;
+var uuid = uuidV4.v4;
 
 export {
   adapterFun,

--- a/packages/node_modules/pouchdb-utils/src/rev.js
+++ b/packages/node_modules/pouchdb-utils/src/rev.js
@@ -1,7 +1,7 @@
-import v4 from 'uuid/v4';
+import uuid from 'uuid';
 
 function rev() {
-  return v4().replace(/-/g, '').toLowerCase();
+  return uuid.v4().replace(/-/g, '').toLowerCase();
 }
 
 export default rev;


### PR DESCRIPTION
With the fancy name we miss dont match https://github.com/pouchdb/pouchdb/blob/master/bin/build-module.js#L45 and treat the import as a local one, with this the only warning now is 

     'default' is imported from external module 'uuid' but never used

Which was there previously and should only mean extra code bundled, although would still like to get rid of it