### PR TITLE
(#7746) - Bump level to the latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,9 @@ matrix:
     - node_js: "10"
       services: docker
       env: CLIENT=node COMMAND=test
+    - node_js: "12"
+      services: docker
+      env: CLIENT=node COMMAND=test
   allow_failures:
     - env: GREP=suite2 SKIP_MIGRATION=true CLIENT="saucelabs:MicrosoftEdge:14:Windows 10" COMMAND=test
     - env: GREP=suite2 INVERT=true SKIP_MIGRATION=true CLIENT="saucelabs:MicrosoftEdge:14:Windows 10" COMMAND=test

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fruitdown": "1.0.2",
     "immediate": "3.0.6",
     "inherits": "2.0.3",
-    "level": "4.0.0",
+    "level": "5.0.1",
     "level-codec": "9.0.1",
     "level-write-stream": "1.0.0",
     "leveldown": "5.0.1",


### PR DESCRIPTION
Level 4 does not compile with node 12

Closes: #7746