### PR TITLE
(#6724) - Fix unpkg download link

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -54,7 +54,7 @@ PouchDB is hosted at these CDNs:
 
 * [cdnjs](https://cdnjs.com/libraries/pouchdb)
 * [jsdelivr](http://www.jsdelivr.com/#!pouchdb)
-* [unpkg](https://unpkg.com/pouchdb@6.0.4/dist/)
+* [unpkg](https://unpkg.com/pouchdb@{{ site.version }}/dist/)
 
 {% include anchor.html class="h3" title="Bower" hash="bower" %}
 


### PR DESCRIPTION
Should now use the latest version instead of being hardcoded to 6.0.4