### PR TITLE
[pouchdb-adapter-http] Expose api.fetchJSON and api.pathToUrl

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -434,12 +434,41 @@ function HttpPouch(opts, callback) {
     }).catch(callback);
   };
 
+  // Converts `path` relative to DB to a fully resolved URL.
+  // If given an absolute path (starting with a slash):
+  //   will base the path off the CouchDB server URL
+  // If given a relative path (not starting with a slash):
+  //   will base the path off the DB URL
+  api.pathToUrl = function (path) {
+    return path.substring(0, 1) === '/' ?
+      genUrl(host, path.substring(1)) :
+      genDBUrl(host, path);
+  };
+
+  // Fetches a resource by a `path` relative to the DB URL (see pathToUrl).
+  //
+  // `options` follow the JS Fetch API.
+  //
+  // Returns a promise same as the JS Fetch API.
   api.fetch = function (path, options) {
     return setup().then(function () {
-      var url = path.substring(0, 1) === '/' ?
-        genUrl(host, path.substring(1)) :
-        genDBUrl(host, path);
-      return ourFetch(url, options);
+      return ourFetch(api.pathToUrl(path), options);
+    });
+  };
+
+  // Fetches a JSON resource by a path relative to the DB URL (see pathToUrl).
+  //
+  // `options` follow the JS Fetch API.
+  // `options.body` should be a JSON encoded string;
+  //   if you need to make a non-JSON request,
+  //   pass the appropriate Content-Type header, too.
+  //
+  // Returns a promise: that resolves to a { ok, status, data } object,
+  //   where `data` is the JSON decoded response body.
+  // The promise is rejected if the response body is not valid JSON.
+  api.fetchJSON = function (path, options) {
+    return setup().then(function () {
+      return fetchJSON(api.pathToUrl(path), options);
     });
   };
 


### PR DESCRIPTION
Closes (#7767)

Besides exposing `fetchJSON`, I also exposed `pathToUrl`, which was similarly hidden in the private implementation and is similarly useful to other plugins.