### PR TITLE
Add an indexing event to show progress of view updates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,7 @@
   "extends": "eslint:recommended",
 
   "parserOptions": {
-    "ecmaVersion": 6,
+    "ecmaVersion": 8,
     "sourceType": "module"
   },
 

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -512,6 +512,13 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       };
     }
 
+    let indexed_docs = 0;
+    let progress = {
+      view: view.name,
+      indexed_docs: indexed_docs
+    };
+    view.sourceDB.emit('indexing', progress);
+
     var queue = new TaskQueue();
 
     function processNextBatch() {
@@ -532,6 +539,16 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       }
       var docIdsToChangesAndEmits = createDocIdsToChangesAndEmits(results);
       queue.add(processChange(docIdsToChangesAndEmits, currentSeq));
+
+      indexed_docs = indexed_docs + results.length;
+      let progress = {
+        view: view.name,
+        last_seq: response.last_seq,
+        results_count: results.length,
+        indexed_docs: indexed_docs
+      };
+      view.sourceDB.emit('indexing', progress);
+      
       if (results.length < opts.changes_batch_size) {
         return;
       }

--- a/tests/integration/test.design_docs.js
+++ b/tests/integration/test.design_docs.js
@@ -96,37 +96,34 @@ adapters.forEach(function (adapter) {
       });
     });
 
-    it('Indexing event', function (done) {
-      var docs1 = [
+    it('Indexing event', async () => {
+      const docs1 = [
         doc,
         {_id: 'dale', score: 3},
         {_id: 'mikeal', score: 5},
         {_id: 'max', score: 4},
         {_id: 'nuno', score: 3},
       ];
-      var db = new PouchDB(dbs.name);
+      let db = new PouchDB(dbs.name);
       // Test invalid if adapter doesnt support mapreduce
       if (!db.query || adapter !== 'local') {
-        return done();
+        return;
       }
 
       let indexingEvents = [];
 
-      db.on('indexing', function (result) {
+      db.on('indexing', (result) => {
         indexingEvents.push(result);
       });
 
-      db.bulkDocs({ docs: docs1 }, function () {
-        db.query('foo/scores', { reduce: false }, function () {          
-          indexingEvents.length.should.equal(2);
-          indexingEvents[0]['indexed_docs'].should.equal(0);
-          indexingEvents[1]['last_seq'].should.equal(5);
-          indexingEvents[1]['results_count'].should.equal(5);
-          indexingEvents[1]['indexed_docs'].should.equal(5);
+      await db.bulkDocs({ docs: docs1 });
+      await db.query('foo/scores', { reduce: false });
 
-          done();
-        });
-      });
+      indexingEvents.length.should.equal(2);
+      indexingEvents[0]['indexed_docs'].should.equal(0);
+      indexingEvents[1]['last_seq'].should.equal(5);
+      indexingEvents[1]['results_count'].should.equal(5);
+      indexingEvents[1]['indexed_docs'].should.equal(5);
     });
 
     it('Concurrent queries', function (done) {


### PR DESCRIPTION
The motivation behind this PR is to show progress of view updates during the indexing. This PR is related to @chrisekelley 's [fork](https://github.com/chrisekelley/pouchdb/pull/1). Our goal is to extract and provide test for these functionalities. 

In this PR:
- Add emit event `indexing` inside the package `pouchdb-abstract-mapreduce` that sends a `progress` object. 
- Add test inside `test.design_docs.js`. But:
1. We are unsure if this is the correct suite to test it.
2. We can only test it if the adapter is `local`, as the `http` adapter does not emit the event. We are guessing that we can't listen to the event on a remote DB over HTTP, hence the test fails.
3. The `progress` object has the following properties: `view`,`last_seq`,`results_count`,`indexed_docs`. Would these follow the `PouchDB` variable name conventions?

Any help would be highly appreciated. Thank you.