### PR TITLE
Update 2014-04-14-pagination-strategies-with-pouchdb.md

### DIFF
--- a/docs/_posts/2014-04-14-pagination-strategies-with-pouchdb.md
+++ b/docs/_posts/2014-04-14-pagination-strategies-with-pouchdb.md
@@ -211,7 +211,7 @@ var options = {limit : 5};
 function fetchNextPage() {
   pouch.allDocs(options, function (err, response) {
     if (response && response.rows.length > 0) {
-      options.startkey = response.rows[response.rows.length - 1];
+      options.startkey = response.rows[response.rows.length - 1].id;
       options.skip = 1;
     }
     // handle err or response


### PR DESCRIPTION
I was having trouble getting the "smart method" to work. I was confused about why you would create a startkey that contains the entire row, instead of just the id for the doc. I finally figured it out. If include_docs = false, then having a startkey like this:

{ id: 'Client Demographics',
  key: 'Client Demographics',
  value: { rev: '569-5a192c494eca04611bc046a50a5283de' } }

seems to work (seems like a bug/side-effect, but it works). However, when you use include_docs=true it also has a doc property, and passing this object doesn't work as a valid startkey.

The solution, which works in both include_docs=true and include_docs=false, and which seems to make much more sense to me, is to only use the id of the doc for the startkey. That's what my pull request does.