### PR TITLE
rev() should clone only when needed

### DIFF
--- a/packages/node_modules/pouchdb-utils/src/rev.js
+++ b/packages/node_modules/pouchdb-utils/src/rev.js
@@ -1,15 +1,18 @@
 import { v4 as uuidV4 } from 'uuid';
 import { stringMd5 } from 'pouchdb-md5';
-import clone from './clone';
 
+/**
+ * Creates a new revision string that does NOT include the revision height
+ * For example '56649f1b0506c6ca9fda0746eb0cacdf'
+ */
 function rev(doc, deterministic_revs) {
-  var clonedDoc = clone(doc);
   if (!deterministic_revs) {
     return uuidV4().replace(/-/g, '').toLowerCase();
   }
 
-  delete clonedDoc._rev_tree;
-  return stringMd5(JSON.stringify(clonedDoc));
+  var mutateableDoc = Object.assign({}, doc);
+  delete mutateableDoc._rev_tree;
+  return stringMd5(JSON.stringify(mutateableDoc));
 }
 
 export default rev;


### PR DESCRIPTION
Doing a deep clone over an object is very expensive. We do this very often when creating new revision keys.
I changed the code to:
- Only clone when needed for deterministic revision
- Do a flat clone via Object.assign because we anyway only need the cloned object for the md5-hash without `_rev_tree`


Question: Shouldnt't we also strip `_rev` from the document data before hashing it?