### PR TITLE
Update package.json to include the repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
     "verify-build": "sh bin/verify-build.sh",
     "test-webpack": "bash bin/test-webpack.sh"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pouchdb/pouchdb.git"
+  },
   "dependencies": {
     "abort-controller": "3.0.0",
     "argsarray": "0.0.1",

--- a/packages/node_modules/pouchdb-collate/package.json
+++ b/packages/node_modules/pouchdb-collate/package.json
@@ -9,6 +9,11 @@
     "couch",
     "couchdb"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pouchdb/pouchdb.git",
+    "directory": "packages/node_modules/pouchdb-collate"
+  },
   "license": "Apache-2.0",
   "jsnext:main": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-for-coverage/package.json
+++ b/packages/node_modules/pouchdb-for-coverage/package.json
@@ -7,6 +7,11 @@
     "Below, the node version is used for coverage tests.",
     "The browser version is actually used for tests/integration/utils.js."
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pouchdb/pouchdb.git",
+    "directory": "packages/node_modules/pouchdb-for-coverage"
+  },
   "browser": {
     "./lib/index.js": "./lib/index-browser.js",
     "./src/pouchdb.js": "./src/pouchdb-browser.js"


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR.

Published NPM packages with repository information:
• pouchdb-monorepo
• pouchdb-collate
• pouchdb-for-coverage