### PR TITLE
(#6945) - remove Promise polyfill (BREAKING)

### DIFF
--- a/bin/rollupPlugins.js
+++ b/bin/rollupPlugins.js
@@ -16,13 +16,11 @@ function rollupPlugins(nodeResolveConfig) {
     inject({
       exclude: [
         '**/pouchdb-utils/src/assign.js',
-        '**/pouchdb-promise/src/index.js',
         '**/pouchdb-collections/src/**'
       ],
       Map: ['pouchdb-collections', 'Map'],
       Set: ['pouchdb-collections', 'Set'],
-      'Object.assign': ['pouchdb-utils', 'assign'],
-      Promise: 'pouchdb-promise'
+      'Object.assign': ['pouchdb-utils', 'assign']
     })
   ];
 }

--- a/packages/node_modules/pouchdb-promise/README.md
+++ b/packages/node_modules/pouchdb-promise/README.md
@@ -3,6 +3,12 @@ pouchdb-promise ![semver non-compliant](https://img.shields.io/badge/semver-non-
 
 Promises as used by PouchDB. By default exports `global.Promise` if available, else falls back to `lie`.
 
+**Deprecation notice**: this package is still published, but it is deprecated in PouchDB 7.0 as PouchDB now uses native promises. If you require a Promise polyfill, please use your own or feel free to use this one, e.g.:
+
+```javascript
+window.Promise = window.Promise || require('pouchdb-promise');
+```
+
 ### Usage
 
 ```bash

--- a/tests/integration/index.html
+++ b/tests/integration/index.html
@@ -7,6 +7,7 @@
   </head>
   <body>
     <div id="mocha"></div>
+    <script src="../../node_modules/lie/dist/lie.polyfill.js"></script>
     <script src="../../node_modules/mocha/mocha.js"></script>
     <script src="../../node_modules/chai/chai.js"></script>
     <script src="../../node_modules/chai-as-promised/lib/chai-as-promised.js"></script>

--- a/tests/mapreduce/index.html
+++ b/tests/mapreduce/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="mocha"></div>
+<script src="../../node_modules/lie/dist/lie.polyfill.js"></script>
 <script src="../../node_modules/mocha/mocha.js"></script>
 <script src="../../node_modules/chai/chai.js"></script>
 <script src="../../node_modules/chai-as-promised/lib/chai-as-promised.js"></script>


### PR DESCRIPTION
Presumably we could also remove the polyfills for `Object.assign`, `Map`, and `Set`, but I believe this may bring minimal benefit (i.e. not reducing the bundle size very much) with some serious downsides (i.e. consumers need to bring their own Map/Set/Object.assign polyfills).

BTW this is a breaking change, intended for 7.0.