### PR TITLE
Correct heading in We Have a Problem with Promises

### DIFF
--- a/docs/_posts/2015-05-18-we-have-a-problem-with-promises.md
+++ b/docs/_posts/2015-05-18-we-have-a-problem-with-promises.md
@@ -329,7 +329,7 @@ Similarly, there is a `Promise.reject()` that you can use to return a promise th
 Promise.reject(new Error('some awful error'));
 ```
 
-Advanced mistake #2: `catch()` isn't exactly like `then(null, ...)`
+Advanced mistake #2: `then(resolveHandler).catch(rejectHandler)` isn't exactly the same as `then(resolveHandler, rejectHandler)`
 ----
 
 I said above that `catch()` is just sugar. So these two snippets are equivalent:


### PR DESCRIPTION
We Have a Problem with Promises is still one of the best articles to send to folks struggling with promise idioms in the day of `async`/`await` (I just sent it to somebody who was fiddling with nested promise constructors and `async`/`await`, not because it addressed what they were doing directly but because the "do"s and "don't"s it discusses would give them better ways to structure their code, with or without the syntactic sugar of `async`). But every once in a while I see people stumble over the statement that "catch() is not exactly like then(null, ...)". What is the difference explained in the article? Well, actually, that statement's the heading to a section that starts by explaining that `catch` *is* exactly like `then` with `null` as the first callback parameter, then goes on to explain the difference between `then` followed by `catch` vs `then` with two callback parameters. And I just now realized I could submit a request on GitHub to make the heading reflect that!

I was ambivalent about possibly using even shorter code in the heading: `then().catch()` and `then(..., ...)` as was the style before (as I said in the commit, I thought about it in terms of the shortest possible restatement of the section's content); but I figure it's easier to take the names back out than to find what the handlers were named elsewhere in the article in order to add consistent names in (which is what I did).

Hope you like the suggestion! 😸 