### PR TITLE
fix: #7916 the remote couchdb bulkDocs with new_edits:false always return empty array

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "change-case": "3.0.1",
     "child-process-promise": "2.2.1",
     "cssmin": "0.4.3",
+    "deep-equal-in-any-order": "^1.0.21",
     "denodeify": "1.2.1",
     "derequire": "2.0.6",
     "es3ify": "0.2.2",

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -896,11 +896,30 @@ AbstractPouchDB.prototype.bulkDocs =
       for (var i = 0, l = res.length; i < l; i++) {
         res[i].id = res[i].id || ids[i];
       }
-    } else if (res && res.length === 0) {
+    } else if (!opts.new_edits && res) {
       // fix #5775: remote couchdb always returns empty array.
-      res = req.docs.map(function(doc){
-        return {ok: true, id: doc._id, rev: doc._rev};
-      })
+      if (res.length <= 0) {
+        // all are successful
+        res = req.docs.map(function(doc){
+          return {ok: true, id: doc._id, rev: doc._rev};
+        });
+      } else {
+        // something is wrong, should merge from errors array
+
+        // get successful items
+        var items = req.docs.filter(function(doc){
+          const item = res.find(function(errItem){
+            if (doc._rev)
+              return errItem.id === doc._id && errItem.rev === doc._rev;
+            else
+              return errItem.id === doc._id;
+          });
+          return !item;
+        }).map(function(doc){
+          return {ok: true, id: doc._id, rev: doc._rev};
+        });
+        res = res.concat(items);
+      }
     }
 
     callback(null, res);

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -882,12 +882,15 @@ AbstractPouchDB.prototype.bulkDocs =
     if (err) {
       return callback(err);
     }
-    if (!opts.new_edits) {
-      // this is what couch does when new_edits is false
-      res = res.filter(function (x) {
-        return x.error;
-      });
-    }
+
+    // fix #5775: bulkDocs with new_edits: false always return empty array.
+    // if (!opts.new_edits) {
+    //   // this is what couch does when new_edits is false
+    //   res = res.filter(function (x) {
+    //     return x.error;
+    //   });
+    // }
+
     // add ids for error/conflict responses (not required for CouchDB)
     if (!isRemote(adapter)) {
       for (var i = 0, l = res.length; i < l; i++) {

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -896,6 +896,11 @@ AbstractPouchDB.prototype.bulkDocs =
       for (var i = 0, l = res.length; i < l; i++) {
         res[i].id = res[i].id || ids[i];
       }
+    } else if (res && res.length === 0) {
+      // fix #5775: remote couchdb always returns empty array.
+      res = req.docs.map(function(doc){
+        return {ok: true, id: doc._id, rev: doc._rev};
+      })
     }
 
     callback(null, res);

--- a/tests/integration/node.setup.js
+++ b/tests/integration/node.setup.js
@@ -21,6 +21,7 @@ exec('mkdir -p ' + testsDir, function () {
 global.testUtils = require('./utils.js');
 var chai = require('chai');
 chai.use(require('chai-as-promised'));
+chai.use(require('deep-equal-in-any-order'));
 global.should = chai.should();
 global.assert = chai.assert;
 

--- a/tests/integration/test.bulk_docs.js
+++ b/tests/integration/test.bulk_docs.js
@@ -280,7 +280,7 @@ adapters.forEach(function (adapter) {
       var db = new PouchDB(dbs.name);
 
       return db.bulkDocs({docs: docs, new_edits: false}).then(function (res) {
-        res.should.deep.equal([
+        res.should.deep.equalInAnyOrder([
           {
             "id": "EE35E",
             "ok": true,
@@ -321,7 +321,7 @@ adapters.forEach(function (adapter) {
       var db = new PouchDB(dbs.name);
 
       return db.bulkDocs({docs: docs, new_edits: false}).then(function (res) {
-        res.should.deep.equal([
+        res.should.deep.equalInAnyOrder([
           {
             "id": "EE35E",
             "ok": true,

--- a/tests/integration/test.bulk_docs.js
+++ b/tests/integration/test.bulk_docs.js
@@ -280,7 +280,18 @@ adapters.forEach(function (adapter) {
       var db = new PouchDB(dbs.name);
 
       return db.bulkDocs({docs: docs, new_edits: false}).then(function (res) {
-        res.should.deep.equal([]);
+        res.should.deep.equal([
+          {
+            "id": "EE35E",
+            "ok": true,
+            "rev": "3-f6d28"
+          },
+          {
+            "id": "EE35E",
+            "ok": true,
+            "rev": "4-70b26"
+          }
+        ]);
         return db.allDocs();
       }).then(function (res) {
         res.total_rows.should.equal(1);
@@ -310,7 +321,18 @@ adapters.forEach(function (adapter) {
       var db = new PouchDB(dbs.name);
 
       return db.bulkDocs({docs: docs, new_edits: false}).then(function (res) {
-        res.should.deep.equal([]);
+        res.should.deep.equal([
+          {
+            "id": "EE35E",
+            "ok": true,
+            "rev": "3-f6d28"
+          },
+          {
+            "id": "EE35E",
+            "ok": true,
+            "rev": "4-70b26"
+          }
+        ]);
         return db.allDocs();
       }).then(function (res) {
         res.total_rows.should.equal(1);

--- a/tests/integration/test.bulk_docs.js
+++ b/tests/integration/test.bulk_docs.js
@@ -428,9 +428,12 @@ adapters.forEach(function (adapter) {
             ]
           }, {new_edits: false});
         }).then(function (res) {
-          res.should.have.length(1);
-          should.exist(res[0].error);
-          res[0].id.should.equal('doc1');
+          res.should.have.length(3);
+          var err = res.find(function(item){
+            return item.error;
+          })
+          should.exist(err);
+          err.id.should.equal('doc1');
         }).then(done);
       });
     });


### PR DESCRIPTION
Refilling the result of the remote couchdb returns to correct.