### PR TITLE
(#5607) Normalize error name eg 'Unauthorized' -> 'unauthorized'

### DIFF
--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -96,7 +96,9 @@ function replicate(src, target, opts, returnValue, result) {
         var error = errorsById[doc._id];
         if (error) {
           result.errors.push(error);
-          if (error.name === 'unauthorized' || error.name === 'forbidden') {
+          // Normalize error name. i.e. 'Unauthorized' -> 'unauthorized' (eg Sync Gateway)
+          var errorName = (error.name || '').toLowerCase();
+          if (errorName === 'unauthorized' || errorName === 'forbidden') {
             returnValue.emit('denied', clone(error));
           } else {
             throw error;
@@ -272,7 +274,9 @@ function replicate(src, target, opts, returnValue, result) {
       fatalError = createError(fatalError);
       fatalError.result = result;
 
-      if (fatalError.name === 'unauthorized' || fatalError.name === 'forbidden') {
+      // Normalize error name. i.e. 'Unauthorized' -> 'unauthorized' (eg Sync Gateway)
+      var errorName = (fatalError.name || '').toLowerCase();
+      if (errorName === 'unauthorized' || errorName === 'forbidden') {
         returnValue.emit('error', fatalError);
         returnValue.removeAllListeners();
       } else {


### PR DESCRIPTION

Apparently 401/403s have been giving Sync Gateway users a headache (for quite a while) when **replication** is used with opts:
 ```javascript
{ retry: true, live: true }
```

Looks like Sync Gateway was returning a 401 with the error name `'Unauthorized'`, and we only look for `'unauthorized'`, hence the 'denied' or 'error' event is never emitted. Instead a `backOff()` occurs and the cycle repeats.

This PR simply normalizes the error response:
```javascript
var errorName = (fatalError.name || '').toLowerCase();
if (errorName === 'unauthorized' || errorName === 'forbidden') {
...
```

Seems like an easy win, with reports here ([comment](https://github.com/pouchdb/pouchdb/issues/5607#issuecomment-346078688)) saying their custom build works well with these changes.

Closes #5607 

Test included.