### PR TITLE
Use fixed-length array in idb/indexeddb allDocs

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/allDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/allDocs.js
@@ -19,7 +19,7 @@ import getAll from './getAll';
 
 function allDocsKeys(keys, docStore, onBatch) {
   // It's not guaranted to be returned in right order  
-  var valuesBatch = [];
+  var valuesBatch = new Array(keys.length);
   var count = 0;
   keys.forEach(function (key, index) {
     docStore.get(key).onsuccess = function (event) {

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/allDocs.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/allDocs.js
@@ -7,7 +7,7 @@ import { DOC_STORE, processAttachment } from './util';
 
 function allDocsKeys(keys, docStore, allDocsInner) {
   // It's not guaranted to be returned in right order  
-  var valuesBatch = [];
+  var valuesBatch = new Array(keys.length);
   var count = 0;
   keys.forEach(function (key, index) {
     docStore.get(key).onsuccess = function (event) {


### PR DESCRIPTION
I've been benchmarking `db.allDocs({ keys: someIds })`, and this PR may have a significant effect for some users.

Initialising arrays with a known length seems to be much faster in Chrome than using `[]`.  In Firefox, there seems to be little difference.

https://jsperf.com/random-array-inserts

Running the same benchmark directly in the Chrome console* seems to have even more marked differences, but presumably there's some other factor at play:

<img width="753" alt="screen shot 2018-01-25 at 14 27 55" src="https://user-images.githubusercontent.com/191496/35386141-fb22e030-01db-11e8-8ad7-9672f0a3a589.png">

N.B. `COUNT = 20000`

*application which includes PouchDB was also loaded in this browser window.