### PR TITLE
chore: pin node-fetch to 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "localstorage-down": "0.6.7",
     "ltgt": "2.2.1",
     "memdown": "1.2.4",
-    "node-fetch": "^2.0.0",
+    "node-fetch": "2.4.1",
     "promise-polyfill": "7.1.2",
     "readable-stream": "1.0.33",
     "request": "2.87.0",


### PR DESCRIPTION
@greenkeeperio-bot says that anything above 2.5 is breaking tests and recommends we should pin it. Thanks Greenkeeper