### PR TITLE
response.buffer() and blob fields doesn't exist in ReactNative

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -506,7 +506,7 @@ function HttpPouch(opts, callback) {
         var path = encodeDocId(doc._id) + '/' + encodeAttachmentId(filename) +
             '?rev=' + doc._rev;
         return ourFetch(genDBUrl(host, path)).then(function (response) {
-          if (typeof process !== 'undefined' && !process.browser) {
+          if ('buffer' in response) {
             return response.buffer();
           } else {
             /* istanbul ignore next */
@@ -514,8 +514,8 @@ function HttpPouch(opts, callback) {
           }
         }).then(function (blob) {
           if (opts.binary) {
-            // TODO: Can we remove this?
-            if (typeof process !== 'undefined' && !process.browser) {
+            var typeFieldDescriptor = Object.getOwnPropertyDescriptor(blob.__proto__, 'type');
+            if (!typeFieldDescriptor || typeFieldDescriptor.set) {
               blob.type = att.content_type;
             }
             return blob;
@@ -875,7 +875,7 @@ function HttpPouch(opts, callback) {
     if (opts.descending) {
       params.descending = true;
     }
-    
+
     /* istanbul ignore if */
     if (opts.update_seq) {
       params.update_seq = true;


### PR DESCRIPTION
Add a check for ReactNative next to the checks for node/browsers so that we don't throw errors using unsupported API's.

Fixes #7688.