### PR TITLE
(#6861) - Remove test for _session access

### DIFF
--- a/tests/integration/test.aa.setup.js
+++ b/tests/integration/test.aa.setup.js
@@ -1,15 +1,6 @@
 'use strict';
+
 describe('DB Setup', function () {
-  it('we can find CouchDB with admin credentials', function (done) {
-    testUtils.ajax({ url: testUtils.couchHost() + '/_session' },
-      function (err, res) {
-        if (err) { return done(err); }
-        should.exist(res.ok, 'Found CouchDB');
-        res.userCtx.roles.should.include('_admin', 'Found admin permissions');
-        done();
-      }
-    );
-  });
 
   it('PouchDB has a version', function () {
     PouchDB.version.should.be.a('string');
@@ -22,4 +13,5 @@ describe('DB Setup', function () {
       PouchDB.version.should.equal(pkg.version);
     });
   }
+
 });


### PR DESCRIPTION
This test was introduced basically to check there was a running server when we only really cared about testing against couchdb. Now its the only bit of pouchdb that depends on couchdb's user permission system and prevents me testing against other servers (pouchdb-express-router for one)

The test for the running server has been moved to npm run dev