### PR TITLE
docs(setup): fix typescript import

### DIFF
--- a/docs/_guides/setup-pouchdb.md
+++ b/docs/_guides/setup-pouchdb.md
@@ -87,7 +87,7 @@ In your `tsconfig.json` activate `allowSyntheticDefaultImports`:
 Then in your TypeScript:
 
 ```typescript
-import PouchDB from 'pouchdb';
+import * as PouchDB from 'pouchdb';
 ```
 
 You can install a plugin (provided there is a [type definition for it in npm](https://www.npmjs.com/search?q=scope:types%20pouchdb)), import it in the same way and then pass the imported name to `PouchDB.plugin()` method just as you would do in JavaScript.


### PR DESCRIPTION
Hi !

I was setting up a Nestjs project with Pouchdb and I'd to face an issue with TS imports. I've follow the documentation, but I've got an `pouchdb_1.default is not a constructor` error. I've manage to make it work by importing the whole package using an alias.

Hope this could help :-)