### PR TITLE
fix(package): update leveldown to version 5.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "level": "6.0.0",
     "level-codec": "9.0.1",
     "level-write-stream": "1.0.0",
-    "leveldown": "5.4.1",
+    "leveldown": "5.6.0",
     "levelup": "4.1.0",
     "localstorage-down": "0.6.7",
     "ltgt": "2.2.1",


### PR DESCRIPTION
Closes #8017

Can we have this? So that 32bit windows builds are working again?