### PR TITLE
Added PouchDB Geospatial to plugins page.

### DIFF
--- a/docs/external.md
+++ b/docs/external.md
@@ -116,6 +116,10 @@ PouchDB/CouchDB replication over WebSockets, using Engine.io (Socket.io).
 
 Multidimensional and spatial queries with PouchDB.
 
+#### [PouchDB Geospatial](https://github.com/dpmcmlxxvi/pouchdb-geospatial)
+
+PouchDB geospatial querying of GeoJSON objects that supports the DE-9IM spatial predicates. ([Documentation](https://dpmcmlxxvi.github.io/pouchdb-geospatial/api/))
+
 #### [Superlogin](https://www.npmjs.com/package/superlogin)
 
 Powerful authentication for APIs and single page apps using the CouchDB ecosystem, which supports a variety of providers.


### PR DESCRIPTION
Updates the "Plugins and External Projects" page to include [pouchdb-geospatial](https://github.com/dpmcmlxxvi/pouchdb-geospatial), a new plugin I recently published that performs GeoJSON spatial querying and supports DE-9IM spatial predicates.