### PR TITLE
(#7571) - Remove rotten link to CouchDB wiki.

### DIFF
--- a/docs/_includes/api/batch_create.html
+++ b/docs/_includes/api/batch_create.html
@@ -268,4 +268,4 @@ db.bulkDocs([
 {% endhighlight %}
 {% include code/end.html %}
 
-**Note:** You can also specify a `new_edits` property on the options object that when set to `false` allows you to post [existing documents from other databases](http://wiki.apache.org/couchdb/HTTP_Bulk_Document_API#Posting_Existing_Revisions). This will not allow you to edit existing local documents and normally only the replication algorithm needs to do this.
+**Note:** If you set a `new_edits` property on the options object to `false`, you can post existing documents from other databases without having new revision IDs assigned to them. Normally, only the [replication algorithm](https://docs.couchdb.org/en/stable/replication/protocol.html?highlight=new_edits#upload-batch-of-changed-documents) needs to do this.


### PR DESCRIPTION
Instead, link to CouchDB docs. Also, some rephrasing.