### PR TITLE
Add Newt to Who's Using PouchDB (https://newt.to)

### DIFF
--- a/docs/users.md
+++ b/docs/users.md
@@ -5,6 +5,11 @@ sidebar: nav.html
 ---
 
 A list of known products and services that are using PouchDB.
+## Newt
+
+{% include img.html width=100 src="newt.png" alt="Newt" %}
+
+[Newt](https://newt.to) lets you read, listen and write thousands of books across devices natively. It runs on Windows, Linux, macOS, Android, iOS & web. Its backed is powered by CouchDB and it uses PouchDB on the web client, desktop client and mobile native app for offline access, live sync, revisions and much more.
 
 ## BikeCommute
 


### PR DESCRIPTION
Hey,
I'd like to add Newt to Who's Using PouchDB.

I'm using PouchDB for the desktop app, mobile native app and web app, and it's available on Android, iOS, macOS, Windows, Linux and Web.

This community is amazing, and Newt wouldn't be what it is today without Pouch.

I'll also add the image to the static/img in another PR.