### PR TITLE
(#8291) - Add contextual data to the error message of failing tryMap and tryReduce

### DIFF
--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -48,7 +48,7 @@ function isGenOne(changes) {
   return changes.length === 1 && /^1-/.test(changes[0].rev);
 }
 
-function emitError(db, e) {
+function emitError(db, e, data) {
   try {
     db.emit('error', e);
   } catch (err) {
@@ -57,7 +57,7 @@ function emitError(db, e) {
       'You can debug this error by doing:\n' +
       'myDatabase.on(\'error\', function (err) { debugger; });\n' +
       'Please double-check your map/reduce function.');
-    guardedConsole('error', e);
+    guardedConsole('error', e, data);
   }
 }
 
@@ -95,7 +95,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
     try {
       fun(doc);
     } catch (e) {
-      emitError(db, e);
+      emitError(db, e, {fun: fun, doc: doc});
     }
   }
 
@@ -107,7 +107,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
     try {
       return {output : fun(keys, values, rereduce)};
     } catch (e) {
-      emitError(db, e);
+      emitError(db, e, {fun: fun, keys: keys, values: values, rereduce: rereduce});
       return {error: e};
     }
   }


### PR DESCRIPTION
When a map/reduce function throws an error, there is not data available in the console to spot what caused the issue.
The only way is to get it, is via debugger, but in a production environment it's hard to understand what document caused the issue and where.

I've added an object attached to the error.

https://github.com/pouchdb/pouchdb/issues/8291