### PR TITLE
Fix breaking change on server info with no JSON

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -301,12 +301,13 @@ function HttpPouch(opts, callback) {
   api.id = adapterFun('id', function (callback) {
     ourFetch(genUrl(host, '')).then(function (response) {
       return response.json();
+    }).catch(function () {
+      return {};
     }).then(function (result) {
+      // Bad response or missing `uuid` should not prevent ID generation.
       var uuid = (result && result.uuid) ?
           (result.uuid + host.db) : genDBUrl(host, '');
       callback(null, uuid);
-    }).catch(function (err) {
-      callback(err);
     });
   });
 


### PR DESCRIPTION
This commit fixes a breaking change introduced in version 7.0.0 by
commit e35f949 "Switch http adapter to use fetch".

Since version 7.0.0, it is no longer possible to replicate a database
from a server that replies an empty response on `GET /` (even with a
`200 OK` code). This worked fine with version 6.4.3 and before.

See code from 6.4.3, that returned an ID even if the response wasn't
JSON-parsable, or if there was an error:
https://github.com/pouchdb/pouchdb/blob/6.4.3/lib/index-browser.js#L8927

Closes #7444.