### PR TITLE
Conform pouchdb find operators to couchdb's 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-tmp
+tmp*
 .DS_Store
 /node_modules
 docs/_site

--- a/packages/node_modules/pouchdb-find/src/adapters/http/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/http/index.js
@@ -1,6 +1,7 @@
 import { generateErrorFromResponse } from 'pouchdb-errors';
 import { Headers } from 'pouchdb-fetch';
 import massageCreateIndexRequest from '../../massageCreateIndexRequest';
+import validateSelector from '../../validateSelector';
 
 function dbFetch(db, path, opts, callback) {
   var status, ok;
@@ -29,6 +30,7 @@ function createIndex(db, requestDef, callback) {
 }
 
 function find(db, requestDef, callback) {
+  validateSelector(requestDef.selector, true);
   dbFetch(db, '_find', {
     method: 'POST',
     body: JSON.stringify(requestDef)

--- a/packages/node_modules/pouchdb-find/src/adapters/local/find/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/find/index.js
@@ -17,6 +17,7 @@ import {
   massageUseIndex
 } from '../utils';
 import {pick} from '../../../utils';
+import validateSelector from '../../../validateSelector';
 
 function indexToSignature(index) {
   // remove '_design/'
@@ -73,6 +74,8 @@ function doAllDocs(db, originalOpts) {
 
 function find(db, requestDef, explain) {
   if (requestDef.selector) {
+    // must be validated before massaging
+    validateSelector(requestDef.selector, false);
     requestDef.selector = massageSelector(requestDef.selector);
   }
 
@@ -91,16 +94,16 @@ function find(db, requestDef, explain) {
     db.constructor.emit('debug', ['find', 'planning query', requestDef]);
     var queryPlan = planQuery(requestDef, getIndexesRes.indexes);
     db.constructor.emit('debug', ['find', 'query plan', queryPlan]);
-    
+
     var indexToUse = queryPlan.index;
-    
+
     validateSort(requestDef, indexToUse);
 
     var opts = Object.assign({
       include_docs: true,
       reduce: false,
       // Add amount of index for doAllDocs to use (related to issue #7810)
-      indexes_count: getIndexesRes.total_rows, 
+      indexes_count: getIndexesRes.total_rows,
     }, queryPlan.queryOpts);
 
     if ('startkey' in opts && 'endkey' in opts &&

--- a/packages/node_modules/pouchdb-find/src/validateSelector.js
+++ b/packages/node_modules/pouchdb-find/src/validateSelector.js
@@ -1,0 +1,132 @@
+// throws if the user is using the wrong query field value type
+function checkFieldValueType(name, value, isHttp) {
+	var message = '';
+	var received = value;
+	var addReceived = true;
+	if ([ '$in', '$nin', '$or', '$and', '$mod', '$nor', '$all' ].indexOf(name) !== -1) {
+		if (!Array.isArray(value)) {
+			message = 'Query operator ' + name + ' must be an array.';
+
+		}
+	}
+
+	if ([ '$not', '$elemMatch', '$allMatch' ].indexOf(name) !== -1) {
+		if (!(!Array.isArray(value) && typeof value === 'object' && value !== null)) {
+			message = 'Query operator ' + name + ' must be an object.';
+		}
+	}
+
+	if (name === '$mod' && Array.isArray(value)) {
+		if (value.length !== 2) {
+			message = 'Query operator $mod must be in the format [divisor, remainder], ' +
+				'where divisor and remainder are both integers.';
+		} else {
+			var divisor = value[0];
+			var mod = value[1];
+			if (divisor === 0) {
+				message = 'Query operator $mod\'s divisor cannot be 0, cannot divide by zero.';
+				addReceived = false;
+			}
+			if (typeof divisor !== 'number' || parseInt(divisor, 10) !== divisor) {
+				message = 'Query operator $mod\'s divisor is not an integer.';
+				received = divisor;
+			}
+			if (parseInt(mod, 10) !== mod) {
+				message = 'Query operator $mod\'s remainder is not an integer.';
+				received = mod;
+			}
+		}
+	}
+	if (name === '$exists') {
+		if (typeof value !== 'boolean') {
+			message = 'Query operator $exists must be a boolean.';
+		}
+	}
+
+	if (name === '$type') {
+		var allowed = [ 'null', 'boolean', 'number', 'string', 'array', 'object' ];
+		var allowedStr = '"' + allowed.slice(0, allowed.length - 1).join('", "') + '", or "' + allowed[allowed.length - 1] + '"';
+		if (typeof value !== 'string') {
+			message = 'Query operator $type must be a string. Supported values: ' + allowedStr + '.';
+		} else if (allowed.indexOf(value) == -1) {
+			message = 'Query operator $type must be a string. Supported values: ' + allowedStr + '.';
+		}
+	}
+
+	if (name === '$size') {
+		if (parseInt(value, 10) !== value) {
+			message = 'Query operator $size must be a integer.';
+		}
+	}
+
+	if (name === '$regex') {
+		if (typeof value !== 'string') {
+			console.log("here", isHttp);
+			if (isHttp) {
+				message = 'Query operator $regex must be a string.';
+			} else if (!(value instanceof RegExp)) {
+				message = 'Query operator $regex must be a string or an instance ' +
+					'of a javascript regular expression.';
+			}
+		}
+	}
+
+	if (message) {
+		if (addReceived) {
+
+			var type = received === null
+			? ' '
+			: Array.isArray(received)
+			? ' array'
+			: ' ' + typeof received;
+			var receivedStr = typeof received === 'object' && received !== null
+			?  JSON.stringify(received, null, '\t')
+			: received;
+
+			message += ' Received' + type + ': ' + receivedStr;
+		}
+		throw new Error(message);
+	}
+}
+
+
+var requireValidation = [ '$all', '$allMatch', '$and', '$elemMatch', '$exists', '$in', '$mod', '$nin', '$nor', '$not', '$or', '$regex', '$size', '$type' ];
+
+var arrayTypeComparisonOperators = [ '$in', '$nin', '$mod', '$all'];
+
+var equalityOperators = [ '$eq', '$gt', '$gte', '$lt', '$lte' ];
+
+// recursively walks down the a query selector validating any operators
+function validateSelector(input, isHttp) {
+	if (Array.isArray(input)) {
+		for (var entry of input) {
+			if (typeof entry === 'object' && value !== null) {
+				validateSelector(entry, isHttp);
+			}
+		}
+	} else {
+		var fields = Object.keys(input);
+
+		for (var i = 0; i < fields.length; i++) {
+			var key = fields[i];
+			var value = input[key];
+
+			if (requireValidation.indexOf(key) !== -1) {
+				checkFieldValueType(key, value, isHttp);
+			}
+			if (equalityOperators.indexOf(key) !== -1) {
+				// skip, explicit comparison operators can be anything
+				continue;
+			}
+			if (arrayTypeComparisonOperators.indexOf(key) !== -1) {
+				// skip, their values are already valid
+				continue;
+			}
+			if (typeof value === 'object' && value !== null) {
+				validateSelector(value, isHttp);
+			}
+		}
+	}
+}
+
+export default validateSelector;

--- a/packages/node_modules/pouchdb-selector-core/src/in-memory-filter.js
+++ b/packages/node_modules/pouchdb-selector-core/src/in-memory-filter.js
@@ -138,16 +138,20 @@ function modField(docFieldValue, userValue) {
 function arrayContainsValue(docFieldValue, userValue) {
   return userValue.some(function (val) {
     if (docFieldValue instanceof Array) {
-      return docFieldValue.indexOf(val) > -1;
+      return docFieldValue.some(function (docFieldValueItem) {
+        return collate(val, docFieldValueItem) === 0;
+      });
     }
 
-    return docFieldValue === val;
+    return collate(val, docFieldValue) === 0;
   });
 }
 
 function arrayContainsAllValues(docFieldValue, userValue) {
   return userValue.every(function (val) {
-    return docFieldValue.indexOf(val) > -1;
+    return docFieldValue.some(function (docFieldValueItem) {
+      return collate(val, docFieldValueItem) === 0;
+    });
   });
 }
 

--- a/packages/node_modules/pouchdb-selector-core/src/in-memory-filter.js
+++ b/packages/node_modules/pouchdb-selector-core/src/in-memory-filter.js
@@ -77,9 +77,33 @@ function matchSelector(matcher, doc, parsedField, docFieldValue) {
 
   // is matcher an object, if so continue recursion
   if (typeof matcher === 'object') {
-    return Object.keys(matcher).every(function (userOperator) {
-      var userValue = matcher[userOperator];
-      return match(userOperator, doc, userValue, parsedField, docFieldValue);
+    return Object.keys(matcher).every(function (maybeUserOperator) {
+      var userValue = matcher[ maybeUserOperator ];
+      // explicit operator
+      if (maybeUserOperator.indexOf("$") === 0) {
+        return match(maybeUserOperator, doc, userValue, parsedField, docFieldValue);
+      } else {
+        var subParsedField = parseField(maybeUserOperator);
+
+        if (
+          docFieldValue === undefined &&
+          typeof userValue !== "object" &&
+          subParsedField.length > 0
+        ) {
+          // the field does not exist, return or getFieldFromDoc will throw
+          return false;
+        }
+
+        var subDocFieldValue = getFieldFromDoc(docFieldValue, subParsedField);
+
+        if (typeof userValue === "object") {
+          // field value is an object that might contain more operators
+          return matchSelector(userValue, doc, parsedField, subDocFieldValue);
+        }
+
+        // implicit operator
+        return match("$eq", doc, userValue, subParsedField, subDocFieldValue);
+      }
     });
   }
 

--- a/packages/node_modules/pouchdb-selector-core/src/in-memory-filter.js
+++ b/packages/node_modules/pouchdb-selector-core/src/in-memory-filter.js
@@ -124,6 +124,11 @@ function fieldIsNotUndefined(docFieldValue) {
 }
 
 function modField(docFieldValue, userValue) {
+  if (typeof docFieldValue !== "number" ||
+    parseInt(docFieldValue, 10) !== docFieldValue) {
+    return false;
+  }
+
   var divisor = userValue[0];
   var mod = userValue[1];
   if (divisor === 0) {
@@ -136,10 +141,6 @@ function modField(docFieldValue, userValue) {
 
   if (parseInt(mod, 10) !== mod ) {
     throw new Error('Modulus is not an integer');
-  }
-
-  if (parseInt(docFieldValue, 10) !== docFieldValue) {
-    return false;
   }
 
   return docFieldValue % divisor === mod;
@@ -283,7 +284,9 @@ var matchers = {
   },
 
   '$size': function (doc, userValue, parsedField, docFieldValue) {
-    return fieldExists(docFieldValue) && arraySize(docFieldValue, userValue);
+    return fieldExists(docFieldValue) &&
+      Array.isArray(docFieldValue) &&
+      arraySize(docFieldValue, userValue);
   },
 
   '$all': function (doc, userValue, parsedField, docFieldValue) {
@@ -291,9 +294,11 @@ var matchers = {
   },
 
   '$regex': function (doc, userValue, parsedField, docFieldValue) {
-    return fieldExists(docFieldValue) && userValue.every(function (regexValue) {
-      return regexMatch(docFieldValue, regexValue);
-    });
+    return fieldExists(docFieldValue) &&
+      typeof docFieldValue == "string" &&
+      userValue.every(function (regexValue) {
+        return regexMatch(docFieldValue, regexValue);
+      });
   },
 
   '$type': function (doc, userValue, parsedField, docFieldValue) {

--- a/packages/node_modules/pouchdb-selector-core/src/in-memory-filter.js
+++ b/packages/node_modules/pouchdb-selector-core/src/in-memory-filter.js
@@ -131,17 +131,6 @@ function modField(docFieldValue, userValue) {
 
   var divisor = userValue[0];
   var mod = userValue[1];
-  if (divisor === 0) {
-    throw new Error('Bad divisor, cannot divide by zero');
-  }
-
-  if (parseInt(divisor, 10) !== divisor ) {
-    throw new Error('Divisor is not an integer');
-  }
-
-  if (parseInt(mod, 10) !== mod ) {
-    throw new Error('Modulus is not an integer');
-  }
 
   return docFieldValue % divisor === mod;
 }
@@ -188,10 +177,6 @@ function typeMatch(docFieldValue, userValue) {
     case 'object':
       return ({}).toString.call(docFieldValue) === '[object Object]';
   }
-
-  throw new Error(userValue + ' not supported as a type.' +
-                  'Please use one of object, string, array, number, boolean or null.');
-
 }
 
 var matchers = {

--- a/packages/node_modules/pouchdb-selector-core/src/utils.js
+++ b/packages/node_modules/pouchdb-selector-core/src/utils.js
@@ -69,6 +69,7 @@ function mergeAndedSelectors(selectors) {
   // $and: [{$gt: 'a'}, {$gt: 'b'}], then it's collapsed into
   // just {$gt: 'b'}
   var res = {};
+  var first = {$or: true, $nor: true};
 
   selectors.forEach(function (selector) {
     Object.keys(selector).forEach(function (field) {
@@ -78,11 +79,32 @@ function mergeAndedSelectors(selectors) {
       }
 
       if (isCombinationalField(field)) {
+        // or, nor
         if (matcher instanceof Array) {
-          res[field] = matcher.map(function (m) {
-            return mergeAndedSelectors([m]);
+          if (first[field]) {
+            first[field] = false;
+            res[field] = matcher;
+            return;
+          }
+
+          var entries = [];
+          res[field].forEach(function (existing) {
+            Object.keys(matcher).forEach(function (key) {
+              var m = matcher[key];
+              var longest = Math.max(Object.keys(existing).length, Object.keys(m).length);
+              var merged = mergeAndedSelectors([existing, m]);
+              if (Object.keys(merged).length <= longest) {
+                // we have a situation like: (a :{$eq :1} || ...) && (a {$eq: 2} || ...)
+                // merging would produce a $eq 2 when actually we shouldn't ever match against these merged conditions
+                // merged should always contain more values to be valid
+                return;
+              }
+              entries.push(merged);
+            });
           });
+          res[field] = entries;
         } else {
+          // not
           res[field] = mergeAndedSelectors([matcher]);
         }
       } else {

--- a/tests/find/test-suite-1/test.array.js
+++ b/tests/find/test-suite-1/test.array.js
@@ -305,6 +305,28 @@ testCases.push(function (dbType, context) {
             resp.docs.should.have.length(0);
         });
       });
+      it('should ignore non-array field values', function () {
+        var db = context.db;
+        return context.db.bulkDocs([
+          { _id: "string", unknown: "str" },
+          { _id: "array", unknown: [ "a", "b", "c" ] },
+        ]).then(function () {
+          return db.find({
+            selector: {
+              unknown: { $size: 3 }
+            },
+          }).then(function (resp) {
+            var docs = resp.docs.map(function (doc) {
+              delete doc._rev;
+              return doc;
+            });
+
+            docs.should.deep.equal([
+              { _id: "array", unknown: [ "a", "b", "c" ] },
+            ]);
+          });
+        });
+      });
     });
 
     describe('$nin', function () {

--- a/tests/find/test-suite-1/test.array.js
+++ b/tests/find/test-suite-1/test.array.js
@@ -192,6 +192,36 @@ testCases.push(function (dbType, context) {
             resp.docs.should.have.length(0);
         });
       });
+      it('should error for non-array query value', function () {
+        var db = context.db;
+        return db.find({
+          selector: {
+            favorites: {
+              $in: 'a'
+            }
+          },
+        }).then(function () {
+          throw new Error('Function should throw');
+        }, function (err) {
+          err.message.should.eq('Query operator $in must be an array. Received string: a');
+        });
+      });
+      it('should NOT error for "invalid operators" inside', function () {
+        var db = context.db;
+        return db.bulkDocs([
+          { _id: "1", list: [ { $or: "allowed" } ] }
+        ]).then(function () {
+          return db.find({
+            selector: {
+              list: { $in: [ { $or: "allowed" } ] },
+            },
+          }).then(function (resp) {
+            resp.docs.map(function (doc) {
+              return doc._id;
+            }).should.deep.equal([ "1" ]);
+          });
+        });
+      });
     });
 
     describe('$all', function () {
@@ -246,6 +276,36 @@ testCases.push(function (dbType, context) {
           },
         }).then(function (resp) {
             resp.docs.should.have.length(0);
+        });
+      });
+      it('should error for non-array query value', function () {
+        var db = context.db;
+        return db.find({
+          selector: {
+            favorites: {
+              $all: 'a'
+            }
+          },
+        }).then(function () {
+          throw new Error('Function should throw');
+        }, function (err) {
+          err.message.should.eq('Query operator $all must be an array. Received string: a');
+        });
+      });
+      it('should NOT error for "invalid operators" inside', function () {
+        var db = context.db;
+        return db.bulkDocs([
+          { _id: "1", list: [ { $or: "allowed" } ] }
+        ]).then(function () {
+          return db.find({
+            selector: {
+              list: { $all: [ { $or: "allowed" } ] },
+            },
+          }).then(function (resp) {
+            resp.docs.map(function (doc) {
+              return doc._id;
+            }).should.deep.equal([ "1" ]);
+          });
         });
       });
     });
@@ -305,6 +365,21 @@ testCases.push(function (dbType, context) {
             resp.docs.should.have.length(0);
         });
       });
+      it('should error on non-int query values', function () {
+        var db = context.db;
+        return db.find({
+          selector: {
+            favorites: {
+              $size: 2.1
+            }
+          },
+        }).then(function () {
+          throw new Error('Function should throw');
+        }, function (err) {
+          err.message.should.eq('Query operator $size must be a integer. Received number: 2.1');
+        });
+      });
+
       it('should ignore non-array field values', function () {
         var db = context.db;
         return context.db.bulkDocs([
@@ -497,6 +572,37 @@ testCases.push(function (dbType, context) {
             ]);
         });
       });
+      it('should error for non-array query value', function () {
+        var db = context.db;
+        return db.find({
+          selector: {
+            favorites: {
+              $nin: 'a'
+            }
+          },
+        }).then(function () {
+          throw new Error('Function should throw');
+        }, function (err) {
+          err.message.should.eq('Query operator $nin must be an array. Received string: a');
+        });
+      });
+      it('should NOT error for "invalid operators" inside', function () {
+        var db = context.db;
+        return db.bulkDocs([
+          { _id: "1", list: [ { $or: "allowed" } ] },
+          { _id: "2", list: [ { $or: "not-allowed" } ] }
+        ]).then(function () {
+          return db.find({
+            selector: {
+              list: { $nin: [ { $or: "not-allowed" } ] },
+            },
+          }).then(function (resp) {
+            resp.docs.map(function (doc) {
+              return doc._id;
+            }).should.deep.equal([ "1" ]);
+          });
+        });
+      });
     });
 
     describe("$allMatch", function () {
@@ -610,6 +716,20 @@ testCases.push(function (dbType, context) {
               {user_id: "a"}
             ]);
           });
+      });
+      it('should error for non-object query value', function () {
+        var db = context.db;
+        return db.find({
+          selector: {
+            bang: {
+              "$allMatch": 'a'
+            }
+          },
+        }).then(function () {
+          throw new Error('Function should throw');
+        }, function (err) {
+          err.message.should.eq('Query operator $allMatch must be an object. Received string: a');
+        });
       });
     });
   });

--- a/tests/find/test-suite-1/test.elem-match.js
+++ b/tests/find/test-suite-1/test.elem-match.js
@@ -65,7 +65,7 @@ testCases.push(function (dbType, context) {
         });
       });
     });
-    
+
     it('with object in array couchdb style', function () {
       var db = context.db;
       var docs = [
@@ -87,6 +87,18 @@ testCases.push(function (dbType, context) {
         });
       });
     });
-    
+
+    it('should error for non-object query value', function () {
+      var db = context.db;
+      return db.find({
+        selector: {
+          events: { $elemMatch: null },
+        },
+      }).then(function () {
+        throw new Error('Function should throw');
+      }, function (err) {
+        err.message.should.eq('Query operator $elemMatch must be an object. Received : null');
+      });
+    });
   });
 });

