### PR TITLE
Add view adapter option

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -144,6 +144,15 @@ following values:
 
 Set this to `1` to skip the migration tests.
 
+#### `VIEW_ADAPTERS` (default: `memory`)
+
+Comma-separated list of preferred view adapter backends that PouchDB will use. 
+This variable overrides the default choice and causes additional adapters to
+be loaded if they're not part of the default distribution.
+
+On Node.js the available adapters are `leveldb` and `memory`. In the
+browser they're `idb`, `indexeddb` and `memory`.
+
 
 ## Other sets of tests
 
@@ -240,6 +249,7 @@ command-line options and their query string equivalents are:
 | `ITERATIONS`         | `iterations`       |
 | `PLUGINS`            | `plugins`          |
 | `POUCHDB_SRC`        | `src`              |
+| `VIEW_ADAPTERS`      | `viewAdapters`     |
 
 
 ## Other test tasks

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -14,6 +14,9 @@ var queryParams = {};
 if (process.env.ADAPTERS) {
   queryParams.adapters = process.env.ADAPTERS;
 }
+if (process.env.VIEW_ADAPTERS) {
+  queryParams.viewAdapters = process.env.VIEW_ADAPTERS;
+}
 if (process.env.AUTO_COMPACTION) {
   queryParams.autoCompaction = true;
 }

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -6,6 +6,8 @@
 
 : ${CLIENT:="node"}
 : ${COUCH_HOST:="http://127.0.0.1:5984"}
