### PR TITLE
(#8222) - fix multiple $regex conditions on same field when using $and

### DIFF
--- a/packages/node_modules/pouchdb-selector-core/src/in-memory-filter.js
+++ b/packages/node_modules/pouchdb-selector-core/src/in-memory-filter.js
@@ -291,7 +291,9 @@ var matchers = {
   },
 
   '$regex': function (doc, userValue, parsedField, docFieldValue) {
-    return fieldExists(docFieldValue) && regexMatch(docFieldValue, userValue);
+    return fieldExists(docFieldValue) && userValue.every(function (regexValue) {
+      return regexMatch(docFieldValue, regexValue);
+    });
   },
 
   '$type': function (doc, userValue, parsedField, docFieldValue) {

--- a/packages/node_modules/pouchdb-selector-core/src/utils.js
+++ b/packages/node_modules/pouchdb-selector-core/src/utils.js
@@ -98,6 +98,8 @@ function mergeAndedSelectors(selectors) {
             return mergeNe(value, fieldMatchers);
           } else if (operator === '$eq') {
             return mergeEq(value, fieldMatchers);
+          } else if (operator === "$regex") {
+            return mergeRegex(value, fieldMatchers);
           }
           fieldMatchers[operator] = value;
         });
@@ -196,6 +198,16 @@ function mergeEq(value, fieldMatchers) {
   fieldMatchers.$eq = value;
 }
 
+// combine $regex values into one array
+function mergeRegex(value, fieldMatchers) {
+  if ('$regex' in fieldMatchers) {
+    // a value could match multiple regexes
+    fieldMatchers.$regex.push(value);
+  } else { // doesn't exist yet
+    fieldMatchers.$regex = [value];
+  }
+}
+
 //#7458: execute function mergeAndedSelectors on nested $and
 function mergeAndedSelectorsNested(obj) {
     for (var prop in obj) {
@@ -274,10 +286,15 @@ function massageSelector(input) {
 
     if (typeof matcher !== 'object' || matcher === null) {
       matcher = {$eq: matcher};
-    } else if ('$ne' in matcher && !wasAnded) {
-      // I put these in an array, since there may be more than one
-      // but in the "mergeAnded" operation, I already take care of that
-      matcher.$ne = [matcher.$ne];
+    } else if (!wasAnded) {
+      // These values must be placed in an array because these operators can be used multiple times on the same field
+      // when $and is used, mergeAndedSelectors takes care of putting them into arrays, otherwise it's done here:
+      if ('$ne' in matcher) {
+        matcher.$ne = [matcher.$ne];
+      }
+      if ('$regex' in matcher) {
+        matcher.$regex = [matcher.$regex];
+      }
     }
     result[field] = matcher;
   }

--- a/tests/find/test-suite-1/test.regex.js
+++ b/tests/find/test-suite-1/test.regex.js
@@ -131,5 +131,36 @@ testCases.push(function (dbType, context) {
         });
       });
     });
+    it('should works with $and with multiple $regex conditions on same field', function () {
+      var db = context.db;
+      var index = {
+        "index": {
+          "fields": ["name"]
+        }
+      };
+      return db.createIndex(index).then(function () {
+        return db.find({
+          selector: {
+            $and: [
+              { name: { $regex: "in" } },
+              { name: { $regex: "n" } },
+            ]
+          },
+          sort: [ 'name' ]
+        }).then(function (resp) {
+          var docs = resp.docs.map(function (doc) {
+            delete doc._rev;
+            return doc;
+          });
+          docs.should.deep.equal([
+            {
+              name: 'Captain Falcon', _id: 'falcon', rank: 4, series: 'F-Zero', debut: 1990,
+              awesome: true
+            },
+            { name: 'Link', rank: 10, _id: 'link', series: 'Zelda', debut: 1986, awesome: true },
+          ]);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Fixes #8222 / #6260

This takes the same approach as the `$ne` operator, placing the values to match in an array so they must all match if `$and` is used.

One thing I noticed but did not fix is that in the [couchdb docs](https://docs.couchdb.org/en/stable/api/database/find.html#condition-operators) it says `$regex` can only match against strings. But there is no check for this, regexes have always been able to match against whatever javascript can match. I looked quickly at the other operators, and for example, it seems `$size` too, does not check it's value is an array. Is a fix to conform more to how couchdb handles the conditions wanted? I can submit a separate PR.