### PR TITLE
Check if doc exist before _attachment attributes #7403

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -40,7 +40,7 @@ var supportsBulkGetMap = {};
 
 function readAttachmentsAsBlobOrBuffer(row) {
   var doc = row.doc || row.ok;
-  var atts = doc._attachments;
+  var atts = doc && doc._attachments;
   if (!atts) {
     return;
   }

--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -3236,6 +3236,24 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('#7403 {attachments: true, binary: true, include_docs: true} in allDocs with one missing doc', function () {
+      var docs = [binAttDoc];
+      var db = new PouchDB(dbs.name);
+      var keys;
+      return db.bulkDocs(docs).then(function () {
+        keys = ['bin_doc', 'thisDocIsNotInDB'];
+        return db.allDocs({
+          keys: keys,
+          attachments: true,
+          binary: true,
+          include_docs: true
+        });
+      }).then(function (result) {
+        should.exist(result.rows[0].doc._attachments);
+        result.rows[1].error.should.equal('not_found');
+      });
+    });
+
   });
 });
 


### PR DESCRIPTION
Fixing the error when requesting all_docs and their attachments in a binary blob if at least one doc doesn't exist in the DB.
More details are available in the issue #7403.