### PR TITLE
Retry of #6877 "Don't use hardcoded firefox version on travis" (#6905)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ sudo:
   false
 
 addons:
-  firefox: "47.0.2"
   jwt:
      secure: YlCp9qGHmnnATcScIQVyOt8eI9FxLhMGAz9iRTHh7r41ADjfGJUzyqkWoBLcCagiQWtqtUujukPAtRuOibbBp9SvmGp+IIdbwHVUDvSZNOvGxkQ1qczeGxJcnht+2YNoCwfzkHW4vFrNiGOULdjvbWAB4sAJ8N0AZPShURwXU1E=
 
@@ -61,26 +60,26 @@ env:
   - CLIENT=node ADAPTER=memory COMMAND=test
 
   # Test in firefox/phantomjs running on travis
-  - CLIENT=selenium:firefox:47.0.2 COMMAND=test
+  - CLIENT=selenium:firefox COMMAND=test
   - CLIENT=selenium:phantomjs COMMAND=test
 
   # Test auto-compaction in Node, Phantom, and Firefox
   - AUTO_COMPACTION=true CLIENT=node COMMAND=test
-  - AUTO_COMPACTION=true CLIENT=selenium:firefox:47.0.2 COMMAND=test
+  - AUTO_COMPACTION=true CLIENT=selenium:firefox COMMAND=test
   - AUTO_COMPACTION=true CLIENT=selenium:phantomjs COMMAND=test
 
   # Test map/reduce
   - TYPE=mapreduce CLIENT=node COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:firefox:47.0.2 COMMAND=test
+  - TYPE=mapreduce CLIENT=selenium:firefox COMMAND=test
   - TYPE=mapreduce CLIENT=selenium:phantomjs COMMAND=test
 
   # Test pouchdb-find
   - COUCH_HOST=http://127.0.0.1:3001 TYPE=find PLUGINS=pouchdb-find CLIENT=node SERVER=couchdb-master COMMAND=test
-  - TYPE=find PLUGINS=pouchdb-find CLIENT=selenium:firefox:47.0.2 SERVER=pouchdb-server COMMAND=test
+  - TYPE=find PLUGINS=pouchdb-find CLIENT=selenium:firefox SERVER=pouchdb-server COMMAND=test
 
   # Testing in saucelabs
   - CLIENT=saucelabs:chrome COMMAND=test
-  - FETCH=1 CLIENT=selenium:firefox:47.0.2 COMMAND=test
+  - FETCH=1 CLIENT=selenium:firefox COMMAND=test
   - CLIENT=saucelabs:safari:7 COMMAND=test
   - CLIENT="saucelabs:internet explorer:10:Windows 8" COMMAND=test
 
@@ -90,22 +89,22 @@ env:
 
   # Test memory / fruitdown etc
   - CLIENT="saucelabs:iphone:8.4:OS X 10.11" ADAPTERS=fruitdown COMMAND=test
-  - CLIENT=selenium:firefox:47.0.2 ADAPTERS=memory COMMAND=test
-  - CLIENT=selenium:firefox:47.0.2 ADAPTERS=localstorage COMMAND=test
+  - CLIENT=selenium:firefox ADAPTERS=memory COMMAND=test
+  - CLIENT=selenium:firefox ADAPTERS=localstorage COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:47.0.2 COMMAND=test-webpack
+  - CLIENT=selenium:firefox COMMAND=test-webpack
 
   # Test CouchDB master (aka bigcouch branch)
   - COUCH_HOST=http://127.0.0.1:3001 CLIENT=node SERVER=couchdb-master COMMAND=test
-  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox:47.0.2 SERVER=couchdb-master COMMAND=test
+  - COUCH_HOST=http://127.0.0.1:3001 SKIP_MIGRATION=true CLIENT=selenium:firefox SERVER=couchdb-master COMMAND=test
 
   # Performance tests
-  - CLIENT=selenium:firefox:47.0.2 PERF=1 COMMAND=test
+  - CLIENT=selenium:firefox PERF=1 COMMAND=test
   - PERF=1 COMMAND=test
 
   # Test Webpack bundle
-  - CLIENT=selenium:firefox:47.0.2 NEXT=1 COMMAND=test
+  - CLIENT=selenium:firefox NEXT=1 COMMAND=test
 
   - COMMAND=test-unit
   - COMMAND=test-component

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -16,7 +16,7 @@ var testTimeout = 30 * 60 * 1000;
 var username = process.env.SAUCE_USERNAME;
 var accessKey = process.env.SAUCE_ACCESS_KEY;
 
-var SELENIUM_VERSION = process.env.SELENIUM_VERSION || '2.53.1';
+var SELENIUM_VERSION = process.env.SELENIUM_VERSION || '3.7.1';
 var FIREFOX_BIN = process.env.FIREFOX_BIN;
 
 // BAIL=0 to disable bailing

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "ua-parser-js": "0.7.14",
     "uglify-js": "3.2.1",
     "watch-glob": "0.1.3",
-    "wd": "1.4.0"
+    "wd": "1.4.1"
   },
   "// greenkeeper": [
     "// chai-as-promised is pinned because of breaking changes in 6.0.0",

--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -74,18 +74,24 @@
     }
   }
 
-  function startTests() {
+  function loadScripts() {
 
     function loadNext() {
       if (scriptsToLoad.length) {
         var script = scriptsToLoad.shift();
         asyncLoadScript(script, loadNext);
       } else {
-        onReady();
+        if (document.readyState === 'complete') {
+          startTests();
+        } else {
+          window.addEventListener("load", startTests);
+        }
       }
     }
 
-    function onReady() {
+    function startTests() {
+      window.removeEventListener("load", startTests);
+
       modifyGlobals();
 
       var runner = mocha.run();
@@ -147,6 +153,6 @@
     loadNext();
   }
 
-  startTests();
+  loadScripts();
 
 })();


### PR DESCRIPTION
As it caused saucelabs failiures, I now changed the code a bit to keep the old behavior for saucelabs and skip waiting for `.get(testUrl)` on Selenium

Fixes #6905 
Should probably wait on #6922