### PR TITLE
(#7095) - Reduce replication to server requests

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/changes.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/changes.js
@@ -89,7 +89,7 @@ function changes(opts, api, dbName, idb) {
       // process the attachment immediately
       // for the benefit of live listeners
       if (opts.attachments && opts.include_docs) {
-        return new Promise(function (resolve, reject) {
+        return new Promise(function (resolve) {
           fetchAttachmentsIfNecessary(winningDoc, opts, txn, function () {
             postProcessAttachments([change], opts.binary).then(function () {
               resolve(change);

--- a/packages/node_modules/pouchdb-adapter-idb/src/changes.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/changes.js
@@ -76,29 +76,33 @@ function changes(opts, api, dbName, idb) {
 
       var filtered = filter(change);
       if (typeof filtered === 'object') { // anything but true/false indicates error
-        return opts.complete(filtered);
+        return Promise.reject(filtered);
       }
 
-      if (filtered) {
-        numResults++;
-        if (returnDocs) {
-          results.push(change);
-        }
-        // process the attachment immediately
-        // for the benefit of live listeners
-        if (opts.attachments && opts.include_docs) {
+      if (!filtered) {
+        return Promise.resolve();
+      }
+      numResults++;
+      if (returnDocs) {
+        results.push(change);
+      }
+      // process the attachment immediately
+      // for the benefit of live listeners
+      if (opts.attachments && opts.include_docs) {
+        return new Promise(function (resolve, reject) {
           fetchAttachmentsIfNecessary(winningDoc, opts, txn, function () {
             postProcessAttachments([change], opts.binary).then(function () {
-              opts.onChange(change);
+              resolve(change);
             });
           });
-        } else {
-          opts.onChange(change);
-        }
+        });
+      } else {
+        return Promise.resolve(change);
       }
     }
 
     function onBatchDone() {
+      var promises = [];
       for (var i = 0, len = winningDocs.length; i < len; i++) {
         if (numResults === limit) {
           break;
@@ -108,8 +112,16 @@ function changes(opts, api, dbName, idb) {
           continue;
         }
         var metadata = metadatas[i];
-        processMetadataAndWinningDoc(metadata, winningDoc);
+        promises.push(processMetadataAndWinningDoc(metadata, winningDoc));
       }
+
+      Promise.all(promises).then(function (changes) {
+        for (var i = 0, len = changes.length; i < len; i++) {
+          if (changes[i]) {
+            opts.onChange(changes[i]);
+          }
+        }
+      }).catch(opts.complete);
 
       if (numResults !== limit) {
         cursor.continue();

--- a/packages/node_modules/pouchdb-adapter-idb/src/runBatchedCursor.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/runBatchedCursor.js
@@ -4,11 +4,13 @@
 // we're not processing each document one-at-a-time.
 function runBatchedCursor(objectStore, keyRange, descending, batchSize, onBatch) {
 
+  if (batchSize === -1) {
+    batchSize = 1000;
+  }
+
   // Bail out of getAll()/getAllKeys() in the following cases:
   // 1) either method is unsupported - we need both
-  // 2) batchSize is 1 (might as well use IDBCursor), or batchSize is -1 (i.e. batchSize unlimited,
-  //    not really clear the user wants a batched approach where the entire DB is read into memory,
-  //    perhaps they are filtering on a per-doc basis)
+  // 2) batchSize is 1 (might as well use IDBCursor)
   // 3) descending – no real way to do this via getAll()/getAllKeys()
 
   var useGetAll = typeof objectStore.getAll === 'function' &&

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -308,7 +308,7 @@ function replicate(src, target, opts, returnValue, result) {
     }
     pendingBatch.seq = change.seq || lastSeq;
     pendingBatch.changes.push(change);
-    nextTick(function() {
+    nextTick(function () {
       processPendingBatch(batches.length === 0 && changesOpts.live);
     });
   }

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -1,4 +1,4 @@
-import { clone, filterChange, uuid } from 'pouchdb-utils';
+import { clone, filterChange, nextTick, uuid } from 'pouchdb-utils';
 import getDocs from './getDocs';
 import Checkpointer from 'pouchdb-checkpointer';
 import backOff from './backoff';
@@ -308,7 +308,9 @@ function replicate(src, target, opts, returnValue, result) {
     }
     pendingBatch.seq = change.seq || lastSeq;
     pendingBatch.changes.push(change);
-    processPendingBatch(batches.length === 0 && changesOpts.live);
+    nextTick(function() {
+      processPendingBatch(batches.length === 0 && changesOpts.live);
+    });
   }
 
 


### PR DESCRIPTION
This solves an issue where a bulkDocs request of two docs with a
continuous replication to the server causes the docs to be sent
in two replication requests rather than one.

Firstly this modifies the runBatchedCursor implementation to use
getAll() and getAllKeys() when a batchSize of -1 (or infinite) is
given. This means the onBatch callback will fire once instead of
once per doc.

Secondly this changes the idb changes implementation to call the
onChange handler in the same tick so all changes get added to the
pending batch before it's processed.

Issue: #7095