### PR TITLE
Ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ lerna-debug.log
 tests/integration/utils-bundle.js
 *.heapsnapshot
 /pouchdb-server-install
+/package-lock.json


### PR DESCRIPTION
If this file isn't going to be committed, it would be really handy to ignore it - it gets regenerated every time I run `npm install`.  Ignoring it in my global gitignore is not suitable, as some projects _do_ commit it.