### PR TITLE
Quote arguments to mocha(1) to make GREP work correctly

### DIFF
--- a/bin/test-node.sh
+++ b/bin/test-node.sh
@@ -33,20 +33,20 @@ if [ $PERF ]; then
 elif [ ! $COVERAGE ]; then
     ./node_modules/.bin/mocha \
         $BAIL_OPT \
-        --timeout $TIMEOUT \
+        --timeout "$TIMEOUT" \
         --require=./tests/integration/node.setup.js \
-        --reporter=$REPORTER \
-        --grep=$GREP \
+        --reporter="$REPORTER" \
+        --grep="$GREP" \
         $TESTS_PATH
 else
     ./node_modules/.bin/istanbul cover \
        --no-default-excludes -x 'tests/**' -x 'node_modules/**' \
        ./node_modules/mocha/bin/_mocha -- \
         $BAIL_OPT \
-        --timeout $TIMEOUT \
+        --timeout "$TIMEOUT" \
         --require=./tests/integration/node.setup.js \
-        --reporter=$REPORTER \
-        --grep=$GREP \
+        --reporter="$REPORTER" \
+        --grep="$GREP" \
         $TESTS_PATH
 
     ./node_modules/.bin/istanbul check-coverage --line 100


### PR DESCRIPTION
Because the arguments in this script are not quoted, using multi-word values for `GREP` to select a particular test doesn't work when running tests on Node.js. For example if you set `GREP='should query correctly with skip'`, the script ends up running `mocha --grep=should query correctly with skip`, so only the word `should` is used for the `--grep` option and the other words become positional arguments and ignored.