### PR TITLE
(#6870) fix usage of query parameters with NEXT=1 integration test + fix bulkDocs of indexeddb

### DIFF
--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -34,7 +34,7 @@ if (process.env.ITERATIONS) {
   queryParams.iterations = process.env.ITERATIONS;
 }
 if (process.env.NEXT) {
-  queryParams.src = '../../packages/node_modules/pouchdb/dist/pouchdb-next.js';
+  queryParams.NEXT = '1';
 }
 
 var rebuildPromise = Promise.resolve();

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -186,7 +186,7 @@ function startSauceConnect(callback) {
 
 function startTest() {
 
-  console.log('Starting', client);
+  console.log('Starting', client, 'on', testUrl);
 
   var opts = {
     browserName: client.browser,

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
@@ -50,7 +50,7 @@ export default function (db, req, opts, metadata, dbOpts, idbChanges, callback) 
   }
 
   // Reads the original doc from the store if available
-  // TODO: I think we can use getAll to remove most of this ugly code?
+  // As in allDocs with keys option using multiple get calls is the fastest way
   function fetchExistingDocs(txn, docs) {
     var fetched = 0;
     var oldDocs = {};
@@ -122,7 +122,6 @@ export default function (db, req, opts, metadata, dbOpts, idbChanges, callback) 
       id: doc.metadata.id,
       rev: doc.metadata.rev,
       rev_tree: doc.metadata.rev_tree,
-      writtenRev: doc.metadata.rev,
       revs: doc.metadata.revs || {}
     };
 
@@ -180,6 +179,8 @@ export default function (db, req, opts, metadata, dbOpts, idbChanges, callback) 
     // We copy the data from the winning revision into the root
     // of the document so that it can be indexed
     var winningRev = calculateWinningRev(doc);
+    // rev of new doc for attachments and to return it
+    var writtenRev = doc.rev;
     var isLocal = /^_local/.test(doc.id);
 
     doc.data = doc.revs[winningRev].data;
@@ -228,25 +229,24 @@ export default function (db, req, opts, metadata, dbOpts, idbChanges, callback) 
             return;
           }
 
-          doc.attachments[attachment.digest].revs[doc.writtenRev] = true;
+          doc.attachments[attachment.digest].revs[writtenRev] = true;
 
         } else {
 
           doc.attachments[attachment.digest] = attachment;
           doc.attachments[attachment.digest].revs = {};
-          doc.attachments[attachment.digest].revs[doc.writtenRev] = true;
+          doc.attachments[attachment.digest].revs[writtenRev] = true;
 
           doc.data._attachments[k] = {
             stub: true,
             digest: attachment.digest,
             content_type: attachment.content_type,
             length: attachment.length,
-            revpos: parseInt(doc.writtenRev, 10)
+            revpos: parseInt(writtenRev, 10)
           };
         }
       }
     }
-    delete doc.writtenRev;
 
     // Local documents have different revision handling
     if (isLocal && doc.deleted) {
@@ -265,7 +265,7 @@ export default function (db, req, opts, metadata, dbOpts, idbChanges, callback) 
       results[i] = {
         ok: true,
         id: doc.id,
-        rev: doc.rev
+        rev: writtenRev
       };
       updateSeq(i);
     };
@@ -340,19 +340,7 @@ export default function (db, req, opts, metadata, dbOpts, idbChanges, callback) 
     }
 
     // Ideally parseDoc would return data in this format, but it is currently
-    // shared
-    var newDoc = {
-      id: result.metadata.id,
-      rev: result.metadata.rev,
-      rev_tree: result.metadata.rev_tree,
-      revs: {}
-    };
-
-    newDoc.revs[newDoc.rev] = {
-      data: result.data,
-      deleted: result.metadata.deleted
-    };
-
+    // shared so we need to convert
     docs.push(convertDocFormat(result));
   }
 

--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -5,9 +5,13 @@
   // eg: test.html?pluginFile=memory.pouchdb.js
   var plugins = window.location.search.match(/[?&]plugins=([^&]+)/);
   var adapters = window.location.search.match(/[?&]adapters=([^&]+)/);
+  var next = window.location.search.match(/[?&]NEXT=([^&]+)/);
+  next = next && next[1] === '1';
   var pouchdbSrc = window.location.search.match(/[?&]src=([^&]+)/);
   if (pouchdbSrc) {
     pouchdbSrc = decodeURIComponent(pouchdbSrc[1]);
+  } else if (next) {
+    pouchdbSrc = '../../packages/node_modules/pouchdb/dist/pouchdb-next.js';
   } else {
     pouchdbSrc = '../../packages/node_modules/pouchdb/dist/pouchdb.js';
   }


### PR DESCRIPTION
PR for #6870 
I chose to just use just the `NEXT=1` query parameter in the test scripts and let webrunner.js load the `pouchdb-next.js`. If you specify both `NEXT=1` and `src` query parameters now, src will be used.