### PR TITLE
Revert "chore: remove unused dependency"

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "argsarray": "0.0.1",
     "buffer-from": "1.1.1",
     "clone-buffer": "1.0.0",
+    "double-ended-queue": "2.1.0-0",
     "fetch-cookie": "0.11.0",
     "fruitdown": "1.0.2",
     "immediate": "3.3.0",


### PR DESCRIPTION
This reverts commit 2c93c04faca48958ffadad7ecca43b371a8980f1.

It looks like this is required for some tests, let’s leave it in for now.

Reverts https://github.com/pouchdb/pouchdb/pull/8344

