### PR TITLE
Adding TypeScript and Storybooks to PouchDB

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test-webpack": "bash bin/test-webpack.sh"
   },
   "dependencies": {
+    "abort-controller": "3.0.0",
     "argsarray": "0.0.1",
     "buffer-from": "1.1.1",
     "clone-buffer": "1.0.0",
@@ -52,7 +53,6 @@
     "ltgt": "2.2.1",
     "memdown": "1.4.1",
     "node-fetch": "2.6.1",
-    "abort-controller": "3.0.0",
     "promise-polyfill": "8.1.3",
     "readable-stream": "1.1.14",
     "request": "2.88.2",

--- a/packages/node_modules/pouchdb-errors-poc/.storybook/decorators/ThemeProvider.js
+++ b/packages/node_modules/pouchdb-errors-poc/.storybook/decorators/ThemeProvider.js
@@ -1,0 +1,4 @@
+import React from 'react';
+
+const ThemeProvider = storyFn => <>{storyFn()}</>;
+export default ThemeProvider;

--- a/packages/node_modules/pouchdb-errors-poc/.storybook/main.js
+++ b/packages/node_modules/pouchdb-errors-poc/.storybook/main.js
@@ -1,0 +1,32 @@
+const path = require('path');
+
+module.exports = {
+    stories: ['../src/**/*.stories.tsx'],
+    addons: ['@storybook/addon-essentials'],
+    webpackFinal: async (config) => {
+        config.module.rules[0].use[0].options.presets = [
+            require.resolve('@babel/preset-react'),
+            require.resolve('@babel/preset-env')
+        ];
+        config.module.rules.push(
+            {
+                test: /\.scss$/,
+                use: ['style-loader', 'css-loader', 'sass-loader'],
+                include: path.resolve(__dirname, '../'),
+            },
+            {
+                test: /\.(ts|tsx)$/,
+                loader: require.resolve('babel-loader'),
+                options: {
+                    presets: [
+                        ['react-app', { flow: false, typescript: true }]
+                    ],
+                },
+            }
+        );
+
+        config.resolve.extensions.push('.ts', '.tsx');
+
+        return config;
+    },
+};

--- a/packages/node_modules/pouchdb-errors-poc/.storybook/preview.js
+++ b/packages/node_modules/pouchdb-errors-poc/.storybook/preview.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { addDecorator } from '@storybook/react';
+
+addDecorator((story) => story());
+
+const customViewports = {
+    mobile: {
+        name: 'Mobile',
+        styles: {
+            height: '665px',
+            width: '400px',
+        },
+        type: 'mobile',
+    },
+    tablet: {
+        name: 'Tablet',
+        styles: {
+            height: '1024px',
+            width: '768px',
+        },
+        type: 'tablet',
+    },
+};
+
+export const parameters = {
+    viewport: {
+        viewports: {
+            ...customViewports,
+        },
+    },
+    layout: 'fullscreen',
+};

--- a/packages/node_modules/pouchdb-errors-poc/LICENSE
+++ b/packages/node_modules/pouchdb-errors-poc/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 PouchDB
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/node_modules/pouchdb-errors-poc/README.md
+++ b/packages/node_modules/pouchdb-errors-poc/README.md
@@ -1,0 +1,41 @@
+pouchdb-errors ![semver non-compliant](https://img.shields.io/badge/semver-non--compliant-red.svg)
+======
+
+Errors exposed by PouchDB.
+
+### Usage
+
+```bash
+npm install --save-exact pouchdb-errors
+```
+
+### Development
+
+`npm run build` -> Rollup bundling process
+
+`npm run storybook` -> Storybook will load up your components at http://localhost:6006
+
+`npm run test:watch` -> To run your tests locally (they will re-run whenever a file is changed)
+
+* If you're on NPM, replace *yarn ...* with *npm run ...*
+
+### Documentation
+
+`npm run storybook:export` -> Export Storybook as static files
+
+### Miscellaneous
+
+`npm run test` -> Used for the CI/CD pipeline
+
+For full API documentation and guides on PouchDB, see [PouchDB.com](http://pouchdb.com/). For details on PouchDB sub-packages, see the [Custom Builds documentation](http://pouchdb.com/custom.html).
+
+### Warning: semver-free zone!
+
+This package is conceptually an internal API used by PouchDB or its plugins. It does not follow semantic versioning (semver), and rather its version is pegged to PouchDB's. Use exact versions when installing, e.g. with `--save-exact`.
+
+### Source
+
+PouchDB and its sub-packages are distributed as a [monorepo](https://github.com/babel/babel/blob/master/doc/design/monorepo.md).
+
+For a full list of packages, see [the GitHub source](https://github.com/pouchdb/pouchdb/tree/master/packages).
+

--- a/packages/node_modules/pouchdb-errors-poc/jest.config.js
+++ b/packages/node_modules/pouchdb-errors-poc/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+    roots: ['./src'],
+    setupFilesAfterEnv: ['./jest.setup.ts'],
+    moduleFileExtensions: ['ts', 'tsx', 'js'],
+    testPathIgnorePatterns: ['node_modules/'],
+    transform: {
+        '^.+\\.tsx?$': 'ts-jest',
+    },
+    testMatch: ['**/*.test.(ts|tsx)'],
+    moduleNameMapper: {
+        // Mocks out all these file formats when tests are run
+        '\\.(png|svg|pdf|jpg|jpeg|ttf)$': '<rootDir>/mocks/fileMock.js',
+        '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+    }
+};

--- a/packages/node_modules/pouchdb-errors-poc/jest.setup.ts
+++ b/packages/node_modules/pouchdb-errors-poc/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/packages/node_modules/pouchdb-errors-poc/mocks/fileMock.js
+++ b/packages/node_modules/pouchdb-errors-poc/mocks/fileMock.js
@@ -1,0 +1,3 @@
+// See https://jestjs.io/docs/webpack#handling-static-assets
+// to understand the following line
+module.exports = 'test-file-stub';

--- a/packages/node_modules/pouchdb-errors-poc/package.json
+++ b/packages/node_modules/pouchdb-errors-poc/package.json
@@ -1,0 +1,64 @@
+{
+    "name": "@pouchdb/errors",
+    "version": "0.0.1",
+    "description": "A set of components for PouchDB Errors",
+    "main": "build/index.js",
+    "scripts": {
+        "build": "rollup -c",
+        "storybook": "start-storybook -p 6006",
+        "storybook:export": "build-storybook",
+        "test": "jest",
+        "test:watch": "jest --watch",
+        "prettier": "prettier --write src/**/*.{ts,tsx,css}",
+        "prettier:check": "prettier --list-different src/**/*.{ts,tsx,css}",
+        "tslint:check": "tslint -c tslint.json 'src/**/*.{ts,tsx}'",
+        "prePublishOnly": "npm run build"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pouchdb/pouchdb-error.git"
+    },
+    "author": "",
+    "license": "ISC",
+    "bugs": {
+        "url": "https://github.com/pouchdb/pouchdb/issues"
+    },
+    "homepage": "https://github.com/pouchdb/pouchdb/",
+    "devDependencies": {
+        "@babel/core": "7.12.10",
+        "@babel/preset-env": "^7.14.2",
+        "@rollup/plugin-commonjs": "^15.1.0",
+        "@rollup/plugin-node-resolve": "^9.0.0",
+        "@rollup/plugin-url": "^6.0.0",
+        "@storybook/addon-essentials": "^6.2.9",
+        "@storybook/react": "^6.2.9",
+        "@testing-library/dom": "^7.26.3",
+        "@testing-library/jest-dom": "^5.11.4",
+        "@testing-library/react": "^11.0.4",
+        "@testing-library/user-event": "^12.1.8",
+        "@types/jest": "^26.0.23",
+        "@types/react": "^16.9.49",
+        "babel-loader": "^8.1.0",
+        "babel-plugin-emotion": "^10.0.33",
+        "babel-preset-react-app": "^9.1.2",
+        "identity-obj-proxy": "^3.0.0",
+        "jest": "^26.4.2",
+        "prettier": "^2.1.2",
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1",
+        "rollup": "^2.28.2",
+        "rollup-plugin-peer-deps-external": "^2.2.3",
+        "rollup-plugin-postcss": "^4.0.0",
+        "rollup-plugin-typescript2": "^0.27.3",
+        "ts-jest": "^26.4.1",
+        "tslint": "^6.1.3",
+        "typescript": "^4.0.3"
+    },
+    "dependencies": {
+        "babel-eslint": "^10.1.0",
+        "eslint": "^7.17.0"
+    },
+    "files": [
+        "build"
+    ]
+}

--- a/packages/node_modules/pouchdb-errors-poc/rollup.config.js
+++ b/packages/node_modules/pouchdb-errors-poc/rollup.config.js
@@ -1,0 +1,39 @@
+import peerDepsExternal from 'rollup-plugin-peer-deps-external';
+import resolve from '@rollup/plugin-node-resolve';
+import typescript from 'rollup-plugin-typescript2';
+import postcss from 'rollup-plugin-postcss';
+import commonjs from '@rollup/plugin-commonjs';
+import url from '@rollup/plugin-url';
+
+export default {
+    input: 'src/index.tsx',
+    output: [
+        {
+            dir: 'build',
+            format: 'esm',
+            sourcemap: true,
+        },
+    ],
+    plugins: [
+        peerDepsExternal(),
+        resolve(),
+        typescript({ useTsconfigDeclarationDir: true }),
+        postcss({
+            modules: true,
+        }),
+        commonjs({
+            include: 'node_modules/**',
+        }),
+        url({
+            include: [
+                '**/*.ttf',
+                '**/*.svg',
+                '**/*.png',
+                '**/*.jp(e)?g',
+                '**/*.gif',
+                '**/*.webp',
+            ],
+            limit: Infinity,
+        }),
+    ],
+};

--- a/packages/node_modules/pouchdb-errors-poc/src/components/default/Default.stories.tsx
+++ b/packages/node_modules/pouchdb-errors-poc/src/components/default/Default.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Default from './Default';
+
+export default {
+    title: 'Default',
+    component: Default,
+};
+
+export const ErrorComponent = ({error, reason}) => {
+    return (
+        <div>
+            {error}
+            {reason}
+        </div>
+    );
+}

--- a/packages/node_modules/pouchdb-errors-poc/src/components/default/Default.stories.tsx
+++ b/packages/node_modules/pouchdb-errors-poc/src/components/default/Default.stories.tsx
@@ -14,3 +14,14 @@ export const ErrorComponent = ({error, reason}) => {
         </div>
     );
 }
+
+export const AnotherErrorComponentExample = ({error, reason}) => {
+    return (
+        <div>
+            {error}
+            {reason}
+        </div>
+    );
+}
+
+// Add more functions here to test them as stories

--- a/packages/node_modules/pouchdb-errors-poc/src/components/default/Default.test.tsx
+++ b/packages/node_modules/pouchdb-errors-poc/src/components/default/Default.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import DefaultProps from './Default.types';
+import { ErrorComponent } from './Default.stories';
+
+describe('Input', () => {
+    let props: DefaultProps;
+
+    beforeEach(() => {
+        props = {
+            error: 'query_parse_errors',
+            reason: 'Some query parameter is invalid'
+        };
+    });
+
+    const renderContent = () => render(<ErrorComponent {...props} />);
+
+    it('should throw error', () => {
+        const { getByText } = renderContent();
+        const element = getByText('query_parse_errors');
+        expect(element).toBeInTheDocument();
+    });
+});

--- a/packages/node_modules/pouchdb-errors-poc/src/components/default/Default.test.tsx
+++ b/packages/node_modules/pouchdb-errors-poc/src/components/default/Default.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import DefaultProps from './Default.types';
 import { ErrorComponent } from './Default.stories';
 
-describe('Input', () => {
+describe('Error', () => {
     let props: DefaultProps;
 
     beforeEach(() => {
@@ -15,7 +15,7 @@ describe('Input', () => {
 
     const renderContent = () => render(<ErrorComponent {...props} />);
 
-    it('should throw error', () => {
+    it('should find text', () => {
         const { getByText } = renderContent();
         const element = getByText('query_parse_errors');
         expect(element).toBeInTheDocument();

--- a/packages/node_modules/pouchdb-errors-poc/src/components/default/Default.tsx
+++ b/packages/node_modules/pouchdb-errors-poc/src/components/default/Default.tsx
@@ -1,0 +1,63 @@
+import ErrorStatus from '../../shared/constants/errorStatus';
+import DefaultProps, { ErrorStatusProps, ErrorResponse } from './Default.types';
+
+const getErrorFromReason = (error: string, reason: string) => {
+  function CustomPouchError(){
+    // inherit error properties from our parent error manually
+    // so as to allow proper JSON parsing.
+    /* jshint ignore:start */
+    const errorName = Object.keys(ErrorStatus) as ErrorStatusProps[];
+    let getErrorDetails = errorName.map((name) => {
+      return name === error;
+    })
+    
+    return {
+      reason,
+      getErrorDetails
+    }
+  }
+  
+  return CustomPouchError();
+}
+
+const Error = ({ error, reason }: DefaultProps) => {
+  
+  function generateErrorFromResponse() {
+    let err = error as ErrorResponse;
+    if (typeof err !== 'object') {
+      const data = err;
+      err = ErrorStatus.UNKNOWN_ERROR;
+      err.data = data;
+    }
+  
+    if ('error' in err && err.error === 'conflict') {
+      err.name = 'conflict';
+      err.status = 409;
+    }
+  
+    if (!('name' in err)) {
+      err.name = err.error || 'unknown';
+    }
+  
+    if (!('status' in err)) {
+      err.status = 500;
+    }
+  
+    if (!('message' in err)) {
+      err.message = err.message || err.reason;
+    }
+  
+    return err;
+  }
+
+  function createError(){
+    return getErrorFromReason(error, reason)
+  }
+  return {
+      ...ErrorStatus,
+      createError,
+      generateErrorFromResponse
+    };
+};
+
+export default Error;

--- a/packages/node_modules/pouchdb-errors-poc/src/components/default/Default.tsx
+++ b/packages/node_modules/pouchdb-errors-poc/src/components/default/Default.tsx
@@ -7,7 +7,7 @@ const getErrorFromReason = (error: string, reason: string) => {
     // so as to allow proper JSON parsing.
     /* jshint ignore:start */
     const errorName = Object.keys(ErrorStatus) as ErrorStatusProps[];
-    let getErrorDetails = errorName.map((name) => {
+    let getErrorDetails = errorName.find((name) => {
       return name === error;
     })
     

--- a/packages/node_modules/pouchdb-errors-poc/src/components/default/Default.types.ts
+++ b/packages/node_modules/pouchdb-errors-poc/src/components/default/Default.types.ts
@@ -1,0 +1,26 @@
+import { DefaultComponent } from '../../shared/interfaces/DefaultComponent.types';
+
+export default interface ErrorProps extends DefaultComponent {
+    error: string;
+    onClear?: (...args: string[]) => any;
+    reason: string;
+}
+
+export type ErrorResponse = {
+    data?: string;
+    name?: string;
+    status?: number;
+    message?: string;
+    error?: string;
+    reason?: string;
+  }
+  
+export type ErrorStatusProps = 
+    'UNAUTHORIZED' | 'MISSING_BULK_DOCS' | 
+    'MISSING_DOC' | 'REV_CONFLICT' | 'INVALID_ID' |
+    'MISSING_ID' | 'RESERVED_ID' | 'NOT_OPEN' |
+    'UNKNOWN_ERROR' | 'BAD_ARG' | 'INVALID_REQUEST' |
+    'QUERY_PARSE_ERROR' | 'DOC_VALIDATION' | 'BAD_REQUEST' |
+    'NOT_AN_OBJECT' | 'DB_MISSING' | 'IDB_ERROR' | 'WSQ_ERROR' |
+    'LDB_ERROR' | 'FORBIDDEN' | 'INVALID_REV' |
+    'FILE_EXISTS' | 'MISSING_STUB' | 'INVALID_URL';

--- a/packages/node_modules/pouchdb-errors-poc/src/components/default/index.ts
+++ b/packages/node_modules/pouchdb-errors-poc/src/components/default/index.ts
@@ -1,0 +1,2 @@
+import Default from "./Default";
+export default Default;

--- a/packages/node_modules/pouchdb-errors-poc/src/index.tsx
+++ b/packages/node_modules/pouchdb-errors-poc/src/index.tsx
@@ -1,0 +1,5 @@
+import Error from './components/default';
+
+export {
+    Error,
+};

--- a/packages/node_modules/pouchdb-errors-poc/src/modules/fonts.d.ts
+++ b/packages/node_modules/pouchdb-errors-poc/src/modules/fonts.d.ts
@@ -1,0 +1,1 @@
+declare module '*.ttf';

--- a/packages/node_modules/pouchdb-errors-poc/src/modules/png.d.ts
+++ b/packages/node_modules/pouchdb-errors-poc/src/modules/png.d.ts
@@ -1,0 +1,4 @@
+declare module '*.png' {
+    const value: any;
+    export = value;
+}

--- a/packages/node_modules/pouchdb-errors-poc/src/modules/svg.d.ts
+++ b/packages/node_modules/pouchdb-errors-poc/src/modules/svg.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+    const content: any;
+    export default content;
+}

--- a/packages/node_modules/pouchdb-errors-poc/src/shared/constants/errorStatus.tsx
+++ b/packages/node_modules/pouchdb-errors-poc/src/shared/constants/errorStatus.tsx
@@ -1,0 +1,125 @@
+const ErrorStatus = {
+    UNAUTHORIZED: {
+      status: 401,
+      error: 'unauthorized',
+      reason: 'Name or password is incorrect'
+    },
+    MISSING_BULK_DOCS: {
+      status: 400,
+      error: 'bad_request',
+      reason: `Missing JSON list of 'docs'`
+    },
+    MISSING_DOC: {
+      status: 404,
+      error: 'not_found',
+      reason: 'missing'
+    },
+    REV_CONFLICT: {
+      status: 409,
+      error: 'conflict',
+      reason: 'Document update conflict'
+    },
+    INVALID_ID: {
+      status: 400,
+      error: 'bad_request',
+      reason: '_id field must contain a string'
+    },
+    MISSING_ID: {
+      status: 412,
+      error: 'missing_id',
+      reason: '_id is required for puts'
+    },
+    RESERVED_ID: {
+      status: 400,
+      error: 'bad_request',
+      reason: 'Only reserved document ids may start with underscore'
+    },
+    NOT_OPEN: {
+      status: 412,
+      error: 'precondition_failed',
+      reason: 'Database not open'
+    },
+    UNKNOWN_ERROR: {
+      status: 500,
+      error: 'unknown_error',
+      reason: 'Database encountered an unknown error'
+    },
+    BAD_ARG: {
+      status: 500,
+      error: 'bad_arg',
+      reason: 'Some query argument is invalid'
+    },
+    INVALID_REQUEST: {
+      status: 400,
+      error: 'invalid_request',
+      reason: 'Request was invalid'
+    },
+    QUERY_PARSE_ERROR: {
+      status: 400,
+      error: 'query_parse_errors',
+      reason: 'Some query parameter is invalid'
+    },
+    DOC_VALIDATION: {
+      status: 500,
+      error: 'doc_validation',
+      reason: 'Bad special document member'
+    },
+    BAD_REQUEST: {
+      status: 400,
+      error: 'bad_request',
+      reason: 'Something wrong with the request'
+    },
+    NOT_AN_OBJECT: {
+      status: 400,
+      error: 'bad_request',
+      reason: 'Document must be a JSON object'
+    },
+    DB_MISSING: {
+      status: 404,
+      error: 'not_found',
+      reason: 'Database not found'
+    },
+    IDB_ERROR: {
+      status: 500,
+      error: 'unknown',
+      reason: 'indexed_db_went_bad'
+    },
+    WSQ_ERROR: {
+      status: 500,
+      error: 'web_sql_went_bad',
+      reason: 'unknown'
+    },
+    LDB_ERROR: {
+      status: 500,
+      error: 'levelDB_went_went_bad',
+      reason: 'unknown'
+    },
+    FORBIDDEN: {
+      status: 403,
+      error: 'forbidden',
+      reason: 'Forbidden by design doc validate_doc_update function'
+    },
+    INVALID_REV: {
+      status: 400,
+      error: 'bad_request',
+      reason: 'Invalid rev format'
+    },
+    FILE_EXISTS: {
+      status: 412,
+      error: 'file_exists',
+      reason: 'The database could not be created, the file already exists'
+    },
+    MISSING_STUB: {
+      status: 412,
+      error: 'missing_stub',
+      reason: 'A pre-existing attachment stub wasn\'t found'
+    },
+    INVALID_URL: {
+      status: 413,
+      error: 'invalid_url',
+      reason: 'Provided URL is invalid'
+    },
+  }
+
+
+export default ErrorStatus;

--- a/packages/node_modules/pouchdb-errors-poc/src/shared/interfaces/DefaultComponent.types.ts
+++ b/packages/node_modules/pouchdb-errors-poc/src/shared/interfaces/DefaultComponent.types.ts
@@ -1,0 +1,3 @@
+export interface DefaultComponent {
+    className?: string;
+}

--- a/packages/node_modules/pouchdb-errors-poc/src/shared/utils/helpers.tsx
+++ b/packages/node_modules/pouchdb-errors-poc/src/shared/utils/helpers.tsx
@@ -1,0 +1,1 @@
+export const testHelper = 123;

--- a/packages/node_modules/pouchdb-errors-poc/tsconfig.json
+++ b/packages/node_modules/pouchdb-errors-poc/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        // It's important to take note of "declaration": true and "declarationDir": "build".
+        // This will generate and place the types of our components within our build folder.
+        // Feel free to adjust this config to your liking.
+        "declaration": true,
+        "declarationDir": "build",
+        "module": "esnext",
+        "target": "es5",
+        "lib": ["es6", "dom", "es2016", "es2017"],
+        "sourceMap": true,
+        "jsx": "react",
+        "moduleResolution": "node",
+        "strict": true,
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+        "noImplicitReturns": true,
+        "removeComments": true,
+        "preserveConstEnums": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "forceConsistentCasingInFileNames": true,
+    },
+    "include": ["src/**/*"],
+    "exclude": [
+        "node_modules",
+        "build",
+        "src/**/*.stories.tsx",
+        "src/**/*.test.tsx"
+    ]
+}

--- a/packages/node_modules/pouchdb-errors-poc/tslint.json
+++ b/packages/node_modules/pouchdb-errors-poc/tslint.json
@@ -1,0 +1,15 @@
+{
+    "defaultSeverity": "error",
+    "extends": ["tslint:recommended"],
+    "jsRules": {},
+    "rules": {
+        "object-literal-sort-keys": false,
+        "ordered-imports": false,
+        "quotemark": [true, "single", "jsx-double"],
+        "trailing-comma": false,
+        "semicolon": [true, "always", "ignore-bound-class-methods"],
+        "arrow-parens": [true, "ban-single-arg-parens"],
+        "interface-over-type-literal": false
+    },
+    "rulesDirectory": []
+}


### PR DESCRIPTION
This is a proof of concept (see #8307) for:

- Adding TypeScript to PouchDB
- Add Storybooks
- Modularize and refactor
- Types
- Test per component/package / Jest
- Refactored PouchDB-Errors to demostrate the change.

As I couldn't properly run `pouchdb-errors`, I tried to replicate as much as I could, with a few things in mind.

- Ease of development of each component
- Add Storybooks to: 
   - Allow to test components in a isolated environment. Storybooks are not included in the final bundle, and are only for development porpuses.
   - Allow new developers to make changes and contributions easily, with components to actually see, and hotload environment for fast development and more.
   - Automatically generate Documentation based on the typings (TS) for each component.
   - Use Stories to replicate new scenarios, for the component to be well built and tested.
   - Use tests to run those stories to see which conflicts.
- Better documentation for running and debugging the project.

- Rollup and so on for building and publishing porpuses are already added and tested.
- Separate ErrorStatus into a new isolated constant, with its actual types.
- Added Prettier for the code to be beautifully formatted, and ESLint

The structure for each component, is:
-/ **src**
--**/modules**
--**/shared**
--**/components**
---**/defaultComponent** _(or any other name, like Error, Find, Utils, ...)_
----**/Default.tsx** _(where the component actually is, and bundled into production)_
----**/Default.types.tsx** _(where types for Default.tsx are)_
----**/Default.stories.tsx** _(where we create new stories, using Default.tsx component to build new scenarios)_
----**/Default.tests.tsx** _(where we write tests using those stories/scenarios)_
----**/index.tsx** _(where the component gets exported)_

Beware that React it's added, but only for development porpuses, for Storybooks. It will, of course, not be loaded into the final bundle, since this must work everywhere.

In order to complete this PR, we should make a call; since a lot of the code from PouchDB-Errors it's not documented, and it's quite confusing to run.


If you all want, we can start to gradually implement this skeleton for each component (pouchdb-find, pouchdb-utils and so on), and ultimately, PouchDB itself.

I left instructions on how to run it.
I'm open to any questions.