--- a/tests/find/test-suite-1/test.eq.js
+++ b/tests/find/test-suite-1/test.eq.js
@@ -361,9 +361,7 @@ testCases.push(function (dbType, context) {
       });
     });
 
-    // TODO: investigate later - this fails in both Couch and Pouch, but I
-    // believe it shouldn't.
-    it.skip('#170 does queries with multiple null values - $gte', function () {
+    it('#170 does queries with multiple null values - $gte', function () {
       var db = context.db;
       var index = {
         "index": {
@@ -383,11 +381,10 @@ testCases.push(function (dbType, context) {
           fields: ["_id"]
         });
       }).then(function (resp) {
-        resp.should.deep.equal({
-          docs: [
-            {_id: '1'}
-          ]
-        });
+        resp.docs.should.deep.equal([
+          {_id: '1'},
+          {_id: '2'}
+        ]);
       });
     });
 

--- a/tests/find/test-suite-1/test.exists.js
+++ b/tests/find/test-suite-1/test.exists.js
@@ -181,5 +181,17 @@ testCases.push(function (dbType, context) {
         ]);
       });
     });
+    it('should error for non-boolean query value', function () {
+      var db = context.db;
+      return db.find({
+        selector: {
+          foo: { '$exists': 'true' },
+        },
+      }).then(function () {
+        throw new Error('Function should throw');
+      }, function (err) {
+        err.message.should.eq('Query operator $exists must be a boolean. Received string: true');
+      });
+    });
   });
 });

