### PR TITLE
(#5710) Add pending property support

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -954,7 +954,11 @@ function HttpPouch(opts, callback) {
             if (returnDocs) {
               results.results.push(c);
             }
-            opts.onChange(c, pending);
+            /* istanbul ignore if */
+            if (typeof pending === 'number') {
+              c.pending = pending;
+            }
+            opts.onChange(c);
           }
           return ret;
         });

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -935,9 +935,10 @@ function HttpPouch(opts, callback) {
       if (res && res.results) {
         raw_results_length = res.results.length;
         results.last_seq = res.last_seq;
+        var pending;
         // Attach 'pending' property if server supports it (CouchDB 2.0+)
         if (typeof res.pending === 'number') {
-          results.pending = res.pending;
+          pending = res.pending;
         }
         // For each change
         var req = {};
@@ -952,7 +953,7 @@ function HttpPouch(opts, callback) {
             if (returnDocs) {
               results.results.push(c);
             }
-            opts.onChange(c, results.pending);
+            opts.onChange(c, pending);
           }
           return ret;
         });

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -935,7 +935,7 @@ function HttpPouch(opts, callback) {
       if (res && res.results) {
         raw_results_length = res.results.length;
         results.last_seq = res.last_seq;
-        var pending;
+        var pending = null;
         // Attach 'pending' property if server supports it (CouchDB 2.0+)
         /* istanbul ignore if */
         if (typeof res.pending === 'number') {

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -935,6 +935,10 @@ function HttpPouch(opts, callback) {
       if (res && res.results) {
         raw_results_length = res.results.length;
         results.last_seq = res.last_seq;
+        // Attach 'pending' property if server supports it (CouchDB 2.0+)
+        if (typeof res.pending === 'number') {
+          results.pending = res.pending;
+        }
         // For each change
         var req = {};
         req.query = opts.query_params;
@@ -948,7 +952,7 @@ function HttpPouch(opts, callback) {
             if (returnDocs) {
               results.results.push(c);
             }
-            opts.onChange(c);
+            opts.onChange(c, results.pending);
           }
           return ret;
         });

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -937,6 +937,7 @@ function HttpPouch(opts, callback) {
         results.last_seq = res.last_seq;
         var pending;
         // Attach 'pending' property if server supports it (CouchDB 2.0+)
+        /* istanbul ignore if */
         if (typeof res.pending === 'number') {
           pending = res.pending;
         }

--- a/packages/node_modules/pouchdb-core/src/changes.js
+++ b/packages/node_modules/pouchdb-core/src/changes.js
@@ -18,10 +18,10 @@ import PouchDB from './setup';
 
 inherits(Changes, EE);
 
-function tryCatchInChangeListener(self, change, pending) {
+function tryCatchInChangeListener(self, change) {
   // isolate try/catches to avoid V8 deoptimizations
   try {
-    self.emit('change', change, pending);
+    self.emit('change', change);
   } catch (e) {
     guardedConsole('error', 'Error in .on("change", function):', e);
   }
@@ -54,12 +54,12 @@ function Changes(db, opts, callback) {
   }
   db.once('destroyed', onDestroy);
 
-  opts.onChange = function (change, pending) {
+  opts.onChange = function (change) {
     /* istanbul ignore if */
     if (self.isCancelled) {
       return;
     }
-    tryCatchInChangeListener(self, change, pending);
+    tryCatchInChangeListener(self, change);
   };
 
   var promise = new Promise(function (fulfill, reject) {

--- a/packages/node_modules/pouchdb-core/src/changes.js
+++ b/packages/node_modules/pouchdb-core/src/changes.js
@@ -18,10 +18,10 @@ import PouchDB from './setup';
 
 inherits(Changes, EE);
 
-function tryCatchInChangeListener(self, change) {
+function tryCatchInChangeListener(self, change, pending) {
   // isolate try/catches to avoid V8 deoptimizations
   try {
-    self.emit('change', change);
+    self.emit('change', change, pending);
   } catch (e) {
     guardedConsole('error', 'Error in .on("change", function):', e);
   }
@@ -54,12 +54,12 @@ function Changes(db, opts, callback) {
   }
   db.once('destroyed', onDestroy);
 
-  opts.onChange = function (change) {
+  opts.onChange = function (change, pending) {
     /* istanbul ignore if */
     if (self.isCancelled) {
       return;
     }
-    tryCatchInChangeListener(self, change);
+    tryCatchInChangeListener(self, change, pending);
   };
 
   var promise = new Promise(function (fulfill, reject) {

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -286,22 +286,25 @@ function replicate(src, target, opts, returnValue, result) {
   }
 
 
-  function onChange(change, pending) {
+  function onChange(change) {
     /* istanbul ignore if */
     if (returnValue.cancelled) {
       return completeReplication();
     }
+    // Attach 'pending' property if server supports it (CouchDB 2.0+)
+    var pending = change.pending;
+    delete change.pending;
+    /* istanbul ignore if */
+    if (typeof pending === 'number') {
+      pendingBatch.pending = pending;
+    }
+
     var filter = filterChange(opts)(change);
     if (!filter) {
       return;
     }
     pendingBatch.seq = change.seq;
     pendingBatch.changes.push(change);
-    // Attach 'pending' property if server supports it (CouchDB 2.0+)
-    /* istanbul ignore if */
-    if (typeof pending === 'number') {
-      pendingBatch.pending = pending;
-    }
     processPendingBatch(batches.length === 0 && changesOpts.live);
   }
 

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -124,6 +124,7 @@ function replicate(src, target, opts, returnValue, result) {
       /* istanbul ignore if */
       if (typeof currentBatch.pending === 'number') {
         outResult.pending = currentBatch.pending;
+        delete currentBatch.pending;
       }
       returnValue.emit('change', outResult);
     }

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -120,6 +120,10 @@ function replicate(src, target, opts, returnValue, result) {
     var outResult = clone(result);
     if (changedDocs.length) {
       outResult.docs = changedDocs;
+      // Attach 'pending' property if server supports it (CouchDB 2.0+)
+      if (typeof currentBatch.pending === 'number') {
+        outResult.pending = currentBatch.pending;
+      }
       returnValue.emit('change', outResult);
     }
     writingCheckpoint = true;
@@ -281,7 +285,7 @@ function replicate(src, target, opts, returnValue, result) {
   }
 
 
-  function onChange(change) {
+  function onChange(change, pending) {
     /* istanbul ignore if */
     if (returnValue.cancelled) {
       return completeReplication();
@@ -292,6 +296,10 @@ function replicate(src, target, opts, returnValue, result) {
     }
     pendingBatch.seq = change.seq;
     pendingBatch.changes.push(change);
+    // Attach 'pending' property if server supports it (CouchDB 2.0+)
+    if (typeof pending === 'number') {
+      pendingBatch.pending = pending;
+    }
     processPendingBatch(batches.length === 0 && changesOpts.live);
   }
 

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -121,6 +121,7 @@ function replicate(src, target, opts, returnValue, result) {
     if (changedDocs.length) {
       outResult.docs = changedDocs;
       // Attach 'pending' property if server supports it (CouchDB 2.0+)
+      /* istanbul ignore if */
       if (typeof currentBatch.pending === 'number') {
         outResult.pending = currentBatch.pending;
       }
@@ -297,6 +298,7 @@ function replicate(src, target, opts, returnValue, result) {
     pendingBatch.seq = change.seq;
     pendingBatch.changes.push(change);
     // Attach 'pending' property if server supports it (CouchDB 2.0+)
+    /* istanbul ignore if */
     if (typeof pending === 'number') {
       pendingBatch.pending = pending;
     }

--- a/tests/integration/test.sync_events.js
+++ b/tests/integration/test.sync_events.js
@@ -66,5 +66,42 @@ adapters.forEach(function (adapters) {
 
     });
 
+    it('#5710 Test pending property support', function (done) {
+
+      var db = new PouchDB(dbs.name);
+      var remote = new PouchDB(dbs.remote);
+      var docId = 0;
+      var numDocs = 10;
+
+      function generateDocs(n) {
+        return Array.apply(null, new Array(n)).map(function () {
+          docId += 1;
+          return {
+            _id: docId.toString(),
+            foo: Math.random().toString()
+          };
+        });
+      }
+      remote.bulkDocs(generateDocs(numDocs)).then(function () {
+        var repl = db.sync(remote, { retry: true, live: false, batch_size: 4 });
+        var pendingSum = 0;
+
+        repl.on('change', function (info) {
+          if (typeof info.change.pending === 'number') {
+            pendingSum += info.change.pending;
+            if (info.change.pending === 0) {
+              pendingSum += info.change.docs.length;
+            }
+          }
+        });
+
+        repl.on('complete', function () {
+          if (pendingSum > 0) {
+            pendingSum.should.equal(numDocs);
+          }
+          done();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR simply passes the 'pending' property to the replication 'change' event when provided by the server (CouchDB 2.0+).

Note: This PR only provides the pending property FROM the server, so it will only appear in the FROM change events. i.e. pending docs to DOWNLOAD. If you know of an easy way to calculate pending docs to UPLOAD, then I'm all ears and will add it to this PR. I tried with some `update_seq`, `last_seq` trickery but failed to get it working in all scenarios.

Tests included.
Closes #5710