### PR TITLE
Typo in bulkDocs.js

### DIFF
--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
@@ -372,7 +372,7 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
       txn = _txn;
 
       txn.onabort = function () {
-        callback(error);
+        callback(txn.error);
       };
       txn.ontimeout = idbError(callback);
 


### PR DESCRIPTION
Error is not defined. I guess it was meant the `txn.error`