### PR TITLE
(#7467) - Implement partial indexes

### DIFF
--- a/packages/node_modules/pouchdb-find/README.md
+++ b/packages/node_modules/pouchdb-find/README.md
@@ -12,9 +12,7 @@ Eventually this will replace PouchDB's map/reduce API entirely. You'll still be 
 Status
 ---
 
-Implemented: `$lt`, `$gt`, `$lte`, `$gte`, `$eq`, `$exists`, `$type`, `$in`, `$nin`, `$all`, `$size`, `$or`, `$nor`, `$not`, `$mod`, `$regex`, `$elemMatch`, multi-field queries, multi-field indexes, multi-field sort, `'deep.fields.like.this'`, ascending and descending sort.
-
-Not implemented: `partial_filter_selector` in non-remote databases, as used for [partial indexes](http://docs.couchdb.org/en/stable/api/database/find.html#find-partial-indexes).
+Implemented: `$lt`, `$gt`, `$lte`, `$gte`, `$eq`, `$exists`, `$type`, `$in`, `$nin`, `$all`, `$size`, `$or`, `$nor`, `$not`, `$mod`, `$regex`, `$elemMatch`, multi-field queries, multi-field indexes, multi-field sort, `'deep.fields.like.this'`, ascending and descending sort, `partial_filter_selector` ([partial indexes](http://docs.couchdb.org/en/stable/api/database/find.html#find-partial-indexes)).
 
 **0.2.0**: `$and`, `$ne`
 

--- a/packages/node_modules/pouchdb-find/src/adapters/local/abstract-mapper.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/abstract-mapper.js
@@ -1,5 +1,5 @@
 import abstractMapReduce from 'pouchdb-abstract-mapreduce';
-import { parseField } from 'pouchdb-selector-core';
+import { massageSelector, parseField, rowFilter } from 'pouchdb-selector-core';
 
 //
 // One thing about these mappers:
@@ -63,6 +63,72 @@ function createShallowMultiMapper(fields, emit) {
   };
 }
 
+function createDeepMultiMapperWithSelector(fields, selector, inMemoryFields, emit) {
+  return function (doc) {
+    if (!rowFilter(doc, selector, inMemoryFields)) {
+      return;
+    }
+
+    var toEmit = [];
+    for (var i = 0, iLen = fields.length; i < iLen; i++) {
+      var parsedField = parseField(fields[i]);
+      var value = doc;
+      for (var j = 0, jLen = parsedField.length; j < jLen; j++) {
+        var key = parsedField[j];
+        value = value[key];
+        if (typeof value === 'undefined') {
+          return; // don't emit
+        }
+      }
+      toEmit.push(value);
+    }
+    emit(toEmit);
+  };
+}
+
+function createDeepSingleMapperWithSelector(field, selector, inMemoryFields, emit) {
+  var parsedField = parseField(field);
+  return function (doc) {
+    if (!rowFilter(doc, selector, inMemoryFields)) {
+      return;
+    }
+
+    var value = doc;
+    for (var i = 0, len = parsedField.length; i < len; i++) {
+      var key = parsedField[i];
+      value = value[key];
+      if (typeof value === 'undefined') {
+        return; // do nothing
+      }
+    }
+    emit(value);
+  };
+}
+
+function createShallowSingleMapperWithSelector(field, selector, inMemoryFields, emit) {
+  return function (doc) {
+    if (!rowFilter(doc, selector, inMemoryFields)) {
+      return;
+    }
+
+    emit(doc[field]);
+  };
+}
+
+function createShallowMultiMapperWithSelector(fields, selector, inMemoryFields, emit) {
+  return function (doc) {
+    if (!rowFilter(doc, selector, inMemoryFields)) {
+      return;
+    }
+
+    var toEmit = [];
+    for (var i = 0, len = fields.length; i < len; i++) {
+      toEmit.push(doc[fields[i]]);
+    }
+    emit(toEmit);
+  };
+}
+
 function checkShallow(fields) {
   for (var i = 0, len = fields.length; i < len; i++) {
     var field = fields[i];
@@ -73,23 +139,51 @@ function checkShallow(fields) {
   return true;
 }
 
-function createMapper(fields, emit) {
+function createMapper(fields, selector, emit) {
   var isShallow = checkShallow(fields);
   var isSingle = fields.length === 1;
+  var inMemoryFields = null;
+
+  if (selector) {
+    /* istanbul ignore if */
+    if (typeof selector !== 'object') {
+      // match the CouchDB error message
+      throw new Error('Selector error: expected a JSON object');
+    }
+
+    selector = massageSelector(selector);
+    inMemoryFields = Object.keys(selector);
+  }
 
   // notice we try to optimize for the most common case,
   // i.e. single shallow indexes
   if (isShallow) {
     if (isSingle) {
-      return createShallowSingleMapper(fields[0], emit);
+      if (selector) {
+        return createShallowSingleMapperWithSelector(fields[0], selector, inMemoryFields, emit);
+      } else {
+        return createShallowSingleMapper(fields[0], emit);
+      }
     } else { // multi
-      return createShallowMultiMapper(fields, emit);
+      if (selector) {
+        return createShallowMultiMapperWithSelector(fields, selector, inMemoryFields, emit);
+      } else {
+        return createShallowMultiMapper(fields, emit);
+      }
     }
   } else { // deep
     if (isSingle) {
-      return createDeepSingleMapper(fields[0], emit);
+      if (selector) {
+        return createDeepSingleMapperWithSelector(fields[0], selector, inMemoryFields, emit);
+      } else {
+        return createDeepSingleMapper(fields[0], emit);
+      }
     } else { // multi
-      return createDeepMultiMapper(fields, emit);
+      if (selector) {
+        return createDeepMultiMapperWithSelector(fields, selector, inMemoryFields, emit);
+      } else {
+        return createDeepMultiMapper(fields, emit);
+      }
     }
   }
 }
@@ -98,8 +192,9 @@ function mapper(mapFunDef, emit) {
   // mapFunDef is a list of fields
 
   var fields = Object.keys(mapFunDef.fields);
+  var selector = mapFunDef.partial_filter_selector;
 
-  return createMapper(fields, emit);
+  return createMapper(fields, selector, emit);
 }
 
 /* istanbul ignore next */

--- a/packages/node_modules/pouchdb-find/src/adapters/local/create-index/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/create-index/index.js
@@ -42,7 +42,8 @@ function createIndex(db, requestDef) {
 
     doc.views[viewName] = {
       map: {
-        fields: mergeObjects(requestDef.index.fields)
+        fields: mergeObjects(requestDef.index.fields),
+        partial_filter_selector: requestDef.index.partial_filter_selector
       },
       reduce: '_count',
       options: {

--- a/tests/find/test-suite-1/test.partial-filter-selector.js
+++ b/tests/find/test-suite-1/test.partial-filter-selector.js
@@ -1,0 +1,34 @@
+'use strict';
+
+testCases.push(function (dbType, context) {
+
+  describe(dbType + ': test.partial-filter-selector.js', function () {
+
+    it('uses partial_filter_selector', function () {
+      var db = context.db;
+      return db.bulkDocs([
+        { _id: 'bookmark:1' },
+        { _id: 'list:1' }
+      ]).then(function () {
+        return db.createIndex({
+          index: {
+            partial_filter_selector: { _id: { $regex: '^bookmark:.+$' } },
+            fields: ['_id'],
+          },
+          ddoc: 'bookmark-search',
+        });
+      }).then(function () {
+        return db.find({
+          selector: { _id: { $gt: null } },
+          fields: ["_id"],
+          use_index: 'bookmark-search',
+        });
+      }).then(function (resp) {
+        resp.docs.should.deep.equal([
+          { _id: 'bookmark:1' },
+        ]);
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
This commit implements [partial indexes](http://docs.couchdb.org/en/stable/api/database/find.html#find-partial-indexes) for #7467.

It attempts to mitigate the work of matching selectors (and follows the style of having the "smallest possible map function") by doing all the massage work of the selector outside of the map functions and duplicating the create functions to avoid a test in the simpler cases.

The added test is derived from the test script provided by @garbados in https://github.com/pouchdb/pouchdb/issues/7467.