### PR TITLE
Fix the `ADAPTERS` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,29 +31,29 @@ env:
   - CLIENT=node COMMAND=test
 
   # Test in-memory in Node
-  #- CLIENT=node ADAPTER=memory COMMAND=test
+  #- CLIENT=node ADAPTERS=memory COMMAND=test
 
   # Test in firefox running on travis
-  #- CLIENT=selenium:firefox ADAPTER=idb COMMAND=test
-  - CLIENT=selenium:firefox ADAPTER=idb POUCHDB_SRC="../../packages/node_modules/pouchdb/dist/pouchdb.min.js" COMMAND=test
-  #- CLIENT=selenium:firefox ADAPTER=indexeddb COMMAND=test
-  - CLIENT=selenium:firefox ADAPTER=indexeddb POUCHDB_SRC="../../packages/node_modules/pouchdb/dist/pouchdb.min.js" COMMAND=test
+  #- CLIENT=selenium:firefox ADAPTERS=idb COMMAND=test
+  - CLIENT=selenium:firefox ADAPTERS=idb POUCHDB_SRC="../../packages/node_modules/pouchdb/dist/pouchdb.min.js" COMMAND=test
+  #- CLIENT=selenium:firefox ADAPTERS=indexeddb COMMAND=test
+  - CLIENT=selenium:firefox ADAPTERS=indexeddb POUCHDB_SRC="../../packages/node_modules/pouchdb/dist/pouchdb.min.js" COMMAND=test
 
   # Test auto-compaction in Node and Firefox
   - AUTO_COMPACTION=true CLIENT=node COMMAND=test
-  #- AUTO_COMPACTION=true CLIENT=selenium:firefox ADAPTER=idb COMMAND=test
-  #- AUTO_COMPACTION=true CLIENT=selenium:firefox ADAPTER=indexeddb COMMAND=test
+  #- AUTO_COMPACTION=true CLIENT=selenium:firefox ADAPTERS=idb COMMAND=test
+  #- AUTO_COMPACTION=true CLIENT=selenium:firefox ADAPTERS=indexeddb COMMAND=test
 
   # Test map/reduce
   - TYPE=mapreduce CLIENT=node COMMAND=test
-  #- TYPE=mapreduce CLIENT=selenium:firefox ADAPTER=idb COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:firefox ADAPTER=indexeddb COMMAND=test
+  #- TYPE=mapreduce CLIENT=selenium:firefox ADAPTERS=idb COMMAND=test
+  - TYPE=mapreduce CLIENT=selenium:firefox ADAPTERS=indexeddb COMMAND=test
 
   # Test pouchdb-find
   - COUCH_HOST=http://127.0.0.1:3001 TYPE=find PLUGINS=pouchdb-find CLIENT=node SERVER=couchdb-master COMMAND=test
   #- COUCH_HOST=http://127.0.0.1:3002 TYPE=find PLUGINS=pouchdb-find CLIENT=node SERVER=couchdb-v2 COMMAND=test
-  #- TYPE=find PLUGINS=pouchdb-find CLIENT=selenium:firefox ADAPTER=idb SERVER=pouchdb-server COMMAND=test
-  - TYPE=find PLUGINS=pouchdb-find CLIENT=selenium:firefox ADAPTER=indexeddb SERVER=pouchdb-server COMMAND=test
+  #- TYPE=find PLUGINS=pouchdb-find CLIENT=selenium:firefox ADAPTERS=idb SERVER=pouchdb-server COMMAND=test
+  - TYPE=find PLUGINS=pouchdb-find CLIENT=selenium:firefox ADAPTERS=indexeddb SERVER=pouchdb-server COMMAND=test
 
   # Test memory
   #- CLIENT=selenium:firefox ADAPTERS=memory COMMAND=test

--- a/TESTING.md
+++ b/TESTING.md
@@ -117,15 +117,15 @@ Note that you must `npm install pouchdb-server` or `npm install express-pouchdb`
 
 Use this option to test the new indexeddb adapter:
 
-    ADAPTER=indexeddb
+    ADAPTERS=indexeddb
 
 Use this option to test the in-memory adapter:
 
-    ADAPTER=memory
+    ADAPTERS=memory
 
 To run the node-websql test in Node, run the tests with:
 
-    ADAPTER=websql
+    ADAPTERS=websql
 
 ### Testing fetch vs XMLHttpRequest
 
