### PR TITLE
Stream test results and beautify output

### DIFF
--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -34,6 +34,9 @@
     });
   }
 
+  var remote = window.location.search.match(/[?&]remote=([^&]+)/);
+  remote = remote && remote[1] === '1';
+
 // Thanks to http://engineeredweb.com/blog/simple-async-javascript-loader/
   function asyncLoadScript(url, callback) {
 
@@ -94,60 +97,79 @@
 
       modifyGlobals();
 
-      var runner = mocha.run();
+      if (remote) {
+        // Capture logs for selenium output
+        var logs = [];
 
-      // Capture logs for selenium output
-      var logs = [];
+        (function () {
 
+          function serializeLogItem(obj, filter, space) {
+            if (typeof obj === 'string') {
+              return obj;
+            } else if (obj instanceof Error) {
+              return obj.stack;
+            } else {
+              return JSON.stringify(obj, filter, space);
+            }
+          }
 
-      (function () {
+          function wrappedLog(oldLog, type) {
+            return function () {
+              var args = Array.prototype.slice.call(arguments);
+              logs.push({
+                type: type,
+                content: args.map(function (arg) {
+                  return serializeLogItem(arg);
+                }).join(' ')
+              });
+              oldLog.apply(console, arguments);
+            };
+          }
 
-        var oldLog = console.log;
-        console.log = function () {
-          var args = Array.prototype.slice.call(arguments);
-          args.unshift('log');
-          logs.push(args);
-          oldLog.apply(console, arguments);
+          console.log = wrappedLog(console.log, 'log');
+          console.error = wrappedLog(console.error, 'error');
+
+        })();
+
+        // Capture test events for selenium output
+        var testEventsBuffer = [];
+
+        window.testEvents = function () {
+          var events = testEventsBuffer;
+          testEventsBuffer = [];
+          return events;
         };
 
-        var oldError = console.error;
-        console.error = function () {
-          var args = Array.prototype.slice.call(arguments);
-          args.unshift('error');
-          logs.push(args);
-          oldError.apply(console, arguments);
-        };
-
-      })();
-
-      window.results = {
-        browser: navigator.userAgent,
-        lastPassed: '',
-        passed: 0,
-        failed: 0,
-        failures: []
-      };
-
-      runner.on('pass', function (e) {
-        window.results.lastPassed = e.title;
-        window.results.passed++;
-      });
-
-      runner.on('fail', function (e) {
-        window.results.logs = logs;
-        window.results.failed++;
-        window.results.failures.push({
-          title: e.title,
-          message: e.err.message,
-          stack: e.err.stack
+        mocha.reporter(function (runner) {
+          var eventNames = ['start', 'end', 'suite', 'suite end', 'pass', 'pending', 'fail'];
+          eventNames.forEach(function (name) {
+            runner.on(name, function (obj, err) {
+              testEventsBuffer.push({
+                name: name,
+                obj: obj && {
+                  root: obj.root,
+                  title: obj.title,
+                  duration: obj.duration,
+                  slow: typeof obj.slow === 'function' ? obj.slow() : undefined,
+                  fullTitle: typeof obj.fullTitle === 'function' ? obj.fullTitle() : undefined
+                },
+                err: err && {
+                  actual: err.actual,
+                  expected: err.expected,
+                  showDiff: err.showDiff,
+                  message: err.message,
+                  stack: err.stack,
+                  uncaught: err.uncaught
+                },
+                logs: logs
+              });
+              logs = [];
+            });
+          });
         });
-      });
+      }
 
-      runner.on('end', function () {
-        window.results.logs = logs;
-        window.results.completed = true;
-        window.results.passed++;
-      });
+      mocha.run();
     }
 
     loadNext();

--- a/tests/performance/index.js
+++ b/tests/performance/index.js
@@ -13,6 +13,7 @@ function runTestSuites(PouchDB) {
 
   function runTestsNow() {
     var reporter = require('./perf.reporter');
+    reporter.startAll();
     reporter.log('Testing PouchDB version ' + PouchDB.version +
       (opts.adapter ?
         (', using adapter: ' + opts.adapter) : '') +

--- a/tests/performance/utils.js
+++ b/tests/performance/utils.js
@@ -100,6 +100,7 @@ exports.runTests = function (PouchDB, suiteName, testCases, opts, callback) {
         }).then(function () {
           t.end();
           if (i === testCases.length - 1) {
+            reporter.endSuite(suiteName);
             callback(adapterUsed);
           }
         });


### PR DESCRIPTION
One of the difficult things I encountered when I first worked on PouchDB
was to understand the output of the remote (i.e. selenium and saucelabs)
tests on Travis.

This PR enhances the test output for selenium/saucelabs test jobs. When
the test is remote (selenium/saucelabs), the mocha runner events are sent
over the network and a mocha Spec reporter is used locally. The output at
the end of the tests cleanly show the failed tests, their actual/expected
values of the failed assertions and their errors stack traces.

The changes have been tested at home:
- with npm run dev (the reporter is still the one in the browser)
- with selenium
- with saucelabs
- with BAIL=0
- with PERF=1
- manually adding errors to test cases to test bailing