### PR TITLE
ADD docker-command for couchdb to TESTING.md

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -6,6 +6,10 @@ The PouchDB test suite expects an instance of CouchDB (version 1.6.1 and above) 
 If you use docker, you can start the couchdb-instance with
 ```bash
     docker run -it --name my-couchdb -p 5984:5984 couchdb:latest
+    
+    # to have a coucchdb with enabled cors, you can use trivago/couchdb-cors
+    docker run -it --name my-couchdb -p 5984:5984 trivago/couchdb-cors:latest
+    
 ```
 
  * PouchDB has been primarily developed on Linux and OSX, if you are using Windows then these instructions will have problems, we would love your help fixing them though.

--- a/TESTING.md
+++ b/TESTING.md
@@ -3,6 +3,11 @@ Running PouchDB Tests
 
 The PouchDB test suite expects an instance of CouchDB (version 1.6.1 and above) running in [Admin Party](http://guide.couchdb.org/draft/security.html#party) on http://127.0.0.1:5984 with [CORS enabled](https://github.com/pouchdb/add-cors-to-couchdb), you can configure this by setting the `COUCH_HOST` env var.
 
+If you use docker, you can start the couchdb-instance with
+```bash
+    docker run -it --name my-couchdb -p 5984:5984 couchdb:latest
+```
+
  * PouchDB has been primarily developed on Linux and OSX, if you are using Windows then these instructions will have problems, we would love your help fixing them though.
 
 ### Node Tests

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,9 +7,8 @@ If you use docker, you can start the couchdb-instance with
 ```bash
     docker run -it --name my-couchdb -p 5984:5984 couchdb:latest
     
-    # to have a coucchdb with enabled cors, you can use trivago/couchdb-cors
+    # to have a couchdb with enabled cors, you can use trivago/couchdb-cors
     docker run -it --name my-couchdb -p 5984:5984 trivago/couchdb-cors:latest
-    
 ```
 
  * PouchDB has been primarily developed on Linux and OSX, if you are using Windows then these instructions will have problems, we would love your help fixing them though.


### PR DESCRIPTION
It took me some time to find out how to start up a valid couchdb-server for running the tests.
Since many devs use docker these days, I think it might be helpful to include the docker command into the test instructions.