### PR TITLE
Don't require an opaque string in the rev

### DIFF
--- a/packages/node_modules/pouchdb-adapter-utils/src/parseDoc.js
+++ b/packages/node_modules/pouchdb-adapter-utils/src/parseDoc.js
@@ -46,7 +46,7 @@ var dataWords = toObject([
 ]);
 
 function parseRevisionInfo(rev) {
-  if (!/^\d+-./.test(rev)) {
+  if (!/^\d+-/.test(rev)) {
     return createError(INVALID_REV);
   }
   var idx = rev.indexOf('-');

--- a/tests/integration/test.bulk_docs.js
+++ b/tests/integration/test.bulk_docs.js
@@ -162,6 +162,21 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it("7829 bare rev 1- with new_edits=false", function (done) {
+      var db = new PouchDB(dbs.name);
+      var docs = [
+        {
+          _id: "foo",
+          _rev: "1-",
+          integer: 1
+        }
+      ];
+      db.bulkDocs({ docs: docs }, { new_edits: false }, function (err) {
+        should.not.exist(err, 'no error');
+        done();
+      });
+    });
+
     it('Test empty bulkDocs', function () {
       var db = new PouchDB(dbs.name);
       return db.bulkDocs([]);


### PR DESCRIPTION
This aims to fix #7829.

PouchDB has a rev-validating regular expression in two places, and they don't match. This makes them match.


    packages/node_modules/pouchdb-adapter-utils/src/parseDoc.js-49-  if (!/^\d+-./.test(rev)) {
    packages/node_modules/pouchdb-adapter-utils/src/parseDoc.js:50:    return createError(INVALID_REV);


and

    packages/node_modules/pouchdb-core/src/adapter.js-584-          if (!(typeof (l) === "string" && /^\d+-/.test(l))) {
    packages/node_modules/pouchdb-core/src/adapter.js:585:            return cb(createError(INVALID_REV));

Notice that the first one requires at least one character after the `-`, the second does not. With this patch, they are consistent.

It might be wise to define this RE in a single location, to avoid this class of error in the future, but I'll leave that as an exercise for someone with more JS experience.