### PR TITLE
Fix use regular `for` loop for IE

### DIFF
--- a/packages/node_modules/pouchdb-errors/src/index.js
+++ b/packages/node_modules/pouchdb-errors/src/index.js
@@ -48,9 +48,10 @@ function createError(error, reason) {
     // inherit error properties from our parent error manually
     // so as to allow proper JSON parsing.
     /* jshint ignore:start */
-    for (var p of Object.getOwnPropertyNames(error)) {
-      if (typeof error[p] !== 'function') {
-        this[p] = error[p];
+    var names = Object.getOwnPropertyNames(error);
+    for (var i = 0, len = names.length; i < len; i++) {
+      if (typeof error[names[i]] !== 'function') {
+        this[names[i]] = error[names[i]];
       }
     }
     /* jshint ignore:end */


### PR DESCRIPTION
Commit 7d058496 _"Fix inheritance of error properties"_ use a `for ... of` loop
which is not available on IE.

This new version have been tested manually on IE 11.