### PR TITLE
(#7739) - Use proper AbortController implementation in pouchdb-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ltgt": "2.2.1",
     "memdown": "1.2.4",
     "node-fetch": "2.4.1",
+    "abort-controller": "3.0.0",
     "promise-polyfill": "8.1.2",
     "readable-stream": "1.0.33",
     "request": "2.87.0",

--- a/packages/node_modules/pouchdb-fetch/src/fetch.js
+++ b/packages/node_modules/pouchdb-fetch/src/fetch.js
@@ -2,13 +2,8 @@
 
 import nodeFetch, {Headers} from 'node-fetch';
 import fetchCookie from 'fetch-cookie';
+import AbortController from 'abort-controller';
 
 var fetch = fetchCookie(nodeFetch);
-
-/* We can fake the abort, the http adapter keeps track
-   of ignoring the result */
-function AbortController() {
-  return {abort: function () {}};
-}
 
 export {fetch, Headers, AbortController};


### PR DESCRIPTION
This allows to cancel long polling changes requests. Using a fake abort controller will leave live requests hanging and cause serious memory leaks.