### PR TITLE
Upgrade pouchdb-express-router to 0.0.11 to fix sync tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "mocha": "3.5.0",
     "mockery": "2.1.0",
     "ncp": "2.0.0",
-    "pouchdb-express-router": "0.0.10",
+    "pouchdb-express-router": "0.0.11",
     "query-string": "6.10.1",
     "replace": "1.1.3",
     "rimraf": "2.7.1",


### PR DESCRIPTION
This is a fix for something mentioned in #8345. We've noticed the integration tests fail non-deterministically. The cause seems to be a bug in `pouchdb-express-router` (the default `SERVER` setting), which means that long-polling requests to `/{db}/_changes` will not return any data if there is a delay waiting for new events to arrive. This was [fixed](https://github.com/pouchdb/pouchdb-express-router/commit/30bd27a748ae69409864d6af87e84086f67eacde) and released in v0.0.11, and bumping this dependency seems to make the integration suite pass reliably.