### PR TITLE
Fix broken avatar image for garethbowen's latest blog

### DIFF
--- a/docs/_data/authors.yml
+++ b/docs/_data/authors.yml
@@ -27,6 +27,7 @@
   github: sphaso
   www: https://it.linkedin.com/in/giovanniornaghi
   gravatar: da853b1ad9ebe5e1c3ab5b340bb63b70
+
 - name: Garren Smith
   twitter: garrensmith
   github: garrensmith
@@ -38,3 +39,9 @@
   github: willholley
   www: https://github.com/willholley/
   gravatar: 059d287498c864868b910fb0db7c469b
+
+- name: Gareth Bowen
+  twitter: garethjtbowen
+  github: garethbowen
+  www: https://bowenwebdesign.co.nz
+  gravatar: eda4874d50a06c7a6b231ba3dd29c7c0

--- a/docs/_includes/post_details.html
+++ b/docs/_includes/post_details.html
@@ -3,7 +3,7 @@
 {% endunless %}
 
 {% assign post_author = post.author %}
-{% assign post_gravatar = 'http://www.fillmurray.com/82/82' %}
+{% assign post_gravatar = 'https://www.fillmurray.com/82/82' %}
 {% assign modified_date = '' %}
 
 {% for author in site.data.authors %}


### PR DESCRIPTION
The current website shows @garethbowen's latest blog post with a broken image. 

![image](https://user-images.githubusercontent.com/3957921/86906198-7cc44b80-c113-11ea-9722-df4b95d7a0a3.png)

Reason: the default avatar image points to `http://www.fillmurray.com/82/82`, that will be blocked by the browser as it doesn't fit the "https" of the site. 

I took the chance to add Gareth to the authors, and add the missing "s" to the default image URL. 

The site now renders locally as:

![image](https://user-images.githubusercontent.com/3957921/86906464-e04e7900-c113-11ea-93b7-89c972b150aa.png)
 