### PR TITLE
Emit an error event if an adapter fails to initialise

### DIFF
--- a/packages/node_modules/pouchdb-core/src/constructor.js
+++ b/packages/node_modules/pouchdb-core/src/constructor.js
@@ -81,6 +81,7 @@ function PouchDB(name, opts) {
 
   PouchDB.adapters[opts.adapter].call(self, opts, function (err) {
     if (err) {
+      self.emit('error', err);
       return self.taskqueue.fail(err);
     }
     prepareForDestruction(self);


### PR DESCRIPTION
I'm using PouchDB for a queued logging solution.

To make sure logs are not lost, I have to make sure PouchDB initialised correctly, and if not, try another adapter.

Since the instance we get from the constructor is an event emitter, we can listen to the "create" event, but not for an "error" event.

This currently forces me to look for errors in the taskqueue.fail property, which gets updated with potential errors.

Now, I don't know it the modification in this PR would solve my issue, but after browsing the source it seemed to be an obvious place to start. 🤔