### PR TITLE
WIP - Only treat express-pouchdb running in fullCouchDB mode as a couchdb instance.

### DIFF
--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -185,7 +185,7 @@ testUtils.putTree = function (db, tree, callback) {
 testUtils.isCouchDB = function (cb) {
   testUtils.ajax({url: testUtils.couchHost() + '/' }, function (err, res) {
     // either CouchDB or pouchdb-server qualify here
-    cb('couchdb' in res || 'express-pouchdb' in res);
+    cb('couchdb' in res || ('express-pouchdb' in res && res['express-pouchdb-mode'] === 'fullCouchDB'));
   });
 };
 


### PR DESCRIPTION
Refs https://github.com/pouchdb/pouchdb-server/pull/276.

cc @marten-de-vries