### PR TITLE
fix description of $in in docs

### DIFF
--- a/docs/_includes/api/query_index.html
+++ b/docs/_includes/api/query_index.html
@@ -85,7 +85,7 @@ The above is a simple example. For an in-depth tutorial, please refer to
   * `$ne` Match fields not equal to this one.
   * `$exists` True if the field should exist, false otherwise.
   * `$type` One of: "null", "boolean", "number", "string", "array", or "object".
-  * `$in` Matches if all the selectors in the array match.
+  * `$in` The document field must exist in the list provided.
   * `$and` Matches if all the selectors in the array match.
   * `$nin` The document field must not exist in the list provided.
   * `$all` Matches an array value if it contains all the elements of the argument array.


### PR DESCRIPTION
I left the order intact, but it would probably be prettier to put e.g. `$in` next to `$nin`, `$and` next to `$or`, etcetera.