### PR TITLE
fix: handle corrupt rev tree

### DIFF
--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -633,6 +633,13 @@ AbstractPouchDB.prototype.get = adapterFun('get', function (id, opts, cb) {
         }
       }
 
+      /* istanbul ignore if */
+      if (!path) {
+        err = new Error('invalid rev tree');
+        err.docId = id;
+        return cb(err);
+      }
+
       var indexOfRev = path.ids.map(function (x) { return x.id; })
         .indexOf(doc._rev.split('-')[1]) + 1;
       var howMany = path.ids.length - indexOfRev;


### PR DESCRIPTION
If a document has a corrupt rev tree it can cause an unhandled exception.

This PR fixes it by fallback to minimal rev tree if the real one is corrupted.

Alternatively we should probably do a `cb(new Error('corrupt rev tree'))` instead of unhandled null reference exception.