### PR TITLE
upgrade leveldown and fix iterator problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "inherits": "2.0.3",
     "level-codec": "7.0.0",
     "level-write-stream": "1.0.0",
-    "leveldown": "1.5.0",
+    "leveldown": "1.7.2",
     "levelup": "1.3.8",
     "lie": "3.1.1",
     "localstorage-down": "0.6.7",

--- a/packages/node_modules/sublevel-pouchdb/src/readStream.js
+++ b/packages/node_modules/sublevel-pouchdb/src/readStream.js
@@ -76,7 +76,7 @@ ReadStream.prototype._cleanup = function (err) {
 
   var self = this;
   /* istanbul ignore if */
-  if (err) {
+  if (err && err.message !== 'iterator has ended') {
     self.emit('error', err);
   }
 


### PR DESCRIPTION
Closes https://github.com/pouchdb/pouchdb/issues/6551

I was a bit unsure on where to check for the error. We have different options here.

At first I wanted to put an error handler on `changeStream` [here](https://github.com/pouchdb/pouchdb/blob/master/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js#L1042), which could check for that particular error. But unclear to me how a different error should be handled. `changeStream` is also completely internal to the `api._changes` function so a bit clunky to handle the errors.

So I tried to go deeper instead and try to stop this error as early as possible and as close to `iterator.next(cb)` as possible and basically don't even emit it on the stream to begin with.

Let me know if you aren't happy with this solution and/or if it should be tweaked.

Cheers