### PR TITLE
[documentation] Attempt to clean up documentation of query()'s options.reduce

### DIFF
--- a/docs/_includes/api/query_database.html
+++ b/docs/_includes/api/query_database.html
@@ -27,7 +27,11 @@ All options default to `false` unless otherwise specified.
   * A full CouchDB-style map/reduce view: `{map : ..., reduce: ...}`.
   * A map function by itself (no reduce).
   * The name of a view in an existing design document (e.g. `'mydesigndoc/myview'`, or `'myview'` as a shorthand for `'myview/myview'`).
-* `options.reduce`: Reduce function, or the string name of a built-in function: `'_sum'`, `'_count'`, or `'_stats'`.  Defaults to `true` when a reduce function is defined, or `false` otherwise.
+* `options.reduce`: Defaults to `true` when a reduce function is defined, or `false` otherwise.  Valid values:
+  * `true` - calls the defined `reduce` function, or the `map` function if no `reduce` is defined.
+  * `false` - calls the defined `map` function.
+  * A reduce function.
+  * The string name of a built-in function: `'_sum'`, `'_count'`, or `'_stats'`.
     * Tip: if you're not using a built-in, [you're probably doing it wrong](http://youtu.be/BKQ9kXKoHS8?t=865s).
     * PouchDB will always call your reduce function with rereduce == false. As for CouchDB, refer to the [CouchDB documentation](http://docs.couchdb.org/en/1.6.1/couchapp/views/intro.html).
 * `options.include_docs`: Include the document in each row in the `doc` field.


### PR DESCRIPTION
I think the current documentation of `query()` is poorly-worded with respect to `options.reduce`.  This PR _attempts_ to clean that up.

Note that this PR documents the current behaviour that when `options.reduce` is set to `true`, but no `reduce` function is defined, the `map` result is returned.  This seems like it may be unintentional; perhaps it shouldn't be documented?

```javascript
db = new PouchDB('test')

Promise.resolve()
  .then(db.post({}))
  .then(db.post({}))
  .then(db.post({}))
  .then(() => {
    db.query(function(doc) { emit(doc.val); }, { reduce:false })
      .then(console.log)
      .catch(console.log)
  })
```

-----

## Current docs:

![current](https://user-images.githubusercontent.com/191496/48056477-30906d80-e1b2-11e8-8fbe-64d7c4c51638.png)

## Proposed docs:

I'm not 100% happy with the second-level indentation of tips, but I can't see a precedent for handling this elsewhere in the docs.
![query-options reduce](https://user-images.githubusercontent.com/191496/48056409-03dc5600-e1b2-11e8-987c-baec6272d4d7.png)
