### PR TITLE
properly handle transaction abort

### DIFF
--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
@@ -5,7 +5,8 @@ import {
   REV_CONFLICT,
   MISSING_DOC,
   MISSING_STUB,
-  BAD_ARG
+  BAD_ARG,
+  UNKNOWN_ERROR
 } from 'pouchdb-errors';
 
 import {
@@ -372,7 +373,7 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
       txn = _txn;
 
       txn.onabort = function () {
-        callback(error);
+        callback(error || createError(UNKNOWN_ERROR, 'transaction was aborted'));
       };
       txn.ontimeout = idbError(callback);
 


### PR DESCRIPTION
This PR fixes the errors of #8309: if the transaction is aborted for some reason, it creates an error using `createError` which fixes the problems in the callbacks.