### PR TITLE
(#8354) - Docs: Update couchdb setup guide

### DIFF
--- a/docs/_guides/setup-couchdb.md
+++ b/docs/_guides/setup-couchdb.md
@@ -25,10 +25,23 @@ In the following examples, we will set up CouchDB and talk to it using a tool yo
 
 {% include anchor.html title="Installing CouchDB" hash="installing-couchdb" %}
 
-If you are on a Debian flavor of Linux (Ubuntu, Mint, etc.), you can install CouchDB with:
+If you are on a Debian flavor of Linux (Ubuntu, Mint, etc.), you can install CouchDB as follows.
+
+First, [enable the CouchDB package repository](https://docs.couchdb.org/en/stable/install/unix.html#enabling-the-apache-couchdb-package-repository) on your machine:
 
 ```
-$ sudo apt-get install couchdb
+$ sudo apt update && sudo apt install -y curl apt-transport-https gnupg
+$ curl https://couchdb.apache.org/repo/keys.asc | gpg --dearmor | sudo tee /usr/share/keyrings/couchdb-archive-keyring.gpg >/dev/null 2>&1
+source /etc/os-release
+$ echo "deb [signed-by=/usr/share/keyrings/couchdb-archive-keyring.gpg] https://apache.jfrog.io/artifactory/couchdb-deb/ ${VERSION_CODENAME} main" \
+    | sudo tee /etc/apt/sources.list.d/couchdb.list >/dev/null
+```
+
+Next, update your package lists and install CouchDB:
+
+```
+$ sudo apt-get update
+$ sudo apt-get install -y couchdb
 ```
 
 If you are on a Mac or Windows you should install the official binaries from [the CouchDB web site](https://couchdb.apache.org/#download).


### PR DESCRIPTION
This adds additional instructions on how to enable the package repository on Debian machines that is required for the installation of CouchDB.

I took the installation instructions from the latest version of [the Apache CouchDB installation guide](https://docs.couchdb.org/en/stable/install/unix.html#enabling-the-apache-couchdb-package-repository).

Closes #8354 

| before | after |
|--|--|
|![image](https://user-images.githubusercontent.com/8811742/132090102-d479ff0c-3d7b-44a0-be37-631335bdea02.png) | ![image](https://user-images.githubusercontent.com/8811742/132090082-813251ab-b223-4db5-bd50-bf019cbb4044.png)|
