### PR TITLE
8190 optimized filter by id

### DIFF
--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -421,8 +421,10 @@ function replicate(src, target, opts, returnValue, result) {
         };
         if (opts.filter) {
           if (typeof opts.filter !== 'string') {
-            // required for the client-side filter in onChange
-            changesOpts.include_docs = true;
+            if(!opts.filter_id_only || opts.include_docs) {
+              // required for the client-side filter in onChange
+              changesOpts.include_docs = true;
+            }
           } else { // ddoc filter
             changesOpts.filter = opts.filter;
           }

--- a/packages/node_modules/pouchdb-utils/src/filterChange.js
+++ b/packages/node_modules/pouchdb-utils/src/filterChange.js
@@ -18,7 +18,11 @@ function filterChange(opts) {
     if (!change.doc) {
       // CSG sends events on the changes feed that don't have documents,
       // this hack makes a whole lot of existing code robust.
-      change.doc = {};
+      if(opts.filter_id_only) {
+        change.doc = { _id: change.id };
+      } else {
+        change.doc = {};
+      }
     }
 
     var filterReturn = hasFilter && tryFilter(opts.filter, change.doc, req);

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -1537,6 +1537,38 @@ adapters.forEach(function (adapters) {
       });
     });
 
+    it('Replication filter_id_only', function (done) {
+      var db = new PouchDB(dbs.name);
+      var remote = new PouchDB(dbs.remote);
+      var docs1 = [
+        {_id: '0', integer: 0},
+        {_id: '1', integer: 1},
+        {_id: '2', integer: 2},
+        {_id: '3', integer: 3}
+      ];
+      remote.bulkDocs({ docs: docs1 }, function () {
+        db.replicate.from(remote, {
+          filter: function (doc) {
+            if(Object.keys(doc).length !== 1 || !doc._id)
+              throw new Error("test fail")
+            return doc._id === '0' || doc._id === '1'
+          }
+        }).on('error', done).on('complete', function () {
+          db.allDocs(function (err, docs) {
+            if (err) { done(err); }
+            docs.rows.length.should.equal(2);
+            db.info(function (err, info) {
+              verifyInfo(info, {
+                update_seq: 2,
+                doc_count: 2
+              });
+              done();
+            });
+          });
+        });
+      });
+    });
+    
     it('Replication with different filters', function (done) {
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -1548,6 +1548,7 @@ adapters.forEach(function (adapters) {
       ];
       remote.bulkDocs({ docs: docs1 }, function () {
         db.replicate.from(remote, {
+          filter_id_only: true,
           filter: function (doc) {
             if(Object.keys(doc).length !== 1 || !doc._id)
               throw new Error("test fail")


### PR DESCRIPTION
Copied from issue description.

# Issue
A replicate.from feed with a client side filter from a large/active remote when you just want to keep existing (already fetched) documents up-to-date is extremely inefficient.

# Info
When you specify filter:a_function on a replicate, PouchDB forces the changes feed (inside the replication) to specify include_docs:true. This will result in all remote changes coming over the wire. Normally this is what you want, however in the (extremely interesting) case of only wanting to keep documents you have already fetched up-to-date, it is very inefficient -- all you really need is the document _id.

With 2 small changes this can be made much more efficient.

One user visible API change: support a filter_id_only: true option to replicate. If specified this suppresses the additional include_docs:true and sends the change to the filter function as {_id: doc_id}

I will followup with a PR in case you want to include this feature