### PR TITLE
Update pouchdb-find readme to clarify that partial indexes are not implemented.

### DIFF
--- a/packages/node_modules/pouchdb-find/README.md
+++ b/packages/node_modules/pouchdb-find/README.md
@@ -14,6 +14,8 @@ Status
 
 Implemented: `$lt`, `$gt`, `$lte`, `$gte`, `$eq`, `$exists`, `$type`, `$in`, `$nin`, `$all`, `$size`, `$or`, `$nor`, `$not`, `$mod`, `$regex`, `$elemMatch`, multi-field queries, multi-field indexes, multi-field sort, `'deep.fields.like.this'`, ascending and descending sort.
 
+Not implemented: `partial_filter_selector` in non-remote databases, as used for [partial indexes](http://docs.couchdb.org/en/stable/api/database/find.html#find-partial-indexes).
+
 **0.2.0**: `$and`, `$ne`
 
 **0.3.0**: `limit`, `skip`, `ddoc` when creating an index


### PR DESCRIPTION
partial_filter_selector isn't yet implemented in pouchdb-find's local adapter, though the remote adapter passes it along to CouchDB just fine. I spent a while trying to figure out why it wasn't working, so I figured it might help to clarify this in the readme.