--- a/tests/find/test-suite-1/test.mod.js
+++ b/tests/find/test-suite-1/test.mod.js
@@ -142,27 +142,26 @@ testCases.push(function (dbType, context) {
       });
     });
 
-    it('should return empty docs for non-integer field', function () {
+    it('should ignore non-int field values', function () {
       var db = context.db;
-      var index = {
-        "index": {
-          "fields": ["name"]
-        }
-      };
-      return db.createIndex(index).then(function () {
+      return context.db.bulkDocs([
+        { _id: "int", int: 10 },
+        { _id: "float", int: 10.1 },
+        { _id: "string", int: "10" },
+      ]).then(function () {
         return db.find({
           selector: {
-            name: {$gte: null},
-            awesome: {$mod: [2, 0]}
+            int: { $mod: [ 3, 1 ] }
           },
-          sort: ['name']
         }).then(function (resp) {
           var docs = resp.docs.map(function (doc) {
             delete doc._rev;
             return doc;
           });
 
-          docs.should.deep.equal([]);
+          docs.should.deep.equal([
+            { _id: "int", int: 10 }
+          ]);
         });
       });
     });

--- a/tests/find/test-suite-1/test.mod.js
+++ b/tests/find/test-suite-1/test.mod.js
@@ -61,7 +61,7 @@ testCases.push(function (dbType, context) {
       });
     });
 
-    it('should return error for zero divisor', function () {
+    it('should error for zero divisor', function () {
       var db = context.db;
       var index = {
         "index": {
@@ -71,28 +71,23 @@ testCases.push(function (dbType, context) {
       return db.createIndex(index).then(function () {
         return db.find({
           selector: {
-            name: {$gte: null},
-            rank: {$mod: [0, 0]}
+            name: { $gte: null },
+            rank: { $mod: [ 0, 0 ] }
           },
-          sort: ['name']
+          sort: [ 'name' ]
         }).then(function () {
-          throw new Error('expected an error here');
+          throw new Error('Function should throw');
         }, function (err) {
-            if (dbType === 'http') {
-              should.exist(err);
-              return;
-            }
-
-            err.message.should.match(/Bad divisor/);
+          err.message.should.eq("Query operator $mod's divisor cannot be 0, cannot divide by zero.");
         });
       });
     });
 
-    it('should return error for non-integer divisor', function () {
+    it('should error for non-integer divisor', function () {
       var db = context.db;
       var index = {
         "index": {
-          "fields": ["name"]
+          "fields": ['name']
         }
       };
       return db.createIndex(index).then(function () {
@@ -103,19 +98,14 @@ testCases.push(function (dbType, context) {
           },
           sort: ['name']
         }).then(function () {
-          throw new Error('expected an error here');
+          throw new Error('Function should throw');
         }, function (err) {
-          if (dbType === 'http') {
-            should.exist(err);
-            return;
-          }
-
-          err.message.should.match(/Divisor is not an integer/);
+          err.message.should.eq("Query operator $mod's divisor is not an integer. Received string: a");
         });
       });
     });
 
-    it('should return error for non-integer modulus', function () {
+    it('should error for non-integer modulus', function () {
       var db = context.db;
       var index = {
         "index": {
@@ -130,14 +120,52 @@ testCases.push(function (dbType, context) {
           },
           sort: ['name']
         }).then(function () {
-          throw new Error('expected an error here');
+          throw new Error('Function should throw');
         }, function (err) {
-          if (dbType === 'http') {
-            should.exist(err);
-            return;
-          }
+          err.message.should.eq("Query operator $mod's remainder is not an integer. Received string: a");
+        });
+      });
+    });
 
-          err.message.should.match(/Modulus is not an integer/);
+    it('should error for non-array modulus', function () {
+      var db = context.db;
+      var index = {
+        "index": {
+          "fields": ["name"]
+        }
+      };
+      return db.createIndex(index).then(function () {
+        return db.find({
+          selector: {
+            name: {$gte: null},
+            rank: {$mod: 'a'}
+          },
+          sort: ['name']
+        }).then(function () {
+          throw new Error('Function should throw');
+        }, function (err) {
+          err.message.should.eq('Query operator $mod must be an array. Received string: a');
+        });
+      });
+    });
+    it('should error for wrong query value length', function () {
+      var db = context.db;
+      var index = {
+        "index": {
+          "fields": ["name"]
+        }
+      };
+      return db.createIndex(index).then(function () {
+        return db.find({
+          selector: {
+            name: {$gte: null},
+            rank: {$mod: [10]}
+          },
+          sort: ['name']
+        }).then(function () {
+          throw new Error('Function should throw');
+        }, function (err) {
+          err.message.should.eq('Query operator $mod must be in the format [divisor, remainder], where divisor and remainder are both integers. Received array: ' + JSON.stringify([10], null, "\t"));
         });
       });
     });

--- a/tests/find/test-suite-1/test.regex.js
+++ b/tests/find/test-suite-1/test.regex.js
@@ -102,6 +102,32 @@ testCases.push(function (dbType, context) {
         });
       });
     });
+    it('should error on non string or regex query values', function () {
+      var db = context.db;
+      var index = {
+        "index": {
+          "fields": [ "name" ]
+        }
+      };
+      return db.createIndex(index).then(function () {
+        return db.find({
+          selector: {
+            $and: [
+              { name: { $regex: 1986 } },
+            ]
+          },
+          sort: [ 'name' ]
+        }).then(function () {
+          throw new Error('Function should throw');
+        }, function (err) {
+          if (dbType === "http") {
+            err.message.should.eq('Query operator $regex must be a string. Received number: 1986');
+          } else {
+            err.message.should.eq('Query operator $regex must be a string or an instance of a javascript regular expression. Received number: 1986');
+          }
+        });
+      });
+    });
 
     it('should works with index on multiple fields', function () {
       var db = context.db;

--- a/tests/find/test-suite-1/test.regex.js
+++ b/tests/find/test-suite-1/test.regex.js
@@ -80,27 +80,25 @@ testCases.push(function (dbType, context) {
       });
     });
 
-    it('does not return docs for regex on non-string field', function () {
+    it('should ignore non-string field values', function () {
       var db = context.db;
-      var index = {
-        "index": {
-          "fields": ["name"]
-        }
-      };
-      return db.createIndex(index).then(function () {
+      return context.db.bulkDocs([
+        { _id: "number", unknown: 10 },
+        { _id: "number-as-string", unknown: "10" },
+      ]).then(function () {
         return db.find({
           selector: {
-            name: {$gte: null},
-            debut: {$regex: "^Mario"}
+            unknown: { $regex: "10" }
           },
-          sort: ['name']
         }).then(function (resp) {
           var docs = resp.docs.map(function (doc) {
             delete doc._rev;
             return doc;
           });
 
-          docs.should.deep.equal([]);
+          docs.should.deep.equal([
+            { _id: "number-as-string", unknown: "10" },
+          ]);
         });
       });
     });

--- a/tests/find/test-suite-1/test.type.js
+++ b/tests/find/test-suite-1/test.type.js
@@ -97,7 +97,7 @@ testCases.push(function (dbType, context) {
       });
     });
 
-    it('throws error for unmatched type', function () {
+    it('should error for unsupported query value', function () {
       var db = context.db;
       return db.find({
         selector: {
@@ -105,7 +105,20 @@ testCases.push(function (dbType, context) {
         },
         fields: ['_id']
       }).catch(function (err) {
-        err.message.should.match(/made-up not supported/);
+        err.message.should.eq('Query operator $type must be a string. Supported values: "null", "boolean", "number", "string", "array", or "object". Received string: made-up');
+      });
+    });
+    it('should error for non-string query value', function () {
+      var db = context.db;
+      return db.find({
+        selector: {
+          'foo': {$type: 0}
+        },
+        fields: ['_id']
+      }).then(function () {
+        throw new Error('Function should throw');
+      }, function (err) {
+        err.message.should.eq('Query operator $type must be a string. Supported values: "null", "boolean", "number", "string", "array", or "object". Received number: 0');
       });
     });
   });


### PR DESCRIPTION
This pull request:

- Fixes pouchdb to conform to [couchdb's operator limitations](https://docs.couchdb.org/en/stable/api/database/find.html#condition-operators) for how it matches against a value, specifically `$size`, `$regex`, and `$mod`. I looked over the other operators and they seem to be fine. 
- Adds a function to validate the selector and check all operator value types (e.g. `$exists` can only be queried by a boolean, `$and` can only be an array, etc.) *before* running / sending the query. 

Notes:

I added a new file `validateSelector` to `pouchdb-find` since there did not seem to be a better place to put it and moved `$mod`'s checks there but did not move the check to see if a "matcher" exists (i.e. the operator is supported by pouch). I left that where it was in `in-memory-filter` because it should be possible to query couchdb with operators that pouchdb does not yet support.

`$regex` is of course also allowed to be an instance of `RegExp` ~~so the validation function won't save users from querying couchdb with one~~ (I fixed it), but I have an idea for how to allow cross-compatible queries. Will file a separate issue.

Other:

The .gitignore is not ignoring all temp db folders generated if they happen to still be around because I stopped a test, etc. Really annoying. I changed mine locally to `tmp*` instead of `tmp`. I can add the changes to this PR or would you prefer a separate one? Or was there some reason for it being just `tmp`?

Also being a double quotes person I tried as much as possible to use single quotes like most of the rest of the source code (though tests has quite the mix), but eslint is not set up with any quote style so some might have slipped through.