### PR TITLE
ensure release.sh stops on error

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ ! -z $DRY_RUN ]; then
   echo "Doing a dry run release..."
 elif [ ! -z $BETA ]; then


### PR DESCRIPTION
During the 6.3.0 release it would have been helpful if the `release.sh` script bailed when it encountered an error, preventing the publishing of bad packages.