### PR TITLE
Fix react-native Fast Refresh error.

### DIFF
--- a/packages/node_modules/pouchdb-replication/src/index.js
+++ b/packages/node_modules/pouchdb-replication/src/index.js
@@ -6,6 +6,7 @@ function replication(PouchDB) {
   PouchDB.sync = sync;
 
   Object.defineProperty(PouchDB.prototype, 'replicate', {
+    configurable: true, // Fix for react native fast refresh
     get: function () {
       var self = this;
       if (typeof this.replicateMethods === 'undefined') {


### PR DESCRIPTION
When using pouchdb with react-native 0.61's Fast Refresh, an error is
thrown when this `Object.defineProperty` is called again during fast
refreshes.