### PR TITLE
Fix escaping of key path segments in indexeddb adapter

### DIFF
--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/rewrite.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/rewrite.js
@@ -4,6 +4,19 @@ var IDB_NULL = Number.MIN_SAFE_INTEGER;
 var IDB_FALSE = Number.MIN_SAFE_INTEGER + 1;
 var IDB_TRUE = Number.MIN_SAFE_INTEGER + 2;
 
+// These are the same as bellow but without the global flag
+// we want to use RegExp.test because it's really fast, but the global flag
+// makes the regex const stateful (seriously) as it walked through all instances
+var TEST_KEY_INVALID = /^[^a-zA-Z_$]|[^a-zA-Z0-9_$]+/;
+var TEST_PATH_INVALID = /\\.|^[^a-zA-Z_$]|[^a-zA-Z0-9_$.]+/;
+function needsSanitise(name, isPath) {
+  if (isPath) {
+    return TEST_PATH_INVALID.test(name);
+  } else {
+    return TEST_KEY_INVALID.test(name);
+  }
+}
+
 //
 // IndexedDB only allows valid JS names in its index paths, whereas JSON allows
 // for any string at all. This converts invalid JS names to valid ones, to allow
@@ -20,22 +33,9 @@ var IDB_TRUE = Number.MIN_SAFE_INTEGER + 2;
 //
 // This is more aggressive than it needs to be, but also simpler.
 //
-var KEY_INVALID = /[^a-zA-Z0-9_$]+|(^[^a-zA-Z_$])/g;
-var PATH_INVALID = /(\\.)|[^a-zA-Z0-9_$.]+|(^[^a-zA-Z_$])/g;
+var KEY_INVALID = new RegExp(TEST_KEY_INVALID.source, 'g');
+var PATH_INVALID = new RegExp(TEST_PATH_INVALID.source, 'g');
 var SLASH = '\\'.charCodeAt(0);
-
-// These are the same as above but without the global flag
-// we want to use RegExp.test because it's really fast, but the global flag
-// makes the regex const stateful (seriously) as it walked through all instances
-var TEST_KEY_INVALID = /[^a-zA-Z0-9_$]+|(^[^a-zA-Z_$])/;
-var TEST_PATH_INVALID = /(\\.)|[^a-zA-Z0-9_$.]+|(^[^a-zA-Z_$])/;
-function needsSanitise(name, isPath) {
-  if (isPath) {
-    return TEST_PATH_INVALID.test(name);
-  } else {
-    return TEST_KEY_INVALID.test(name);
-  }
-}
 
 function sanitise(name, isPath) {
   var correctCharacters = function (match) {

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/rewrite.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/rewrite.js
@@ -8,7 +8,7 @@ var IDB_TRUE = Number.MIN_SAFE_INTEGER + 2;
 // we want to use RegExp.test because it's really fast, but the global flag
 // makes the regex const stateful (seriously) as it walked through all instances
 var TEST_KEY_INVALID = /^[^a-zA-Z_$]|[^a-zA-Z0-9_$]+/;
-var TEST_PATH_INVALID = /\\.|^[^a-zA-Z_$]|[^a-zA-Z0-9_$.]+/;
+var TEST_PATH_INVALID = /\\.|(^|\.)[^a-zA-Z_$]|[^a-zA-Z0-9_$.]+/;
 function needsSanitise(name, isPath) {
   if (isPath) {
     return TEST_PATH_INVALID.test(name);
@@ -36,6 +36,7 @@ function needsSanitise(name, isPath) {
 var KEY_INVALID = new RegExp(TEST_KEY_INVALID.source, 'g');
 var PATH_INVALID = new RegExp(TEST_PATH_INVALID.source, 'g');
 var SLASH = '\\'.charCodeAt(0);
+const IS_DOT = '.'.charCodeAt(0);
 
 function sanitise(name, isPath) {
   var correctCharacters = function (match) {
@@ -48,11 +49,14 @@ function sanitise(name, isPath) {
       // e.g., if you want to index THIS string:
       //   {"foo": {"bar.baz": "THIS"}}
       // Your index path would be "foo.bar\.baz".
-      if (code === SLASH && isPath) {
-        continue;
-      }
 
-      good += '_c' + code + '_';
+      if (code === IS_DOT && isPath && i === 0) {
+        good += '.';
+      } else if (code === SLASH && isPath) {
+        continue;
+      } else {
+        good += '_c' + code + '_';
+      }
     }
     return good;
   };

--- a/tests/find/test-suite-1/test.escaping.js
+++ b/tests/find/test-suite-1/test.escaping.js
@@ -187,4 +187,54 @@ describe('test.escaping.js', function () {
       res.docs.should.deep.equal([doc]);
     });
   });
+
+  it('internal digits are not escaped', function () {
+    var db = context.db;
+    var index = {
+      "index": {
+        "fields": [
+          "foo0bar"
+        ]
+      },
+      "name": "foo-index",
+      "type": "json"
+    };
+    return db.bulkDocs([
+      {_id: 'doc', 'foo0bar': 'a'}
+    ]).then(function () {
+      return db.createIndex(index);
+    }).then(function () {
+      return db.find({
+        selector: {'foo0bar': 'a'},
+        fields: ['_id', 'foo0bar']
+      });
+    }).then(function (res) {
+      res.docs.should.deep.equal([{ "_id": "doc", "foo0bar": "a" }]);
+    });
+  });
+
+  it('handles escape patterns', function () {
+    var db = context.db;
+    var index = {
+      "index": {
+        "fields": [
+          "foo_c46_bar"
+        ]
+      },
+      "name": "foo-index",
+      "type": "json"
+    };
+    return db.bulkDocs([
+      {_id: 'doc', 'foo_c46_bar': 'a'}
+    ]).then(function () {
+      return db.createIndex(index);
+    }).then(function () {
+      return db.find({
+        selector: {'foo_c46_bar': 'a'},
+        fields: ['_id', 'foo_c46_bar']
+      });
+    }).then(function (res) {
+      res.docs.should.deep.equal([{ "_id": "doc", "foo_c46_bar": "a" }]);
+    });
+  });
 });


### PR DESCRIPTION
The test `deeper values can be escaped` in `tests/find/test-suite-1/test.escaping.js` is broken on `indexeddb` because its `sanitise()` function does not deal correctly with key paths like `foo.0bar`, where a path segment is not a valid JS name. This is because the `PATH_INVALID` regex only handles the special case where a digit appears at the very beginning of a string, not at the beginning of a path segment following a `.` character.

Here @AlbaHerrerias and I have fixed this by replacing `^` with `(^|\.)` in the regex. We considered using a lookbehind like `(?<=\.)` but this isn't supported in Safari. That means we also need to handle `.` characters we don't want to escape, e.g. in the key path `foo.0bar` the regex will match `.0` and we only want to escape the `0`, but leave the `.` as-is to be interpreted by IndexedDB. So the resulting string should be `foo._c48_bar`.

We handle this by noting the pattern has three branches:

- `\\.`: this will always match a literal `\` followed by a single char
- `(^|\.)[^a-zA-Z_$]`: this will either be a single char that's not a legal first char for a JS name, or it will be a `.` followed by such a char; it could therefore match `'..'`
- `[^a-zA-Z0-9_$.]+`: this will never contain a `.` char

So, we special-case `.` chars appearing as the first char in the match, since these must be produced by the second branch. This is tightly coupled to the structure of the pattern though, and might be easily broken, so I'd appreciate any suggestion for a better way to handle this.