### PR TITLE
(#5547) - add multipart support for bulkGet api

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -296,6 +296,35 @@ function HttpPouch(opts, callback) {
   api.bulkGet = coreAdapterFun('bulkGet', function (opts, callback) {
     var self = this;
 
+    function wrapCallbackForMultipart(cb) {
+      return function (err, obj, resp) {
+        if (err || !resp || !resp.contentType) {
+          cb(err, obj, resp);
+          return;
+        }
+
+        var matches = resp.contentType.match(/(.*);\s*boundary="(.*)"/);
+        if (!matches || matches[1] != 'multipart/mixed') {
+          cb(err, obj, resp);
+          return;
+        }
+        var results = obj.map(function (item) {
+          if (item.error) {
+            return {
+              "docs": [{"error": item}],
+              "id": item["_id"]
+            };
+          } else {
+            return {
+              "docs": [{"ok": item}],
+              "id": item["_id"]
+            };
+          }
+        });
+        cb(err, {"results": results}, resp);
+      };
+    }
+
     function doBulkGet(cb) {
       var params = {};
       if (opts.revs) {
@@ -311,8 +340,9 @@ function HttpPouch(opts, callback) {
       ajax(opts, {
         url: genDBUrl(host, '_bulk_get' + paramsToStr(params)),
         method: 'POST',
-        body: { docs: opts.docs}
-      }, cb);
+        body: { docs: opts.docs},
+        acceptJsonMultipart: true
+      }, wrapCallbackForMultipart(cb));
     }
 
     /* istanbul ignore next */

--- a/packages/node_modules/pouchdb-ajax/src/ajaxCore.js
+++ b/packages/node_modules/pouchdb-ajax/src/ajaxCore.js
@@ -20,11 +20,37 @@ function ajaxCore(options, callback) {
 
   options = Object.assign(defaultOptions, options);
 
+
+  function parseJsonMultipart(obj, boundary) {
+    var results = [];
+    var blocks = obj.split("--" + boundary);
+    for (var i = 0; i < blocks.length; i++) {
+      var block = blocks[i];
+      var contentIndex = block.indexOf('Content-Type: application/json');
+      if (contentIndex >= 0) {
+        var jsonContent = block.substring(contentIndex + 'Content-Type: application/json'.length).trim();
+        if (jsonContent.length > 0) {
+          results.push(JSON.parse(jsonContent));
+        }
+      }
+    }
+    return results;
+  }
+
   function onSuccess(obj, resp, cb) {
     if (!options.binary && options.json && typeof obj === 'string') {
       /* istanbul ignore next */
       try {
-        obj = JSON.parse(obj);
+        if (options.acceptJsonMultipart) {
+          var matches = resp.contentType.match(/(.*);\s*boundary="(.*)"/);
+          if (matches && matches[1] === 'multipart/mixed') {
+            obj = parseJsonMultipart(obj, matches[2]);
+          } else {
+            obj = JSON.parse(obj);
+          }
+        } else {
+          obj = JSON.parse(obj);
+        }
       } catch (e) {
         // Probably a malformed JSON from server
         return cb(e);
@@ -48,6 +74,9 @@ function ajaxCore(options, callback) {
   if (options.json) {
     if (!options.binary) {
       options.headers.Accept = 'application/json';
+      if (options.acceptJsonMultipart) {
+          options.headers.Accept = 'application/json, multipart/mixed';
+      }
     }
     options.headers['Content-Type'] = options.headers['Content-Type'] ||
       'application/json';

--- a/packages/node_modules/pouchdb-ajax/src/request-browser.js
+++ b/packages/node_modules/pouchdb-ajax/src/request-browser.js
@@ -153,6 +153,9 @@ function xhRequest(options, callback) {
     delete options.headers['Content-Type'];
   } else if (options.json) {
     options.headers.Accept = 'application/json';
+    if (options.acceptJsonMultipart) {
+      options.headers.Accept = 'application/json, multipart/mixed';
+    }
     options.headers['Content-Type'] = options.headers['Content-Type'] ||
       'application/json';
     if (options.body &&
@@ -195,7 +198,8 @@ function xhRequest(options, callback) {
     }
 
     var response = {
-      statusCode: xhr.status
+      statusCode: xhr.status,
+      contentType: xhr.getResponseHeader("Content-Type")
     };
 
     if (xhr.status >= 200 && xhr.status < 300) {


### PR DESCRIPTION
The bulk_get api from CSG is returning as multipart/mixed. But pouchdb
expecting application/json. This commit is to add the multipart/mixed
support for bulkGet api to support CSG.