### PR TITLE
Update request to newest version 2.81.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ltgt": "2.2.0",
     "memdown": "1.2.4",
     "readable-stream": "1.0.33",
-    "request": "2.80.0",
+    "request": "2.81.1",
     "spark-md5": "3.0.0",
     "through2": "2.0.3",
     "uuid": "^3.1.0",


### PR DESCRIPTION
Prior to 2.81.0, `request` was using a version `tunnel-agent` lower then 0.6.0, which is vulnerable to Uninitialized Memory Exposure.

More details here: https://snyk.io/vuln/npm:tunnel-agent:20170305

Looking at the request changelog, all other changes seem pretty minor: https://github.com/request/request/commits/v2.81.1
