### PR TITLE
(#7571) - Remove rotten link to CouchDB wiki.

### DIFF
--- a/docs/_includes/api/create_document.html
+++ b/docs/_includes/api/create_document.html
@@ -9,7 +9,7 @@ Create a new document or update an existing document. If the document already ex
 
 If you want to update an existing document even if there's conflict, you should specify the base revision `_rev` and use `force=true` option, then a new conflict revision will be created.
 
-There are some [restrictions on valid property names of the documents](http://wiki.apache.org/couchdb/HTTP_Document_API#Special_Fields). If you try to store non-JSON data (for instance `Date` objects) you may see [inconsistent results](http://pouchdb.com/errors.html#could_not_be_cloned).
+`doc` must be a "pure JSON object", i.e. a collection of name/value pairs. If you try to store non-JSON data (for instance `Date` objects) you may see [inconsistent results](http://pouchdb.com/errors.html#could_not_be_cloned).
 
 #### Example Usage:
 


### PR DESCRIPTION
Instead, use wording about "pure JSON object".