### PR TITLE
update node on travis to version 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "6"
+  - "10"
 
 services:
   - docker


### PR DESCRIPTION
I think a lot of the builds are now failing because the node version is to low.