@@ -153,7 +153,7 @@ You can also use `LEVEL_ADAPTER` to use a certain "DOWN" adapter:
 
 You can also test against node-websql:
 
-    PERF=1 ADAPTER=websql npm test
+    PERF=1 ADAPTERS=websql npm test
 
 You can also override the default number of iterations:
 

--- a/bin/build-pouchdb.js
+++ b/bin/build-pouchdb.js
@@ -28,7 +28,7 @@ var builtInModules = require('builtin-modules');
 var external = Object.keys(require('../package.json').dependencies)
   .concat(builtInModules);
 
-var plugins = ['localstorage', 'memory', 'find'];
+var plugins = ['indexeddb', 'localstorage', 'memory', 'find'];
 
 var currentYear = new Date().getFullYear();
 
@@ -40,6 +40,8 @@ var comments = {
   'version 2.0.' +
   '\n// For all details and documentation:' +
   '\n// http://pouchdb.com\n',
+
+  'indexeddb': '// PouchDB indexeddb plugin ' + version + '\n',
 
   'memory': '// PouchDB in-memory plugin ' + version +
   '\n// Based on MemDOWN: https://github.com/rvagg/memdown' +

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -26,9 +26,6 @@ if (process.env.PLUGINS) {
 if (process.env.COUCH_HOST) {
   queryParams.couchHost = process.env.COUCH_HOST;
 }
-if (process.env.ADAPTER) {
-  queryParams.adapter = process.env.ADAPTER;
-}
 if (process.env.ITERATIONS) {
   queryParams.iterations = process.env.ITERATIONS;
 }

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -84,9 +84,6 @@ if (process.env.PLUGINS) {
 if (process.env.COUCH_HOST) {
   qs.couchHost = process.env.COUCH_HOST;
 }
-if (process.env.ADAPTER) {
-  qs.adapter = process.env.ADAPTER;
-}
 if (process.env.ITERATIONS) {
   qs.iterations = process.env.ITERATIONS;
 }

--- a/packages/node_modules/pouchdb/src/plugins/indexeddb.js
+++ b/packages/node_modules/pouchdb/src/plugins/indexeddb.js
@@ -1,0 +1,14 @@
+/* global PouchDB */
+
+// this code only runs in the browser, as its own dist/ script
+
+import IndexeddbPouchPlugin from 'pouchdb-adapter-indexeddb';
+import { guardedConsole } from 'pouchdb-utils';
+
+if (typeof PouchDB === 'undefined') {
+  guardedConsole('error', 'indexeddb adapter plugin error: ' +
+    'Cannot find global "PouchDB" object! ' +
+    'Did you remember to include pouchdb.js?');
+} else {
+  PouchDB.plugin(IndexeddbPouchPlugin);
+}

--- a/tests/integration/test.defaults.js
+++ b/tests/integration/test.defaults.js
@@ -2,7 +2,7 @@
 if (!process.env.LEVEL_ADAPTER &&
     !process.env.LEVEL_PREFIX &&
     !process.env.AUTO_COMPACTION &&
-    !process.env.ADAPTER) {
+    !process.env.ADAPTERS) {
   // these tests don't make sense for anything other than default leveldown
   var path = require('path');
   var mkdirp = require('mkdirp');

--- a/tests/integration/test.failures.js
+++ b/tests/integration/test.failures.js
@@ -3,7 +3,7 @@
 if (!process.env.LEVEL_ADAPTER &&
   !process.env.LEVEL_PREFIX &&
   !process.env.AUTO_COMPACTION &&
-  !process.env.ADAPTER) {
+  !process.env.ADAPTERS) {
   // these tests don't make sense for anything other than default leveldown
 
   describe('test.failures.js', function () {

--- a/tests/integration/test.issue915.js
+++ b/tests/integration/test.issue915.js
@@ -2,7 +2,7 @@
 if (!process.env.LEVEL_ADAPTER &&
     !process.env.LEVEL_PREFIX &&
     !process.env.AUTO_COMPACTION &&
-    !process.env.ADAPTER) {
+    !process.env.ADAPTERS) {
   // these tests don't make sense for anything other than default leveldown
   var fs = require('fs');
   var bufferFrom = require('buffer-from');

--- a/tests/integration/test.migration.js
+++ b/tests/integration/test.migration.js
@@ -2,7 +2,7 @@
 if (!process.env.LEVEL_ADAPTER &&
     !process.env.LEVEL_PREFIX &&
     !process.env.AUTO_COMPACTION &&
-    !process.env.ADAPTER) {
+    !process.env.ADAPTERS) {
   // these tests don't make sense for anything other than default leveldown
   var fs = require('fs');
   var ncp = require('ncp').ncp;

--- a/tests/integration/test.node-websql.js
+++ b/tests/integration/test.node-websql.js
@@ -1,6 +1,6 @@
 'use strict';
 
-if (process.env.ADAPTER === 'websql') {
+if (process.env.ADAPTERS === 'websql') {
   describe('test.node-websql.js', function () {
     it('should run websql when we are actually testing websql', function () {
       var db = new PouchDB('testdb');

--- a/tests/integration/test.prefix.js
+++ b/tests/integration/test.prefix.js
@@ -38,7 +38,7 @@ describe('test.prefix.js', function () {
 if (typeof process !== 'undefined' &&
     !process.env.LEVEL_ADAPTER &&
     !process.env.LEVEL_PREFIX &&
-    !process.env.ADAPTER &&
+    !process.env.ADAPTERS &&
     // fails on windows with EBUSY - "resource busy or locked", not worth fixing
     require('os').platform() !== 'win32') {
 

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -351,7 +351,7 @@ if (typeof process !== 'undefined' && !process.browser) {
       auto_compaction: true,
       prefix: './tmp/_pouch_'
     });
-  } else if (process.env.ADAPTER === 'websql') {
+  } else if (process.env.ADAPTERS === 'websql') {
     // test WebSQL in Node
     // (the two strings are just to fool Browserify because sqlite3 fails
     // in Node 0.11-0.12)
@@ -361,7 +361,7 @@ if (typeof process !== 'undefined' && !process.browser) {
     global.PouchDB = global.PouchDB.defaults({
       prefix: path.resolve('./tmp/_pouch_')
     });
-  } else if (process.env.ADAPTER === 'memory') {
+  } else if (process.env.ADAPTERS === 'memory') {
     global.PouchDB.plugin(require('../../packages/node_modules/' +
       'pouchdb-adapter-memory'));
     global.PouchDB.preferredAdapters = ['memory', 'leveldb'];

--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -11,7 +11,7 @@
   var pouchdbSrc = params.src || scriptPath + '/pouchdb.js';
 
   var scriptsToLoad = [pouchdbSrc];
-  var pluginAdapters = ['localstorage', 'memory'];
+  var pluginAdapters = ['indexeddb', 'localstorage', 'memory'];
 
   adapters.forEach(function (adapter) {
     if (pluginAdapters.includes(adapter)) {

--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -7,19 +7,20 @@
   var params = testUtils.params();
   var plugins = ('plugins' in params) ? params.plugins.split(',') : [];
   var adapters = ('adapters' in params) ? params.adapters.split(',') : [];
-  var pouchdbSrc = params.src || '../../packages/node_modules/pouchdb/dist/pouchdb.js';
+  var scriptPath = '../../packages/node_modules/pouchdb/dist';
+  var pouchdbSrc = params.src || scriptPath + '/pouchdb.js';
+
   var scriptsToLoad = [pouchdbSrc];
+  var pluginAdapters = ['localstorage', 'memory'];
+
   adapters.forEach(function (adapter) {
-    if (adapter !== 'idb') {
-      // load from plugin
-      scriptsToLoad.push(
-        '../../packages/node_modules/pouchdb/dist/pouchdb.' + adapter + '.js');
+    if (pluginAdapters.includes(adapter)) {
+      plugins.push(adapter);
     }
   });
   plugins.forEach(function (plugin) {
     plugin = plugin.replace(/^pouchdb-/, '');
-    scriptsToLoad.push(
-      '../../packages/node_modules/pouchdb/dist/pouchdb.' + plugin + '.js');
+    scriptsToLoad.push(scriptPath + '/pouchdb.' + plugin + '.js');
   });
 
   var remote = params.remote === '1';

--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -3,35 +3,26 @@
   'use strict';
   // use query parameter pluginFile if present,
   // eg: test.html?pluginFile=memory.pouchdb.js
-  var plugins = window.location.search.match(/[?&]plugins=([^&]+)/);
-  var adapters = window.location.search.match(/[?&]adapters=([^&]+)/);
-  var pouchdbSrc = window.location.search.match(/[?&]src=([^&]+)/);
-  if (pouchdbSrc) {
-    pouchdbSrc = decodeURIComponent(pouchdbSrc[1]);
-  } else {
-    pouchdbSrc = '../../packages/node_modules/pouchdb/dist/pouchdb.js';
-  }
-  var scriptsToLoad = [pouchdbSrc];
-  if (adapters) {
-    adapters = adapters[1].split(',');
-    adapters.forEach(function (adapter) {
-      if (adapter !== 'idb') {
-        // load from plugin
-        scriptsToLoad.push(
-          '../../packages/node_modules/pouchdb/dist/pouchdb.' + adapter + '.js');
-      }
-    });
-  }
-  if (plugins) {
-    plugins[1].split(',').forEach(function (plugin) {
-      plugin = plugin.replace(/^pouchdb-/, '');
-      scriptsToLoad.push(
-        '../../packages/node_modules/pouchdb/dist/pouchdb.' + plugin + '.js');
-    });
-  }
 
-  var remote = window.location.search.match(/[?&]remote=([^&]+)/);
-  remote = remote && remote[1] === '1';
+  var params = testUtils.params();
+  var plugins = ('plugins' in params) ? params.plugins.split(',') : [];
+  var adapters = ('adapters' in params) ? params.adapters.split(',') : [];
+  var pouchdbSrc = params.src || '../../packages/node_modules/pouchdb/dist/pouchdb.js';
+  var scriptsToLoad = [pouchdbSrc];
+  adapters.forEach(function (adapter) {
+    if (adapter !== 'idb') {
+      // load from plugin
+      scriptsToLoad.push(
+        '../../packages/node_modules/pouchdb/dist/pouchdb.' + adapter + '.js');
+    }
+  });
+  plugins.forEach(function (plugin) {
+    plugin = plugin.replace(/^pouchdb-/, '');
+    scriptsToLoad.push(
+      '../../packages/node_modules/pouchdb/dist/pouchdb.' + plugin + '.js');
+  });
+
+  var remote = params.remote === '1';
 
 // Thanks to http://engineeredweb.com/blog/simple-async-javascript-loader/
   function asyncLoadScript(url, callback) {
@@ -65,10 +56,10 @@
   }
 
   function modifyGlobals() {
-    if (adapters) {
+    if (adapters.length > 0) {
       window.PouchDB.preferredAdapters = adapters;
     }
-    if (window.location.search.indexOf('autoCompaction') !== -1) {
+    if ('autoCompaction' in params) {
       window.PouchDB = window.PouchDB.defaults({ auto_compaction: true });
     }
   }

--- a/tests/performance/index.js
+++ b/tests/performance/index.js
@@ -4,8 +4,8 @@
 var opts = {};
 
 if (typeof process !== 'undefined' && process.env) {
-  if (process.env.ADAPTER) {
-    opts.adapter = process.env.ADAPTER;
+  if (process.env.ADAPTERS) {
+    opts.adapter = process.env.ADAPTERS;
   }
 }
 


### PR DESCRIPTION
This addresses an issue I mentioned in #8345. While running the tests we were confused about the behaviour of the `ADAPTER` and `ADAPTERS` options, particularly when running in the browser. We observed that:

- `ADAPTER` (singular) seems to have no effect, we can't find anything in the browser build scripts that makes use of it other that adding it to the query string of `tests/integration/index.html`; we believe this means that CI tasks using `ADAPTER=indexeddb` will have had no effect, and will actually have been running the `idb` adapter.
- `ADAPTERS` (plural) has two responsibilities: it sets the value of `PouchDB.preferredAdapters` and so changes the default adapter choice, _and_ it causes any requested adapters to be loaded from `packages/node_modules/pouchdb/dist`.

The problem this causes is that setting e.g. `ADAPTERS=idb` causes the build to fail, because `idb` is baked into the core PouchDB bundle, it's not a separate file. Trying to [load it dynamically](https://github.com/pouchdb/pouchdb/blob/9f5da871ac5748bca187f97b3926326cdbddcce5/tests/integration/webrunner.js#L15-L24) fails, which ultimately causes `window.testEvents()` to not be defined, which causes an error when the test script tries to poll for results.

This PR addresses these problems by unifying the two options, keeping the plural form which was added much earlier in the project history. Requested adapters are only dynamically loaded if we know they are a plugin compiled into the `pouchdb/dist` directory.

The final commit here makes the new `indexeddb` adapter into such a plugin, in order that it can be loaded in a browser-compatible bundle and activated via the `ADAPTERS` option. This might require further work if we don't wish to distribute this adapter as part of the `pouchdb` package but it's currently the simplest way to be able to compile a browser bundle and run the tests against it.