### PR TITLE
Don't include leveldown in browsers

### DIFF
--- a/bin/build-module.js
+++ b/bin/build-module.js
@@ -30,6 +30,9 @@ var AGGRESSIVELY_BUNDLED_PACKAGES =
 // packages that only have a browser version
 var BROWSER_ONLY_PACKAGES =
   ['pouchdb-browser'];
+// packages that only use the browser field to ignore dependencies
+var BROWSER_DEPENDENCY_ONLY_PACKAGES =
+  ['pouchdb-adapter-leveldb'];
 
 function buildModule(filepath) {
   var pkg = require(path.resolve(filepath, 'package.json'));
@@ -49,7 +52,9 @@ function buildModule(filepath) {
 
   // technically this is necessary in source code because browserify
   // needs to know about the browser switches in the lib/ folder
-  if (pkg.browser && pkg.browser['./lib/index.js'] !==
+  // some modules don't need this check and should be skipped
+  var skipBrowserField = BROWSER_DEPENDENCY_ONLY_PACKAGES.indexOf(pkg.name) !== -1;
+  if (!skipBrowserField && pkg.browser && pkg.browser['./lib/index.js'] !==
       './lib/index-browser.js') {
     return Promise.reject(new Error(pkg.name +
       ' is missing a "lib/index.js" entry in the browser field'));

--- a/packages/node_modules/pouchdb-adapter-leveldb/package.json
+++ b/packages/node_modules/pouchdb-adapter-leveldb/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "keywords": [],
   "browser": {
-    "leveldown": true
+    "leveldown": false
   },
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",

--- a/packages/node_modules/pouchdb-adapter-leveldb/package.json
+++ b/packages/node_modules/pouchdb-adapter-leveldb/package.json
@@ -4,6 +4,9 @@
   "description": "PouchDB adapter using LevelDB as its backing store.",
   "main": "./lib/index.js",
   "keywords": [],
+  "browser": {
+    "leveldown": true
+  },
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",


### PR DESCRIPTION
I'm getting errors trying to use this in browser environments due to the migrate.js script always requiring leveldown.

This will cue Webpack and Browserify to ignore that module.