### PR TITLE
    Fix warning no index found message (altered in couchbase 3.1)

### DIFF
--- a/docs/_guides/mango-queries.md
+++ b/docs/_guides/mango-queries.md
@@ -314,7 +314,7 @@ You may also want to pay attention to the `"warning"` value included in your res
 ```js
 {
   "docs": [ /* ... */ ],
-  "warning": "no matching index found, create an index to optimize query time"
+  "warning": "No matching index found, create an index to optimize query time."
 }
 ```
 

--- a/docs/_includes/api/query_index.html
+++ b/docs/_includes/api/query_index.html
@@ -107,7 +107,7 @@ If there's no index that matches your `selector`/`sort`, then this method will i
 {% highlight js %}
 {
   "docs": [ /* ... */ ],
-  "warning": "no matching index found, create an index to optimize query time"
+  "warning": "No matching index found, create an index to optimize query time."
 }
 {% endhighlight %}
 

--- a/packages/node_modules/pouchdb-find/src/adapters/local/find/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/find/index.js
@@ -150,7 +150,7 @@ function find(db, requestDef, explain) {
       };
 
       if (indexToUse.defaultUsed) {
-        resp.warning = 'no matching index found, create an index to optimize query time';
+        resp.warning = 'No matching index found, create an index to optimize query time.';
       }
 
       return resp;

--- a/tests/find/test-suite-1/test.default-index.js
+++ b/tests/find/test-suite-1/test.default-index.js
@@ -164,7 +164,12 @@ testCases.push(function (dbType, context) {
       //     { _id: '3'}
       //   ]
       // });
-      resp.warning.should.equal('No matching index found, create an index to optimize query time.');
+      resp.warning.should.be.oneOf(
+        [
+          'no matching index found, create an index to optimize query time',
+          'No matching index found, create an index to optimize query time.'
+        ]
+      );
       resp.docs.should.deep.equal([
         { _id: '2'},
         { _id: '3'}
@@ -197,14 +202,19 @@ testCases.push(function (dbType, context) {
         sort: [{foo: "desc"}]
       });
     }).then(function (resp) {
-      resp.should.deep.equal({
-        warning: 'No matching index found, create an index to optimize query time.',
-        docs: [
-          {_id: '4'},
-          {_id: '2'},
-          {_id: '1'}
+      resp.warning.should.be.oneOf(
+        [
+          'no matching index found, create an index to optimize query time',
+          'No matching index found, create an index to optimize query time.'
         ]
-      });
+      );
+      resp.docs.should.deep.equal(
+        [
+          { _id: '4' },
+          { _id: '2' },
+          { _id: '1' }
+        ]
+      );
     });
   });
 
@@ -230,10 +240,14 @@ testCases.push(function (dbType, context) {
         },
         fields: ['_id']
       }).then(function (resp) {
-        resp.should.deep.equal({
-          warning: 'No matching index found, create an index to optimize query time.',
-          docs: []
-        });
+        resp.warning.should.be.oneOf(
+          [
+            'no matching index found, create an index to optimize query time',
+            'No matching index found, create an index to optimize query time.'
+          ]
+        );
+        resp.docs.should.deep.equal([]
+        );
       });
     });
   });
@@ -258,15 +272,19 @@ testCases.push(function (dbType, context) {
         },
         fields: ['_id']
       }).then(function (resp) {
-        resp.should.deep.equal({
-          warning: 'No matching index found, create an index to optimize query time.',
-          docs: [
+        resp.warning.should.be.oneOf(
+          [
+            'no matching index found, create an index to optimize query time',
+            'No matching index found, create an index to optimize query time.'
+          ]
+        );
+        resp.docs.should.deep.equal([
             {_id: '1'},
             {_id: '2'},
             {_id: '3'},
             {_id: '4'}
           ]
-        });
+        );
       });
     });
   });

--- a/tests/find/test-suite-1/test.default-index.js
+++ b/tests/find/test-suite-1/test.default-index.js
@@ -158,13 +158,13 @@ testCases.push(function (dbType, context) {
     }).then(function (resp) {
       // console.log(resp);
       // resp.should.deep.equal({
-      //   warning: 'no matching index found, create an index to optimize query time',
+      //   warning: 'No matching index found, create an index to optimize query time.',
       //   docs: [
       //     { _id: '2'},
       //     { _id: '3'}
       //   ]
       // });
-      resp.warning.should.equal('no matching index found, create an index to optimize query time');
+      resp.warning.should.equal('No matching index found, create an index to optimize query time.');
       resp.docs.should.deep.equal([
         { _id: '2'},
         { _id: '3'}
@@ -198,7 +198,7 @@ testCases.push(function (dbType, context) {
       });
     }).then(function (resp) {
       resp.should.deep.equal({
-        warning: 'no matching index found, create an index to optimize query time',
+        warning: 'No matching index found, create an index to optimize query time.',
         docs: [
           {_id: '4'},
           {_id: '2'},
@@ -231,7 +231,7 @@ testCases.push(function (dbType, context) {
         fields: ['_id']
       }).then(function (resp) {
         resp.should.deep.equal({
-          warning: 'no matching index found, create an index to optimize query time',
+          warning: 'No matching index found, create an index to optimize query time.',
           docs: []
         });
       });
@@ -259,7 +259,7 @@ testCases.push(function (dbType, context) {
         fields: ['_id']
       }).then(function (resp) {
         resp.should.deep.equal({
-          warning: 'no matching index found, create an index to optimize query time',
+          warning: 'No matching index found, create an index to optimize query time.',
           docs: [
             {_id: '1'},
             {_id: '2'},

--- a/tests/find/test-suite-2/test.kitchen-sink.js
+++ b/tests/find/test-suite-2/test.kitchen-sink.js
@@ -91,8 +91,9 @@
             ids.should.deep.equal(testConfig.output.res.docs);
           } else {
             should.exist(res.warning, 'expected a warning');
-            res.warning.should.equal('no matching index found, create an ' +
-              'index to optimize query time');
+            res.warning.should.be.oneOf([
+              'No matching index found, create an index to optimize query time.',
+              'no matching index found, create an index to optimize query time']);
           }
         }, function (err) {
           if (testConfig.output.res) {


### PR DESCRIPTION
In this [commit](https://github.com/apache/couchdb/commit/f86747f02a8b066f136a275fa28e92200404d0e7) CouchDB changed the formatting of the `no matching index found, create an index to optimize query time` warning message.

This PR applies the same change to the _pouchdb-find_ implementation, and updated the corresponding tests to support both old and new message. That way both CouchDB <3.1 and >3.1 are supported to test against.

Updated corresponding documentation as well.

There are a couple of tests in pouchdb-find that use the No matching index found warning. We need to support both variations (CouchDB pre 3.1 and post 3.1).
I did not change the tests themselves. Most of them are still skipped, or not even part of the describe scope, therefor not run.

The pouchdb-find test suite and code still needs work, imo. But that's for another PR.
