### PR TITLE
DO NOT MERGE - Backport iOS Safari IDB fixes to v6.4.3

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/blobSupport.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/blobSupport.js
@@ -27,7 +27,7 @@ function checkBlobSupport(txn) {
         parseInt(matchedChrome[1], 10) >= 43);
     };
 
-    txn.onabort = function (e) {
+    req.onerror = txn.onabort = function (e) {
       // If the transaction aborts now its due to not being able to
       // write to the database, likely due to the disk being full
       e.preventDefault();

--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -800,26 +800,15 @@ function init(api, opts, callback) {
 }
 
 IdbPouch.valid = function () {
-  // Issue #2533, we finally gave up on doing bug
-  // detection instead of browser sniffing. Safari brought us
-  // to our knees.
-  var isSafari = typeof openDatabase !== 'undefined' &&
-    /(Safari|iPhone|iPad|iPod)/.test(navigator.userAgent) &&
-    !/Chrome/.test(navigator.userAgent) &&
-    !/BlackBerry/.test(navigator.platform);
-
-  // Safari <10.1 does not meet our requirements for IDB support (#5572)
-  // since Safari 10.1 shipped with fetch, we can use that to detect it
-  var hasFetch = typeof fetch === 'function' &&
-    fetch.toString().indexOf('[native code') !== -1;
+  // Following #7085 buggy idb versions (typically Safari < 10.1) are
+  // considered valid.
 
   // On Firefox SecurityError is thrown while referencing indexedDB if cookies
   // are not allowed. `typeof indexedDB` also triggers the error.
   try {
     // some outdated implementations of IDB that appear on Samsung
     // and HTC Android devices <4.4 are missing IDBKeyRange
-    return (!isSafari || hasFetch) && typeof indexedDB !== 'undefined' &&
-      typeof IDBKeyRange !== 'undefined';
+    return typeof indexedDB !== 'undefined' && typeof IDBKeyRange !== 'undefined';
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
I wasn't entirely sure how to send in this PR since there's no v6 branch, so this is my best attempt.

This backports two commits (4c65dd4 and bb5827d) made after the v6.4.3 release that fix PouchDB in iOS 11.3. In my testing I discovered that IndexedDB behaves differently in the iOS Simulator, so this is unfortunately the only device I was able to test on.

I didn't run the tests that required CouchDB, but I at least got `?grep=test.basics.js-local` passing again.