### PR TITLE
(#6943) - WIP - remove WebSQL adapter (BREAKING)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,17 +61,17 @@ env:
 
   # Test in firefox/phantomjs running on travis
   - CLIENT=selenium:firefox COMMAND=test
-  - CLIENT=selenium:phantomjs COMMAND=test
+  - CLIENT=selenium:phantomjs ADAPTERS=websql COMMAND=test
 
   # Test auto-compaction in Node, Phantom, and Firefox
   - AUTO_COMPACTION=true CLIENT=node COMMAND=test
   - AUTO_COMPACTION=true CLIENT=selenium:firefox COMMAND=test
-  - AUTO_COMPACTION=true CLIENT=selenium:phantomjs COMMAND=test
+  - AUTO_COMPACTION=true CLIENT=selenium:phantomjs ADAPTERS=websql COMMAND=test
 
   # Test map/reduce
   - TYPE=mapreduce CLIENT=node COMMAND=test
   - TYPE=mapreduce CLIENT=selenium:firefox COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:phantomjs COMMAND=test
+  - TYPE=mapreduce CLIENT=selenium:phantomjs ADAPTERS=websql COMMAND=test
 
   # Test pouchdb-find
   - COUCH_HOST=http://127.0.0.1:3001 TYPE=find PLUGINS=pouchdb-find CLIENT=node SERVER=couchdb-master COMMAND=test

--- a/bin/build-pouchdb.js
+++ b/bin/build-pouchdb.js
@@ -32,7 +32,7 @@ var builtInModules = require('builtin-modules');
 var external = Object.keys(require('../package.json').dependencies)
   .concat(builtInModules);
 
-var plugins = ['fruitdown', 'localstorage', 'memory', 'find'];
+var plugins = ['fruitdown', 'localstorage', 'memory', 'find', 'websql'];
 
 var currentYear = new Date().getFullYear();
 
@@ -79,7 +79,16 @@ var comments = {
   '\n// PouchDB may be freely distributed under the Apache license, ' +
   'version 2.0.' +
   '\n// For all details and documentation:' +
-  '\n// http://pouchdb.com\n'
+  '\n// http://pouchdb.com\n',
+
+  'websql': '// PouchDB websql plugin ' + version +
+  '\n// Since PouchDB 7.0.0, shipped as a separate plugin.' +
+  '\n// ' +
+  '\n// (c) 2012-' + currentYear + ' Dale Harvey and the PouchDB team' +
+  '\n// PouchDB may be freely distributed under the Apache license, ' +
+  'version 2.0.' +
+  '\n// For all details and documentation:' +
+  '\n// http://pouchdb.com\n',
 };
 
 function doRollup(entry, browser, formatsToFiles) {

--- a/docs/_includes/api/create_database.html
+++ b/docs/_includes/api/create_database.html
@@ -13,7 +13,7 @@ This method creates a database or opens an existing one. If you use a URL like `
 **Options for local databases:**
 
 * `auto_compaction`: This turns on auto compaction, which means `compact()` is called after every change to the database. Defaults to `false`.
-* `adapter`: One of `'idb'`, `'leveldb'`, `'websql'`, or `'http'`. If unspecified, PouchDB will infer this automatically, preferring IndexedDB to WebSQL in browsers that support both (i.e. Chrome, Opera and Android 4.4+).
+* `adapter`: One of `'idb'`, `'leveldb'`, or `'http'`.
 * `revs_limit`: Specify how many old revisions we keep track (not a copy) of. Specifying a low value means Pouch may not be able to figure out whether a new revision received via replication is related to any it currently has which could result in a conflict. Defaults to `1000`.
 
 **Options for remote databases:**
@@ -31,7 +31,9 @@ This method creates a database or opens an existing one. If you use a URL like `
 
 **WebSQL-only options:**
 
-* `size`: Amount in MB to request for storage, which you will need if you are storing >5MB in order to [avoid storage limit errors on iOS/Safari](/errors.html#not_enough_space). Persistent views use a separate database per view which will also request storage space so keep in mind the upper storage limits when using persistent views on iOS.
+_Note:_ as of PouchDB 7.0.0, this requires installing WebSQL as an add-on adapter.
+
+* `size`: Amount in MB to request for storage, which you will need if you are storing >5MB in order to [avoid storage limit errors in WebSQL on iOS/Safari](/errors.html#not_enough_space). Persistent views use a separate database per view which will also request storage space so keep in mind the upper storage limits when using persistent views on iOS.
 
 **Notes:**
 
@@ -50,7 +52,7 @@ var db = new PouchDB('dbname');
 var db = new PouchDB('http://localhost:5984/dbname');
 {% endhighlight %}
 
-Create a PouchDB that explicitly uses WebSQL:
+Create a PouchDB that explicitly uses WebSQL (must install `pouchdb-adapter-websql` first):
 
 {% highlight js %}
 var db = new PouchDB('dbname', {adapter : 'websql'});

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -4,7 +4,7 @@ title: Adapters
 sidebar: nav.html
 ---
 
-PouchDB is not a self-contained database; it is a CouchDB-style abstraction layer over other databases. By default, PouchDB ships with [IndexedDB][] and [WebSQL][] adapters in the browser, and a [LevelDB][] adapter in Node.js. This can be visualized as so:
+PouchDB is not a self-contained database; it is a CouchDB-style abstraction layer over other databases. By default, PouchDB ships with the [IndexedDB][] adapter for the browser, and a [LevelDB][] adapter in Node.js. This can be visualized as so:
 
 <object data="static/svg/pouchdb_adapters.svg" type="image/svg+xml">
     <img src="static/img/pouchdb_adapters.png" alt="adapters">
@@ -48,7 +48,7 @@ In the browser, PouchDB prefers IndexedDB, and falls back to WebSQL if IndexedDB
 	<td>&#10003; (10+)</td>
 	<td>&#10003;</td>
 	<td>&#10003;</td>
-	<td></td>
+	<td>&#10003; (10.1+)</td>
 	<td>&#10003;</td>
 </tr>
 <tr>
@@ -90,7 +90,7 @@ In the browser, PouchDB prefers IndexedDB, and falls back to WebSQL if IndexedDB
 </tr>
 <tr>
     <td>IndexedDB</td>
-    <td></td>
+    <td>&#10003; (10.3+)</td>
     <td></td>
     <td>&#10003; (4.4+)</td>
     <td>&#10003; (10+)</td>
@@ -114,14 +114,14 @@ In the browser, PouchDB prefers IndexedDB, and falls back to WebSQL if IndexedDB
 </div>
 
 {% include alert/start.html variant="info"%}
-Safari 7.1+ and iOS 8+ supposedly support IndexedDB, but their implementation has many bugs, so PouchDB currently ignores it.
+Prior to PouchDB 7.0.0, the WebSQL adapter was always used for Safari/iOS. The WebSQL adapter no longer ships as a default adapter in PouchDB, but may be installed separately.
 {% include alert/end.html%}
 
 If you're ever curious which adapter is being used in a particular browser, you can use the following method:
 
 ```js
 var pouch = new PouchDB('myDB');
-console.log(pouch.adapter); // prints either 'idb' or 'websql'
+console.log(pouch.adapter); // prints 'idb'
 ```
 
 ### SQLite plugin for Cordova/PhoneGap
@@ -154,7 +154,7 @@ The built-in IndexedDB and WebSQL adapters are nearly always more performant and
 
 ### Browser adapter plugins
 
-PouchDB also offers separate browser plugins that use backends other than IndexedDB and WebSQL. These plugins fully pass the PouchDB test suite and are rigorously tested in our CI process.
+PouchDB also offers separate browser plugins that use backends other than IndexedDB. These plugins fully pass the PouchDB test suite and are rigorously tested in our CI process.
 
 **Downloads:**
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -158,6 +158,7 @@ PouchDB also offers separate browser plugins that use backends other than Indexe
 
 **Downloads:**
 
+* [pouchdb.websql.js](https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb.websql.js) (Minified: [pouchdb.websql.min.js](https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb.websql.min.js))
 * [pouchdb.memory.js](https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb.memory.js) (Minified: [pouchdb.memory.min.js](https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb.memory.min.js))
 * [pouchdb.localstorage.js](https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb.localstorage.js) (Minified: [pouchdb.localstorage.min.js](https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb.localstorage.min.js))
 * [pouchdb.fruitdown.js](https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb.fruitdown.js) (Minified: [pouchdb.fruitdown.min.js](https://github.com/pouchdb/pouchdb/releases/download/{{ site.version }}/pouchdb.fruitdown.min.js))
@@ -167,6 +168,21 @@ PouchDB also offers separate browser plugins that use backends other than Indexe
 These plugins add a hefty footprint due to external dependencies, so take them with a grain of salt.
 {% endmarkdown %}
 {% include alert/end.html%}
+
+#### WebSQL adapter
+
+Prior to PouchDB 7.0.0, this was included in PouchDB itself. If you need to support old versions of Safari (<10.1) or iOS (<10.3) then you will need this plugin.
+
+```html
+<script src="pouchdb.js"></script>
+<script src="pouchdb.websql.js"></script>
+<script>
+  // this pouch uses WebSQL
+  var pouch = new PouchDB('mydb', {adapter: 'websql'});
+  // this pouch will use WebSQL if the current browser doesn't support IDB but supports WebSQL
+  var otherPouch = new PouchDB('myotherdb', {adapter: 'websql'});
+</script>
+```
 
 #### In-memory adapter
 

--- a/docs/custom.md
+++ b/docs/custom.md
@@ -56,8 +56,8 @@ plugins. You are free to create your own presets, but PouchDB provides a few fir
 ### pouchdb-browser
 
 The `pouchdb-browser` preset contains the version of PouchDB that is designed
-for the browser. In particular, it ships with the IndexedDB and WebSQL adapters
-as its default adapters. It also contains the replication, HTTP, and map/reduce plugins.
+for the browser. In particular, it ships with the IndexedDB adapter
+as its default adapter. It also contains the replication, HTTP, and map/reduce plugins.
 
 Use this preset if you only want to use PouchDB in the browser,
 and don't want to use it in Node.js. (E.g. to avoid installing LevelDB.)
@@ -78,7 +78,6 @@ var db = new PouchDB('mydb');
 ```js
 var PouchDB = require('pouchdb-core')
   .plugin(require('pouchdb-adapter-idb'))
-  .plugin(require('pouchdb-adapter-websql'))
   .plugin(require('pouchdb-adapter-http'))
   .plugin(require('pouchdb-mapreduce'))
   .plugin(require('pouchdb-replication'));
@@ -158,7 +157,7 @@ console.log(db.adapter); // 'idb'
 ### pouchdb-adapter-websql
 
 The secondary adapter used by PouchDB in the browser, using WebSQL. The adapter
-name is `'websql'`.
+name is `'websql'`. Before PouchDB 7.0.0, this was shipped as a default adapter.
 
 #### Example usage
 

--- a/docs/custom.md
+++ b/docs/custom.md
@@ -135,7 +135,7 @@ Plugins contain functionality that can be added to a `PouchDB` instance using `P
 
 There is also a special type of plugin called an _adapter plugin_.  Adapter plugins (such as IndexedDB, WebSQL, LevelDB, and HTTP) determine the storage format that
 PouchDB uses. For the non-HTTP adapters, the plugin order matters, i.e. if you
-want IndexedDB to be preferred to WebSQL, then you should load it first. (Notice that `pouchdb-browser` does exactly this.)
+want IndexedDB to be preferred to WebSQL, then you should load it first.
 
 ### pouchdb-adapter-idb
 
@@ -156,8 +156,10 @@ console.log(db.adapter); // 'idb'
 
 ### pouchdb-adapter-websql
 
-The secondary adapter used by PouchDB in the browser, using WebSQL. The adapter
-name is `'websql'`. Before PouchDB 7.0.0, this was shipped as a default adapter.
+An adapter used by PouchDB in the browser, using WebSQL. The adapter
+name is `'websql'`.
+
+Before PouchDB 7.0.0, this was shipped as a default adapter. As of PouchDB 7.0.0, it must be loaded as a separate plugin.
 
 #### Example usage
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -46,7 +46,7 @@ In **Firefox**, PouchDB uses IndexedDB. Though Firefox has no upper limit beside
 
 **Internet Exporer 10+** has a hard 250MB limit, and will prompt the user with a non-modal dialog at 10MB.
 
-**Mobile Safari** on iOS has a hard 50MB limit, whereas **desktop Safari** has no limit. Both will prompt the user with a modal dialog if an application requests more than 5MB of data, at increments of 5MB, 10MB, 50MB, 100MB, etc. Some versions of Safari have a bug where they only let you request additional storage once, so you'll need to request the desired space up-front. PouchDB allows you to do this using [the `size` option](http://pouchdb.com/api.html#create_database).
+**Mobile Safari** on iOS has a hard 50MB limit for WebSQL, whereas **desktop Safari** has no limit. Both will prompt the user with a modal dialog if an application requests more than 5MB of data, at increments of 5MB, 10MB, 50MB, 100MB, etc. Some versions of Safari have a bug where they only let you request additional storage once, so you'll need to request the desired space up-front. PouchDB allows you to do this using [the `size` option](http://pouchdb.com/api.html#create_database).
 
 **iOS Web Application**, a page saved on the homescreen behaves different than apps in Mobile Safari (at least from iOS 9.3.2+). No specifics are published online by Apple, but WebSQL storage seems not limited to 50mb and there will not be any prompts when requesting data storage. Use [`<meta name="apple-mobile-web-app-capable" content="yes">`](https://developer.apple.com/library/ios/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW3) in your html header and use *Add to Home Screen* in the share menu of Safari. Please note, IndexedDB is not available, so FruitDown won't work. It seems there is different behaviour for different models of iPad and iPhone. You can check your mileage using the [storage abuser](http://demo.agektmr.com/storage/), which you can *Add to Home Screen* on your device. **Caveat**: when iOS is running low on storage space, the OS might decide to delete all data without any notice or warning to the end user. Be sure to use devices with plenty of spare space, or your users will lose unsynced data.
 
@@ -90,6 +90,7 @@ Here are the strategies used by various browsers in PouchDB:
 	<th><img src="static/img/browser-logos/chrome_32x32.png" alt="Chrome"/></th>
 	<th><img src="static/img/browser-logos/safari_32x32.png" alt="Safari"/></th>
 	<th><img src="static/img/browser-logos/safari_32x32.png" alt="Safari"/></th>
+	<th><img src="static/img/browser-logos/safari_32x32.png" alt="Safari"/></th>
 </tr>
 <tr>
     <th>Adapter</th>
@@ -98,7 +99,8 @@ Here are the strategies used by various browsers in PouchDB:
 	<th>Chrome < 43,<br/>Android</th>
 	<th>Chrome >= 43</th>
 	<th>Safari < 7.1,<br/>iOS < 8</th>
-	<th>Safari >= 7.1,<br/>iOS >= 8</th>
+	<th>Safari < 10.1, >= 7.1,<br/>iOS < 10.3, >= 8</th>
+	<th>Safari >= 10.1,<br/>iOS >= 10.3</th>
 </tr>
 <tr>
     <td>IndexedDB</td>
@@ -108,6 +110,7 @@ Here are the strategies used by various browsers in PouchDB:
 	<td>Blob</td>
 	<td></td>
 	<td></td>
+	<td>Blob</td>
 </tr>
 <tr>
 	<td>WebSQL</td>
@@ -117,6 +120,7 @@ Here are the strategies used by various browsers in PouchDB:
 	<td>Blob</td>
 	<td>UTF-16 Blob</td>
 	<td>Blob</td>
+	<td></td>
 </tr>
 </table>
 </div>

--- a/packages/node_modules/pouchdb-browser/src/index.js
+++ b/packages/node_modules/pouchdb-browser/src/index.js
@@ -1,13 +1,11 @@
 import PouchDB from 'pouchdb-core';
 
 import IDBPouch from 'pouchdb-adapter-idb';
-import WebSqlPouch from 'pouchdb-adapter-websql';
 import HttpPouch from 'pouchdb-adapter-http';
 import mapreduce from 'pouchdb-mapreduce';
 import replication from 'pouchdb-replication';
 
 PouchDB.plugin(IDBPouch)
-  .plugin(WebSqlPouch)
   .plugin(HttpPouch)
   .plugin(mapreduce)
   .plugin(replication);

--- a/packages/node_modules/pouchdb/src/plugins/websql.js
+++ b/packages/node_modules/pouchdb/src/plugins/websql.js
@@ -1,0 +1,14 @@
+/* global PouchDB */
+
+// this code only runs in the browser, as its own dist/ script
+
+import WebsqlPouchPlugin from 'pouchdb-adapter-websql';
+import { guardedConsole } from 'pouchdb-utils';
+
+if (typeof PouchDB === 'undefined') {
+  guardedConsole('error', 'websql adapter plugin error: ' +
+    'Cannot find global "PouchDB" object! ' +
+    'Did you remember to include pouchdb.js?');
+} else {
+  PouchDB.plugin(WebsqlPouchPlugin);
+}

--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -19,7 +19,7 @@
   if (adapters) {
     adapters = adapters[1].split(',');
     adapters.forEach(function (adapter) {
-      if (adapter !== 'websql' && adapter !== 'idb') {
+      if (adapter !== 'idb') {
         // load from plugin
         scriptsToLoad.push(
           '../../packages/node_modules/pouchdb/dist/pouchdb.' + adapter + '.js');


### PR DESCRIPTION
Opening a PR to see if any tests break. I think PhantomJS uses IndexedDB now, but I'm not sure.

Open question is whether we should ship browser builds WebSQL as we do fruitdown, memory, and localstorage. ~~I think we should probably just stop doing that altogether – it's too much effort to build and maintain browser versions for each of these three; anyone who wants to use them can just build them with browserify/webpack/etc.~~ _(on second thought: this is too much work)_

Then again, such a change would make our tests a little harder to write, since they rely on being able to include basic `<script>` tags. There's some cleanup work here to do.
  