### PR TITLE
remove catastrophic backtracking vulnerability

### DIFF
--- a/packages/node_modules/pouchdb-utils/src/functionName.js
+++ b/packages/node_modules/pouchdb-utils/src/functionName.js
@@ -15,7 +15,13 @@ if (hasName) {
   };
 } else {
   res = function (fun) {
-    return fun.toString().match(/^\s*function\s*(\S*)\s*\(/)[1];
+    var match = fun.toString().match(/^\s*function\s*(?:(\S+)\s*)?\(/);
+    if (match && match[1]) {
+      return match[1];
+    }
+    else {
+      return '';
+    }
   };
 }
 


### PR DESCRIPTION
Problem:
A regex to parse function names was vulnerable to catastrophic
backtracking.

Solution:
Alter the regex to make it safe.
The new regex matches almost the same language.
The only differences should not be a problem in the input space.

This regex is not exploitable for REDOS as currently used.
This change is for future-proofing.