### PR TITLE
**WIP** Proposal: Stream test results and beautify output

### DIFF
--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -100,8 +100,15 @@ testUrl += querystring.stringify(qs);
 function testError(e) {
   console.error(e);
   console.error('Doh, tests failed');
-  sauceClient.quit();
-  process.exit(3);
+  sauceClient.quit().then(function () {
+    if (sauceConnectProcess) {
+      sauceConnectProcess.close(function () {
+        process.exit(3);
+      });
+    } else {
+      process.exit(3);
+    }
+  });
 }
 
 function testComplete(result) {
@@ -268,7 +275,7 @@ function startTest() {
                 }
               }
             });
-          }, /*10 * */1000);
+          }, 10 * 1000);
 
         }
       });

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -176,7 +176,7 @@ RemoteRunner.prototype.handleEvents = function (events) {
     self.completed = self.completed || event.name === 'end';
     self.failed = self.failed || event.name === 'fail';
 
-    var additionalProps = event.name !== 'pass' ? {} : {
+    var additionalProps = ['pass', 'fail', 'pending'].indexOf(event.name) === -1 ? {} : {
       slow: event.obj.slow ? function () { return event.obj.slow; } : undefined,
       fullTitle: event.obj.fullTitle ? function () { return event.obj.fullTitle; } : undefined
     };

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -146,13 +146,13 @@ function startSauceConnect(callback) {
     tunnelIdentifier: tunnelId
   };
 
-  sauceConnectLauncher(options, function (err, process) {
+  sauceConnectLauncher(options, function (err, sauceProcess) {
     if (err) {
       console.error('Failed to connect to saucelabs');
       console.error(err);
       return process.exit(1);
     }
-    sauceConnectProcess = process;
+    sauceConnectProcess = sauceProcess;
     sauceClient = wd.promiseChainRemote("localhost", 4445, username, accessKey);
     callback();
   });

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -262,7 +262,12 @@ function startTest() {
 
                 if (runner.completed || (runner.failed && bail)) {
                   if (!runner.completed && runner.failed) {
-                    runner.bail();
+                    try {
+                      runner.bail();
+                    } catch (e) {
+                      // Temporary debugging of bailing failure
+                      console.log(e);
+                    }
                   }
 
                   clearInterval(interval);

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -254,23 +254,29 @@ function startTest() {
           /* jshint evil: true */
           var interval = setInterval(function () {
             sauceClient.eval('window.testEvents()', function (err, events) {
-              if (err) {
-                clearInterval(interval);
-                testError(err);
-              } else if (events) {
-                runner.handleEvents(events);
-
-                if (runner.completed || (runner.failed && bail)) {
-                  if (!runner.completed && runner.failed) {
-                    runner.bail();
-                  }
-
+              try {
+                if (err) {
                   clearInterval(interval);
+                  testError(err);
+                } else if (events) {
+                  runner.handleEvents(events);
 
-                  closeClient(function () {
-                    process.exit(!process.env.PERF && runner.failed ? 1 : 0);
-                  });
+                  if (runner.completed || (runner.failed && bail)) {
+                    if (!runner.completed && runner.failed) {
+                      runner.bail();
+
+                      clearInterval(interval);
+
+                      closeClient(function () {
+                        process.exit(!process.env.PERF && runner.failed ? 1 : 0);
+                      });
+                    }
+                  }
                 }
+              } catch (e) {
+                // Temporary debugging of bailing failure
+                console.log('An error occurred while processing test events:');
+                console.log(e);
               }
             });
           }, 10 * 1000);

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -177,8 +177,8 @@ RemoteRunner.prototype.handleEvents = function (events) {
     self.failed = self.failed || event.name === 'fail';
 
     var additionalProps = event.name !== 'pass' ? {} : {
-      slow() { return event.obj.slow; },
-      fullTitle() { return event.obj.fullTitle; }
+      slow: event.obj.slow ? function () { return event.obj.slow; } : undefined,
+      fullTitle: event.obj.fullTitle ? function () { return event.obj.fullTitle; } : undefined
     };
     var obj = Object.assign({}, event.obj, additionalProps);
 
@@ -262,12 +262,7 @@ function startTest() {
 
                 if (runner.completed || (runner.failed && bail)) {
                   if (!runner.completed && runner.failed) {
-                    try {
-                      runner.bail();
-                    } catch (e) {
-                      // Temporary debugging of bailing failure
-                      console.log(e);
-                    }
+                    runner.bail();
                   }
 
                   clearInterval(interval);

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -7,7 +7,6 @@ wd.configureHttp({timeout: 180000}); // 3 minutes
 var sauceConnectLauncher = require('sauce-connect-launcher');
 var selenium = require('selenium-standalone');
 var querystring = require("querystring");
-var request = require('request').defaults({json: true});
 
 var MochaSpecReporter = require('mocha').reporters.Spec;
 
@@ -105,40 +104,14 @@ function testError(e) {
   process.exit(3);
 }
 
-function postResult(result) {
-  if (process.env.PERF && process.env.DASHBOARD_HOST) {
-    result.branch = process.env.TRAVIS_BRANCH || process.env.BRANCH || false;
-    result.commit = process.env.TRAVIS_COMMIT || process.env.COMMIT || false;
-    result.pull_request = process.env.TRAVIS_PULL_REQUEST;
-    var commits = 'https://api.github.com/repos/pouchdb/pouchdb/git/commits/';
-    request({
-      method: 'GET',
-      uri: commits + result.commit,
-      headers: {'User-Agent': 'request'}
-    }, function (error, response, body) {
-      result._id = result.date = body.committer.date;
-      request({
-        method: 'POST',
-        uri: process.env.DASHBOARD_HOST + '/performance_results',
-        json: result
-      }, function (error) {
-        console.log(result);
-        process.exit(!!error);
-      });
-    });
-    return;
-  }
-  process.exit(!process.env.PERF && result.failures ? 1 : 0);
-}
-
 function testComplete(result) {
   sauceClient.quit().then(function () {
     if (sauceConnectProcess) {
       sauceConnectProcess.close(function () {
-        postResult(result);
+        process.exit(!process.env.PERF && result.failures ? 1 : 0);
       });
     } else {
-      postResult(result);
+      process.exit(!process.env.PERF && result.failures ? 1 : 0);
     }
   });
 }

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -188,10 +188,10 @@ RemoteRunner.prototype.handleEvents = function (events) {
 
     if (event.logs && event.logs.length > 0) {
       event.logs.forEach(function (line) {
-        if (line[0] === 'log') {
-          console.log.apply(null, line.slice(1));
-        } else if (line[0] === 'error') {
-          console.error.apply(null, line.slice(1));
+        if (line.type === 'log') {
+          console.log(line.content);
+        } else if (line.type === 'error') {
+          console.error(line.content);
         } else {
           console.error('Invalid log line', line);
         }

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -276,13 +276,13 @@ function startTest() {
                         console.log('An error occurred while bailing:');
                         console.log(e);
                       }
-
-                      clearInterval(interval);
-
-                      closeClient(function () {
-                        process.exit(!process.env.PERF && runner.failed ? 1 : 0);
-                      });
                     }
+
+                    clearInterval(interval);
+
+                    closeClient(function () {
+                      process.exit(!process.env.PERF && runner.failed ? 1 : 0);
+                    });
                   }
                 }
             });

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -268,11 +268,11 @@ function startTest() {
 
           /* jshint evil: true */
           var interval = setInterval(function () {
-            sauceClient.eval('window.testEvents()', function (err, events) {
+            sauceClient.eval('typeof window.testEvents === \'function\' && window.testEvents()', function (err, events) {
               if (err) {
                 clearInterval(interval);
                 testError(err);
-              } else {
+              } else if (events) {
                 runner.handleEvents(events);
 
                 if (runner.completed || (runner.failed && bail)) {

--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -122,19 +122,20 @@
         })();
 
         // Capture test events for selenium output
-        window.testEventsBuffer = [];
+        var testEventsBuffer = [];
 
         window.testEvents = function () {
-          var events = window.testEventsBuffer;
-          window.testEventsBuffer = [];
+          var events = testEventsBuffer;
+          testEventsBuffer = [];
           return events;
         };
 
         mocha.reporter(function (runner) {
-          ['start', 'end', 'suite', 'suite end', 'pass', 'pending', 'fail'].forEach(function (name) {
+          var eventNames = ['start', 'end', 'suite', 'suite end', 'pass', 'pending', 'fail'];
+          eventNames.forEach(function (name) {
             runner.on(name, function (obj, err) {
-              window.testEventsBuffer.push({
-                name,
+              testEventsBuffer.push({
+                name: name,
                 obj: obj && {
                   root: obj.root,
                   title: obj.title,

--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -161,7 +161,7 @@
                   stack: err.stack,
                   uncaught: err.uncaught
                 },
-                logs: JSON.parse(stringifyWithErrors(logs))
+                logs: logs
               });
               logs = [];
             });

--- a/tests/performance/index.js
+++ b/tests/performance/index.js
@@ -13,6 +13,7 @@ function runTestSuites(PouchDB) {
 
   function runTestsNow() {
     var reporter = require('./perf.reporter');
+    reporter.startAll();
     reporter.log('Testing PouchDB version ' + PouchDB.version +
       (opts.adapter ?
         (', using adapter: ' + opts.adapter) : '') +

--- a/tests/performance/perf.reporter.js
+++ b/tests/performance/perf.reporter.js
@@ -4,14 +4,15 @@ var UAParser = require('ua-parser-js');
 var ua = !isNode && new UAParser(navigator.userAgent);
 var marky = require('marky');
 var median = require('median');
-global.results = {
+
+var results = {
   tests: {}
 };
 
 // Capture test events for selenium output
 var testEventsBuffer = [];
 
-window.testEvents = function () {
+global.testEvents = function () {
   var events = testEventsBuffer;
   testEventsBuffer = [];
   return events;
@@ -49,14 +50,14 @@ exports.start = function (testCase, iter) {
   var key = testCase.name;
   log('Starting test: ' + key + ' with ' + testCase.assertions +
     ' assertions and ' + iter + ' iterations... ');
-  global.results.tests[key] = {
+  results.tests[key] = {
     iterations: []
   };
 };
 
 exports.end = function (testCase) {
   var key = testCase.name;
-  var obj = global.results.tests[key];
+  var obj = results.tests[key];
   obj.median = median(obj.iterations);
   obj.numIterations = obj.iterations.length;
   delete obj.iterations; // keep it simple when reporting
@@ -71,7 +72,7 @@ exports.startIteration = function (testCase) {
 
 exports.endIteration = function (testCase) {
   var entry = marky.stop(testCase.name);
-  global.results.tests[testCase.name].iterations.push(entry.duration);
+  results.tests[testCase.name].iterations.push(entry.duration);
 };
 
 exports.startAll = function () {
@@ -79,13 +80,13 @@ exports.startAll = function () {
 };
 
 exports.complete = function (adapter) {
-  global.results.completed = true;
+  results.completed = true;
   if (isNode) {
-    global.results.client = {
+    results.client = {
       node: process.version
     };
   } else {
-    global.results.client = {
+    results.client = {
       browser: ua.getBrowser(),
       device: ua.getDevice(),
       engine: ua.getEngine(),
@@ -94,9 +95,9 @@ exports.complete = function (adapter) {
       userAgent: navigator.userAgent
     };
   }
-  global.results.adapter = adapter;
-  console.log('=>', JSON.stringify(global.results, null, '  '), '<=');
+  results.adapter = adapter;
+  console.log('=>', JSON.stringify(results, null, '  '), '<=');
   log('\nTests Complete!\n\n');
-  testEventsBuffer.push({ name: 'end' });
+  testEventsBuffer.push({ name: 'end', obj: results });
 };
 

--- a/tests/performance/utils.js
+++ b/tests/performance/utils.js
@@ -100,6 +100,7 @@ exports.runTests = function (PouchDB, suiteName, testCases, opts, callback) {
         }).then(function () {
           t.end();
           if (i === testCases.length - 1) {
+            reporter.endSuite(suiteName);
             callback(adapterUsed);
           }
         });


### PR DESCRIPTION
One of the difficult things I encountered when I first worked on PouchDB was to understand the output of the remote (i.e. selenium and saucelabs) tests on Travis.

This PR is a proposal to enhance the test output for selenium/saucelabs test jobs. When the test is remote (selenium/saucelabs), the mocha runner events are sent over the network and a mocha Spec reporter is used locally. The output at the end of the tests cleanly show the failed tests, their actual/expected values of the failed assertions and their errors stack traces.

The changes have been tested at home:
- with `npm run dev` (the reporter is still the one in the browser)
- with selenium
- with `BAIL=0`

#### Pros:
- test results are easy to understand
- test results are formatted as the node test results
- logs are attached to each test and displayed after the Spec reported line

#### Cons:
- more data is sent over the network

#### Yet to do:
- understand what the `postResults(...)` function does and what data the so-called `DASHBOARD_HOST` expects.