### PR TITLE
Fix inheritance of network error properties

### DIFF
--- a/packages/node_modules/pouchdb-errors/src/index.js
+++ b/packages/node_modules/pouchdb-errors/src/index.js
@@ -48,7 +48,7 @@ function createError(error, reason) {
     // inherit error properties from our parent error manually
     // so as to allow proper JSON parsing.
     /* jshint ignore:start */
-    for (var p in error) {
+    for (var p of Object.getOwnPropertyNames(error)) {
       if (typeof error[p] !== 'function') {
         this[p] = error[p];
       }


### PR DESCRIPTION
The goal of this commit is to copy error properties in the case the error is a
network [`TypeError` error] from the [`Fetch` API].

I don't know precisely why, but [`TypeError` error] properties are not
iterable with javascript `for in`.
This html example shows it:
```html
<html>
  <script>
    fetch('missing.png').catch(function(error) {
      for (var i in error)
        console.warn(i); // nothing
      for (var i of Object.getOwnPropertyNames(error))
        console.log(i); // stack, message
    });
  </script>
</html>
```

Thus, when a replication failed on such error, we get almost no details and
can't handle it:
```json
{
  "result": {
    "ok": false,
    "start_time": "2020-03-10T14:03:22.316Z",
    "docs_read": 0,
    "docs_written": 0,
    "doc_write_failures": 0,
    "errors": [],
    "status": "aborting",
    "end_time": "2020-03-10T14:03:22.333Z",
    "last_seq": 0
  }
}
```

To quickly test it (inside a browser that use the Fecth API):
```html
<html>
  <script src="packages/node_modules/pouchdb/dist/pouchdb.js"></script>
  <script>
    var localDB = new PouchDB('mylocaldb')
    var remoteDB = new PouchDB('http://localhost:5984/myremotedb')
    localDB.replicate.to(remoteDB).on('error', function (err) {
      console.warn('failure', err)  // Go look inside `err`
    });
  </script>
</html>
```


[`TypeError` error]: https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/TypeError
[`Fetch` API]: https://developer.mozilla.org/fr/docs/Web/API/Fetch_API