### PR TITLE
Add checkpoint events during replication

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,7 @@
   "extends": "eslint:recommended",
 
   "parserOptions": {
-    "ecmaVersion": 6,
+    "ecmaVersion": 8,
     "sourceType": "module"
   },
 

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -132,6 +132,7 @@ function replicate(src, target, opts, returnValue, result) {
     writingCheckpoint = true;
     return checkpointer.writeCheckpoint(currentBatch.seq,
         session).then(function () {
+      returnValue.emit('checkpoint', { 'checkpoint': currentBatch.seq });
       writingCheckpoint = false;
       /* istanbul ignore if */
       if (returnValue.cancelled) {
@@ -149,6 +150,7 @@ function replicate(src, target, opts, returnValue, result) {
   function getDiffs() {
     var diff = {};
     currentBatch.changes.forEach(function (change) {
+      returnValue.emit('checkpoint', { 'revs_diff': change });
       // Couchbase Sync Gateway emits these, but we can ignore them
       /* istanbul ignore if */
       if (change.id === "_user/") {
@@ -189,6 +191,7 @@ function replicate(src, target, opts, returnValue, result) {
       return;
     }
     currentBatch = batches.shift();
+    returnValue.emit('checkpoint', { 'start_next_batch': currentBatch.seq });
     getDiffs()
       .then(getBatchDocs)
       .then(writeDocs)
@@ -307,6 +310,7 @@ function replicate(src, target, opts, returnValue, result) {
     }
     pendingBatch.seq = change.seq || lastSeq;
     pendingBatch.changes.push(change);
+    returnValue.emit('checkpoint', { 'pending_batch': pendingBatch.seq });
     nextTick(function () {
       processPendingBatch(batches.length === 0 && changesOpts.live);
     });

--- a/tests/integration/test.replication_events.js
+++ b/tests/integration/test.replication_events.js
@@ -401,7 +401,7 @@ adapters.forEach(function (adapters) {
     // Note: Uppercase 'Unauthorized' response
     describe('#5607 handle uppercase third-party error responses', replication401TestFunction('Unauthorized'));
 
-    it('Test checkpoint events', (done) => {
+    it('Test checkpoint events', async () => {
       const docs = {
         docs: [
           {_id: '0', integer: 0, string: '0'},
@@ -409,31 +409,28 @@ adapters.forEach(function (adapters) {
           {_id: '2', integer: 2, string: '2'},
         ],
       };
-      let remote = new PouchDB(dbs.remote);
-      let checkpointEvents = [];
+      const remote = new PouchDB(dbs.remote);
+      const checkpointEvents = [];
 
-      remote.bulkDocs(docs, {}, () => {
-        let replication = PouchDB.replicate(dbs.remote, dbs.name, {}, () => {
-          checkpointEvents[0]['pending_batch'].should.equal(1);
-          checkpointEvents[1]['pending_batch'].should.equal(2);
-          checkpointEvents[2]['pending_batch'].should.equal(3);
-          checkpointEvents[3]['start_next_batch'].should.equal(3);
-          checkpointEvents[4]['revs_diff'].should.have.property('id');
-          checkpointEvents[4]['revs_diff']['id'].should.equal('0');
-          checkpointEvents[4]['revs_diff']['seq'].should.equal(1);
-          checkpointEvents[5]['revs_diff'].should.have.property('changes');
-          checkpointEvents[5]['revs_diff']['id'].should.equal('1');
-          checkpointEvents[5]['revs_diff']['seq'].should.equal(2);
-          checkpointEvents[6]['revs_diff'].should.have.property('changes');
-          checkpointEvents[6]['revs_diff']['id'].should.equal('2');
-          checkpointEvents[6]['revs_diff']['seq'].should.equal(3);
-          checkpointEvents[7]['checkpoint'].should.equal(3);
+      await remote.bulkDocs(docs, {});
+      const replication = PouchDB.replicate(dbs.remote, dbs.name, {});
+      replication.on('checkpoint', result => checkpointEvents.push(result));
+      await replication;
 
-          done();
-        });
-
-        replication.on('checkpoint', result => checkpointEvents.push(result));
-      });
+      checkpointEvents[0]['pending_batch'].should.equal(1);
+      checkpointEvents[1]['pending_batch'].should.equal(2);
+      checkpointEvents[2]['pending_batch'].should.equal(3);
+      checkpointEvents[3]['start_next_batch'].should.equal(3);
+      checkpointEvents[4]['revs_diff'].should.have.property('id');
+      checkpointEvents[4]['revs_diff']['id'].should.equal('0');
+      checkpointEvents[4]['revs_diff']['seq'].should.equal(1);
+      checkpointEvents[5]['revs_diff'].should.have.property('changes');
+      checkpointEvents[5]['revs_diff']['id'].should.equal('1');
+      checkpointEvents[5]['revs_diff']['seq'].should.equal(2);
+      checkpointEvents[6]['revs_diff'].should.have.property('changes');
+      checkpointEvents[6]['revs_diff']['id'].should.equal('2');
+      checkpointEvents[6]['revs_diff']['seq'].should.equal(3);
+      checkpointEvents[7]['checkpoint'].should.equal(3);
     });
   });
 });


### PR DESCRIPTION
The motivation behind this PR is to emit checkpoint events during the replication process. This PR is related to @chrisekelley 's [fork](https://github.com/chrisekelley/pouchdb/pull/1). Our goal is to extract and provide test for these functionalities. 

In this PR:
- Add emit event `checkpoint` inside the package `pouchdb-replication`. 
We emit an object, which can contain the following property names: `checkpoint`, `revs_diff`, `start_next_batch` and `pending_batch`. Would these follow `PouchDB` variable name conventions? We will be happy to refactor them if someone comes up with better naming for these.
- Add test inside `test.replication_events.js`, but we are unsure if this is the correct suite to test it.

Any help would be highly appreciated. Thank you.