### PR TITLE
(#8229) - indexeddb: ensure errors are propagated and handle database deletion

### DIFF
--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
@@ -39,7 +39,7 @@ function IdbPouch(dbOpts, callback) {
         args.unshift(res.idb);
         fun.apply(api, args);
       }).catch(function (err) {
-        var last = args.unshift();
+        var last = args.pop();
         if (typeof last === 'function') {
           last(err);
         } else {
@@ -53,14 +53,11 @@ function IdbPouch(dbOpts, callback) {
     return function () {
       var args = Array.prototype.slice.call(arguments);
 
-      return new Promise(function (resolve, reject) {
-        setup(openDatabases, api, dbOpts).then(function (res) {
-          metadata = res.metadata;
-          args.unshift(res.idb);
+      return setup(openDatabases, api, dbOpts).then(function (res) {
+        metadata = res.metadata;
+        args.unshift(res.idb);
 
-          return fun.apply(api, args);
-        }).then(resolve)
-          .catch(reject);
+        return fun.apply(api, args);
       });
     };
   };
@@ -78,12 +75,13 @@ function IdbPouch(dbOpts, callback) {
       setup(openDatabases, api, dbOpts).then(function (res) {
         metadata = res.metadata;
         txn.txn = res.idb.transaction(stores, mode);
-        args.unshift(txn);
-        fun.apply(api, args);
       }).catch(function (err) {
         console.error('Failed to establish transaction safely');
         console.error(err);
         txn.error = err;
+      }).then(function () {
+        args.unshift(txn);
+        fun.apply(api, args);
       });
     };
   };

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/setup.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/setup.js
@@ -115,6 +115,11 @@ function openDatabase(openDatabases, api, opts, resolve, reject) {
       // migrate between the two. In the future, dependent on performance tests,
       // we might silently migrate
       throw new Error('Incorrect adapter: you should specify the "idb" adapter to open this DB');
+    } else if (e.oldVersion === 0 && e.newVersion < versionMultiplier) {
+      // Firefox still creates the database with version=1 even if we throw,
+      // so we need to be sure to destroy the empty database before throwing
+      indexedDB.deleteDatabase(opts.name);
+      throw new Error('Database was deleted while open');
     }
 
     var db = e.target.result;
@@ -146,6 +151,13 @@ function openDatabase(openDatabases, api, opts, resolve, reject) {
       console.log('Database was made stale, closing handle');
       openDatabases[opts.name].versionchanged = true;
       idb.close();
+    };
+
+    idb.onclose = function () {
+      console.log('Database was made stale, closing handle');
+      if (opts.name in openDatabases) {
+        openDatabases[opts.name].versionchanged = true;
+      }
     };
 
     var metadata = {id: META_STORE};


### PR DESCRIPTION
Fixes #8229 

This will prevent the database from being reopened/recreated with `version=1` if it got deleted on Firefox or Chrome, which currently prevents it from ever being opened again.
Also, transactions errors are properly propagated.