### PR TITLE
Basic WIP idea of attachment:false replication

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
@@ -172,15 +172,16 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
 
     var req = attachStore.get(digest);
     req.onsuccess = function (e) {
-      if (!e.target.result) {
-        var err = createError(MISSING_STUB,
-          'unknown stub attachment with digest ' +
-          digest);
-        err.status = 412;
-        callback(err);
-      } else {
-        callback();
-      }
+      callback();
+      // if (!e.target.result) {
+      //   var err = createError(MISSING_STUB,
+      //     'unknown stub attachment with digest ' +
+      //     digest);
+      //   err.status = 412;
+      //   callback(err);
+      // } else {
+      //   callback();
+      // }
     };
   }
 

--- a/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
@@ -1,4 +1,3 @@
-import { createError, MISSING_STUB } from 'pouchdb-errors';
 import {
   preprocessAttachments,
   processDocs,
@@ -171,17 +170,10 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
   function verifyAttachment(digest, callback) {
 
     var req = attachStore.get(digest);
-    req.onsuccess = function (e) {
+    req.onsuccess = function () {
+      // Due to the option of having attachments: false for replications
+      // We now allow having a doc without the actual attachment
       callback();
-      // if (!e.target.result) {
-      //   var err = createError(MISSING_STUB,
-      //     'unknown stub attachment with digest ' +
-      //     digest);
-      //   err.status = 412;
-      //   callback(err);
-      // } else {
-      //   callback();
-      // }
     };
   }
 

--- a/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
@@ -1,3 +1,4 @@
+import { createError, MISSING_STUB } from 'pouchdb-errors';
 import {
   preprocessAttachments,
   processDocs,
@@ -39,6 +40,7 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
   var docInfoError;
   var metaDoc;
 
+  console.log('dd', docInfos);
   for (var i = 0, len = docInfos.length; i < len; i++) {
     var doc = docInfos[i];
     if (doc._id && isLocalId(doc._id)) {
@@ -167,43 +169,62 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
     callback(null, results);
   }
 
-  function verifyAttachment(digest, callback) {
-
+  function verifyAttachment(att, callback) {
+    var digest = att.digest;
     var req = attachStore.get(digest);
-    req.onsuccess = function () {
-      // Due to the option of having attachments: false for replications
-      // We now allow having a doc without the actual attachment
-      callback();
+    req.onsuccess = function (e) {
+      if (!e.target.result) {
+        console.log('ATT HERE', att);
+        if (att.unfetched) {
+          callback();
+        } else {
+          var err = createError(MISSING_STUB,
+            'unknown stub attachment with digest ' +
+            digest);
+          err.status = 412;
+          callback(err);
+        }
+      } else {
+        // Check that unfetched is set for an attachment this db actually has,
+        // if it does have it remove the unfetched field
+        if (att.unfetched) {
+          console.log('REMOVE unfetched');
+          delete att.unfetched;
+        }
+        callback();
+      }
     };
   }
 
   function verifyAttachments(finish) {
 
 
-    var digests = [];
+    var atts = [];
     docInfos.forEach(function (docInfo) {
       if (docInfo.data && docInfo.data._attachments) {
         Object.keys(docInfo.data._attachments).forEach(function (filename) {
           var att = docInfo.data._attachments[filename];
+          console.log('LOOK AT', att, att.digest);
+          // if (att.stub && !att.unfetched) {
           if (att.stub) {
-            digests.push(att.digest);
+            atts.push(att);
           }
         });
       }
     });
-    if (!digests.length) {
+    if (!atts.length) {
       return finish();
     }
     var numDone = 0;
     var err;
 
     function checkDone() {
-      if (++numDone === digests.length) {
+      if (++numDone === atts.length) {
         finish(err);
       }
     }
-    digests.forEach(function (digest) {
-      verifyAttachment(digest, function (attErr) {
+    atts.forEach(function (att) {
+      verifyAttachment(att, function (attErr) {
         if (attErr && !err) {
           err = attErr;
         }

--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -21,7 +21,6 @@ import {
   MISSING_DOC,
   REV_CONFLICT,
   IDB_ERROR,
-  MISSING_STUB,
   createError
 } from 'pouchdb-errors';
 

--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -21,6 +21,7 @@ import {
   MISSING_DOC,
   REV_CONFLICT,
   IDB_ERROR,
+  MISSING_STUB,
   createError
 } from 'pouchdb-errors';
 
@@ -379,6 +380,10 @@ function init(api, opts, callback) {
     var type = attachment.content_type;
 
     txn.objectStore(ATTACH_STORE).get(digest).onsuccess = function (e) {
+      if (!e.target.result) {
+        callback(null, null);
+        return;
+      }
       var body = e.target.result.body;
       readBlobData(body, type, opts.binary, function (blobData) {
         callback(null, blobData);

--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -379,10 +379,11 @@ function init(api, opts, callback) {
     var type = attachment.content_type;
 
     txn.objectStore(ATTACH_STORE).get(digest).onsuccess = function (e) {
-      if (!e.target.result) {
+      if (!e.target.result && attachment.unfetched) {
         callback(null, null);
         return;
       }
+
       var body = e.target.result.body;
       readBlobData(body, type, opts.binary, function (blobData) {
         callback(null, blobData);

--- a/packages/node_modules/pouchdb-adapter-utils/src/preprocessAttachments.js
+++ b/packages/node_modules/pouchdb-adapter-utils/src/preprocessAttachments.js
@@ -39,6 +39,10 @@ function preprocessString(att, blobType, callback) {
 }
 
 function preprocessBlob(att, blobType, callback) {
+  if (!att.data) {
+    callback();
+    return;
+  }
   binaryMd5(att.data, function (md5) {
     att.digest = 'md5-' + md5;
     // size is for blobs (browser), length is for buffers (node)

--- a/packages/node_modules/pouchdb-adapter-utils/src/preprocessAttachments.js
+++ b/packages/node_modules/pouchdb-adapter-utils/src/preprocessAttachments.js
@@ -39,10 +39,6 @@ function preprocessString(att, blobType, callback) {
 }
 
 function preprocessBlob(att, blobType, callback) {
-  if (!att.data) {
-    callback();
-    return;
-  }
   binaryMd5(att.data, function (md5) {
     att.digest = 'md5-' + md5;
     // size is for blobs (browser), length is for buffers (node)

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -69,7 +69,7 @@ function cleanDocs(docs) {
       for (var j = 0; j < atts.length; j++) {
         var att = atts[j];
         doc._attachments[att] = pick(doc._attachments[att],
-          ['data', 'digest', 'content_type', 'length', 'revpos', 'stub']);
+          ['data', 'digest', 'content_type', 'length', 'revpos', 'stub', 'unfetched']);
       }
     }
   }

--- a/packages/node_modules/pouchdb-generate-replication-id/src/index.js
+++ b/packages/node_modules/pouchdb-generate-replication-id/src/index.js
@@ -35,6 +35,11 @@ function generateReplicationId(src, target, opts) {
   return Promise.all([src.id(), target.id()]).then(function (res) {
     var queryData = res[0] + res[1] + filterFun + filterViewName +
       queryParams + docIds + selector;
+      
+    if (opts.attachments === false) {
+      queryData += 'attachments:false';
+    }
+
     return new Promise(function (resolve) {
       binaryMd5(queryData, resolve);
     });

--- a/packages/node_modules/pouchdb-generate-replication-id/src/index.js
+++ b/packages/node_modules/pouchdb-generate-replication-id/src/index.js
@@ -35,9 +35,9 @@ function generateReplicationId(src, target, opts) {
   return Promise.all([src.id(), target.id()]).then(function (res) {
     var queryData = res[0] + res[1] + filterFun + filterViewName +
       queryParams + docIds + selector;
-      
+
     if (opts.attachments === false) {
-      queryData += 'attachments:false';
+      queryData += 'attachments:' + opts.attachments;
     }
 
     return new Promise(function (resolve) {

--- a/packages/node_modules/pouchdb-replication/src/getDocs.js
+++ b/packages/node_modules/pouchdb-replication/src/getDocs.js
@@ -68,7 +68,7 @@ function createBulkGetOpts(diffs) {
 // changes to "cancelled", then the returned promise will be rejected.
 // Else it will be resolved with a list of fetched documents.
 //
-function getDocs(src, target, diffs, state) {
+function getDocs(src, target, diffs, state, opts) {
   diffs = clone(diffs); // we do not need to modify this
 
   var resultDocs = [],
@@ -97,7 +97,7 @@ function getDocs(src, target, diffs, state) {
             ok = false;
           }
 
-          if (!remoteDoc || !remoteDoc._attachments) {
+          if (!remoteDoc || !remoteDoc._attachments || !opts.attachments) {
             return remoteDoc;
           }
 

--- a/packages/node_modules/pouchdb-replication/src/getDocs.js
+++ b/packages/node_modules/pouchdb-replication/src/getDocs.js
@@ -90,6 +90,7 @@ function getDocs(src, target, diffs, state, opts) {
       return Promise.all(bulkGetResponse.results.map(function (bulkGetInfo) {
         return Promise.all(bulkGetInfo.docs.map(function (doc) {
           var remoteDoc = doc.ok;
+          console.log('DODO', doc, remoteDoc);
 
           if (doc.error) {
             // when AUTO_COMPACTION is set, docs can be returned which look
@@ -98,6 +99,12 @@ function getDocs(src, target, diffs, state, opts) {
           }
 
           if (!remoteDoc || !remoteDoc._attachments || !opts.attachments) {
+            if (remoteDoc._attachments) {
+              console.log('BOOKK', remoteDoc);
+              Object.keys(remoteDoc._attachments).forEach(function (filename) {
+                remoteDoc._attachments[filename].unfetched = true;
+              });
+            }
             return remoteDoc;
           }
 
@@ -108,6 +115,7 @@ function getDocs(src, target, diffs, state, opts) {
                              .forEach(function (attachment, i) {
                                         var att = remoteDoc._attachments[filenames[i]];
                                         delete att.stub;
+                                        delete att.unfetched;
                                         delete att.length;
                                         att.data = attachment;
                                       });

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -170,7 +170,7 @@ function replicate(src, target, opts, returnValue, result) {
   }
 
   function getBatchDocs() {
-    return getDocs(src, target, currentBatch.diffs, returnValue).then(function (got) {
+    return getDocs(src, target, currentBatch.diffs, returnValue, opts).then(function (got) {
       currentBatch.error = !got.ok;
       got.docs.forEach(function (doc) {
         delete currentBatch.diffs[doc._id];

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -29,6 +29,10 @@ function replicate(src, target, opts, returnValue, result) {
   // Like couchdb, every replication gets a unique session id
   var session = uuid();
 
+  if (opts.attachments === undefined) {
+    opts.attachments = true;
+  }
+
   result = result || {
     ok: true,
     start_time: new Date().toISOString(),
@@ -78,7 +82,7 @@ function replicate(src, target, opts, returnValue, result) {
         throw new Error('cancelled');
       }
 
-      // `res` doesn't include full documents (which live in `docs`), so we create a map of 
+      // `res` doesn't include full documents (which live in `docs`), so we create a map of
       // (id -> error), and check for errors while iterating over `docs`
       var errorsById = Object.create(null);
       res.forEach(function (res) {

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -75,6 +75,7 @@ function replicate(src, target, opts, returnValue, result) {
     }
     var docs = currentBatch.docs;
     var bulkOpts = {timeout: opts.timeout};
+    console.log('writeDocs', docs);
     return target.bulkDocs({docs: docs, new_edits: false}, bulkOpts).then(function (res) {
       /* istanbul ignore if */
       if (returnValue.cancelled) {

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -4233,7 +4233,6 @@ adapters.forEach(function (adapters) {
         done();
         return;
       }
-      console.log('DB', dbs.name, dbs.remote);
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
       var thedocs = [
@@ -4259,7 +4258,6 @@ adapters.forEach(function (adapters) {
         return db.replicate.from(remote, {attachments: false});
       })
       .then(function () {
-        console.log('DONE 1');
         return db.get('3');
       })
       .then(function (doc) {
@@ -4268,7 +4266,6 @@ adapters.forEach(function (adapters) {
         att.revpos.should.equal(1);
         att.stub.should.true;
 
-        console.log('FETCH D1');
         return db.get('3');
       })
       .then(function (doc) {

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -2,8 +2,8 @@
 
 var adapters = [
   ['local', 'http'],
-  // ['http', 'http'],
-  // ['http', 'local'],
+  ['http', 'http'],
+  ['http', 'local'],
   ['local', 'local']
 ];
 
@@ -4178,7 +4178,13 @@ adapters.forEach(function (adapters) {
       });
     });
 
-    it.only('attachment:false does not replicate attachments', function (done) {
+    it('attachment:false does not replicate attachments', function (done) {
+      // Cannot test this with CouchDB as target
+      if (adapters[0] === 'http') {
+        done();
+        return;
+      }
+
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
       var thedocs = [
@@ -4214,16 +4220,21 @@ adapters.forEach(function (adapters) {
 
         return db.get('3', {attachments: true});
       })
-      .then(doc => {
+      .then(function (doc) {
         var att = doc._attachments['att.txt'];
         should.not.exist(att.data);
         done();
       });
     });
 
-    it('attachment: false replication 2nd time replicates attachments', function (done) {
+    it('attachment:false replicates changes back to source db', function (done) {
+      // Cannot test this with CouchDB as target
+      if (adapters[0] === 'http') {
+        done();
+        return;
+      }
+      console.log('DB', dbs.name, dbs.remote);
       var db = new PouchDB(dbs.name);
-      console.log('dd', db.name, dbs.remote);
       var remote = new PouchDB(dbs.remote);
       var thedocs = [
         {
@@ -4248,27 +4259,36 @@ adapters.forEach(function (adapters) {
         return db.replicate.from(remote, {attachments: false});
       })
       .then(function () {
-        return db.get('3', {attachments: true});
+        console.log('DONE 1');
+        return db.get('3');
       })
       .then(function (doc) {
         var att = doc._attachments['att.txt'];
         att.content_type.should.equal("text/plain");
         att.revpos.should.equal(1);
-        should.not.exist(att.data);
-        return db.replicate.from(remote, {attachments: true});
+        att.stub.should.true;
+
+        console.log('FETCH D1');
+        return db.get('3');
+      })
+      .then(function (doc) {
+        doc.newField = 'hello world';
+        return db.put(doc);
       })
       .then(function () {
-        return db.get('3', {attachments: true});
+        return db.replicate.to(remote, {attachments: false});
+      })
+      .then(function () {
+        return remote.get('3', {attachments: true});
       })
       .then(function (doc) {
+        doc.newField.should.equal('hello world');
         var att = doc._attachments['att.txt'];
-        console.log('AA', att);
-        att.content_type.should.equal("text/plain");
-        att.revpos.should.equal(1);
         att.data.should.equal('Zm9v');
         done();
       });
     });
+
   });
 });
 

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -1,9 +1,9 @@
 'use strict';
 
 var adapters = [
-  ['local', 'http'],
-  ['http', 'http'],
-  ['http', 'local'],
+  // ['local', 'http'],
+  // ['http', 'http'],
+  // ['http', 'local'],
   ['local', 'local']
 ];
 
@@ -4217,7 +4217,7 @@ adapters.forEach(function (adapters) {
         att.content_type.should.equal("text/plain");
         att.revpos.should.equal(1);
         att.stub.should.true;
-
+        att.unfetched.should.true;
         return db.get('3', {attachments: true});
       })
       .then(function (doc) {
@@ -4276,6 +4276,15 @@ adapters.forEach(function (adapters) {
         return db.replicate.to(remote, {attachments: false});
       })
       .then(function () {
+        return remote.get('3', {attachments: false});
+      })
+      .then(function (doc) {
+        doc.newField.should.equal('hello world');
+        var att = doc._attachments['att.txt'];
+        console.log('ATT', att);
+        should.not.exist(att.unfetched);
+      })
+      .then(function () {
         return remote.get('3', {attachments: true});
       })
       .then(function (doc) {
@@ -4286,6 +4295,65 @@ adapters.forEach(function (adapters) {
       });
     });
 
+    it.only('attachment:false followed by attachment:true replicates attachments', function (done) {
+      // Cannot test this with CouchDB as target
+      if (adapters[0] === 'http') {
+        done();
+        return;
+      }
+      var db = new PouchDB(dbs.name);
+      var remote = new PouchDB(dbs.remote);
+      var thedocs = [
+        {
+          _id: '3',
+          integer: 3,
+          string: '3',
+          _attachments: {
+            'att.txt': {
+              data: 'Zm9v', // 'foo'
+              content_type: 'text/plain'
+            }
+          }
+        },
+        {
+          _id: '4',
+          integer: 4,
+          string: '4'
+        },
+      ];
+      remote.bulkDocs(thedocs)
+      .then(function () {
+        return db.replicate.from(remote, {attachments: false});
+      })
+      .then(function () {
+        return db.get('3');
+      })
+      .then(function (doc) {
+        var att = doc._attachments['att.txt'];
+        att.content_type.should.equal("text/plain");
+        att.revpos.should.equal(1);
+        att.stub.should.true;
+        console.log('2nd rep');
+        return db.replicate.from(remote, {attachments: true});
+      })
+      .then(function () {
+        return db.get('3', {attachments: false});
+      })
+      .then(function (doc) {
+        console.log('DD', doc);
+        var att = doc._attachments['att.txt'];
+        should.not.exist(att.unfetched);
+      })
+      .then(function () {
+        return db.get('3', {attachments: true});
+      })
+      .then(function (doc) {
+        doc.newField.should.equal('hello world');
+        var att = doc._attachments['att.txt'];
+        att.data.should.equal('Zm9v');
+        done();
+      });
+    });
   });
 });
 


### PR DESCRIPTION
This is a very basic idea for implementing #4362 which is to be able to replicate documents that have attachments from one database but not replicate the attachments. Rather just add stubs.

At this stage, it can replicate from a CouchDB to PouchDB and from PouchDB to PouchDB. I don't think it would be possible to do a replication from PouchDB to CouchDB with this option without first modifying CouchDB. 

What I'm not sure how to do is if a second replication happens later with `{attachments: true}` how to get it to replicate the attachments this time. I'm not sure where I would do a check to see if we have the attachments. 

I would like some feedback before proceeding any further on this.

