### PR TITLE
Some IDBNext fixes

### DIFF
--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
@@ -192,8 +192,11 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
     if (rewriteEnabled) {
       // doc.data is what we index, so we need to clone and rewrite it, and clean
       // it up for indexability
-      doc.data = rewrite(theDoc);
-      delete doc.data._attachments;
+      var result = rewrite(theDoc);
+      if (result) {
+        doc.data = result;
+        delete doc.data._attachments;
+      }
     } else {
       doc.data = theDoc;
     }

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
@@ -31,6 +31,7 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
   var lastWriteIndex;
 
   var revsLimit = dbOpts.revs_limit || 1000;
+  var rewriteEnabled = dbOpts.name.indexOf("-mrview-") === -1;
 
   // We only need to track 1 revision for local documents
   function docsRevsLimit(doc) {
@@ -188,10 +189,14 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
 
     var theDoc = doc.revs[winningRev].data;
 
-    // doc.data is what we index, so we need to clone and rewrite it, and clean
-    // it up for indexability
-    doc.data = rewrite(theDoc);
-    delete doc.data._attachments;
+    if (rewriteEnabled) {
+      // doc.data is what we index, so we need to clone and rewrite it, and clean
+      // it up for indexability
+      doc.data = rewrite(theDoc);
+      delete doc.data._attachments;
+    } else {
+      doc.data = theDoc;
+    }
 
     doc.rev = winningRev;
     // .deleted needs to be an int for indexing

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
@@ -196,6 +196,8 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
       if (result) {
         doc.data = result;
         delete doc.data._attachments;
+      } else {
+        doc.data = theDoc;
       }
     } else {
       doc.data = theDoc;

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/rewrite.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/rewrite.js
@@ -24,6 +24,19 @@ var KEY_INVALID = /[^a-zA-Z0-9_$]+|(^[^a-zA-Z_$])/g;
 var PATH_INVALID = /(\\.)|[^a-zA-Z0-9_$.]+|(^[^a-zA-Z_$])/g;
 var SLASH = '\\'.charCodeAt(0);
 
+// These are the same as above but without the global flag
+// we want to use RegExp.test because it's really fast, but the global flag
+// makes the regex const stateful (seriously) as it walked through all instances
+var TEST_KEY_INVALID = /[^a-zA-Z0-9_$]+|(^[^a-zA-Z_$])/;
+var TEST_PATH_INVALID = /(\\.)|[^a-zA-Z0-9_$.]+|(^[^a-zA-Z_$])/;
+function needsSanitise(name, isPath) {
+  if (isPath) {
+    return TEST_PATH_INVALID.test(name);
+  } else {
+    return TEST_KEY_INVALID.test(name);
+  }
+}
+
 function sanitise(name, isPath) {
   var correctCharacters = function (match) {
     var good = '';
@@ -51,7 +64,23 @@ function sanitise(name, isPath) {
   }
 }
 
+function needsRewrite(data) {
+  for (var key of Object.keys(data)) {
+    if (needsSanitise(key)) {
+      return true;
+    } else if (data[key] === null || typeof data[key] === 'boolean') {
+      return true;
+    } else if (typeof data[key] === 'object') {
+      return needsRewrite(data[key]);
+    }
+  }
+}
+
 function rewrite(data) {
+  if (!needsRewrite(data)) {
+    return data;
+  }
+
   var isArray = Array.isArray(data);
   var clone = isArray
     ? []

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/rewrite.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/rewrite.js
@@ -78,7 +78,7 @@ function needsRewrite(data) {
 
 function rewrite(data) {
   if (!needsRewrite(data)) {
-    return data;
+    return false;
   }
 
   var isArray = Array.isArray(data);

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/setup.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/setup.js
@@ -58,7 +58,7 @@ function maintainNativeIndexes(openReq, reject) {
       return Object.keys(ddoc.views).reduce(function (acc, viewName) {
         var fields = rawIndexFields(ddoc, viewName);
 
-        if (fields) {
+        if (fields && fields.length > 0) {
           acc[naturalIndexName(fields)] = correctIndexFields(fields);
         }
 

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/setup.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/setup.js
@@ -135,7 +135,7 @@ function openDatabase(openDatabases, api, opts, resolve, reject) {
     };
 
     idb.onversionchange = function () {
-      console.log('Database was made stale by being opened in another tab');
+      console.log('Database was made stale, closing handle');
       openDatabases[opts.name].versionchanged = true;
       idb.close();
     };

--- a/tests/find/test-suite-1/test.escaping.js
+++ b/tests/find/test-suite-1/test.escaping.js
@@ -131,4 +131,40 @@ testCases.push(function (dbType, context) {
     });
   });
 
+  it('deeper values can be escaped', function () {
+      var db = context.db;
+      var index = {
+        "index": {
+          "fields": [
+            "foo.bar.0foobar"
+          ]
+        },
+        "name": "foo-index",
+        "type": "json"
+      };
+      var foo = {
+        bar: {
+          '0foobar': 'a'
+        },
+        "0baz": false,
+        just: {
+          normal: "stuff"
+        }
+      };
+      return db.bulkDocs([{
+        _id: 'doc',
+        foo: foo
+      }
+      ]).then(function () {
+        return db.createIndex(index);
+      }).then(function () {
+        return db.find({
+          selector: {'foo.bar.0foobar': 'a'},
+          fields: ['_id', 'foo']
+        });
+      }).then(function (res) {
+        res.docs.should.deep.equal([foo]);
+      });
+    });
+
 });

--- a/tests/find/test-suite-1/test.escaping.js
+++ b/tests/find/test-suite-1/test.escaping.js
@@ -142,20 +142,20 @@ testCases.push(function (dbType, context) {
         "name": "foo-index",
         "type": "json"
       };
-      var foo = {
-        bar: {
-          '0foobar': 'a'
-        },
-        "0baz": false,
-        just: {
-          normal: "stuff"
+      var doc = {
+        _id: 'doc',
+        foo: {
+          bar: {
+            '0foobar': 'a'
+          },
+          "0baz": false,
+          just: {
+            normal: "stuff"
+          }
         }
       };
-      return db.bulkDocs([{
-        _id: 'doc',
-        foo: foo
-      }
-      ]).then(function () {
+      return db.bulkDocs([doc])
+      .then(function () {
         return db.createIndex(index);
       }).then(function () {
         return db.find({
@@ -163,7 +163,7 @@ testCases.push(function (dbType, context) {
           fields: ['_id', 'foo']
         });
       }).then(function (res) {
-        res.docs.should.deep.equal([foo]);
+        res.docs.should.deep.equal([doc]);
       });
     });
 

--- a/tests/performance/perf.basics.js
+++ b/tests/performance/perf.basics.js
@@ -68,7 +68,7 @@ module.exports = function (PouchDB, opts, callback) {
         // algorithm (eg cloning) very slow.
         // We're also adding in something that IndexedDB needs to rewrite (slowing things down more)
         // Other implementations are welcome to put things here that cause write slowness
-        var innerDoc = function(count) {
+        var innerDoc = function (count) {
           var inner = {};
 
           if (count > 6) {
@@ -80,13 +80,13 @@ module.exports = function (PouchDB, opts, callback) {
               inner["sovery"+i] = i + "cool";
             }
           } else {
-            for (var i = 0; i < 4; i++) {
-              inner["sovery"+i] = innerDoc(count + 1)
+            for (var ii = 0; ii < 4; ii++) {
+              inner["sovery"+ii] = innerDoc(count + 1);
             }
           }
 
           return inner;
-        }
+        };
 
         for (var d = 0; d < 50; d++) {
           docs.push(innerDoc(1));

--- a/tests/performance/perf.basics.js
+++ b/tests/performance/perf.basics.js
@@ -22,40 +22,6 @@ module.exports = function (PouchDB, opts, callback) {
       }
     },
     {
-      name: 'basic-inserts-large-docs',
-      assertions: 1,
-      iterations: 100,
-      setup: function (db, callback) {
-        var doc = {};
-        for (var i = 0; i < 100; i++) {
-          doc['hello' + i] = "hey" + i;
-        }
-        callback(null, {doc : doc});
-      },
-      test: function (db, itr, doc, done) {
-        db.post(doc, done);
-      }
-    },
-    {
-      name: 'basic-inserts-deep-docs',
-      assertions: 1,
-      iterations: 100,
-      setup: function (db, callback) {
-        var doc = {};
-        for (var i = 0; i < 50; i++) {
-          var inner = {};
-          for (var j = 0; j < 100; j++) {
-            inner["sovery"+j] = j + "cool";
-          }
-          doc['hello' + i] = inner;
-        }
-        callback(null, {doc : doc});
-      },
-      test: function (db, itr, doc, done) {
-        db.post(doc, done);
-      }
-    },
-    {
       name: 'bulk-inserts',
       assertions: 1,
       iterations: 100,
@@ -64,6 +30,52 @@ module.exports = function (PouchDB, opts, callback) {
         for (var i = 0; i < 100; i++) {
           docs.push({much : 'docs', very : 'bulk'});
         }
+        callback(null, {docs : docs});
+      },
+      test: function (db, itr, docs, done) {
+        db.bulkDocs(docs, done);
+      }
+    },
+    {
+      name: 'bulk-inserts-large-docs',
+      assertions: 1,
+      iterations: 100,
+      setup: function (db, callback) {
+        var docs = [];
+
+        for (var d = 0; d < 100; d++) {
+          var doc = {};
+          for (var i = 0; i < 100; i++) {
+            doc['hello' + i] = "hey" + i;
+          }
+          docs.push(doc);
+        }
+
+        callback(null, {docs : docs});
+      },
+      test: function (db, itr, docs, done) {
+        db.bulkDocs(docs, done);
+      }
+    },
+    {
+      name: 'bulk-inserts-deep-docs',
+      assertions: 1,
+      iterations: 100,
+      setup: function (db, callback) {
+        var docs = [];
+
+        for (var d = 0; d < 100; d++) {
+          var doc = {};
+          for (var i = 0; i < 50; i++) {
+            var inner = {};
+            for (var j = 0; j < 100; j++) {
+              inner["sovery"+j] = j + "cool";
+            }
+            doc['hello' + i] = inner;
+          }
+          docs.push(doc);
+        }
+
         callback(null, {docs : docs});
       },
       test: function (db, itr, docs, done) {


### PR DESCRIPTION
So I started using IDBNext at work to prototype perf increases in our app, and I found a couple of bugs.

First, `rewrite`'s aggression turns out to matter much more than I thought it did, making view generation very slow (well, as slow as current master is, but idbnext is supposed to be faster than that!). Adding a check to the front of rewrite to only rewrite if you need to makes view generation 20x faster for me. I tried writing even more optimal algorithms than that, but I didn't really any more substantial improvement that what is in this PR, so I didn't think it was worth the complexity.

Finally, I made a boo boo when generating native indexes, and accidentally generated a base index if you had any normal, non-mango views.

[side note: using IDBNext in our app I was able to increase refresh time by 2x, and the time it takes it to initially start and generate indexes by 50x. Looking forward to mainlining this thing!]