### PR TITLE
Replaceing uglify with terser

### DIFF
--- a/bin/build-utils.js
+++ b/bin/build-utils.js
@@ -12,7 +12,7 @@ var writeFileAsync = denodeify(fs.writeFile);
 var renameAsync = denodeify(fs.rename);
 var streamToPromise = require('stream-to-promise');
 
-var UglifyJS = require("uglify-js");
+var terser = require("terser");
 
 function addPath(pkgName, otherPath) {
   return path.resolve('packages/node_modules/' + pkgName, otherPath);
@@ -29,7 +29,7 @@ function writeFile(filename, contents) {
 }
 
 function doUglify(pkgName, code, prepend, fileOut) {
-  var miniCode = prepend + UglifyJS.minify(code).code;
+  var miniCode = prepend + terser.minify(code).code;
   return writeFile(addPath(pkgName, fileOut), miniCode);
 }
 

--- a/bin/verify-bundle-size.sh
+++ b/bin/verify-bundle-size.sh
@@ -6,7 +6,7 @@ MAX=50000
 
 # testing pouchdb.js instead of pouchdb.min.js because minification isn't run in Travis
 # in order to make our builds faster
-SIZE=`./node_modules/.bin/uglifyjs -mc < packages/node_modules/pouchdb/dist/pouchdb.js 2>/dev/null | gzip -c | wc -c`
+SIZE=`./node_modules/.bin/terser -mc < packages/node_modules/pouchdb/dist/pouchdb.js 2>/dev/null | gzip -c | wc -c`
 
 echo "Checking that pouchdb.min.js size $SIZE is less than $MAX and greater than 20"
 

--- a/package.json
+++ b/package.json
@@ -109,9 +109,9 @@
     "selenium-standalone": "6.16.0",
     "stream-to-promise": "1.1.1",
     "tape": "4.13.0",
+    "terser": "4.8.0",
     "throw-max-listeners-error": "1.0.1",
     "ua-parser-js": "0.7.21",
-    "uglify-js": "3.7.5",
     "watch-glob": "0.1.3",
     "wd": "1.11.4"
   },


### PR DESCRIPTION
Terser supports ES6+ and is API/CLI compatibility with `uglify-js`

Terser Docs: https://github.com/terser/terser

```
Before Changes (uglify):
$ ./bin/verify-bundle-size.sh 
Checking that pouchdb.min.js size 40550 is less than 50000 and greater than 20
Success

After Changes (terser):
$ ./bin/verify-bundle-size.sh 
Checking that pouchdb.min.js size 40449 is less than 50000 and greater than 20
Success
```