+: ${VIEW_ADAPTERS:="memory"}
+export VIEW_ADAPTERS
 
 pouchdb-setup-server() {
   # in CI, link pouchdb-servers dependencies on pouchdb

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -66,6 +66,9 @@ if (process.env.GREP) {
 if (process.env.ADAPTERS) {
   qs.adapters = process.env.ADAPTERS;
 }
+if (process.env.VIEW_ADAPTERS) {
+  qs.viewAdapters = process.env.VIEW_ADAPTERS;
+}
 if (process.env.AUTO_COMPACTION) {
   qs.autoCompaction = true;
 }

--- a/docs/_includes/api/create_database.html
+++ b/docs/_includes/api/create_database.html
@@ -17,6 +17,7 @@ This method creates a database or opens an existing one. If you use a URL like `
 * `revs_limit`: Specify how many old revisions we keep track (not a copy) of. Specifying a low value means Pouch may not be able to figure out whether a new revision received via replication is related to any it currently has which could result in a conflict. Defaults to `1000`.
 * `deterministic_revs`: Use a md5 hash to create a deterministic revision number for documents. Setting it to false will mean that the revision number will be a random UUID. Defaults to true.
 * `view_update_changes_batch_size`: Specify how many change records will be consumed at a time when rebuilding view indexes when the `query()` method is used. Defaults to 50.
+* `view_adapter`: Specify a different adapter to store the view index data.
 
 **Options for remote databases:**
 

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
@@ -27,6 +27,10 @@ var openDatabases = {};
 
 function IdbPouch(dbOpts, callback) {
 
+  if (dbOpts.view_adapter) {
+    console.log('Please note that the indexeddb adapter manages _find indexes itself, therefore it is not using your specified view_adapter');
+  }
+  
   var api = this;
   var metadata = {};
 

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -12,7 +12,8 @@ import {
   upsert,
   bulkGetShim,
   invalidIdError,
-  nextTick
+  nextTick,
+  clone
 } from 'pouchdb-utils';
 import {
   traverseRevTree,
@@ -902,7 +903,12 @@ AbstractPouchDB.prototype.bulkDocs =
 AbstractPouchDB.prototype.registerDependentDatabase =
   adapterFun('registerDependentDatabase', function (dependentDb,
                                                           callback) {
-  var depDB = new this.constructor(dependentDb, this.__opts);
+  const dbOptions = clone(this.__opts);
+  if (this.__opts.view_adapter) {
+    dbOptions.adapter = this.__opts.view_adapter;
+  }
+
+  var depDB = new this.constructor(dependentDb, dbOptions);
 
   function diffFun(doc) {
     doc.dependentDbs = doc.dependentDbs || {};

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -903,7 +903,7 @@ AbstractPouchDB.prototype.bulkDocs =
 AbstractPouchDB.prototype.registerDependentDatabase =
   adapterFun('registerDependentDatabase', function (dependentDb,
                                                           callback) {
-  const dbOptions = clone(this.__opts);
+  var dbOptions = clone(this.__opts);
   if (this.__opts.view_adapter) {
     dbOptions.adapter = this.__opts.view_adapter;
   }

--- a/packages/node_modules/pouchdb-core/src/constructor.js
+++ b/packages/node_modules/pouchdb-core/src/constructor.js
@@ -78,6 +78,13 @@ function PouchDB(name, opts) {
     throw new Error('Invalid Adapter: ' + opts.adapter);
   }
 
+  if (opts.view_adapter) {
+    if (!PouchDB.adapters[opts.view_adapter] ||
+        !PouchDB.adapters[opts.view_adapter].valid()) {
+      throw new Error('Invalid View Adapter: ' + opts.view_adapter);
+    }
+  }
+
   Adapter.call(self);
   self.taskqueue = new TaskQueue();
 

--- a/tests/common-utils.js
+++ b/tests/common-utils.js
@@ -30,6 +30,12 @@ commonUtils.adapters = function () {
   return adapters ? adapters.split(',') : [];
 };
 
+commonUtils.viewAdapters = function () {
+  var viewAdapters = commonUtils.isNode() ? 
+    process.env.VIEW_ADAPTERS : commonUtils.params().viewAdapters;
+  return viewAdapters ? viewAdapters.split(',') : [];
+};
+
 commonUtils.plugins = function () {
   var plugins = commonUtils.isNode() ? process.env.PLUGINS : commonUtils.params().plugins;
   return plugins ? plugins.split(',') : [];
@@ -42,9 +48,11 @@ commonUtils.loadPouchDB = function (opts) {
 
   var params = commonUtils.params();
   var adapters = commonUtils.adapters().concat(opts.adapters || []);
+  var viewAdapters = commonUtils.viewAdapters().concat(opts.viewAdapters || []);
   var plugins = commonUtils.plugins().concat(opts.plugins || []);
 
-  for (let adapter of adapters) {
+  const allAdapters = [...adapters, ...viewAdapters];
+  for (let adapter of allAdapters) {
     if (adapter === 'websql') {
       adapter = 'node-websql';
     }

--- a/tests/integration/index.html
+++ b/tests/integration/index.html
@@ -55,6 +55,7 @@
     <script src='test.reserved.js'></script>
     <script src='test.prefix.js'></script>
     <script src='test.deterministicrevs.js'></script>
+    <script src='test.viewadapter.js'></script>
     <script src='browser.worker.js'></script>
     <script type="text/javascript" src="./webrunner.js"></script>
   </body>

--- a/tests/integration/node.setup.js
+++ b/tests/integration/node.setup.js
@@ -1,5 +1,4 @@
 "use strict";
-
 // throw an error if any EventEmitter adds too many listeners
 require('throw-max-listeners-error');
 
@@ -25,3 +24,4 @@ chai.use(require('chai-as-promised'));
 global.should = chai.should();
 global.assert = chai.assert;
 require('mkdirp').sync('./tmp');
+global.fs = require('fs');

--- a/tests/integration/test.constructor.js
+++ b/tests/integration/test.constructor.js
@@ -25,6 +25,19 @@ describe('constructor errors', function () {
     }
   });
 
+  it('should error on an undefined view adapter', function (done) {
+    try {
+      new PouchDB('foo', {view_adapter : 'myFakeViewAdapter'});
+      done('Should have thrown');
+    } catch (err) {
+      should.equal(err instanceof Error, true, 'should be an error');
+      err.message.should
+        .equal('Invalid View Adapter: myFakeViewAdapter',
+               'should give the correct error message');
+      done();
+    }
+  });
+
   it('should error on a null name', function (done) {
     try {
       new PouchDB(null);

--- a/tests/integration/test.viewadapter.js
+++ b/tests/integration/test.viewadapter.js
@@ -1,24 +1,12 @@
-/* To test these adapters, you can run
-ADAPTERS=memory CLIENT=selenium:firefox npm run test */
 'use strict';
 
-const fs = require('fs');
+const viewAdapters = testUtils.viewAdapters();
 
-let hasIndexedDB = false;
-try {
- indexedDB;
- hasIndexedDB = true;
-} catch (_) {
- hasIndexedDB = false;
-}
+viewAdapters.forEach(viewAdapter => {
+  describe('test.viewadapter.js-' + 'local' + '-' + viewAdapter, function () {
+    let dbs = {};
 
-var adapters = [ hasIndexedDB ? ['idb', 'memory'] : ['leveldb', 'memory'] ];
-
-adapters.forEach(function ([primaryAdapter, secondaryAdapter]) {
-  describe('test.viewadapter.js-' + primaryAdapter + '-' + secondaryAdapter, function () {
-    var dbs = {};
-
-    var docs = [
+    const docs = [
       {title : 'abc', value: 1, _id: 'doc1'},
       {title : 'def', value: 2, _id: 'doc2'},
       {
@@ -36,115 +24,101 @@ adapters.forEach(function ([primaryAdapter, secondaryAdapter]) {
     ];
 
     function getDBNames(localStorage) {
-      var savedDbNames = Object.keys(localStorage).filter(function (key) {
+      const savedDbNames = Object.keys(localStorage).filter(function (key) {
         return key.includes(dbs.name);
       });
 
       // This is the name of the db where view index data is stored.
-      var viewDbName = savedDbNames.find(function (dbName) {
+      const viewDbName = savedDbNames.find(function (dbName) {
         return dbName.includes('-mrview-');
       });
       // This is the name of the db where documents are stored.
-      var docDbName = savedDbNames.find(function (dbName) {
+      const docDbName = savedDbNames.find(function (dbName) {
         return !dbName.includes('-mrview-');
       });
       return { viewDbName, docDbName };
     }
 
     function getDbNamesFromLevelDBFolder(name) {
-      const dbs = fs.readdirSync('./tmp');
+      const dbs = global.fs.readdirSync('./tmp');
       return dbs.filter((dbName => dbName.includes(name)));
     }
 
     beforeEach(function () {
-      dbs.name = testUtils.adapterUrl(primaryAdapter, 'testdb');
+      dbs.name = testUtils.adapterUrl('local', 'testdb');
     });
 
-    afterEach(function (done) {
-      testUtils.cleanup([dbs.name], done);
-      done();
+    it('Create pouch with separate view adapters', async function () {
+      const db = new PouchDB(dbs.name, {view_adapter: viewAdapter});
+
+      if (db.adapter === viewAdapter) {
+        return;
+      }
+
+      await db.bulkDocs(docs);
+      await db.query('index', { key: 'abc', include_docs: true });
+
+      if (testUtils.isNode()) {
+        const dbs = getDbNamesFromLevelDBFolder(db.name);
+        dbs.length.should.equal(1); // only one db created on disk, no dependent db created
+      } else {
+        const { viewDbName, docDbName } = getDBNames(localStorage);
+        // check indexedDB for saved views
+        // need to add '_pouch_' because views are saved in memory
+        const viewRequest = indexedDB.open('_pouch_' + viewDbName, 1);
+        viewRequest.onupgradeneeded = function (event) {
+          // The version of the view database created is 1 which shows that this
+          // database was newly created in IndexedDB and did not exist there
+          // before. So the view database was created in the database specified in
+          // the view_adapter and not in the default `idb`adapter.
+          event.oldVersion.should.equal(0);
+          event.newVersion.should.equal(1);
+        };
+
+        viewRequest.onsuccess = function () {
+          // Nothing is saved here
+          viewRequest.result.objectStoreNames.length.should.equal(0);
+          viewRequest.result.version.should.equal(1);
+        };
+
+        // check indexedDB for saved docs
+        const docRequest = indexedDB.open(docDbName, 5);
+        docRequest.onsuccess = function () {
+          // something is saved here
+          docRequest.result.objectStoreNames.length.should.equal(7);
+        };
+      }
     });
 
-    it('Create pouch with separate view adapters', function (done) {
-      var db = new PouchDB(dbs.name, {adapter: primaryAdapter, view_adapter: secondaryAdapter});
+    it('Create pouch with no view adapters', async function () {
+      const db = new PouchDB(dbs.name);
 
-      db.bulkDocs(docs).then(function () {
-        db.query('index', {
-          key: 'abc',
-          include_docs: true
-        }).then(function () {
+      await db.bulkDocs(docs);
+      await db.query('index', { key: 'abc', include_docs: true });
 
-          if (hasIndexedDB) {
-            var { viewDbName, docDbName } = getDBNames(localStorage);
-  
-            // check indexedDB for saved views
-            // need to add '_pouch_' because views are saved in memory
-            var viewRequest = indexedDB.open('_pouch_' + viewDbName, 1);
-            viewRequest.onupgradeneeded = function (event) {
-              // The version of the view database created is 1 which shows that this
-              // database was newly created in IndexedDB and did not exist there
-              // before. So the view database was created in the database specified in
-              // the view_adapter and not in the default `idb`adapter.
-              event.oldVersion.should.equal(0);
-              event.newVersion.should.equal(1);
-            };
-  
-            viewRequest.onsuccess = function () {
-              // Nothing is saved here
-              viewRequest.result.objectStoreNames.length.should.equal(0);
-              viewRequest.result.version.should.equal(1);
-            };
-  
-            // check indexedDB for saved docs
-            var docRequest = indexedDB.open(docDbName, 5);
-            docRequest.onsuccess = function () {
-              // something is saved here
-              docRequest.result.objectStoreNames.length.should.equal(7);
-              done();
-            };
-          } else { // !hasIndexedDB
-            const dbs = getDbNamesFromLevelDBFolder(db.name);
-            dbs.length.should.equal(1); // only one db created on disk, no dependent db created
-            done();
-          }
-        });
-      });
-    });
+      if (testUtils.isNode()) {
+        const dbs = getDbNamesFromLevelDBFolder(db.name);
+        const expectedLength = db.adapter === 'memory' ? 0 : 2;
+        dbs.length.should.equal(expectedLength);
+      } else {
+        const { viewDbName, docDbName } = getDBNames(localStorage);
 
-    it('Create pouch with no view adapters', function (done) {
-      var db = new PouchDB(dbs.name, {adapter: primaryAdapter});
+        // check indexedDB for saved views
+        const viewRequest = indexedDB.open(viewDbName, 5);
+        viewRequest.onsuccess = function () {
+          // Something is saved here
+          // This shows that without a view_adapter specified
+          // the view query data is stored in the default adapter database.
+          viewRequest.result.objectStoreNames.length.should.equal(7);
+        };
 
-      db.bulkDocs(docs).then(function () {
-        db.query('index', {
-          key: 'abc',
-          include_docs: true
-        }).then(function () {
-          if (hasIndexedDB) {
-            var { viewDbName, docDbName } = getDBNames(localStorage);
-  
-            // check indexedDB for saved views
-            var viewRequest = indexedDB.open(viewDbName, 5);
-            viewRequest.onsuccess = function () {
-              // Something is saved here
-              // This shows that without a view_adapter specified
-              // the view query data is stored in the default adapter database.
-              viewRequest.result.objectStoreNames.length.should.equal(7);
-            };
-  
-            // check indexedDB for saved docs
-            var docRequest = indexedDB.open(docDbName, 5);
-            docRequest.onsuccess = function () {
-              // something is saved here
-              docRequest.result.objectStoreNames.length.should.equal(7);
-              done();
-            };
-          } else { // !hasIndexedDB
-            const dbs = getDbNamesFromLevelDBFolder(db.name);
-            dbs.length.should.equal(2); // db and dependent db created
-            done();
-          }
-        });
-      });
+        // check indexedDB for saved docs
+        const docRequest = indexedDB.open(docDbName, 5);
+        docRequest.onsuccess = function () {
+          // something is saved here
+          docRequest.result.objectStoreNames.length.should.equal(7);
+        };
+      }
     });
   });
 });

--- a/tests/integration/test.viewadapter.js
+++ b/tests/integration/test.viewadapter.js
@@ -1,0 +1,150 @@
+/* To test these adapters, you can run
+ADAPTERS=memory CLIENT=selenium:firefox npm run test */
+'use strict';
+
+const fs = require('fs');
+
+let hasIndexedDB = false;
+try {
+ indexedDB;
+ hasIndexedDB = true;
+} catch (_) {
+ hasIndexedDB = false;
+}
+
+var adapters = [ hasIndexedDB ? ['idb', 'memory'] : ['leveldb', 'memory'] ];
+
+adapters.forEach(function ([primaryAdapter, secondaryAdapter]) {
+  describe('test.viewadapter.js-' + primaryAdapter + '-' + secondaryAdapter, function () {
+    var dbs = {};
+
+    var docs = [
+      {title : 'abc', value: 1, _id: 'doc1'},
+      {title : 'def', value: 2, _id: 'doc2'},
+      {
+        _id: '_design/index',
+        views: {
+          index: {
+            map: function mapFun(doc) {
+              if (doc.title) {
+                emit(doc.title);
+              }
+            }.toString()
+          }
+        }
+      }
+    ];
+
+    function getDBNames(localStorage) {
+      var savedDbNames = Object.keys(localStorage).filter(function (key) {
+        return key.includes(dbs.name);
+      });
+
+      // This is the name of the db where view index data is stored.
+      var viewDbName = savedDbNames.find(function (dbName) {
+        return dbName.includes('-mrview-');
+      });
+      // This is the name of the db where documents are stored.
+      var docDbName = savedDbNames.find(function (dbName) {
+        return !dbName.includes('-mrview-');
+      });
+      return { viewDbName, docDbName };
+    }
+
+    function getDbNamesFromLevelDBFolder(name) {
+      const dbs = fs.readdirSync('./tmp');
+      return dbs.filter((dbName => dbName.includes(name)));
+    }
+
+    beforeEach(function () {
+      dbs.name = testUtils.adapterUrl(primaryAdapter, 'testdb');
+    });
+
+    afterEach(function (done) {
+      testUtils.cleanup([dbs.name], done);
+      done();
+    });
+
+    it('Create pouch with separate view adapters', function (done) {
+      var db = new PouchDB(dbs.name, {adapter: primaryAdapter, view_adapter: secondaryAdapter});
+
+      db.bulkDocs(docs).then(function () {
+        db.query('index', {
+          key: 'abc',
+          include_docs: true
+        }).then(function () {
+
+          if (hasIndexedDB) {
+            var { viewDbName, docDbName } = getDBNames(localStorage);
+  
+            // check indexedDB for saved views
+            // need to add '_pouch_' because views are saved in memory
+            var viewRequest = indexedDB.open('_pouch_' + viewDbName, 1);
+            viewRequest.onupgradeneeded = function (event) {
+              // The version of the view database created is 1 which shows that this
+              // database was newly created in IndexedDB and did not exist there
+              // before. So the view database was created in the database specified in
+              // the view_adapter and not in the default `idb`adapter.
+              event.oldVersion.should.equal(0);
+              event.newVersion.should.equal(1);
+            };
+  
+            viewRequest.onsuccess = function () {
+              // Nothing is saved here
+              viewRequest.result.objectStoreNames.length.should.equal(0);
+              viewRequest.result.version.should.equal(1);
+            };
+  
+            // check indexedDB for saved docs
+            var docRequest = indexedDB.open(docDbName, 5);
+            docRequest.onsuccess = function () {
+              // something is saved here
+              docRequest.result.objectStoreNames.length.should.equal(7);
+              done();
+            };
+          } else { // !hasIndexedDB
+            const dbs = getDbNamesFromLevelDBFolder(db.name);
+            dbs.length.should.equal(1); // only one db created on disk, no dependent db created
+            done();
+          }
+        });
+      });
+    });
+
+    it('Create pouch with no view adapters', function (done) {
+      var db = new PouchDB(dbs.name, {adapter: primaryAdapter});
+
+      db.bulkDocs(docs).then(function () {
+        db.query('index', {
+          key: 'abc',
+          include_docs: true
+        }).then(function () {
+          if (hasIndexedDB) {
+            var { viewDbName, docDbName } = getDBNames(localStorage);
+  
+            // check indexedDB for saved views
+            var viewRequest = indexedDB.open(viewDbName, 5);
+            viewRequest.onsuccess = function () {
+              // Something is saved here
+              // This shows that without a view_adapter specified
+              // the view query data is stored in the default adapter database.
+              viewRequest.result.objectStoreNames.length.should.equal(7);
+            };
+  
+            // check indexedDB for saved docs
+            var docRequest = indexedDB.open(docDbName, 5);
+            docRequest.onsuccess = function () {
+              // something is saved here
+              docRequest.result.objectStoreNames.length.should.equal(7);
+              done();
+            };
+          } else { // !hasIndexedDB
+            const dbs = getDbNamesFromLevelDBFolder(db.name);
+            dbs.length.should.equal(2); // db and dependent db created
+            done();
+          }
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
(I’m posting this for @ninetteadhikari, who is on vacation atm)

## Current setup
Currently PouchDB uses a single adapter to store all application data in one place including the core data as well as the view index data. The adapter for dependent databases is registered in `registerDependentDatabase` in the `adapter.js` file.

## Issue
The use of a single adapter per database becomes a problem when the user wants to store their core data and view index data separately in multiple databases. The current setup does not provide the option to do so. 

## Use case
One of the use cases for using separate adapters can include using the `memory` adapter for indexes to speed up queries. Separate adapters is also helpful in taking advantage of the encryption options of the different databases.

## Approach
This PR provides an option for the user to specify a separate adapter to store their view index in addition to the main adapter for their core data.
For example the user will be able to define their main adapter using `adapter` and view index adapter using `view_adapter`. Here the core data will be stored in IndexedDB and view index data in WebSQL.
```
const db = new PouchDB(DB_NAME, {adapter: 'idb', view_adapter: 'websql'})
```

* * *

We’re mainly looking for guidance from the PouchDB team on the following points:

1. Should this be added? We believe the patch is small enough for a special-interest feature that is annoying to maintain outside of PouchDB, but others might disagree :)
2. Is `view_adapter` a sensible option name. A little more precise might be `index_adapter`, happy to bikeshed this.
3. other users might want to pass additional options to the view adapter, and so far they’d have to pass them into their local `new PouchDB()` options, which is “good enough™” for us, but we could see a future PR where `view_adapter` takes an object with per-adapter infos. We wanted to keep this simple for now.

