### PR TITLE
chore: remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "argsarray": "0.0.1",
     "buffer-from": "1.1.1",
     "clone-buffer": "1.0.0",
-    "double-ended-queue": "2.1.0-0",
     "fetch-cookie": "0.11.0",
     "fruitdown": "1.0.2",
     "immediate": "3.3.0",


### PR DESCRIPTION
A search for [`double-ended-queue` in the repo only shows `package.json`](https://github.com/pouchdb/pouchdb/search?q=double-ended-queue).