### PR TITLE
6643 - support seq_interval for changes and use during replication

### DIFF
--- a/docs/_includes/api/changes.html
+++ b/docs/_includes/api/changes.html
@@ -37,6 +37,7 @@ All options default to `false` unless otherwise specified.
 * `options.return_docs` (previously `options.returnDocs`): Is available for non-http databases and defaults to `true`. Passing `false` prevents the changes feed from keeping all the documents in memory &ndash; in other words complete always has an empty results array, and the `change` event is the only way to get the event. Useful for large change sets where otherwise you would run out of memory.
 * `options.batch_size`: Only available for http databases, this configures how many changes to fetch at a time. Increasing this can reduce the number of requests made. Default is 25.
 * `options.style`: Specifies how many revisions are returned in the changes array. The default, `'main_only'`, will only return the current "winning" revision; `'all_docs'` will return all leaf revisions (including conflicts and deleted former conflicts). Most likely you won't need this unless you're writing a replicator.
+* `options.seq_interval`: Only available for http databases. Specifies that seq information only be generated every N changes. Larger values can improve changes throughput with CouchDB 2.0 and later. Note that `last_seq` is always populated regardless.
 
 #### Example Usage:
 

--- a/docs/_includes/api/replication.html
+++ b/docs/_includes/api/replication.html
@@ -32,6 +32,7 @@ All options default to `false` unless otherwise specified.
 * `options.batches_limit`: Number of batches to process at a time. Defaults to 10. This (along wtih `batch_size`) controls how many docs are kept in memory at a time, so the maximum docs in memory at once would equal `batch_size` &times; `batches_limit`.
 * `options.back_off_function`: backoff function to be used in `retry` replication. This is a function that takes the current backoff as input (or 0 the first time) and returns a new backoff in milliseconds. You can use this to tweak when and how replication will try to reconnect to a remote database when the user goes offline. Defaults to a function that chooses a random backoff between 0 and 2 seconds and doubles every time it fails to connect. The default delay will never exceed 10 minutes. (See [Customizing retry replication](#customizing-retry-replication) below.)
 * `options.checkpoint`: Can be used if you want to disable checkpoints on the source, target, or both. Setting this option to `false` will prevent writing checkpoints on both source and target. Setting it to `source` will only write checkpoints on the source. Setting it to `target` will only write checkpoints on the target.
+* `options.seq_interval`: Only available for http databases. Specifies that seq information only be generated every N changes. Larger values can improve changes throughput with CouchDB 2.0 and later. By default, Pouch will use seq_interval == batch size. Set to `false` to prevent passing seq_interval completely.
 
 #### Example Usage:
 

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -819,6 +819,10 @@ function HttpPouch(opts, callback) {
       params.feed = 'longpoll';
     }
 
+    if (opts.seq_interval) {
+      params.seq_interval = opts.seq_interval;
+    }
+
     if (opts.conflicts) {
       params.conflicts = true;
     }

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -28,6 +28,7 @@ function replicate(src, target, opts, returnValue, result) {
   var changedDocs = [];
   // Like couchdb, every replication gets a unique session id
   var session = uuid();
+  var seq_interval = opts.seq_interval;
 
   result = result || {
     ok: true,
@@ -401,6 +402,9 @@ function replicate(src, target, opts, returnValue, result) {
           selector: selector,
           return_docs: true // required so we know when we're done
         };
+        if (seq_interval !== false) {
+          changesOpts.seq_interval = seq_interval || batch_size;
+        }
         if (opts.filter) {
           if (typeof opts.filter !== 'string') {
             // required for the client-side filter in onChange

--- a/tests/integration/test.http.js
+++ b/tests/integration/test.http.js
@@ -263,4 +263,66 @@ describe('test.http.js', function () {
 
   });
 
+  it('changes respects seq_interval', function (done) {
+    var docs = [
+      {_id: '0', integer: 0, string: '0'},
+      {_id: '1', integer: 1, string: '1'},
+      {_id: '2', integer: 2, string: '2'}
+    ];
+
+    var db = new PouchDB(dbs.name);
+    var seqCount = 0;
+    var changesCount = 0;
+    db.bulkDocs(docs).then(function () {
+      db.changes({ seq_interval: 4 })
+      .on('change', function (change) {
+        if (change.seq !== null) {
+          seqCount++;
+        }
+        changesCount++;
+      }).on('error', function (err) {
+        done(err);
+      }).on('complete', function (info) {
+        try {
+          changesCount.should.equal(3);
+
+          // we can't know in advance which
+          // order the changes arrive in so sort them
+          // so that nulls appear last
+          info.results.sort(function (a, b) {
+            if (a.seq !== null && b.seq === null) {
+              return -1;
+            }
+
+            if (a.seq === null && b.seq !== null) {
+              return 1;
+            }
+
+            return 0;
+          });
+
+          // first change always contains a seq
+          should.not.equal(info.results[0].seq, null);
+          should.not.equal(info.last_seq, null);
+
+          // CouchDB 1.x should just ignore seq_interval
+          // (added in CouchDB 2.0), but not fail with an error
+          if (testUtils.isCouchMaster()) {
+            // one change (the "first") always contains a seq
+            seqCount.should.equal(1);
+            should.equal(info.results[1].seq, null);
+            should.equal(info.results[2].seq, null);
+          }
+          else {
+            seqCount.should.equal(3);
+          }
+
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
+      });
+    });
+  });
 });

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -4219,7 +4219,6 @@ adapters.forEach(function (adapters) {
         err.reason.should.contain('expected a JSON object');
       });
     });
-
   });
 });
 


### PR DESCRIPTION
CouchDB 2.x adds a new parameter to _changes, `seq_interval`, that allows seq information to be skipped for intermediate changes within a batch. This can improve changes response time (and therefore replication throughput) considerably. It is safely ignored by CouchDB 1.x so I think it makes sense for PouchDB to use it during replication.

The potential breaking change here is if a user listens to the `change` event of `sync` or `replication` - seq values for those changes may now be null. If this impacts users, specifying `{seq_interval: false}` as an option to replication will disable the new behaviour.