### PR TITLE
fix(http): prevent field lookup on undefined value

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -165,7 +165,7 @@ function HttpPouch(opts, callback) {
   api._ajax = ajaxCore;
 
   function ajax(userOpts, options, callback) {
-    var reqAjax = userOpts.ajax || {};
+    var reqAjax = (userOpts || {}).ajax || {};
     var reqOpts = Object.assign(clone(ajaxOpts), reqAjax, options);
     var defaultHeaders = clone(ajaxOpts.headers || {});
     reqOpts.headers = Object.assign(defaultHeaders, reqAjax.headers,


### PR DESCRIPTION
# problem statement

`userOpts` is not always provided by consumers within http adapter.

# solution

validate the lookup before assigning the default

# discussion

i cant believe i haven't hit this before!