### PR TITLE
Fix node build ordering

### DIFF
--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -52,6 +52,13 @@ pouchdb-link-server-modules() {
   cd ..
 }
 
+pouchdb-build-node() {
+  if [[ $BUILD_NODE_DONE -ne 1 ]]; then
+    npm run build-node
+    BUILD_NODE_DONE=1
+  fi
+}
+
 if [[ ! -z $SERVER ]]; then
   if [ "$SERVER" == "pouchdb-server" ]; then
     export COUCH_HOST='http://127.0.0.1:6984'
@@ -69,10 +76,12 @@ if [[ ! -z $SERVER ]]; then
       export COUCH_HOST="http://127.0.0.1:5984"
     fi
   elif [ "$SERVER" == "pouchdb-express-router" ]; then
+    pouchdb-build-node
     node ./tests/misc/pouchdb-express-router.js &
     export SERVER_PID=$!
     export COUCH_HOST='http://127.0.0.1:3000'
   elif [ "$SERVER" == "express-pouchdb-minimum" ]; then
+    pouchdb-build-node
     node ./tests/misc/express-pouchdb-minimum-for-pouchdb.js &
     export SERVER_PID=$!
     export COUCH_HOST='http://127.0.0.1:3000'
@@ -103,6 +112,7 @@ printf '\nHost started :)'
 if [ "$CLIENT" == "unit" ]; then
     npm run test-unit
 elif [ "$CLIENT" == "node" ]; then
+    pouchdb-build-node
     npm run test-node
 elif [ "$CLIENT" == "dev" ]; then
     npm run launch-dev-server

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -7,42 +7,56 @@
 : ${CLIENT:="node"}
 : ${COUCH_HOST:="http://127.0.0.1:5984"}
 
+pouchdb-setup-server() {
+  # in travis, link pouchdb-servers dependencies on pouchdb
+  # modules to the current implementations
+  mkdir pouchdb-server-install
+  cd pouchdb-server-install
+  npm init -y
+  npm install pouchdb-server
+  cd ..
+
+  for pkg in packages/node_modules/* ; do
+    pouchdb-link-server-modules "$(basename "$pkg")"
+  done
+
+  TESTDIR=./tests/pouchdb_server
+  rm -rf $TESTDIR && mkdir -p $TESTDIR
+  FLAGS="$POUCHDB_SERVER_FLAGS --dir $TESTDIR"
+  echo -e "Starting up pouchdb-server with flags: $FLAGS \n"
+  ./pouchdb-server-install/node_modules/.bin/pouchdb-server -n -p 6984 $FLAGS &
+  export SERVER_PID=$!
+}
+
+pouchdb-link-server-modules() {
+  local pkg="$1"
+
+  cd "packages/node_modules/${pkg}"
+  npm link
+  cd ../../../pouchdb-server-install/
+
+  # node_modules of pouchdb-server-install
+  if [ -d "node_modules/${pkg}" ]; then
+    echo -e "\nnpm link ${pkg} for pouchdb-server-install"
+    npm link "${pkg}"
+  fi
+
+  # internal node_modules of other packages
+  for subPkg in $(ls -d node_modules/**/node_modules/${pkg}/ 2>/dev/null); do
+    cd ${subPkg}../..
+    echo -e "\nnpm link ${pkg} for ${subPkg}"
+    npm link "${pkg}"
+    cd ../..
+  done
+
+  cd ..
+}
+
 if [[ ! -z $SERVER ]]; then
   if [ "$SERVER" == "pouchdb-server" ]; then
     export COUCH_HOST='http://127.0.0.1:6984'
     if [[ "$TRAVIS_REPO_SLUG" == "pouchdb/pouchdb" || "$COVERAGE" == 1 ]]; then
-      # in travis, link pouchdb-servers dependencies on pouchdb
-      # modules to the current implementations
-      mkdir pouchdb-server-install
-      cd pouchdb-server-install
-      npm init -y
-      npm install pouchdb-server
-      cd ..
-      PKGS=$(ls packages/node_modules);
-      for pkg in $PKGS; do
-        cd packages/node_modules/${pkg}
-        npm link
-        cd ../../../pouchdb-server-install/
-        # node_modules of pouchdb-server-install
-        if [ -d "node_modules/${pkg}" ]; then
-          echo -e "\nnpm link ${pkg} for pouchdb-server-install"
-        npm link ${pkg}
-        fi
-        # internal node_modules of other packages
-        for subPkg in $(ls -d node_modules/**/node_modules/${pkg}/ 2>/dev/null); do
-          cd ${subPkg}../..
-          echo -e "\nnpm link ${pkg} for ${subPkg}"
-        npm link ${pkg}
-          cd ../..
-        done
-        cd ..
-      done
-      TESTDIR=./tests/pouchdb_server
-      rm -rf $TESTDIR && mkdir -p $TESTDIR
-      FLAGS="$POUCHDB_SERVER_FLAGS --dir $TESTDIR"
-      echo -e "Starting up pouchdb-server with flags: $FLAGS \n"
-      ./pouchdb-server-install/node_modules/.bin/pouchdb-server -n -p 6984 $FLAGS &
-      export SERVER_PID=$!
+      pouchdb-setup-server
     else
       echo -e "pouchdb-server should be running on $COUCH_HOST\n"
     fi

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-node": "bash bin/build-node.sh",
     "build-modules": "node bin/build-modules.js",
     "test-unit": "mocha tests/unit",
-    "test-node": "npm run build-node && bash bin/test-node.sh",
+    "test-node": "bash bin/test-node.sh",
     "test-component": "mocha tests/component",
     "test-fuzzy": "TYPE=fuzzy npm run test",
     "test-browser": "npm run build-test && node ./bin/test-browser.js",


### PR DESCRIPTION
We have been observing that when running `npm test`, the tests don't
seem to run the current version of the code. It's possible to make edits
to the code, and the first time you run the tests, your edits won't have
any effect. They only apply the second time you run the tests.

This seems to be because of the order things are done in
`bin/run-test.sh`. Depending on the value of `SERVER`, it might start a
server using this command:

    node ./tests/misc/pouchdb-express-router.js

This process will import `packages/node_modules/pouchdb`, which in turn
imports other packages, whose `main` file is usually `lib/index.js`.
This file is not source code but is generated by the build process.

After it's started the server, `bin/run-test.sh` then runs one of the
test suites, with `test-node` being the default because `CLIENT`
defaults to `node`. The npm `test-node` command runs the `build-node`
command, which is what triggers the build of all packages and updates
their `lib` directories.

Because this happens after the server is started, the server is then
running out-of-date code. We fix this by putting code in
`bin/run-test.sh` to run `npm run build-node` if it's not already been
run, before any command that needs the node.js packages up-to-date, and
removing the call to `build-node` from the `test-node` command. This
should be safe because the only place the `test-node` task is invoked is
in `bin/run-test.sh`.