### PR TITLE
Update 2015-10-06-pouchdb-5.0.0-five-years-of-pouchdb.md

### DIFF
--- a/docs/_posts/2015-10-06-pouchdb-5.0.0-five-years-of-pouchdb.md
+++ b/docs/_posts/2015-10-06-pouchdb-5.0.0-five-years-of-pouchdb.md
@@ -77,7 +77,7 @@ This was an alternative IndexedDB adapter based on [Level.js](https://github.com
 
 * Maintain canceled state in replicator better ([#4276](http://github.com/pouchdb/pouchdb/issues/4276))
 * Don't mutate binary objects provided by the user ([#3955](http://github.com/pouchdb/pouchdb/issues/3955) [#4273](http://github.com/pouchdb/pouchdb/issues/4273))
-* Fire events on sync, eensure we only fire one active event ([#4251](http://github.com/pouchdb/pouchdb/issues/4251))
+* Fire events on sync, ensure we only fire one active event ([#4251](http://github.com/pouchdb/pouchdb/issues/4251))
 * Catch errors from WebSQL `openDatabase()` ([#4018](http://github.com/pouchdb/pouchdb/issues/4018))
 * Ensure setup errors propagate to the API ([#4358](http://github.com/pouchdb/pouchdb/issues/4358))
 * Prevent replication firing extra events ([#4293](http://github.com/pouchdb/pouchdb/issues/4293))


### PR DESCRIPTION
single typo fix

don't know where the second hunk, for line 92, comes from. Edited directly in github site.