### PR TITLE
Let caller set the change batch size when updating views

### DIFF
--- a/docs/_includes/api/create_database.html
+++ b/docs/_includes/api/create_database.html
@@ -16,6 +16,7 @@ This method creates a database or opens an existing one. If you use a URL like `
 * `adapter`: One of `'indexeddb'`, `'idb'`, `'leveldb'`, or `'http'`.
 * `revs_limit`: Specify how many old revisions we keep track (not a copy) of. Specifying a low value means Pouch may not be able to figure out whether a new revision received via replication is related to any it currently has which could result in a conflict. Defaults to `1000`.
 * `deterministic_revs`: Use a md5 hash to create a deterministic revision number for documents. Setting it to false will mean that the revision number will be a random UUID. Defaults to true.
+* `view_update_changes_batch_size`: Specify how many change records will be consumed at a time when rebuilding view indexes when the `query()` method is used. Defaults to 50.
 
 **Options for remote databases:**
 

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -868,7 +868,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
     }
 
     var updateViewOpts = {
-      changes_batch_size: CHANGES_BATCH_SIZE
+      changes_batch_size: db.__opts.view_update_changes_batch_size || CHANGES_BATCH_SIZE
     };
 
     if (typeof fun !== 'string') {

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -481,13 +481,13 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
     return queue;
   }
 
-  function updateView(view) {
+  function updateView(view, opts) {
     return sequentialize(getQueue(view), function () {
-      return updateViewInQueue(view);
+      return updateViewInQueue(view, opts);
     })();
   }
 
-  function updateViewInQueue(view) {
+  function updateViewInQueue(view, opts) {
     // bind the emit function once
     var mapResults;
     var doc;
@@ -521,7 +521,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
         include_docs: true,
         style: 'all_docs',
         since: currentSeq,
-        limit: CHANGES_BATCH_SIZE
+        limit: opts.changes_batch_size
       }).then(processBatch);
     }
 
@@ -532,7 +532,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       }
       var docIdsToChangesAndEmits = createDocIdsToChangesAndEmits(results);
       queue.add(processChange(docIdsToChangesAndEmits, currentSeq));
-      if (results.length < CHANGES_BATCH_SIZE) {
+      if (results.length < opts.changes_batch_size) {
         return;
       }
       return processNextBatch();
@@ -867,6 +867,10 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       return httpQuery(db, fun, opts);
     }
 
+    var updateViewOpts = {
+      changes_batch_size: CHANGES_BATCH_SIZE
+    };
+
     if (typeof fun !== 'string') {
       // temp_view
       checkQueryParseError(opts, fun);
@@ -880,7 +884,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
           /* temporary */ true,
           /* localDocName */ localDocName);
         return createViewPromise.then(function (view) {
-          return fin(updateView(view).then(function () {
+          return fin(updateView(view, updateViewOpts).then(function () {
             return queryView(view, opts);
           }), function () {
             return view.db.destroy();
@@ -917,12 +921,12 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
           if (opts.stale === 'ok' || opts.stale === 'update_after') {
             if (opts.stale === 'update_after') {
               nextTick(function () {
-                updateView(view);
+                updateView(view, updateViewOpts);
               });
             }
             return queryView(view, opts);
           } else { // stale not ok
-            return updateView(view).then(function () {
+            return updateView(view, updateViewOpts).then(function () {
               return queryView(view, opts);
             });
           }


### PR DESCRIPTION
Some users need to be able to increase or reduce the size of changes
batches used when updating view indexes, to make the best use of the
storage adapter they're running.

For example, memory constraints or processing capacity might necessitate
using smaller batch sizes.

This change lets the caller set a DB option named `index_batch_size`,
which changes the batch size we use for updating views in
`abstract-mapreduce`. It defaults to 50, the value of the existing
`CHANGES_BATCH_SIZE` constant in this module.

We'd appreciate some guidance on how this change should be tested. This
change was originally done by @chrisekelley on their fork so they may
be able to provide some more context.