### PR TITLE
allDocs safely in case docs get corrupted, not resulting in complete failure

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/allDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/allDocs.js
@@ -142,7 +142,7 @@ function idbAllDocs(opts, idb, callback) {
   function fetchDocAsynchronously(metadata, row, winningRev) {
     var key = metadata.id + "::" + winningRev;
     docIdRevIndex.get(key).onsuccess =  function onGetDoc(e) {
-      row.doc = decodeDoc(e.target.result);
+      row.doc = decodeDoc(e.target.result) || {};
       if (opts.conflicts) {
         var conflicts = collectConflicts(metadata);
         if (conflicts.length) {


### PR DESCRIPTION
This is the fix for #7020 and solves the problem in case for some reason there is a mismatch between document store ID's and getting the document from the docIdRevIndex results in a empty result which causes a global error, failing the DB
This fix should at least get all the other documents, not resulting in a complete loss and can keep the conflicts which could be used to get older version in case they can be used.
This would be impossible to test as the only scenario (I have) this would happen is when IDB does not create correctly the index.