### PR TITLE
(#6855) - fix(ajax): cache bust GET requests on IE11

### DIFF
--- a/packages/node_modules/pouchdb-ajax/src/prequest-browser.js
+++ b/packages/node_modules/pouchdb-ajax/src/prequest-browser.js
@@ -10,12 +10,13 @@ function ajax(opts, callback) {
 
   var isSafari = ua.indexOf('safari') !== -1 && ua.indexOf('chrome') === -1;
   var isIE = ua.indexOf('msie') !== -1;
+  var isTrident = ua.indexOf('trident') !== -1;
   var isEdge = ua.indexOf('edge') !== -1;
 
   // it appears the new version of safari also caches GETs,
   // see https://github.com/pouchdb/pouchdb/issues/5010
   var shouldCacheBust = (isSafari ||
-    ((isIE || isEdge) && opts.method === 'GET'));
+    ((isIE || isTrident || isEdge) && opts.method === 'GET'));
 
   var cache = 'cache' in opts ? opts.cache : true;
 


### PR DESCRIPTION
Fixes #6855

Identify IE11 by matching 'Trident' in its user-agent string.

See:
- MSDN – Understanding user-agent strings
  https://msdn.microsoft.com/en-us/library/ms537503(v=vs.85).aspx#TriToken

- MSDN – Compatibility changes in IE11
  https://msdn.microsoft.com/library/bg182625(v=vs.85)