### PR TITLE
Use index even for non-logical operators

### DIFF
--- a/packages/node_modules/pouchdb-find/src/adapters/local/find/query-planner.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/find/query-planner.js
@@ -147,14 +147,6 @@ function checkFieldsLogicallySound(indexFields, selector) {
     return true;
   }
 
-  var hasLogicalOperator = Object.keys(matcher).some(function (matcherKey) {
-    return !(isNonLogicalMatcher(matcherKey));
-  });
-
-  if (!hasLogicalOperator) {
-    return false;
-  }
-
   var isInvalidNe = Object.keys(matcher).length === 1 &&
     getKey(matcher) === '$ne';
 
@@ -276,6 +268,10 @@ function getSingleFieldQueryOptsFor(userOperator, userValue) {
         inclusive_start: false
       };
   }
+
+  return {
+    startkey: COLLATE_LO
+  };
 }
 
 function getSingleFieldCoreQueryPlan(selector, index) {
@@ -293,7 +289,6 @@ function getSingleFieldCoreQueryPlan(selector, index) {
 
     if (isNonLogicalMatcher(userOperator)) {
       inMemoryFields.push(field);
-      return;
     }
 
     var userValue = matcher[userOperator];


### PR DESCRIPTION
When selecting an index for a query don't reject the index if the field
found in the selector is non-logical. Rather use the index with the
default start key. Using the index will automatically
narrow down the list of documents so that is better than using
_all_docs. This fix helps pouchdb-find match CouchDB Mango on index selection.