### PR TITLE
Fix `allDocs` options formatting

### DIFF
--- a/docs/_includes/api/batch_fetch.html
+++ b/docs/_includes/api/batch_fetch.html
@@ -11,9 +11,9 @@ Fetch multiple documents, indexed and sorted by the `_id`.  Deleted documents ar
 All options default to `false` unless otherwise specified.
 
 * `options.include_docs`: Include the document itself in each row in the `doc` field. Otherwise by default you only get the `_id` and `_rev` properties.
-    - `options.conflicts`: Include conflict information in the `_conflicts` field of a doc.
-  - `options.attachments`: Include attachment data as base64-encoded string.
-    - `options.binary`: Return attachment data as Blobs/Buffers, instead of as base64-encoded strings.
+* `options.conflicts`: Include conflict information in the `_conflicts` field of a doc.
+* `options.attachments`: Include attachment data as base64-encoded string.
+* `options.binary`: Return attachment data as Blobs/Buffers, instead of as base64-encoded strings.
 * `options.startkey` &amp; `options.endkey`: Get documents with IDs in a certain range (inclusive/inclusive).
 * `options.inclusive_end`: Include documents having an ID equal to the given `options.endkey`. Default: `true`.
 * `options.limit`: Maximum number of documents to return.


### PR DESCRIPTION
Adjusts the list item position for `conflicts`, `attachments`, and `binary` options.