### PR TITLE
update travis to skip saucelabs faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ addons:
   firefox: "47.0.2"
 
 before_install:
+  - |
+    if [[ $TRAVIS_SECURE_ENV_VARS == "false"  ]] && [[ $CLIENT == saucelabs:* ]]; then
+       echo "Not running test, cannot connect to saucelabs in Pull Request"
+       travis_terminate 0
+    fi
   # Because Saucelabs doesnt proxy 5984 on OSX
   - "if [ -z \"$COUCH_HOST\" ]; then export COUCH_HOST=http://127.0.0.1:3000; fi"
 

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -95,10 +95,11 @@ if (process.env.NEXT) {
 testUrl += '?';
 testUrl += querystring.stringify(qs);
 
+// This should actually be already handled in .travis.yml 
 if (process.env.TRAVIS &&
     client.runner === 'saucelabs' &&
     process.env.TRAVIS_SECURE_ENV_VARS === 'false') {
-  console.error('Not running test, cannot connect to saucelabs');
+  console.error('Not running test, cannot connect to saucelabs in Pull Request');
   process.exit(0);
 }
 

--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -2600,7 +2600,7 @@ adapters.forEach(function (adapter) {
       changes.on('change', function () {
         ++count;
         if (count === 1) {
-          throw new Error('an error');
+          throw new Error('deliberate error in changes');
         } else if (count === 3) {
           changes.cancel();
         }

--- a/tests/integration/test.get.js
+++ b/tests/integration/test.get.js
@@ -357,7 +357,8 @@ adapters.forEach(function (adapter) {
     it('#2951 Parallelized gets with 409s/404s', function () {
       var db = new PouchDB(dbs.name);
 
-      var numSimultaneous = 20;
+      // we don't want to overload the server and get timeout errors
+      var numSimultaneous = adapter === 'http' ? 3 : 20;
       var numDups = 3;
 
       var tasks = [];
@@ -395,7 +396,8 @@ adapters.forEach(function (adapter) {
     it('#2951 Parallelized _local gets with 409s/404s', function () {
       var db = new PouchDB(dbs.name);
 
-      var numSimultaneous = 20;
+      // we don't want to overload the server and get timeout errors
+      var numSimultaneous = adapter === 'http' ? 3 : 20;
       var numDups = 3;
 
       var tasks = [];


### PR DESCRIPTION
This should reduce build times on PRs by terminating saucelabs build jobs in `before_install` of travis, so `npm install` does not need to be run.

I also renamed an error which confused me a bit when I saw this in the travis log.

 