### PR TITLE
Update learn.md

### DIFF
--- a/docs/learn.md
+++ b/docs/learn.md
@@ -35,4 +35,4 @@ PouchDB can also run as its own CouchDB-compatible web server, using [PouchDB Se
 
 [IndexedDB]: http://caniuse.com/#feat=indexeddb
 [WebSQL]: http://caniuse.com/#feat=sql-storage
-[LevelDB]: http://leveldb.org/
+[LevelDB]: https://github.com/google/leveldb


### PR DESCRIPTION
Fixes broken link to non-existent LevelDB Website, links to repo instead. Looked through all of the website, didn't find any other occurrence.