### PR TITLE
Update rollup-plugin-node-resolve to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "rimraf": "2.6.1",
     "rollup": "0.52.0",
     "rollup-plugin-inject": "2.0.0",
-    "rollup-plugin-node-resolve": "2.1.0",
+    "rollup-plugin-node-resolve": "2.1.1",
     "rollup-plugin-replace": "1.2.1",
     "sauce-connect-launcher": "1.2.2",
     "seedrandom": "2.4.3",


### PR DESCRIPTION
Has already been issued [here](https://github.com/pouchdb/pouchdb/pull/6393#issuecomment-327501416): on windows the 2.1.0 version does not work