### PR TITLE
Add some find perf tests

### DIFF
--- a/tests/performance/index.html
+++ b/tests/performance/index.html
@@ -6,8 +6,8 @@
   <body>
     <pre style="width: 100%; height: 100%;" id="output"></pre>
     <script src="/packages/node_modules/pouchdb/dist/pouchdb.js"></script>
+    <script src="/packages/node_modules/pouchdb/dist/pouchdb.find.js"></script>
     <script src="/packages/node_modules/pouchdb/dist/pouchdb.localstorage.js"></script>
-    <script src="/packages/node_modules/pouchdb/dist/pouchdb.fruitdown.js"></script>
     <script src="/packages/node_modules/pouchdb/dist/pouchdb.memory.js"></script>
     <script src="../performance-bundle.js"></script>
   </body>

--- a/tests/performance/index.js
+++ b/tests/performance/index.js
@@ -22,13 +22,14 @@ function runTestSuites(PouchDB) {
     var count = 0;
     function checkDone(adapterUsed) {
       theAdapterUsed = theAdapterUsed || adapterUsed;
-      if (++count === 3) { // number of perf.xxxx.js tests
+      if (++count === 4) { // number of perf.xxxx.js tests
         reporter.complete(theAdapterUsed);
       }
     }
 
     require('./perf.basics')(PouchDB, opts, checkDone);
     require('./perf.views')(PouchDB, opts, checkDone);
+    require('./perf.find')(PouchDB, opts, checkDone);
     require('./perf.attachments')(PouchDB, opts, checkDone);
   }
 

--- a/tests/performance/index.js
+++ b/tests/performance/index.js
@@ -70,8 +70,14 @@ if (global.window && global.window.location && global.window.location.search) {
   }
 }
 if (startNow) {
-  var PouchDB = process.browser ? window.PouchDB :
-    require('../../packages/node_modules/pouchdb');
+  var PouchDB;
+  if (process.browser) {
+    PouchDB = window.PouchDB;
+  } else {
+    PouchDB = require('../../packages/node_modules/pouchdb');
+    PouchDB.plugin(require('../../packages/node_modules/' +
+      'pouchdb-find'));
+  }
   if (!process.browser) {
     PouchDB.plugin(require('../../packages/node_modules/' +
       'pouchdb-adapter-memory'));

--- a/tests/performance/perf.attachments.js
+++ b/tests/performance/perf.attachments.js
@@ -52,6 +52,6 @@ module.exports = function (PouchDB, opts, callback) {
     }
   ];
 
-  utils.runTests(PouchDB, 'views', testCases, opts, callback);
+  utils.runTests(PouchDB, 'attachments', testCases, opts, callback);
 
 };

--- a/tests/performance/perf.find.js
+++ b/tests/performance/perf.find.js
@@ -1,0 +1,123 @@
+'use strict';
+
+module.exports = function (PouchDB, opts, callback) {
+
+  var utils = require('./utils');
+
+  function makeTestDocs() {
+    var docs = [];
+    for (var i = 0; i < 1000; i++) {
+      docs.push({
+        key: i % 47,
+        even: i % 2 === 0,
+        str: ['foo', 'bar', 'smang', 'foobar'][i % 3]
+      });
+    }
+    return docs;
+  }
+
+  var testCases = [
+    {
+      name: 'create-index',
+      assertions: 1,
+      iterations: 1,
+      setup: function (db, callback) {
+        db.bulkDocs(makeTestDocs())
+          .then(function () {
+            callback();
+          }, callback);
+      },
+      test: function (db, itr, doc, done) {
+        db.createIndex({
+          index: {
+            fields: ['key']
+          }
+        }).then(function () {
+          done();
+        }, done);
+      }
+    },
+    {
+      name: 'simple-find-query',
+      assertions: 1,
+      iterations: 10,
+      setup: function (db, callback) {
+        db.bulkDocs(makeTestDocs())
+          .then(function () {
+            return db.createIndex({
+              index: {
+                fields: ['key']
+              }
+            });
+          }).then(function () {
+            callback();
+          }, callback);
+      },
+      test: function (db, itr, doc, done) {
+        db.find({
+          selector: { key: 'foo'}
+        }).then(function () {
+          done();
+        }, done);
+      }
+    },
+    {
+      name: 'complex-find-query',
+      assertions: 1,
+      iterations: 10,
+      setup: function (db, callback) {
+        db.bulkDocs(makeTestDocs())
+          .then(function () {
+            return db.createIndex({
+              index: {
+                fields: ['key']
+              }
+            });
+          }).then(function () {
+            callback();
+          }, callback);
+      },
+      test: function (db, itr, doc, done) {
+        db.find({
+          selector: {
+            $and: [
+              {key: { $gt: 4 }},
+              {key: { $ne: 7 }}
+            ]
+          }
+        }).then(function () {
+          done();
+        }, done);
+      }
+    },
+    {
+      name: 'multi-field-query',
+      assertions: 1,
+      iterations: 10,
+      setup: function (db, callback) {
+        db.bulkDocs(makeTestDocs())
+          .then(function () {
+            return db.createIndex({
+              index: {
+                fields: ['key']
+              }
+            });
+          }).then(function () {
+            callback();
+          }, callback);
+      },
+      test: function (db, itr, doc, done) {
+        db.find({
+          selector: {
+            key: { $gt: 5 },
+            str: 'foo'
+          }
+        }).then(function () {
+          done();
+        }, done);
+      }
+    }
+  ];
+
+  utils.runTests(PouchDB, 'find', testCases, opts, callback);
+};

--- a/tests/performance/perf.find.js
+++ b/tests/performance/perf.find.js
@@ -62,6 +62,24 @@ module.exports = function (PouchDB, opts, callback) {
       }
     },
     {
+      name: 'simple-find-query-no-index',
+      assertions: 1,
+      iterations: 10,
+      setup: function (db, callback) {
+        db.bulkDocs(makeTestDocs())
+          .then(function () {
+            callback();
+          }, callback);
+      },
+      test: function (db, itr, doc, done) {
+        db.find({
+          selector: { key: 'foo'}
+        }).then(function () {
+          done();
+        }, done);
+      }
+    },
+    {
       name: 'complex-find-query',
       assertions: 1,
       iterations: 10,


### PR DESCRIPTION
There is probably a lot more interesting stuff we can do here. These
follow the level of complexity that existing perf tests look to have,
and try to keep their run times reasonably low while testing useful
things.

This is some pre-amble work before implementing find for idbnext (the
'indexeddb' adapter, as opposed to the existing 'idb' adapter), so we
can understand performance differences between the adapters.