### PR TITLE
(#6859) Update run-tests.sh to use updated packages for the pouchdb-server test

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "inherits": "2.0.3",
     "level-codec": "7.0.1",
     "level-write-stream": "1.0.0",
-    "leveldown": "2.0.2",
+    "leveldown": "1.7.2",
     "levelup": "1.3.9",
     "lie": "3.1.1",
     "localstorage-down": "0.6.7",


### PR DESCRIPTION
Some builds fail because on travis pouchdb-server does not use updated packages.
[Example 1 Build 32](https://github.com/pouchdb/pouchdb/pull/6858#issuecomment-346413720)
[Example 2](https://github.com/pouchdb/pouchdb/pull/6833#issuecomment-346588271)

I now updated the run-tests.sh to update ALL the packages it can find in the pouchdb-server-install folder. Maybe thats to much