### PR TITLE
Bump Node Fetch for Secuirty

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "localstorage-down": "0.6.7",
     "ltgt": "2.2.1",
     "memdown": "1.4.1",
-    "node-fetch": "2.6.0",
+    "node-fetch": "^2.6.1",
     "abort-controller": "3.0.0",
     "promise-polyfill": "8.1.3",
     "readable-stream": "1.1.14",


### PR DESCRIPTION
While a low severity issue, node-fetch 2.6.0 has vulnerabilities. It is a good idea to bump node-fetch used from 2.6.0 to 2.6.1.

https://github.com/node-fetch/node-fetch/blob/master/docs/CHANGELOG.md#v261

Thats about it!