### PR TITLE
Fix Rollup warnings

### DIFF
--- a/bin/build-module.js
+++ b/bin/build-module.js
@@ -71,7 +71,7 @@ function buildModule(filepath) {
   }).then(function () {
     return all(versions.map(function (isBrowser) {
       return rollup({
-        entry: path.resolve(filepath, './src/index.js'),
+        input: path.resolve(filepath, './src/index.js'),
         external: depsToSkip,
         plugins: rollupPlugins({
           skip: depsToSkip,
@@ -81,14 +81,14 @@ function buildModule(filepath) {
       }).then(function (bundle) {
         var formats = ['cjs', 'es'];
         return all(formats.map(function (format) {
-          var dest = (isBrowser ? 'lib/index-browser' : 'lib/index') +
+          var file = (isBrowser ? 'lib/index-browser' : 'lib/index') +
             (format === 'es' ? '.es.js' : '.js');
           return bundle.write({
             format: format,
-            dest: path.resolve(filepath, dest)
+            file: path.resolve(filepath, file)
           }).then(function () {
             console.log('  \u2713' + ' wrote ' +
-              path.basename(filepath) + '/' + dest + ' in ' +
+              path.basename(filepath) + '/' + file + ' in ' +
                 (isBrowser ? 'browser' :
                 versions.length > 1 ? 'node' : 'vanilla') +
               ' mode');

--- a/bin/build-pouchdb.js
+++ b/bin/build-pouchdb.js
@@ -82,10 +82,10 @@ var comments = {
   '\n// http://pouchdb.com\n'
 };
 
-function doRollup(entry, browser, formatsToFiles) {
+function doRollup(input, browser, formatsToFiles) {
   var start = process.hrtime();
   return rollup.rollup({
-    entry: addPath('pouchdb', entry),
+    input: addPath('pouchdb', input),
     external: external,
     plugins: rollupPlugins({
       skip: external,
@@ -100,7 +100,7 @@ function doRollup(entry, browser, formatsToFiles) {
         if (DEV_MODE) {
           var ms = Math.round(process.hrtime(start)[1] / 1000000);
           console.log('    took ' + ms + ' ms to rollup ' +
-                      path.dirname(entry) + '/' + path.basename(entry));
+                      path.dirname(input) + '/' + path.basename(input));
         }
         return writeFile(addPath('pouchdb', fileOut), bundle.code);
       });


### PR DESCRIPTION
Rollup is warning us about using these deprecated API names.