### PR TITLE
fix example in 2018-01-23-pouchdb-6.4.2.md

### DIFF
--- a/docs/_posts/2018-01-23-pouchdb-6.4.2.md
+++ b/docs/_posts/2018-01-23-pouchdb-6.4.2.md
@@ -34,7 +34,7 @@ function openDB(name, opts) {
       var newopts = opts || {};
       newopts.adapter = 'idb';
 
-      var newdb = new PouchDB(name, opts);
+      var newdb = new PouchDB(name, newopts);
       var replicate = localdb.replicate.to(newdb);
       replicate.then(function() {
         resolve(newdb);


### PR DESCRIPTION
The new instance should use the new opts to make the migration from WebSQL to IDB work ;)