### PR TITLE
enable stateful filtering by adding the options object as third argument to the filter function

### DIFF
--- a/packages/node_modules/pouchdb-utils/src/filterChange.js
+++ b/packages/node_modules/pouchdb-utils/src/filterChange.js
@@ -1,8 +1,8 @@
 import { createError, BAD_REQUEST } from 'pouchdb-errors';
 
-function tryFilter(filter, doc, req) {
+function tryFilter(filter, doc, req, opts) {
   try {
-    return !filter(doc, req);
+    return !filter(doc, req, opts);
   } catch (err) {
     var msg = 'Filter function threw: ' + err.toString();
     return createError(BAD_REQUEST, msg);
@@ -21,7 +21,7 @@ function filterChange(opts) {
       change.doc = {};
     }
 
-    var filterReturn = hasFilter && tryFilter(opts.filter, change.doc, req);
+    var filterReturn = hasFilter && tryFilter(opts.filter, change.doc, req, opts);
 
     if (typeof filterReturn === 'object') {
       return filterReturn;


### PR DESCRIPTION
We are partially replicating databases based on a number of external conditions. For this to work, we need an object that is accessible over multiple calls to filter().

We're using typescipt natively so passing an reference to a class instance looks cleaner than a global object, which would be an alternative. 

A basic usage example looks like:

```
class DBGetter {
  // db declarations for local and remote db
  counter = 0
  myFilter(doc: any, req: any, opts: any): boolean {
    const self = opts.self
    self.counter++
    return (self.counter % 2 === 1)
  }

  getHalfOfIt() {
    this.db.replicate.from(this.remoteDB, {
      filter: this.myFilter,
      self: this
    })
  }
}
```

