### PR TITLE
FIX update_seq - change not affecting other tabs

### DIFF
--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -247,7 +247,7 @@ function LevelPouch(opts, callback) {
   };
 
   api._info = function (callback) {
-    return stores.metaStore.get(UPDATE_SEQ_KEY, function (err, value) {
+    stores.metaStore.get(UPDATE_SEQ_KEY, function (err, value) {
       if (err) {
           callback(err, null);
       } else {
@@ -896,9 +896,19 @@ function LevelPouch(opts, callback) {
           };
           /* istanbul ignore if */
           if (opts.update_seq) {
-            returnVal.update_seq = db._updateSeq;
+              stores.metaStore.get(UPDATE_SEQ_KEY, function (err, value) {
+                if (err) {
+                    callback(err, null);
+                } else {
+                    var _updateSeq = value || 0;
+                    db._updateSeq = _updateSeq;
+                    returnVal.update_seq = db._updateSeq;
+                    return callback(null, returnVal);
+                }
+              });
+          } else {
+              return callback(null, returnVal);
           }
-          return callback(null, returnVal);
         }
         var results = [];
         var docstream = stores.docStore.readStream(readstreamOpts);
@@ -983,9 +993,19 @@ function LevelPouch(opts, callback) {
 
             /* istanbul ignore if */
             if (opts.update_seq) {
-              returnVal.update_seq = db._updateSeq;
-            }
-            callback(null, returnVal);
+                stores.metaStore.get(UPDATE_SEQ_KEY, function (err, value) {
+                  if (err) {
+                      callback(err, null);
+                  } else {
+                      var _updateSeq = value || 0;
+                      db._updateSeq = _updateSeq;
+                      returnVal.update_seq = db._updateSeq;
+                      return callback(null, returnVal);
+                  }
+                });
+          } else {
+              callback(null, returnVal);
+          }
           }, callback);
           next();
         }).on('unpipe', function () {

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -247,13 +247,19 @@ function LevelPouch(opts, callback) {
   };
 
   api._info = function (callback) {
-    var res = {
-      doc_count: db._docCount,
-      update_seq: db._updateSeq,
-      backend_adapter: functionName(leveldown)
-    };
-    return nextTick(function () {
-      callback(null, res);
+    return stores.metaStore.get(UPDATE_SEQ_KEY, function (err, value) {
+      if (err) {
+          callback(err, null);
+      } else {
+          var _updateSeq = value || 0;
+          db._updateSeq = _updateSeq;
+          var res = {
+              doc_count: db._docCount,
+              update_seq: db._updateSeq,
+              backend_adapter: functionName(leveldown)
+          };
+          callback(null, res);
+      }
     });
   };
 


### PR DESCRIPTION
When pouchdb is used in multiple tabs with the localstorage-adapter, the seq-number is not reflected between them.

To reproduce do the following:
- Open this [fiddle](https://jsfiddle.net/cuyhxefm/41/) on 2 browser-windows
- Open the developer-console on both windows.
- One the first window, click "insert" and "getAll"
- As you can see, the seq-number is now increased and displayed correctly
- In the second window, the seq-number is not updated. You have to reload the page to get the new seq-number

This PR will:
- Remove the caching of `db._updateSeq` whenever `pouch.info()` is called.
- Assign the new seq-number to `db._updateSeq` so the cache updates.
