### PR TITLE
pouchdb-utils: fix circular dependency

### DIFF
--- a/packages/node_modules/pouchdb-utils/src/rev.js
+++ b/packages/node_modules/pouchdb-utils/src/rev.js
@@ -1,6 +1,6 @@
 import uuid from 'uuid';
 import { stringMd5 } from 'pouchdb-md5';
-import { clone } from 'pouchdb-utils';
+import clone from './clone';
 
 function rev(doc, deterministic_revs) {
   var clonedDoc = clone(doc);


### PR DESCRIPTION
I got Circular dependency: ../node_modules/pouchdb-utils/lib/index.es.js -> ../node_modules/pouchdb-utils/lib/index.es.js
/
```js
node_modules/pouchdb-utils/lib/index.es.js:import { clone } from 'pouchdb-utils';
```