### PR TITLE
(#7495) - Fix how `fetch` resolves absolute URIs

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -435,7 +435,7 @@ function HttpPouch(opts, callback) {
 
   api.fetch = function (path, options) {
     return setup().then(function () {
-      let url = path.startsWith('/') ?
+      var url = path.startsWith('/') ?
         genUrl(host, path.substring(1)) :
         genDBUrl(host, path);
       return ourFetch(url, options);

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -435,7 +435,10 @@ function HttpPouch(opts, callback) {
 
   api.fetch = function (path, options) {
     return setup().then(function () {
-      return ourFetch(genDBUrl(host, path), options);
+      let url = path.startsWith('/') ?
+        genUrl(host, path.substring(1)) :
+        genDBUrl(host, path);
+      return ourFetch(url, options);
     });
   };
 

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -435,7 +435,7 @@ function HttpPouch(opts, callback) {
 
   api.fetch = function (path, options) {
     return setup().then(function () {
-      var url = path.startsWith('/') ?
+      var url = path.substring(0, 1) === '/' ?
         genUrl(host, path.substring(1)) :
         genDBUrl(host, path);
       return ourFetch(url, options);

--- a/tests/component/test.ajax.js
+++ b/tests/component/test.ajax.js
@@ -27,4 +27,36 @@ describe('test.ajax.js', function () {
       });
     });
   });
+
+  it('fetch handles relative uris', function (done) {
+    var server = http.createServer(function (req, res) {
+      res.end(JSON.stringify({ok: req.url === '/testdb/path'}));
+    });
+    server.listen(6000, function () {
+      var db = new PouchDB('http://127.0.0.1:6000/testdb', { skip_setup: true });
+      db.fetch('path').then(function (response) {
+        return response.json();
+      }).then(function (res) {
+        server.close();
+        should.equal(res.ok, true, "Fetch did not resolve uri");
+        done();
+      });
+    });
+  });
+
+  it('fetch handles absolute uris', function (done) {
+    var server = http.createServer(function (req, res) {
+      res.end(JSON.stringify({ok: req.url === '/root-path'}));
+    });
+    server.listen(6000, function () {
+      var db = new PouchDB('http://127.0.0.1:6000/testdb', { skip_setup: true });
+      db.fetch('/root-path').then(function (response) {
+        return response.json();
+      }).then(function (res) {
+        server.close();
+        should.equal(res.ok, true, "Fetch did not resolve uri");
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
If the provided path is an absolute path, then resolve the path on the host directly.