### PR TITLE
[pouchdb-replication] add replicating flag to pass through wrappered functions.

### DIFF
--- a/packages/node_modules/pouchdb-replication/src/getDocs.js
+++ b/packages/node_modules/pouchdb-replication/src/getDocs.js
@@ -13,7 +13,7 @@ function fileHasChanged(localDoc, remoteDoc, filename) {
 function getDocAttachments(db, doc) {
   var filenames = Object.keys(doc._attachments);
   return Promise.all(filenames.map(function (filename) {
-    return db.getAttachment(doc._id, filename, {rev: doc._rev});
+    return db.getAttachment(doc._id, filename, {rev: doc._rev, replicating: true});
   }));
 }
 
@@ -28,7 +28,7 @@ function getDocAttachmentsFromTargetOrSource(target, src, doc) {
   return target.get(doc._id).then(function (localDoc) {
     return Promise.all(filenames.map(function (filename) {
       if (fileHasChanged(localDoc, doc, filename)) {
-        return src.getAttachment(doc._id, filename);
+        return src.getAttachment(doc._id, filename, {replicating: true});
       }
 
       return target.getAttachment(localDoc._id, filename);
@@ -58,6 +58,7 @@ function createBulkGetOpts(diffs) {
   return {
     docs: requests,
     revs: true,
+    replicating: true,
     latest: true
   };
 }
@@ -137,6 +138,7 @@ function getDocs(src, target, diffs, state) {
     return src.allDocs({
       keys: ids,
       include_docs: true,
+      replicating: true,
       conflicts: true
     }).then(function (res) {
       if (state.cancelled) {

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -38,7 +38,7 @@ function replicate(src, target, opts, returnValue, result) {
     errors: []
   };
 
-  var changesOpts = {};
+  var changesOpts = {replicating: true};
   returnValue.ready(src, target);
 
   function initCheckpointer() {
@@ -78,7 +78,7 @@ function replicate(src, target, opts, returnValue, result) {
         throw new Error('cancelled');
       }
 
-      // `res` doesn't include full documents (which live in `docs`), so we create a map of 
+      // `res` doesn't include full documents (which live in `docs`), so we create a map of
       // (id -> error), and check for errors while iterating over `docs`
       var errorsById = Object.create(null);
       res.forEach(function (res) {
@@ -411,6 +411,7 @@ function replicate(src, target, opts, returnValue, result) {
       return checkpointer.getCheckpoint().then(function (checkpoint) {
         last_seq = checkpoint;
         changesOpts = {
+          replicating: true,
           since: last_seq,
           limit: batch_size,
           batch_size: batch_size,


### PR DESCRIPTION
We can encrypt/decrypt data through wrappped functions transparently.  But we do not wanna decrypt data in the remote replication for e2e ecnryption.
So we need pass a `replicating` flag to the wrapped functions to specify under the replcation.