### PR TITLE
Handle non-buffer binary data in node

### DIFF
--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -781,13 +781,27 @@ function LevelPouch(opts, callback) {
           // small optimization - don't bother writing it again
           return callback(err);
         }
-        txn.batch([{
-          type: 'put',
-          prefix: stores.binaryStore,
-          key: digest,
-          value: bufferFrom(data, 'binary')
-        }]);
-        callback();
+        if (Buffer.isBuffer(data) || typeof FileReader === "undefined") {
+          txn.batch([{
+            type: 'put',
+            prefix: stores.binaryStore,
+            key: digest,
+            value: bufferFrom(data, 'binary')
+          }]);
+          callback();
+        } else {
+          var fileReader = new FileReader();
+          fileReader.onload = function (event) {
+              txn.batch([{
+                type: 'put',
+                prefix: stores.binaryStore,
+                key: digest,
+                value: Buffer.from(event.target.result)
+              }]);
+              callback();
+          };
+          fileReader.readAsArrayBuffer(data);
+        }
       });
     }
 

--- a/packages/node_modules/pouchdb-md5/src/binaryMd5.js
+++ b/packages/node_modules/pouchdb-md5/src/binaryMd5.js
@@ -1,8 +1,18 @@
 import crypto from 'crypto';
+import { Buffer } from 'buffer';
 
 function binaryMd5(data, callback) {
-  var base64 = crypto.createHash('md5').update(data, 'binary').digest('base64');
-  callback(base64);
+  if (Buffer.isBuffer(data) || typeof FileReader === "undefined") {
+    var base64 = crypto.createHash('md5').update(data, 'binary').digest('base64');
+    callback(base64);
+  } else {
+    var fileReader = new FileReader();
+    fileReader.onload = function (event) {
+        var base64 = crypto.createHash('md5').update(Buffer.from(event.target.result), 'binary').digest('base64');
+        callback(base64);
+    };
+    fileReader.readAsArrayBuffer(data);
+  }
 }
 
 export default binaryMd5;


### PR DESCRIPTION
The difference between browser and node generally works well. However, there are some instances in which the boundaries are not that clear. For example:

- Jest runtime that loads jsdom in the background
- Server side rendering of single-page applications (that may also rely on some kind of DOM implementation in node to simulate a browser-like environment)

I bumped into this issue when testing attachments in my application. I believe these changes fix the issue.

Apologies for not adding any tests. This is my first contribution and for what I can see, node tests are run with mocha and browser tests with a headless browser.

If tests are required, I can add them but I'd need to know which would be the best way of replicating those two use cases above in current tests setup