### PR TITLE
Fix #7331 - close leveldb file handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ lerna-debug.log
 tests/integration/utils-bundle.js
 *.heapsnapshot
 /pouchdb-server-install
+package-lock.json
+yarn.lock

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -1182,7 +1182,7 @@ function LevelPouch(opts, callback) {
           eventEmitter.removeAllListeners();
           eventEmitter.close();
           adapterStore.delete(key);
-        })
+        });
         
         callback();
       }

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -134,7 +134,7 @@ function fetchAttachments(results, stores, opts) {
       return;
     }
     var attNames = Object.keys(row.doc._attachments);
-    attNames.forEach(function (attName) {
+    attNames.forEach(function pa(attName) {
       var att = row.doc._attachments[attName];
       if (!('data' in att)) {
         atts.push(att);
@@ -1173,6 +1173,16 @@ function LevelPouch(opts, callback) {
         callback(err);
       } else {
         dbStore.delete(name);
+
+        var adapterName = functionName(leveldown);
+        var adapterStore = dbStores.get(adapterName);
+        var keys = adapterStore.keys();
+        keys.forEach(key => {
+          var eventEmitter = adapterStore.get(key)
+          eventEmitter.removeAllListeners()
+          eventEmitter.close()
+          adapterStore.delete(key)
+        })
         callback();
       }
     });

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -1176,13 +1176,14 @@ function LevelPouch(opts, callback) {
 
         var adapterName = functionName(leveldown);
         var adapterStore = dbStores.get(adapterName);
-        var keys = adapterStore.keys();
+        var keys = [...adapterStore.keys()].filter(k => k.includes("-mrview-"));
         keys.forEach(key => {
           var eventEmitter = adapterStore.get(key)
           eventEmitter.removeAllListeners()
           eventEmitter.close()
           adapterStore.delete(key)
         })
+        
         callback();
       }
     });

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -1178,10 +1178,10 @@ function LevelPouch(opts, callback) {
         var adapterStore = dbStores.get(adapterName);
         var keys = [...adapterStore.keys()].filter(k => k.includes("-mrview-"));
         keys.forEach(key => {
-          var eventEmitter = adapterStore.get(key)
-          eventEmitter.removeAllListeners()
-          eventEmitter.close()
-          adapterStore.delete(key)
+          var eventEmitter = adapterStore.get(key);
+          eventEmitter.removeAllListeners();
+          eventEmitter.close();
+          adapterStore.delete(key);
         })
         
         callback();

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -134,7 +134,7 @@ function fetchAttachments(results, stores, opts) {
       return;
     }
     var attNames = Object.keys(row.doc._attachments);
-    attNames.forEach(function pa(attName) {
+    attNames.forEach(function (attName) {
       var att = row.doc._attachments[attName];
       if (!('data' in att)) {
         atts.push(att);

--- a/packages/node_modules/pouchdb-collections/src/Map.js
+++ b/packages/node_modules/pouchdb-collections/src/Map.js
@@ -22,7 +22,7 @@ Map.prototype.has = function (key) {
 };
 Map.prototype.keys = function () {
   return Object.keys(this._store).map(k => unmangle(k));
-}
+};
 Map.prototype.delete = function (key) {
   var mangled = mangle(key);
   var res = mangled in this._store;

--- a/packages/node_modules/pouchdb-collections/src/Map.js
+++ b/packages/node_modules/pouchdb-collections/src/Map.js
@@ -20,6 +20,9 @@ Map.prototype.has = function (key) {
   var mangled = mangle(key);
   return mangled in this._store;
 };
+Map.prototype.keys = function () {
+  return Object.keys(this._store).map(k => unmangle(k));
+}
 Map.prototype.delete = function (key) {
   var mangled = mangle(key);
   var res = mangled in this._store;


### PR DESCRIPTION
This fixes #7331 so "mrview" folders can be deleted/repaired after closing the db and without having to restart the app.