### PR TITLE
 (#7085) - Accept all IDB versions as valid 

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -800,26 +800,15 @@ function init(api, opts, callback) {
 }
 
 IdbPouch.valid = function () {
-  // Issue #2533, we finally gave up on doing bug
-  // detection instead of browser sniffing. Safari brought us
-  // to our knees.
-  var isSafari = typeof openDatabase !== 'undefined' &&
-    /(Safari|iPhone|iPad|iPod)/.test(navigator.userAgent) &&
-    !/Chrome/.test(navigator.userAgent) &&
-    !/BlackBerry/.test(navigator.platform);
-
-  // Safari <10.1 does not meet our requirements for IDB support (#5572)
-  // since Safari 10.1 shipped with fetch, we can use that to detect it
-  var hasFetch = typeof fetch === 'function' &&
-    fetch.toString().indexOf('[native code') !== -1;
+  // Following #7085 buggy idb versions (typically Safari < 10.1) are
+  // considered valid.
 
   // On Firefox SecurityError is thrown while referencing indexedDB if cookies
   // are not allowed. `typeof indexedDB` also triggers the error.
   try {
     // some outdated implementations of IDB that appear on Samsung
     // and HTC Android devices <4.4 are missing IDBKeyRange
-    return (!isSafari || hasFetch) && typeof indexedDB !== 'undefined' &&
-      typeof IDBKeyRange !== 'undefined';
+    return typeof indexedDB !== 'undefined' && typeof IDBKeyRange !== 'undefined';
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
As described in #7085, the fact that people tend to polyfill `fetch` a lot makes some trouble with our Safari version detection.

As the Gamepad interface appeared [in the same release](https://webkit.org/blog/7477/new-web-features-in-safari-10-1), and it is a less commonly polyfilled API (I do not have hard numbers, but I think it is a safe bet), let's use it.

Unfortunately I do not have access to a machine with an older version of Safari and could not test that the test fails there...

Closes #7085 