### PR TITLE
(#6946) - Remove debug dep

### DIFF
--- a/packages/node_modules/pouchdb-core/src/index.js
+++ b/packages/node_modules/pouchdb-core/src/index.js
@@ -1,10 +1,6 @@
 import PouchDB from './setup';
 import version from './version';
-import pouchDebug from 'pouchdb-debug';
 import pouchChangesFilter from 'pouchdb-changes-filter';
-
-// TODO: remove from pouchdb-core (breaking)
-PouchDB.plugin(pouchDebug);
 
 // TODO: remove from pouchdb-core (breaking)
 PouchDB.plugin(pouchChangesFilter);


### PR DESCRIPTION
Would like to move pouchdb-debug to pouchdb-community, but this is a first step