### PR TITLE
feat: support partial_filter_selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test-webpack": "bash bin/test-webpack.sh"
   },
   "dependencies": {
+    "abort-controller": "3.0.0",
     "argsarray": "0.0.1",
     "buffer-from": "1.1.1",
     "clone-buffer": "1.0.0",
@@ -52,7 +53,6 @@
     "ltgt": "2.2.1",
     "memdown": "1.4.1",
     "node-fetch": "2.6.1",
-    "abort-controller": "3.0.0",
     "promise-polyfill": "8.1.3",
     "readable-stream": "1.1.14",
     "request": "2.88.2",

--- a/packages/node_modules/pouchdb-find/README.md
+++ b/packages/node_modules/pouchdb-find/README.md
@@ -12,9 +12,7 @@ Eventually this will replace PouchDB's map/reduce API entirely. You'll still be 
 Status
 ---
 
-Implemented: `$lt`, `$gt`, `$lte`, `$gte`, `$eq`, `$exists`, `$type`, `$in`, `$nin`, `$all`, `$size`, `$or`, `$nor`, `$not`, `$mod`, `$regex`, `$elemMatch`, multi-field queries, multi-field indexes, multi-field sort, `'deep.fields.like.this'`, ascending and descending sort.
-
-Not implemented: `partial_filter_selector` in non-remote databases, as used for [partial indexes](http://docs.couchdb.org/en/stable/api/database/find.html#find-partial-indexes).
+Implemented: `$lt`, `$gt`, `$lte`, `$gte`, `$eq`, `$exists`, `$type`, `$in`, `$nin`, `$all`, `$size`, `$or`, `$nor`, `$not`, `$mod`, `$regex`, `$elemMatch`, multi-field queries, multi-field indexes, multi-field sort, `'deep.fields.like.this'`, ascending and descending sort, [partial indexes](http://docs.couchdb.org/en/stable/api/database/find.html#find-partial-indexes).
 
 **0.2.0**: `$and`, `$ne`
 

--- a/packages/node_modules/pouchdb-find/src/adapters/local/abstract-mapper.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/abstract-mapper.js
@@ -1,5 +1,5 @@
 import abstractMapReduce from 'pouchdb-abstract-mapreduce';
-import { parseField } from 'pouchdb-selector-core';
+import { matchesSelector, parseField } from 'pouchdb-selector-core';
 
 //
 // One thing about these mappers:
@@ -13,8 +13,9 @@ import { parseField } from 'pouchdb-selector-core';
 //
 
 
-function createDeepMultiMapper(fields, emit) {
+function createDeepMultiMapper(fields, emit, selector) {
   return function (doc) {
+    if (!matchesSelector(doc, selector)) { return; }
     var toEmit = [];
     for (var i = 0, iLen = fields.length; i < iLen; i++) {
       var parsedField = parseField(fields[i]);
@@ -32,9 +33,10 @@ function createDeepMultiMapper(fields, emit) {
   };
 }
 
-function createDeepSingleMapper(field, emit) {
+function createDeepSingleMapper(field, emit, selector) {
   var parsedField = parseField(field);
   return function (doc) {
+    if (!matchesSelector(doc, selector)) { return; }
     var value = doc;
     for (var i = 0, len = parsedField.length; i < len; i++) {
       var key = parsedField[i];
@@ -47,14 +49,16 @@ function createDeepSingleMapper(field, emit) {
   };
 }
 
-function createShallowSingleMapper(field, emit) {
+function createShallowSingleMapper(field, emit, selector) {
   return function (doc) {
+    if (!matchesSelector(doc, selector)) { return; }
     emit(doc[field]);
   };
 }
 
-function createShallowMultiMapper(fields, emit) {
+function createShallowMultiMapper(fields, emit, selector) {
   return function (doc) {
+    if (!matchesSelector(doc, selector)) { return; }
     var toEmit = [];
     for (var i = 0, len = fields.length; i < len; i++) {
       toEmit.push(doc[fields[i]]);
@@ -73,7 +77,7 @@ function checkShallow(fields) {
   return true;
 }
 
-function createMapper(fields, emit) {
+function createMapper(fields, emit, selector) {
   var isShallow = checkShallow(fields);
   var isSingle = fields.length === 1;
 
@@ -81,15 +85,15 @@ function createMapper(fields, emit) {
   // i.e. single shallow indexes
   if (isShallow) {
     if (isSingle) {
-      return createShallowSingleMapper(fields[0], emit);
+      return createShallowSingleMapper(fields[0], emit, selector);
     } else { // multi
-      return createShallowMultiMapper(fields, emit);
+      return createShallowMultiMapper(fields, emit, selector);
     }
   } else { // deep
     if (isSingle) {
-      return createDeepSingleMapper(fields[0], emit);
+      return createDeepSingleMapper(fields[0], emit, selector);
     } else { // multi
-      return createDeepMultiMapper(fields, emit);
+      return createDeepMultiMapper(fields, emit, selector);
     }
   }
 }
@@ -97,9 +101,10 @@ function createMapper(fields, emit) {
 function mapper(mapFunDef, emit) {
   // mapFunDef is a list of fields
 
-  var fields = Object.keys(mapFunDef.fields);
+  const fields = Object.keys(mapFunDef.fields);
+  const partialSelector = mapFunDef.partial_filter_selector;
 
-  return createMapper(fields, emit);
+  return createMapper(fields, emit, partialSelector);
 }
 
 /* istanbul ignore next */

--- a/packages/node_modules/pouchdb-find/src/adapters/local/abstract-mapper.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/abstract-mapper.js
@@ -15,7 +15,7 @@ import { matchesSelector, parseField } from 'pouchdb-selector-core';
 
 function createDeepMultiMapper(fields, emit, selector) {
   return function (doc) {
-    if (!matchesSelector(doc, selector)) { return; }
+    if (selector && !matchesSelector(doc, selector)) { return; }
     var toEmit = [];
     for (var i = 0, iLen = fields.length; i < iLen; i++) {
       var parsedField = parseField(fields[i]);
@@ -36,7 +36,7 @@ function createDeepMultiMapper(fields, emit, selector) {
 function createDeepSingleMapper(field, emit, selector) {
   var parsedField = parseField(field);
   return function (doc) {
-    if (!matchesSelector(doc, selector)) { return; }
+    if (selector && !matchesSelector(doc, selector)) { return; }
     var value = doc;
     for (var i = 0, len = parsedField.length; i < len; i++) {
       var key = parsedField[i];
@@ -51,14 +51,14 @@ function createDeepSingleMapper(field, emit, selector) {
 
 function createShallowSingleMapper(field, emit, selector) {
   return function (doc) {
-    if (!matchesSelector(doc, selector)) { return; }
+    if (selector && !matchesSelector(doc, selector)) { return; }
     emit(doc[field]);
   };
 }
 
 function createShallowMultiMapper(fields, emit, selector) {
   return function (doc) {
-    if (!matchesSelector(doc, selector)) { return; }
+    if (selector && !matchesSelector(doc, selector)) { return; }
     var toEmit = [];
     for (var i = 0, len = fields.length; i < len; i++) {
       toEmit.push(doc[fields[i]]);

--- a/tests/find/index.html
+++ b/tests/find/index.html
@@ -49,6 +49,7 @@
     <script src='./test-suite-1/test.not.js'></script>
     <script src='./test-suite-1/test.or.js'></script>
     <script src='./test-suite-1/test.pick-fields.js'></script>
+    <script src='./test-suite-1/test.partial.js'></script>
     <script src='./test-suite-1/test.regex.js'></script>
     <script src='./test-suite-1/test.set-operations.js'></script>
     <script src='./test-suite-1/test.skip.js'></script>

--- a/tests/find/test-suite-1/test.partial.js
+++ b/tests/find/test-suite-1/test.partial.js
@@ -15,7 +15,9 @@ testCases.push(function (dbType, context) {
         ddoc: 'test-partial',
         name: 'type-x'
       });
-      Promise.all([write, index]).then(done);
+      Promise.all([write, index]).then(() => {
+        done();
+      });
     });
     it('should apply the partial filter', function (done) {
       context.db.find({

--- a/tests/find/test-suite-1/test.partial.js
+++ b/tests/find/test-suite-1/test.partial.js
@@ -1,0 +1,32 @@
+'use strict';
+
+testCases.push(function (dbType, context) {
+  const { db } = context;
+  describe(`${dbType}: test.partial.js`, function () {
+    beforeEach(function () {
+      const write = db.bulkDocs({ docs: [
+        { _id: 'a', type: 'x', hello: 'world' },
+        { _id: 'a', type: 'y', hello: 'world' }
+      ]});
+      const index = db.createIndex({
+        index: {
+          fields: ['hello'],
+          partial_filter_selector: { type: 'x' }
+        },
+        ddoc: 'test-partial',
+        name: 'type-x'
+      });
+      Promise.all([write, index]);
+    });
+    it('should apply the partial filter', function () {
+      db.find({
+        selector: { hello: 'world' },
+        use_index: ['_design/test-partial', 'type-x']
+      }).then((result) => {
+        result.should.deep.equals({
+          docs: [{ _id: 'a', type: 'x', hello: 'world' }]
+        });
+      });
+    });
+  });
+});

--- a/tests/find/test-suite-1/test.partial.js
+++ b/tests/find/test-suite-1/test.partial.js
@@ -21,10 +21,12 @@ testCases.push(function (dbType, context) {
       return context.db.find({
         selector: { hello: 'world' },
         use_index: ['_design/test-partial', 'type-x']
-      }).then((result) => {
-        result.should.deep.equals({
-          docs: [{ _id: 'a', type: 'x', hello: 'world' }]
-        });
+      }).then(function (result) {
+        result.docs.should.have.length(1);
+        const [{ _id: id, type, hello }] = result.docs;
+        id.should.equal('a');
+        type.should.equal('x');
+        hello.should.equal('world');
       });
     });
   });

--- a/tests/find/test-suite-1/test.partial.js
+++ b/tests/find/test-suite-1/test.partial.js
@@ -1,14 +1,13 @@
 'use strict';
 
 testCases.push(function (dbType, context) {
-  const { db } = context;
   describe(`${dbType}: test.partial.js`, function () {
     beforeEach(function () {
-      const write = db.bulkDocs({ docs: [
+      const write = context.db.bulkDocs({ docs: [
         { _id: 'a', type: 'x', hello: 'world' },
         { _id: 'a', type: 'y', hello: 'world' }
       ]});
-      const index = db.createIndex({
+      const index = context.db.createIndex({
         index: {
           fields: ['hello'],
           partial_filter_selector: { type: 'x' }
@@ -19,7 +18,7 @@ testCases.push(function (dbType, context) {
       Promise.all([write, index]);
     });
     it('should apply the partial filter', function () {
-      db.find({
+      context.db.find({
         selector: { hello: 'world' },
         use_index: ['_design/test-partial', 'type-x']
       }).then((result) => {

--- a/tests/find/test-suite-1/test.partial.js
+++ b/tests/find/test-suite-1/test.partial.js
@@ -2,7 +2,7 @@
 
 testCases.push(function (dbType, context) {
   describe(`${dbType}: test.partial.js`, function () {
-    beforeEach(function () {
+    beforeEach(function (done) {
       const write = context.db.bulkDocs({ docs: [
         { _id: 'a', type: 'x', hello: 'world' },
         { _id: 'a', type: 'y', hello: 'world' }
@@ -15,9 +15,9 @@ testCases.push(function (dbType, context) {
         ddoc: 'test-partial',
         name: 'type-x'
       });
-      Promise.all([write, index]);
+      Promise.all([write, index]).then(done);
     });
-    it('should apply the partial filter', function () {
+    it('should apply the partial filter', function (done) {
       context.db.find({
         selector: { hello: 'world' },
         use_index: ['_design/test-partial', 'type-x']
@@ -25,6 +25,7 @@ testCases.push(function (dbType, context) {
         result.should.deep.equals({
           docs: [{ _id: 'a', type: 'x', hello: 'world' }]
         });
+        done();
       });
     });
   });

--- a/tests/find/test-suite-1/test.partial.js
+++ b/tests/find/test-suite-1/test.partial.js
@@ -2,7 +2,7 @@
 
 testCases.push(function (dbType, context) {
   describe(`${dbType}: test.partial.js`, function () {
-    beforeEach(function (done) {
+    beforeEach(function () {
       const write = context.db.bulkDocs({ docs: [
         { _id: 'a', type: 'x', hello: 'world' },
         { _id: 'a', type: 'y', hello: 'world' }
@@ -15,19 +15,16 @@ testCases.push(function (dbType, context) {
         ddoc: 'test-partial',
         name: 'type-x'
       });
-      Promise.all([write, index]).then(() => {
-        done();
-      });
+      return Promise.all([write, index]);
     });
-    it('should apply the partial filter', function (done) {
-      context.db.find({
+    it('should apply the partial filter', function () {
+      return context.db.find({
         selector: { hello: 'world' },
         use_index: ['_design/test-partial', 'type-x']
       }).then((result) => {
         result.should.deep.equals({
           docs: [{ _id: 'a', type: 'x', hello: 'world' }]
         });
-        done();
       });
     });
   });


### PR DESCRIPTION
This PR closes https://github.com/pouchdb/pouchdb/issues/8276 by modifying the abstract mapper used by pouchdb-find so that it will apply a partial_filter_selector at index time if one is present.

- [x] Includes tests.
- [x] Updates documentation.