### PR TITLE
Fix mapreduce tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,15 @@ env:
   #- AUTO_COMPACTION=true CLIENT=selenium:firefox ADAPTERS=indexeddb COMMAND=test
 
   # Test map/reduce
-  - TYPE=mapreduce CLIENT=node COMMAND=test
-  #- TYPE=mapreduce CLIENT=selenium:firefox ADAPTERS=idb COMMAND=test
-  - TYPE=mapreduce CLIENT=selenium:firefox ADAPTERS=indexeddb COMMAND=test
+  - TYPE=mapreduce CLIENT=node ADAPTERS=http SERVER=couchdb-master COUCH_HOST=http://127.0.0.1:3001
+  - TYPE=mapreduce CLIENT=node ADAPTERS=http SERVER=pouchdb-server
+  - TYPE=mapreduce CLIENT=node ADAPTERS=leveldb
+  - TYPE=mapreduce CLIENT=node ADAPTERS=memory
+  - TYPE=mapreduce CLIENT=selenium:firefox ADAPTERS=http SERVER=couchdb-master COUCH_HOST=http://127.0.0.1:3001
+  - TYPE=mapreduce CLIENT=selenium:firefox ADAPTERS=http SERVER=pouchdb-server
+  - TYPE=mapreduce CLIENT=selenium:firefox ADAPTERS=idb
+  - TYPE=mapreduce CLIENT=selenium:firefox ADAPTERS=indexeddb
+  - TYPE=mapreduce CLIENT=selenium:firefox ADAPTERS=memory
 
   # Test pouchdb-find
   - TYPE=find PLUGINS=pouchdb-find CLIENT=node ADAPTERS=http SERVER=couchdb-master COUCH_HOST=http://127.0.0.1:3001

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
@@ -79,17 +79,17 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
       var newDoc;
 
       // The first document write cannot be a deletion
-      if ('was_delete' in opts && !(oldDocs.hasOwnProperty(doc.id))) {
+      if ('was_delete' in opts && !(Object.prototype.hasOwnProperty.call(oldDocs, doc.id))) {
         newDoc = createError(MISSING_DOC, 'deleted');
 
       // The first write of a document cannot specify a revision
       } else if (opts.new_edits &&
-                 !oldDocs.hasOwnProperty(doc.id) &&
+                 !Object.prototype.hasOwnProperty.call(oldDocs, doc.id) &&
                  rootIsMissing(doc)) {
         newDoc = createError(REV_CONFLICT);
 
       // Update the existing document
-      } else if (oldDocs.hasOwnProperty(doc.id)) {
+      } else if (Object.prototype.hasOwnProperty.call(oldDocs, doc.id)) {
         newDoc = update(txn, doc, oldDocs[doc.id]);
         // The update can be rejected if it is an update to an existing
         // revision, if so skip it

--- a/tests/mapreduce/test.mapreduce.js
+++ b/tests/mapreduce/test.mapreduce.js
@@ -1,17 +1,13 @@
 /* global sum */
 'use strict';
 
-var adapters = ['local', 'http'];
+var viewTypes = ['persisted', 'temp'];
+viewTypes.forEach(function (viewType) {
+  var suiteName = 'test.mapreduce.js-' + viewType;
+  var adapter = testUtils.adapterType();
+  var dbName = testUtils.adapterUrl(adapter, 'testdb');
 
-adapters.forEach(function (adapter) {
-
-  var viewTypes = ['persisted', 'temp'];
-  viewTypes.forEach(function (viewType) {
-    var suiteName = 'test.mapreduce.js-' + adapter + '-' + viewType;
-    var dbName = testUtils.adapterUrl(adapter, 'testdb');
-
-    tests(suiteName, dbName, adapter, viewType);
-  });
+  tests(suiteName, dbName, adapter, viewType);
 });
 
 function tests(suiteName, dbName, dbType, viewType) {

--- a/tests/mapreduce/test.mapreduce.js
+++ b/tests/mapreduce/test.mapreduce.js
@@ -1205,7 +1205,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     }
 
     it('Query result should include _conflicts', function () {
-      var db2name = 'test2b' + Math.random();
+      var db2name = testUtils.adapterUrl(dbType, 'test2b');
       var cleanup = function () {
         return new PouchDB(db2name).destroy();
       };
@@ -1518,7 +1518,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Views should include _conflicts', function () {
-      var db2name = 'test2' + Math.random();
+      var db2name = testUtils.adapterUrl(dbType, 'test2');
       var cleanup = function () {
         return new PouchDB(db2name).destroy();
       };
@@ -2980,6 +2980,7 @@ function tests(suiteName, dbName, dbType, viewType) {
 
     it('should query correctly after replicating and other ddoc', function () {
       var db = new PouchDB(dbName);
+      var db2 = new PouchDB(testUtils.adapterUrl(dbType, 'local-other'));
       return createView(db, {
         map: function (doc) {
           emit(doc.name);
@@ -2991,7 +2992,6 @@ function tests(suiteName, dbName, dbType, viewType) {
           res.rows.map(function (x) {return x.key; }).should.deep.equal([
             'foobar'
           ], 'test db before replicating');
-          var db2 = new PouchDB('local-other');
           return db.replicate.to(db2).then(function () {
             return db.query(queryFun);
           }).then(function (res) {
@@ -3020,11 +3020,11 @@ function tests(suiteName, dbName, dbType, viewType) {
               'foobar'
             ], 'test db2');
           }).catch(function (err) {
-            return new PouchDB('local-other').destroy().then(function () {
+            return db2.destroy().then(function () {
               throw err;
             });
           }).then(function () {
-            return new PouchDB('local-other').destroy();
+            return db2.destroy();
           });
         });
       });

--- a/tests/mapreduce/test.mapreduce.js
+++ b/tests/mapreduce/test.mapreduce.js
@@ -14,7 +14,7 @@ function tests(suiteName, dbName, dbType, viewType) {
 
   describe(suiteName, function () {
 
-    var Promise;
+    var Promise = testUtils.Promise;
 
     var createView;
     if (dbType === 'http' || viewType === 'persisted') {
@@ -50,14 +50,9 @@ function tests(suiteName, dbName, dbType, viewType) {
       };
     }
 
-    beforeEach(function () {
-      Promise = testUtils.Promise;
-      return new PouchDB(dbName).destroy();
-    });
     afterEach(function () {
       return new PouchDB(dbName).destroy();
     });
-
 
     it("Test basic view", function () {
       var db = new PouchDB(dbName);

--- a/tests/mapreduce/test.mapreduce.js
+++ b/tests/mapreduce/test.mapreduce.js
@@ -1687,13 +1687,13 @@ function tests(suiteName, dbName, dbType, viewType) {
         return db.query(queryFun, {group_level: -1, reduce: true}).then(function (res) {
           res.should.not.exist('expected error on invalid group_level');
         }).catch(function (err) {
-          err.status.should.equal(400);
+          err.status.should.be.oneOf([400, 500]);
           err.message.should.be.a('string');
           return db.query(queryFun, { group_level: 'exact', reduce: true});
         }).then(function (res) {
           res.should.not.exist('expected error on invalid group_level');
         }).catch(function (err) {
-          err.status.should.equal(400);
+          err.status.should.be.oneOf([400, 500]);
           err.message.should.be.a('string');
         });
       });
@@ -1748,13 +1748,13 @@ function tests(suiteName, dbName, dbType, viewType) {
         }).then(function (res) {
           res.should.not.exist('expected error on invalid group_level');
         }).catch(function (err) {
-          err.status.should.equal(400);
+          err.status.should.be.oneOf([400, 500]);
           err.message.should.be.a('string');
           return db.query(queryFun, { limit: '1a', group: true, reduce: true});
         }).then(function (res) {
           res.should.not.exist('expected error on invalid group_level');
         }).catch(function (err) {
-          err.status.should.equal(400);
+          err.status.should.be.oneOf([400, 500]);
           err.message.should.be.a('string');
         });
       });
@@ -1865,13 +1865,13 @@ function tests(suiteName, dbName, dbType, viewType) {
         }).then(function (res) {
           res.should.not.exist('expected error on invalid group_level');
         }).catch(function (err) {
-          err.status.should.equal(400);
+          err.status.should.be.oneOf([400, 500]);
           err.message.should.be.a('string');
           return db.query(queryFun, { skip: '1a', group: true, reduce: true});
         }).then(function (res) {
           res.should.not.exist('expected error on invalid group_level');
         }).catch(function (err) {
-          err.status.should.equal(400);
+          err.status.should.be.oneOf([400, 500]);
           err.message.should.be.a('string');
         });
       });
@@ -2693,7 +2693,7 @@ function tests(suiteName, dbName, dbType, viewType) {
           return db.query(mapFun, {startkey : '5', endkey : '4'}).then(function (res) {
             res.should.not.exist('expected error on reversed start/endkey');
           }).catch(function (err) {
-            err.status.should.equal(400);
+            err.status.should.be.oneOf([400, 500]);
             err.message.should.be.a('string');
           });
         });
@@ -2964,7 +2964,7 @@ function tests(suiteName, dbName, dbType, viewType) {
           return db.query(queryFun, {include_docs : true}).then(function (res) {
             should.not.exist(res);
           }).catch(function (err) {
-            err.status.should.equal(400);
+            err.status.should.be.oneOf([400, 500]);
             err.message.should.be.a('string');
             // include_docs is invalid for reduce
           });
@@ -3229,12 +3229,12 @@ function tests(suiteName, dbName, dbType, viewType) {
         return db.query(queryFun, opts).then(function (res) {
           should.not.exist(res);
         }).catch(function (err) {
-          err.status.should.equal(400);
+          err.status.should.be.oneOf([400, 500]);
           opts = {keys: keys};
           return db.query(queryFun, opts).then(function (res) {
             should.not.exist(res);
           }).catch(function (err) {
-            err.status.should.equal(400);
+            err.status.should.be.oneOf([400, 500]);
             opts = {keys: keys, reduce : false};
             return db.query(queryFun, opts).then(function () {
               opts = {keys: keys, group: true};
@@ -3660,7 +3660,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         //shouldn't happen
         true.should.equal(false);
       }).catch(function (err) {
-        err.status.should.equal(404);
+        err.status.should.be.oneOf([404, 500]);
       });
     });
 

--- a/tests/mapreduce/test.mapreduce.js
+++ b/tests/mapreduce/test.mapreduce.js
@@ -17,10 +17,10 @@ function tests(suiteName, dbName, dbType, viewType) {
     var Promise;
 
     var createView;
-    if (viewType === 'persisted') {
+    if (dbType === 'http' || viewType === 'persisted') {
       createView = function (db, viewObj) {
         var storableViewObj = {
-          map : viewObj.map.toString()
+          map: viewObj.map.toString()
         };
         if (viewObj.reduce) {
           storableViewObj.reduce = viewObj.reduce.toString();
@@ -149,7 +149,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         });
       });
     }
-    if (viewType === 'temp') {
+    if (viewType === 'temp' && dbType !== 'http') {
 
       it('Test simultaneous temp views', function () {
         var db = new PouchDB(dbName);
@@ -1186,7 +1186,7 @@ function tests(suiteName, dbName, dbType, viewType) {
       }).should.be.rejected;
     });
 
-    if (viewType === 'temp') {
+    if (viewType === 'temp' && dbType !== 'http') {
       it("No reduce function, passing just a function", function () {
         var db = new PouchDB(dbName);
         return db.post({foo: 'bar'}).then(function () {

--- a/tests/mapreduce/test.mapreduce.js
+++ b/tests/mapreduce/test.mapreduce.js
@@ -50,6 +50,17 @@ function tests(suiteName, dbName, dbType, viewType) {
       };
     }
 
+    beforeEach(function () {
+      if (dbType === 'http') {
+        var uri = testUtils.parseUri(dbName);
+        var dbUrl = `${uri.protocol}://${uri.host}:${uri.port}${uri.path}`;
+        return PouchDB.fetch(dbUrl + '?q=1', {
+          method: 'PUT',
+          headers: { Authorization: 'Basic ' + testUtils.btoa(uri.userInfo) }
+        });
+      }
+    });
+
     afterEach(function () {
       return new PouchDB(dbName).destroy();
     });

--- a/tests/mapreduce/test.persisted.js
+++ b/tests/mapreduce/test.persisted.js
@@ -4,7 +4,7 @@ describe('test.persisted.js', function () {
   var dbType = testUtils.adapterType();
   var dbName = testUtils.adapterUrl(dbType, 'testdb');
 
-  var Promise;
+  var Promise = testUtils.Promise;
 
   function setTimeoutPromise(time) {
     return new Promise(function (resolve) {
@@ -35,10 +35,6 @@ describe('test.persisted.js', function () {
     });
   }
 
-  beforeEach(function () {
-    Promise = testUtils.Promise;
-    return new PouchDB(dbName).destroy();
-  });
   afterEach(function () {
     return new PouchDB(dbName).destroy();
   });

--- a/tests/mapreduce/test.persisted.js
+++ b/tests/mapreduce/test.persisted.js
@@ -324,7 +324,7 @@ describe('test.persisted.js', function () {
       }).then(function (res) {
         res.total_rows.should.be.within(0, 2);
         res.rows.length.should.be.within(0, 2);
-        return setTimeoutPromise(5);
+        return setTimeoutPromise(50);
       }).then(function () {
         return db.query(queryFun, {stale : 'ok'});
       }).then(function (res) {

--- a/tests/mapreduce/test.persisted.js
+++ b/tests/mapreduce/test.persisted.js
@@ -1,61 +1,102 @@
 'use strict';
 
-var adapters = ['local', 'http'];
+describe('test.persisted.js', function () {
+  var dbType = testUtils.adapterType();
+  var dbName = testUtils.adapterUrl(dbType, 'testdb');
 
-adapters.forEach(function (adapter) {
+  var Promise;
 
-  var suiteName = 'test.persisted.js-' + adapter;
-  var dbName = testUtils.adapterUrl(adapter, 'testdb');
+  function setTimeoutPromise(time) {
+    return new Promise(function (resolve) {
+      setTimeout(function () { resolve(true); }, time);
+    });
+  }
 
-  tests(suiteName, dbName, adapter);
-});
-
-function tests(suiteName, dbName, dbType) {
-
-  describe(suiteName, function () {
-
-    var Promise;
-
-    function setTimeoutPromise(time) {
-      return new Promise(function (resolve) {
-        setTimeout(function () { resolve(true); }, time);
-      });
+  function createView(db, viewObj) {
+    var storableViewObj = {
+      map : viewObj.map.toString()
+    };
+    if (viewObj.reduce) {
+      storableViewObj.reduce = viewObj.reduce.toString();
     }
+    return new Promise(function (resolve, reject) {
+      db.put({
+        _id: '_design/theViewDoc',
+        views: {
+          'theView' : storableViewObj
+        }
+      }, function (err) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve('theViewDoc/theView');
+        }
+      });
+    });
+  }
 
-    function createView(db, viewObj) {
-      var storableViewObj = {
-        map : viewObj.map.toString()
-      };
-      if (viewObj.reduce) {
-        storableViewObj.reduce = viewObj.reduce.toString();
+  beforeEach(function () {
+    Promise = testUtils.Promise;
+    return new PouchDB(dbName).destroy();
+  });
+  afterEach(function () {
+    return new PouchDB(dbName).destroy();
+  });
+
+  it('Test destroyed event on auxiliary db', function () {
+    var db = new PouchDB(dbName);
+    var rev;
+    return db.put({
+      _id: '_design/name',
+      views: {
+        name: {
+          map: function (doc) {
+            emit(doc.name);
+          }.toString()
+        }
       }
-      return new Promise(function (resolve, reject) {
-        db.put({
-          _id: '_design/theViewDoc',
-          views: {
-            'theView' : storableViewObj
+    }).then(function (res) {
+      rev = res.rev;
+      return db.bulkDocs([
+        {_id: 'foo', name: 'foo', title: 'yo'},
+        {_id: 'baz', name: 'bar', title: 'hey'},
+        {_id: 'bar', name: 'baz', title: 'wuzzup'}
+      ]);
+    }).then(function () {
+      return db.query('name');
+    }).then(function () {
+      return db.remove('_design/name', rev);
+    }).then(function () {
+      return db.viewCleanup();
+    }).then(function () {
+      return db.put({
+        _id: '_design/title',
+        views: {
+          title: {
+            map: function (doc) {
+              emit(doc.title);
+            }.toString()
           }
-        }, function (err) {
-          if (err) {
-            reject(err);
-          } else {
-            resolve('theViewDoc/theView');
-          }
-        });
+        }
       });
-    }
-
-    beforeEach(function () {
-      Promise = testUtils.Promise;
-      return new PouchDB(dbName).destroy();
-    });
-    afterEach(function () {
-      return new PouchDB(dbName).destroy();
-    });
-
-    it('Test destroyed event on auxiliary db', function () {
-      var db = new PouchDB(dbName);
-      var rev;
+    }).then(function (res) {
+      rev = res.rev;
+    }).then(function () {
+      return db.query('title');
+    }).then(function () {
+      return db.remove('_design/title', rev);
+    }).then(function () {
+      return db.viewCleanup();
+    }).then(function () {
+      var views = ['name', 'title'];
+      return testUtils.Promise.all(views.map(function (view) {
+        return db.query(view).then(function () {
+          throw new Error('expected an error');
+        }, function (err) {
+          should.exist(err);
+        });
+      }));
+    }).then(function () {
       return db.put({
         _id: '_design/name',
         views: {
@@ -67,708 +108,655 @@ function tests(suiteName, dbName, dbType) {
         }
       }).then(function (res) {
         rev = res.rev;
-        return db.bulkDocs([
-          {_id: 'foo', name: 'foo', title: 'yo'},
-          {_id: 'baz', name: 'bar', title: 'hey'},
-          {_id: 'bar', name: 'baz', title: 'wuzzup'}
-        ]);
-      }).then(function () {
         return db.query('name');
-      }).then(function () {
-        return db.remove('_design/name', rev);
-      }).then(function () {
-        return db.viewCleanup();
-      }).then(function () {
-        return db.put({
-          _id: '_design/title',
-          views: {
-            title: {
-              map: function (doc) {
-                emit(doc.title);
-              }.toString()
-            }
-          }
-        });
       }).then(function (res) {
-        rev = res.rev;
-      }).then(function () {
-        return db.query('title');
-      }).then(function () {
-        return db.remove('_design/title', rev);
-      }).then(function () {
-        return db.viewCleanup();
-      }).then(function () {
-        var views = ['name', 'title'];
-        return testUtils.Promise.all(views.map(function (view) {
-          return db.query(view).then(function () {
-            throw new Error('expected an error');
+        res.rows.map(function (row) {
+          return [row.id, row.key];
+        }).should.deep.equal([
+            ['baz', 'bar'],
+            ['bar', 'baz'],
+            ['foo', 'foo']
+          ]);
+      });
+    });
+  });
+
+  it('Returns ok for viewCleanup on empty db', function () {
+    var db = new PouchDB(dbName);
+    return db.viewCleanup().then(function (res) {
+      res.ok.should.equal(true);
+    });
+  });
+
+  it('Returns ok for viewCleanup on empty db, callback style', function () {
+    var db = new PouchDB(dbName);
+    return new Promise(function (resolve, reject) {
+      db.viewCleanup(function (err, res) {
+        if (err) {
+          return reject(err);
+        }
+        resolve(res);
+      });
+    }).then(function (res) {
+      res.ok.should.equal(true);
+    });
+  });
+
+  it('Returns ok for viewCleanup after modifying view', function () {
+    var db = new PouchDB(dbName);
+    var ddoc = {
+      _id: '_design/myview',
+      views: {
+        myview: {
+          map: function (doc) {
+            emit(doc.firstName);
+          }.toString()
+        }
+      }
+    };
+    var doc = {
+      _id: 'foo',
+      firstName: 'Foobar',
+      lastName: 'Bazman'
+    };
+    return db.bulkDocs({docs: [ddoc, doc]}).then(function (info) {
+      ddoc._rev = info[0].rev;
+      return db.query('myview');
+    }).then(function (res) {
+      res.rows.should.deep.equal([
+        {id: 'foo', key: 'Foobar', value: null}
+      ]);
+      ddoc.views.myview.map = function (doc) {
+        emit(doc.lastName);
+      }.toString();
+      return db.put(ddoc);
+    }).then(function () {
+      return db.query('myview');
+    }).then(function (res) {
+      res.rows.should.deep.equal([
+        {id: 'foo', key: 'Bazman', value: null}
+      ]);
+      return db.viewCleanup();
+    });
+  });
+
+  it('Return ok for viewCleanup after modding view, old format', function () {
+    var db = new PouchDB(dbName);
+    var ddoc = {
+      _id: '_design/myddoc',
+      views: {
+        myview: {
+          map: function (doc) {
+            emit(doc.firstName);
+          }.toString()
+        }
+      }
+    };
+    var doc = {
+      _id: 'foo',
+      firstName: 'Foobar',
+      lastName: 'Bazman'
+    };
+    return db.bulkDocs({docs: [ddoc, doc]}).then(function (info) {
+      ddoc._rev = info[0].rev;
+      return db.query('myddoc/myview');
+    }).then(function (res) {
+      res.rows.should.deep.equal([
+        {id: 'foo', key: 'Foobar', value: null}
+      ]);
+      ddoc.views.myview.map = function (doc) {
+        emit(doc.lastName);
+      }.toString();
+      return db.put(ddoc);
+    }).then(function () {
+      return db.query('myddoc/myview');
+    }).then(function (res) {
+      res.rows.should.deep.equal([
+        {id: 'foo', key: 'Bazman', value: null}
+      ]);
+      return db.viewCleanup();
+    });
+  });
+
+  it("Query non existing view throws error", function () {
+    var db = new PouchDB(dbName);
+    var doc = {
+      _id: '_design/barbar',
+      views: {
+        scores: {
+          map: 'function(doc) { if (doc.score) { emit(null, doc.score); } }'
+        }
+      }
+    };
+    return db.post(doc).then(function () {
+      return db.query('barbar/dontExist', {key: 'bar'}).should.be.rejected;
+    });
+  });
+
+  it("Query non-string view throws error", function () {
+    var db = new PouchDB(dbName);
+    var doc = {
+      _id: '_design/barbar',
+      views: {
+        scores: {
+          map: 1
+        }
+      }
+    };
+    return db.post(doc).then(function () {
+      return db.query('barbar/scores', {key: 'bar'}).should.be.rejected;
+    });
+  });
+
+  it('many simultaneous persisted views', function () {
+    this.timeout(120000);
+    var db = new PouchDB(dbName);
+
+    var views = [];
+    var doc = {_id: 'foo'};
+    for (var i = 0; i < 20; i++) {
+      views.push('foo_' + i);
+      doc['foo_' + i] = 'bar_' + i;
+    }
+
+    return db.put(doc).then(function () {
+      return Promise.all(views.map(function (_, i) {
+        var fun = "function (doc) { emit(doc.foo_" + i + ");}";
+
+        var ddocId = 'theViewDoc_' + i;
+        var ddoc = {
+          _id: '_design/' + ddocId,
+          views: {
+            theView : {map: fun}
+          }
+        };
+
+        return db.put(ddoc).then(function (res) {
+          ddoc._rev = res.rev;
+          return db.query(ddocId + '/theView');
+        }).then(function (res) {
+          res.rows.should.have.length(1);
+          res.rows[0].key.should.equal('bar_' + i);
+          res.rows[0].id.should.equal('foo');
+          return db.remove(ddoc);
+        }).then(function () {
+          return db.viewCleanup();
+        }).then(function () {
+          return db.query(ddocId + '/theView').then(function () {
+            throw new Error('view should have been deleted');
           }, function (err) {
             should.exist(err);
           });
-        }));
-      }).then(function () {
-        return db.put({
-          _id: '_design/name',
-          views: {
-            name: {
-              map: function (doc) {
-                emit(doc.name);
-              }.toString()
-            }
-          }
-        }).then(function (res) {
-          rev = res.rev;
-          return db.query('name');
-        }).then(function (res) {
-          res.rows.map(function (row) {
-            return [row.id, row.key];
-          }).should.deep.equal([
-              ['baz', 'bar'],
-              ['bar', 'baz'],
-              ['foo', 'foo']
-            ]);
         });
-      });
+      }));
     });
+  });
 
-    it('Returns ok for viewCleanup on empty db', function () {
-      var db = new PouchDB(dbName);
-      return db.viewCleanup().then(function (res) {
-        res.ok.should.equal(true);
-      });
+  it('should error with a callback', function (done) {
+    var db = new PouchDB(dbName);
+    db.query('fake/thing', function (err) {
+      should.exist(err);
+      done();
     });
+  });
 
-    it('Returns ok for viewCleanup on empty db, callback style', function () {
-      var db = new PouchDB(dbName);
-      return new Promise(function (resolve, reject) {
-        db.viewCleanup(function (err, res) {
-          if (err) {
-            return reject(err);
-          }
-          resolve(res);
-        });
-      }).then(function (res) {
-        res.ok.should.equal(true);
-      });
-    });
-
-    it('Returns ok for viewCleanup after modifying view', function () {
-      var db = new PouchDB(dbName);
-      var ddoc = {
-        _id: '_design/myview',
-        views: {
-          myview: {
-            map: function (doc) {
-              emit(doc.firstName);
-            }.toString()
-          }
-        }
-      };
-      var doc = {
-        _id: 'foo',
-        firstName: 'Foobar',
-        lastName: 'Bazman'
-      };
-      return db.bulkDocs({docs: [ddoc, doc]}).then(function (info) {
-        ddoc._rev = info[0].rev;
-        return db.query('myview');
-      }).then(function (res) {
-        res.rows.should.deep.equal([
-          {id: 'foo', key: 'Foobar', value: null}
-        ]);
-        ddoc.views.myview.map = function (doc) {
-          emit(doc.lastName);
-        }.toString();
-        return db.put(ddoc);
-      }).then(function () {
-        return db.query('myview');
-      }).then(function (res) {
-        res.rows.should.deep.equal([
-          {id: 'foo', key: 'Bazman', value: null}
-        ]);
-        return db.viewCleanup();
-      });
-    });
-
-    it('Return ok for viewCleanup after modding view, old format', function () {
-      var db = new PouchDB(dbName);
-      var ddoc = {
-        _id: '_design/myddoc',
-        views: {
-          myview: {
-            map: function (doc) {
-              emit(doc.firstName);
-            }.toString()
-          }
-        }
-      };
-      var doc = {
-        _id: 'foo',
-        firstName: 'Foobar',
-        lastName: 'Bazman'
-      };
-      return db.bulkDocs({docs: [ddoc, doc]}).then(function (info) {
-        ddoc._rev = info[0].rev;
-        return db.query('myddoc/myview');
-      }).then(function (res) {
-        res.rows.should.deep.equal([
-          {id: 'foo', key: 'Foobar', value: null}
-        ]);
-        ddoc.views.myview.map = function (doc) {
-          emit(doc.lastName);
-        }.toString();
-        return db.put(ddoc);
-      }).then(function () {
-        return db.query('myddoc/myview');
-      }).then(function (res) {
-        res.rows.should.deep.equal([
-          {id: 'foo', key: 'Bazman', value: null}
-        ]);
-        return db.viewCleanup();
-      });
-    });
-
-    it("Query non existing view throws error", function () {
-      var db = new PouchDB(dbName);
-      var doc = {
-        _id: '_design/barbar',
-        views: {
-          scores: {
-            map: 'function(doc) { if (doc.score) { emit(null, doc.score); } }'
-          }
-        }
-      };
-      return db.post(doc).then(function () {
-        return db.query('barbar/dontExist', {key: 'bar'}).should.be.rejected;
-      });
-    });
-
-    it("Query non-string view throws error", function () {
-      var db = new PouchDB(dbName);
-      var doc = {
-        _id: '_design/barbar',
-        views: {
-          scores: {
-            map: 1
-          }
-        }
-      };
-      return db.post(doc).then(function () {
-        return db.query('barbar/scores', {key: 'bar'}).should.be.rejected;
-      });
-    });
-
-    it('many simultaneous persisted views', function () {
-      this.timeout(120000);
-      var db = new PouchDB(dbName);
-
-      var views = [];
-      var doc = {_id: 'foo'};
-      for (var i = 0; i < 20; i++) {
-        views.push('foo_' + i);
-        doc['foo_' + i] = 'bar_' + i;
+  it('should query correctly when stale', function () {
+    var db = new PouchDB(dbName);
+    return createView(db, {
+      map : function (doc) {
+        emit(doc.name);
       }
-
-      return db.put(doc).then(function () {
-        return Promise.all(views.map(function (_, i) {
-          var fun = "function (doc) { emit(doc.foo_" + i + ");}";
-
-          var ddocId = 'theViewDoc_' + i;
-          var ddoc = {
-            _id: '_design/' + ddocId,
-            views: {
-              theView : {map: fun}
-            }
-          };
-
-          return db.put(ddoc).then(function (res) {
-            ddoc._rev = res.rev;
-            return db.query(ddocId + '/theView');
-          }).then(function (res) {
-            res.rows.should.have.length(1);
-            res.rows[0].key.should.equal('bar_' + i);
-            res.rows[0].id.should.equal('foo');
-            return db.remove(ddoc);
-          }).then(function () {
-            return db.viewCleanup();
-          }).then(function () {
-            return db.query(ddocId + '/theView').then(function () {
-              throw new Error('view should have been deleted');
-            }, function (err) {
-              should.exist(err);
-            });
-          });
-        }));
-      });
-    });
-
-    it('should error with a callback', function (done) {
-      var db = new PouchDB(dbName);
-      db.query('fake/thing', function (err) {
-        should.exist(err);
-        done();
-      });
-    });
-
-    it('should query correctly when stale', function () {
-      var db = new PouchDB(dbName);
-      return createView(db, {
-        map : function (doc) {
-          emit(doc.name);
+    }).then(function (queryFun) {
+      return db.bulkDocs({docs : [
+        {name : 'bar', _id : '1'},
+        {name : 'foo', _id : '2'}
+      ]}).then(function () {
+        return db.query(queryFun, {stale : 'ok'});
+      }).then(function (res) {
+        res.total_rows.should.be.within(0, 2);
+        res.offset.should.equal(0);
+        res.rows.length.should.be.within(0, 2);
+        return db.query(queryFun, {stale : 'update_after'});
+      }).then(function (res) {
+        res.total_rows.should.be.within(0, 2);
+        res.rows.length.should.be.within(0, 2);
+        return setTimeoutPromise(5);
+      }).then(function () {
+        return db.query(queryFun, {stale : 'ok'});
+      }).then(function (res) {
+        res.total_rows.should.equal(2);
+        res.rows.length.should.equal(2);
+        return db.get('2');
+      }).then(function (doc2) {
+        return db.remove(doc2);
+      }).then(function () {
+        return db.query(queryFun, {stale : 'ok', include_docs : true});
+      }).then(function (res) {
+        res.total_rows.should.be.within(1, 2);
+        res.rows.length.should.be.within(1, 2);
+        if (res.rows.length === 2) {
+          res.rows[1].key.should.equal('foo');
+          should.not.exist(res.rows[1].doc,
+                            'should not throw if doc removed');
         }
-      }).then(function (queryFun) {
-        return db.bulkDocs({docs : [
-          {name : 'bar', _id : '1'},
-          {name : 'foo', _id : '2'}
-        ]}).then(function () {
-          return db.query(queryFun, {stale : 'ok'});
-        }).then(function (res) {
-          res.total_rows.should.be.within(0, 2);
-          res.offset.should.equal(0);
-          res.rows.length.should.be.within(0, 2);
-          return db.query(queryFun, {stale : 'update_after'});
-        }).then(function (res) {
-          res.total_rows.should.be.within(0, 2);
-          res.rows.length.should.be.within(0, 2);
-          return setTimeoutPromise(5);
-        }).then(function () {
-          return db.query(queryFun, {stale : 'ok'});
-        }).then(function (res) {
-          res.total_rows.should.equal(2);
-          res.rows.length.should.equal(2);
-          return db.get('2');
-        }).then(function (doc2) {
-          return db.remove(doc2);
-        }).then(function () {
-          return db.query(queryFun, {stale : 'ok', include_docs : true});
-        }).then(function (res) {
-          res.total_rows.should.be.within(1, 2);
-          res.rows.length.should.be.within(1, 2);
-          if (res.rows.length === 2) {
-            res.rows[1].key.should.equal('foo');
-            should.not.exist(res.rows[1].doc,
-                             'should not throw if doc removed');
-          }
-          return db.query(queryFun);
-        }).then(function (res) {
-          res.total_rows.should.equal(1, 'equals1-1');
-          res.rows.length.should.equal(1, 'equals1-2');
-          return db.get('1');
-        }).then(function (doc1) {
-          doc1.name = 'baz';
-          return db.post(doc1);
-        }).then(function () {
-          return db.query(queryFun, {stale : 'update_after'});
-        }).then(function (res) {
-          res.rows.length.should.equal(1);
-          ['baz', 'bar'].indexOf(res.rows[0].key).should.be
-            .above(-1, 'key might be stale, thats ok');
-          return setTimeoutPromise(1000);
-        }).then(function () {
-          return db.query(queryFun, {stale : 'ok'});
-        }).then(function (res) {
-          res.rows.length.should.equal(1);
-          res.rows[0].key.should.equal('baz');
-        });
+        return db.query(queryFun);
+      }).then(function (res) {
+        res.total_rows.should.equal(1, 'equals1-1');
+        res.rows.length.should.equal(1, 'equals1-2');
+        return db.get('1');
+      }).then(function (doc1) {
+        doc1.name = 'baz';
+        return db.post(doc1);
+      }).then(function () {
+        return db.query(queryFun, {stale : 'update_after'});
+      }).then(function (res) {
+        res.rows.length.should.equal(1);
+        ['baz', 'bar'].indexOf(res.rows[0].key).should.be
+          .above(-1, 'key might be stale, thats ok');
+        return setTimeoutPromise(1000);
+      }).then(function () {
+        return db.query(queryFun, {stale : 'ok'});
+      }).then(function (res) {
+        res.rows.length.should.equal(1);
+        res.rows[0].key.should.equal('baz');
       });
     });
+  });
 
-    it('should query correctly with stale update_after', function () {
-      var pouch = new PouchDB(dbName);
+  it('should query correctly with stale update_after', function () {
+    var pouch = new PouchDB(dbName);
 
-      return createView(pouch, {map: function (doc) {
-        emit(doc.foo);
-      }}).then(function (queryFun) {
-        var docs = [];
-
-        for (var i = 0; i < 10; i++) {
-          docs.push({foo: 'bar'});
-        }
-
-        return pouch.bulkDocs(docs).then(function () {
-          return pouch.query(queryFun, {stale: 'update_after'});
-        }).then(function (res) {
-          res.rows.should.have.length(0, 'query() returned immediately');
-          return setTimeoutPromise(1000);
-        }).then(function () {
-          return pouch.query(queryFun, {stale: 'ok'});
-        }).then(function (res) {
-          res.rows.should.have.length(10, 'index was built in background');
-        });
-      });
-    });
-
-    it('should delete duplicate indexes', function () {
+    return createView(pouch, {map: function (doc) {
+      emit(doc.foo);
+    }}).then(function (queryFun) {
       var docs = [];
+
       for (var i = 0; i < 10; i++) {
-        docs.push(
-          {
-            _id : '_design/view' + i,
-            views : {
-              view : {
-                map : "function(doc){emit('foo');}"
-              }
-            }
-          }
-        );
+        docs.push({foo: 'bar'});
       }
-      var db = new PouchDB(dbName);
-      return db.bulkDocs({docs : docs}).then(function (responses) {
-        var tasks = [];
-        for (var i = 0; i < docs.length; i++) {
-          /* jshint loopfunc:true */
-          docs[i]._rev = responses[i].rev;
-          tasks.push(db.query('view' + i + '/view'));
-        }
-        return Promise.all(tasks);
+
+      return pouch.bulkDocs(docs).then(function () {
+        return pouch.query(queryFun, {stale: 'update_after'});
+      }).then(function (res) {
+        res.rows.should.have.length(0, 'query() returned immediately');
+        return setTimeoutPromise(1000);
       }).then(function () {
-        docs.forEach(function (doc) {
-          doc._deleted = true;
-        });
-        return db.bulkDocs({docs : docs});
-      }).then(function () {
-        return db.viewCleanup();
+        return pouch.query(queryFun, {stale: 'ok'});
+      }).then(function (res) {
+        res.rows.should.have.length(10, 'index was built in background');
       });
     });
+  });
 
-    if (dbType === 'local' &&
-        // can't test this in Node due to the vm
-        (typeof process === 'undefined' || process.browser)) {
-      it('issue 4967 map() called twice', function () {
-        var db = new PouchDB(dbName);
-        var globalObj = (typeof process !== 'undefined' && !process.browser) ?
-          global : window;
-        globalObj.__mapreduce_called = {};
-        var docs = Array.apply(null, Array(5)).map(function (_, i) {
-          return {
-            _id: 'doc_' + i,
-            data: Math.random().toString(36).substr(2)
-          };
-        }).concat({
-          _id: '_design/test',
-          views: {
-            test: {
-              map: (function (doc) {
-                /* global __mapreduce_called */
-                __mapreduce_called[doc._id] = __mapreduce_called[doc._id] || 0;
-                __mapreduce_called[doc._id]++;
-                emit(doc.data, 1);
-              }).toString()
-            }
-          }
-        });
-        return db.bulkDocs(docs).then(function () {
-          return Promise.all([
-            db.query('test', {}),
-            db.query('test', {})
-          ]);
-        }).then(function () {
-          globalObj.__mapreduce_called.should.deep.equal({
-            doc_0 : 1,
-            doc_1 : 1,
-            doc_2 : 1,
-            doc_3 : 1,
-            doc_4 : 1
-          });
-          delete globalObj.__mapreduce_called;
-        });
-      });
-    }
-
-    it('test docs with reserved IDs', function () {
-      var db = new PouchDB(dbName);
-
-      var docs = [
-        {_id: 'constructor'},
-        {_id: 'isPrototypeOf'},
-        {_id: 'hasOwnProperty'},
+  it('should delete duplicate indexes', function () {
+    var docs = [];
+    for (var i = 0; i < 10; i++) {
+      docs.push(
         {
-          _id : '_design/view',
+          _id : '_design/view' + i,
           views : {
             view : {
-              map : "function(doc){emit(doc._id);}"
+              map : "function(doc){emit('foo');}"
             }
           }
         }
-      ];
-      return db.bulkDocs(docs).then(function () {
-        return db.query('view/view', {include_docs: true});
-      }).then(function (res) {
-        var rows = res.rows.map(function (row) {
-          return {
-            id: row.id,
-            key: row.key,
-            docId: row.doc._id
-          };
-        });
-        assert.deepEqual(rows, [
-          { "id": "constructor",
-            "key": "constructor",
-            "docId": "constructor"
-          },
-          {
-            "id": "hasOwnProperty",
-            "key": "hasOwnProperty",
-            "docId": "hasOwnProperty"
-          },
-          {
-            "id": "isPrototypeOf",
-            "key": "isPrototypeOf",
-            "docId": "isPrototypeOf"
+      );
+    }
+    var db = new PouchDB(dbName);
+    return db.bulkDocs({docs : docs}).then(function (responses) {
+      var tasks = [];
+      for (var i = 0; i < docs.length; i++) {
+        /* jshint loopfunc:true */
+        docs[i]._rev = responses[i].rev;
+        tasks.push(db.query('view' + i + '/view'));
+      }
+      return Promise.all(tasks);
+    }).then(function () {
+      docs.forEach(function (doc) {
+        doc._deleted = true;
+      });
+      return db.bulkDocs({docs : docs});
+    }).then(function () {
+      return db.viewCleanup();
+    });
+  });
+
+  if (dbType === 'local' &&
+      // can't test this in Node due to the vm
+      (typeof process === 'undefined' || process.browser)) {
+    it('issue 4967 map() called twice', function () {
+      var db = new PouchDB(dbName);
+      var globalObj = (typeof process !== 'undefined' && !process.browser) ?
+        global : window;
+      globalObj.__mapreduce_called = {};
+      var docs = Array.apply(null, Array(5)).map(function (_, i) {
+        return {
+          _id: 'doc_' + i,
+          data: Math.random().toString(36).substr(2)
+        };
+      }).concat({
+        _id: '_design/test',
+        views: {
+          test: {
+            map: (function (doc) {
+              /* global __mapreduce_called */
+              __mapreduce_called[doc._id] = __mapreduce_called[doc._id] || 0;
+              __mapreduce_called[doc._id]++;
+              emit(doc.data, 1);
+            }).toString()
           }
+        }
+      });
+      return db.bulkDocs(docs).then(function () {
+        return Promise.all([
+          db.query('test', {}),
+          db.query('test', {})
         ]);
-        return db.viewCleanup();
       }).then(function () {
-        return db.get('_design/view');
-      }).then(function (doc) {
-        return db.remove(doc);
-      }).then(function () {
-        return db.viewCleanup();
+        globalObj.__mapreduce_called.should.deep.equal({
+          doc_0 : 1,
+          doc_1 : 1,
+          doc_2 : 1,
+          doc_3 : 1,
+          doc_4 : 1
+        });
+        delete globalObj.__mapreduce_called;
       });
     });
+  }
 
-    it('should handle user errors in design doc names', function () {
-      var db = new PouchDB(dbName);
-      return db.put({
-        _id : '_design/theViewDoc'
-      }).then(function () {
-        return db.query('foo/bar');
+  it('test docs with reserved IDs', function () {
+    var db = new PouchDB(dbName);
+
+    var docs = [
+      {_id: 'constructor'},
+      {_id: 'isPrototypeOf'},
+      {_id: 'hasOwnProperty'},
+      {
+        _id : '_design/view',
+        views : {
+          view : {
+            map : "function(doc){emit(doc._id);}"
+          }
+        }
+      }
+    ];
+    return db.bulkDocs(docs).then(function () {
+      return db.query('view/view', {include_docs: true});
+    }).then(function (res) {
+      var rows = res.rows.map(function (row) {
+        return {
+          id: row.id,
+          key: row.key,
+          docId: row.doc._id
+        };
+      });
+      assert.deepEqual(rows, [
+        { "id": "constructor",
+          "key": "constructor",
+          "docId": "constructor"
+        },
+        {
+          "id": "hasOwnProperty",
+          "key": "hasOwnProperty",
+          "docId": "hasOwnProperty"
+        },
+        {
+          "id": "isPrototypeOf",
+          "key": "isPrototypeOf",
+          "docId": "isPrototypeOf"
+        }
+      ]);
+      return db.viewCleanup();
+    }).then(function () {
+      return db.get('_design/view');
+    }).then(function (doc) {
+      return db.remove(doc);
+    }).then(function () {
+      return db.viewCleanup();
+    });
+  });
+
+  it('should handle user errors in design doc names', function () {
+    var db = new PouchDB(dbName);
+    return db.put({
+      _id : '_design/theViewDoc'
+    }).then(function () {
+      return db.query('foo/bar');
+    }).then(function (res) {
+      should.not.exist(res);
+    }).catch(function (err) {
+      err.status.should.equal(404);
+      return db.put(
+        {_id : '_design/void', views : {1 : null}}
+      ).then(function () {
+        return db.query('void/1');
       }).then(function (res) {
         should.not.exist(res);
       }).catch(function (err) {
-        err.status.should.equal(404);
-        return db.put(
-          {_id : '_design/void', views : {1 : null}}
-        ).then(function () {
-          return db.query('void/1');
-        }).then(function (res) {
-          should.not.exist(res);
-        }).catch(function (err) {
-          err.status.should.be.a('number');
-          // this might throw due to erroneous ddoc, but that's ok
-          return db.viewCleanup().catch(function (err) {
-            err.status.should.equal(500);
-          });
+        err.status.should.be.a('number');
+        // this might throw due to erroneous ddoc, but that's ok
+        return db.viewCleanup().catch(function (err) {
+          err.status.should.equal(500);
         });
       });
     });
+  });
 
-    it('should allow the user to create many design docs', function () {
-      function getKey(row) {
-        return row.key;
+  it('should allow the user to create many design docs', function () {
+    function getKey(row) {
+      return row.key;
+    }
+    var db = new PouchDB(dbName);
+    return db.put({
+      _id : '_design/foo',
+      views : {
+        byId : { map : function (doc) { emit(doc._id); }.toString()},
+        byField : { map : function (doc) { emit(doc.field); }.toString()}
       }
-      var db = new PouchDB(dbName);
+    }).then(function () {
+      return db.put({_id : 'myDoc', field : 'myField'});
+    }).then(function () {
+      return db.query('foo/byId');
+    }).then(function (res) {
+      res.rows.map(getKey).should.deep.equal(['myDoc']);
       return db.put({
-        _id : '_design/foo',
+        _id : '_design/bar',
         views : {
-          byId : { map : function (doc) { emit(doc._id); }.toString()},
-          byField : { map : function (doc) { emit(doc.field); }.toString()}
+          byId : {map : function (doc) { emit(doc._id); }.toString()}
         }
-      }).then(function () {
-        return db.put({_id : 'myDoc', field : 'myField'});
-      }).then(function () {
-        return db.query('foo/byId');
-      }).then(function (res) {
-        res.rows.map(getKey).should.deep.equal(['myDoc']);
-        return db.put({
-          _id : '_design/bar',
-          views : {
-            byId : {map : function (doc) { emit(doc._id); }.toString()}
-          }
-        });
-      }).then(function () {
-        return db.query('bar/byId');
-      }).then(function (res) {
-        res.rows.map(getKey).should.deep.equal(['myDoc']);
-      }).then(function () {
-        return db.viewCleanup();
-      }).then(function () {
-        return db.query('foo/byId');
-      }).then(function (res) {
-        res.rows.map(getKey).should.deep.equal(['myDoc']);
-        return db.query('foo/byField');
-      }).then(function (res) {
-        res.rows.map(getKey).should.deep.equal(['myField']);
-        return db.query('bar/byId');
-      }).then(function (res) {
-        res.rows.map(getKey).should.deep.equal(['myDoc']);
-        return db.get('_design/bar');
-      }).then(function (barDoc) {
-        return db.remove(barDoc);
-      }).then(function () {
-        return db.get('_design/foo');
-      }).then(function (fooDoc) {
-        delete fooDoc.views.byField;
-        return db.put(fooDoc);
-      }).then(function () {
-        return db.query('foo/byId');
-      }).then(function (res) {
-        res.rows.map(getKey).should.deep.equal(['myDoc']);
-        return db.viewCleanup();
-      }).then(function () {
-        return db.query('foo/byId');
-      }).then(function (res) {
-        res.rows.map(getKey).should.deep.equal(['myDoc']);
-        return db.query('foo/byField').then(function (res) {
+      });
+    }).then(function () {
+      return db.query('bar/byId');
+    }).then(function (res) {
+      res.rows.map(getKey).should.deep.equal(['myDoc']);
+    }).then(function () {
+      return db.viewCleanup();
+    }).then(function () {
+      return db.query('foo/byId');
+    }).then(function (res) {
+      res.rows.map(getKey).should.deep.equal(['myDoc']);
+      return db.query('foo/byField');
+    }).then(function (res) {
+      res.rows.map(getKey).should.deep.equal(['myField']);
+      return db.query('bar/byId');
+    }).then(function (res) {
+      res.rows.map(getKey).should.deep.equal(['myDoc']);
+      return db.get('_design/bar');
+    }).then(function (barDoc) {
+      return db.remove(barDoc);
+    }).then(function () {
+      return db.get('_design/foo');
+    }).then(function (fooDoc) {
+      delete fooDoc.views.byField;
+      return db.put(fooDoc);
+    }).then(function () {
+      return db.query('foo/byId');
+    }).then(function (res) {
+      res.rows.map(getKey).should.deep.equal(['myDoc']);
+      return db.viewCleanup();
+    }).then(function () {
+      return db.query('foo/byId');
+    }).then(function (res) {
+      res.rows.map(getKey).should.deep.equal(['myDoc']);
+      return db.query('foo/byField').then(function (res) {
+        should.not.exist(res);
+      }).catch(function (err) {
+        err.status.should.equal(404);
+        return db.query('bar/byId').then(function (res) {
           should.not.exist(res);
         }).catch(function (err) {
           err.status.should.equal(404);
-          return db.query('bar/byId').then(function (res) {
-            should.not.exist(res);
-          }).catch(function (err) {
-            err.status.should.equal(404);
-            return db.get('_design/foo').then(function (fooDoc) {
-              return db.remove(fooDoc).then(function () {
-                return db.viewCleanup();
-              });
+          return db.get('_design/foo').then(function (fooDoc) {
+            return db.remove(fooDoc).then(function () {
+              return db.viewCleanup();
             });
           });
         });
       });
     });
+  });
 
-    it('should allow view names without slashes', function () {
-      var ddocRev;
-      var db = new PouchDB(dbName);
-      return db.put({
-        _id : '_design/foo',
-        views : {
-          foo : { map : function (doc) { emit(doc._id); }.toString()}
-        }
-      }).then(function (info) {
-        ddocRev = info.rev;
-        return db.bulkDocs({docs : [{_id : 'baz'}, {_id : 'bar'}]});
-      }).then(function () {
-        return db.query('foo');
+  it('should allow view names without slashes', function () {
+    var ddocRev;
+    var db = new PouchDB(dbName);
+    return db.put({
+      _id : '_design/foo',
+      views : {
+        foo : { map : function (doc) { emit(doc._id); }.toString()}
+      }
+    }).then(function (info) {
+      ddocRev = info.rev;
+      return db.bulkDocs({docs : [{_id : 'baz'}, {_id : 'bar'}]});
+    }).then(function () {
+      return db.query('foo');
+    }).then(function (res) {
+      res.rows[0].key.should.equal('bar');
+      res.rows[1].key.should.equal('baz');
+      return db.remove({_id : '_design/foo', _rev : ddocRev});
+    });
+  });
+
+  it('test 304s in Safari (issue 69)', function () {
+    var db = new PouchDB(dbName);
+    return createView(db, {
+      map : function (doc) {
+        emit(doc.name);
+      }
+    }).then(function (queryFun) {
+      return db.bulkDocs({docs : [
+        {name : 'foo'}
+      ]}).then(function () {
+        return db.query(queryFun, {keys : ['foo']});
       }).then(function (res) {
-        res.rows[0].key.should.equal('bar');
-        res.rows[1].key.should.equal('baz');
-        return db.remove({_id : '_design/foo', _rev : ddocRev});
+        res.rows.should.have.length(1);
+        return db.query(queryFun, {keys : ['foo']});
+      }).then(function (res) {
+        res.rows.should.have.length(1);
+        return db.query(queryFun, {keys : ['foo']});
+      }).then(function (res) {
+        res.rows.should.have.length(1);
       });
     });
+  });
 
-    it('test 304s in Safari (issue 69)', function () {
-      var db = new PouchDB(dbName);
-      return createView(db, {
-        map : function (doc) {
+  var isNode = typeof window === 'undefined';
+  if (dbType === 'local' && isNode) {
+    it('#239 test memdown db', function () {
+      var destroyedDBs = [];
+      PouchDB.on('destroyed', function (db) {
+        destroyedDBs.push(db);
+      });
+
+      // make sure prefixed DBs are tied to regular DBs
+      var db = new PouchDB(dbName, {db: require('memdown')});
+      return testUtils.fin(createView(db, {
+        map: function (doc) {
           emit(doc.name);
         }
       }).then(function (queryFun) {
-        return db.bulkDocs({docs : [
-          {name : 'foo'}
-        ]}).then(function () {
-          return db.query(queryFun, {keys : ['foo']});
+        return db.post({name: 'foo'}).then(function () {
+          return db.query(queryFun);
         }).then(function (res) {
           res.rows.should.have.length(1);
-          return db.query(queryFun, {keys : ['foo']});
-        }).then(function (res) {
-          res.rows.should.have.length(1);
-          return db.query(queryFun, {keys : ['foo']});
-        }).then(function (res) {
-          res.rows.should.have.length(1);
+          res.rows[0].key.should.equal('foo');
+          var ddocId = '_design/' + queryFun.split('/')[0];
+          return db.get(ddocId);
+        }).then(function (ddoc) {
+          return db.remove(ddoc);
+        }).then(function () {
+          return db.viewCleanup();
+        });
+      }), function () {
+        return db.destroy().then(function () {
+          var chain = Promise.resolve();
+          // for each of the supposedly destroyed DBs,
+          // check that there isn't a normal DB hanging around
+          destroyedDBs.forEach(function (dbName) {
+            chain = chain.then(function () {
+              var db = new PouchDB(dbName);
+              var promise = db.info().then(function (info) {
+                info.update_seq.should.equal(0);
+              });
+              return testUtils.fin(promise, function () {
+                return db.destroy();
+              });
+            });
+          });
+          return chain;
+        }).then(function () {
+          PouchDB.removeAllListeners('destroyed');
         });
       });
     });
 
-    var isNode = typeof window === 'undefined';
-    if (dbType === 'local' && isNode) {
-      it('#239 test memdown db', function () {
-        var destroyedDBs = [];
-        PouchDB.on('destroyed', function (db) {
-          destroyedDBs.push(db);
-        });
-
-        // make sure prefixed DBs are tied to regular DBs
-        var db = new PouchDB(dbName, {db: require('memdown')});
-        return testUtils.fin(createView(db, {
-          map: function (doc) {
-            emit(doc.name);
-          }
-        }).then(function (queryFun) {
-          return db.post({name: 'foo'}).then(function () {
-            return db.query(queryFun);
-          }).then(function (res) {
-            res.rows.should.have.length(1);
-            res.rows[0].key.should.equal('foo');
-            var ddocId = '_design/' + queryFun.split('/')[0];
-            return db.get(ddocId);
-          }).then(function (ddoc) {
-            return db.remove(ddoc);
-          }).then(function () {
-            return db.viewCleanup();
-          });
-        }), function () {
-          return db.destroy().then(function () {
-            var chain = Promise.resolve();
-            // for each of the supposedly destroyed DBs,
-            // check that there isn't a normal DB hanging around
-            destroyedDBs.forEach(function (dbName) {
-              chain = chain.then(function () {
-                var db = new PouchDB(dbName);
-                var promise = db.info().then(function (info) {
-                  info.update_seq.should.equal(0);
-                });
-                return testUtils.fin(promise, function () {
-                  return db.destroy();
-                });
-              });
-            });
-            return chain;
-          }).then(function () {
-            PouchDB.removeAllListeners('destroyed');
-          });
-        });
+    it('#239 test prefixed db', function () {
+      var destroyedDBs = [];
+      PouchDB.on('destroyed', function (db) {
+        destroyedDBs.push(db);
       });
 
-      it('#239 test prefixed db', function () {
-        var destroyedDBs = [];
-        PouchDB.on('destroyed', function (db) {
-          destroyedDBs.push(db);
+      // make sure prefixed DBs are tied to regular DBs
+      require('mkdirp').sync('./myprefix_./tmp/'); // TODO: bit hacky
+      var db = new PouchDB(dbName, {prefix: './myprefix_'});
+      return testUtils.fin(createView(db, {
+        map: function (doc) {
+          emit(doc.name);
+        }
+      }).then(function (queryFun) {
+        return db.post({name: 'foo'}).then(function () {
+          return db.query(queryFun);
+        }).then(function (res) {
+          res.rows.should.have.length(1);
+          res.rows[0].key.should.equal('foo');
+          var ddocId = '_design/' + queryFun.split('/')[0];
+          return db.get(ddocId);
+        }).then(function (ddoc) {
+          return db.remove(ddoc);
+        }).then(function () {
+          return db.viewCleanup();
         });
-
-        // make sure prefixed DBs are tied to regular DBs
-        require('mkdirp').sync('./myprefix_./tmp/'); // TODO: bit hacky
-        var db = new PouchDB(dbName, {prefix: './myprefix_'});
-        return testUtils.fin(createView(db, {
-          map: function (doc) {
-            emit(doc.name);
-          }
-        }).then(function (queryFun) {
-          return db.post({name: 'foo'}).then(function () {
-            return db.query(queryFun);
-          }).then(function (res) {
-            res.rows.should.have.length(1);
-            res.rows[0].key.should.equal('foo');
-            var ddocId = '_design/' + queryFun.split('/')[0];
-            return db.get(ddocId);
-          }).then(function (ddoc) {
-            return db.remove(ddoc);
-          }).then(function () {
-            return db.viewCleanup();
-          });
-        }), function () {
-          return db.destroy().then(function () {
-            var chain = Promise.resolve();
-            // for each of the supposedly destroyed DBs,
-            // check that there isn't a normal DB hanging around
-            destroyedDBs.forEach(function (dbName) {
-              chain = chain.then(function () {
-                var db = new PouchDB(dbName);
-                var promise = db.info().then(function (info) {
-                  info.update_seq.should.equal(0);
-                });
-                return testUtils.fin(promise, function () {
-                  return db.destroy();
-                });
+      }), function () {
+        return db.destroy().then(function () {
+          var chain = Promise.resolve();
+          // for each of the supposedly destroyed DBs,
+          // check that there isn't a normal DB hanging around
+          destroyedDBs.forEach(function (dbName) {
+            chain = chain.then(function () {
+              var db = new PouchDB(dbName);
+              var promise = db.info().then(function (info) {
+                info.update_seq.should.equal(0);
+              });
+              return testUtils.fin(promise, function () {
+                return db.destroy();
               });
             });
-            return chain;
-          }).then(function () {
-            PouchDB.removeAllListeners('destroyed');
           });
+          return chain;
+        }).then(function () {
+          PouchDB.removeAllListeners('destroyed');
         });
       });
-    }
-
-  });
-}
+    });
+  }
+});

--- a/tests/mapreduce/test.persisted.js
+++ b/tests/mapreduce/test.persisted.js
@@ -243,9 +243,13 @@ describe('test.persisted.js', function () {
         }
       }
     };
-    return db.post(doc).then(function () {
-      return db.query('barbar/scores', {key: 'bar'}).should.be.rejected;
-    });
+    if (dbType === 'http') {
+      return db.post(doc).should.be.rejected;
+    } else {
+      return db.post(doc).then(function () {
+        return db.query('barbar/scores', {key: 'bar'}).should.be.rejected;
+      });
+    }
   });
 
   it('many simultaneous persisted views', function () {

--- a/tests/mapreduce/test.views.js
+++ b/tests/mapreduce/test.views.js
@@ -3,6 +3,8 @@
 
 describe('test.views.js', function () {
   var dbType = testUtils.adapterType();
+  if (dbType === 'http') { return; }
+
   var dbs = {};
 
   beforeEach(function (done) {

--- a/tests/mapreduce/test.views.js
+++ b/tests/mapreduce/test.views.js
@@ -1,699 +1,693 @@
 /*jshint expr:true */
 'use strict';
 
-var adapters = [
-  ['local', 'http']
-];
+describe('test.views.js', function () {
+  var dbType = testUtils.adapterType();
+  var dbs = {};
 
-adapters.forEach(function (adapters) {
-  describe('test.views.js-' + adapters[0] + '-' + adapters[1], function () {
+  beforeEach(function (done) {
+    dbs.name = testUtils.adapterUrl(dbType, 'testdb');
+    dbs.remote = testUtils.adapterUrl(dbType, 'test_repl_remote');
+    testUtils.cleanup([dbs.name, dbs.remote], done);
+  });
 
-    var dbs = {};
-
-    beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
-      dbs.remote = testUtils.adapterUrl(adapters[1], 'test_repl_remote');
-      testUtils.cleanup([dbs.name, dbs.remote], done);
-    });
-
-    after(function (done) {
-      testUtils.cleanup([dbs.name, dbs.remote], done);
-    });
+  after(function (done) {
+    testUtils.cleanup([dbs.name, dbs.remote], done);
+  });
 
 
-    it('Test basic view', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.bulkDocs({
-        docs: [
-          { foo: 'bar' },
-          {
-            _id: 'volatile',
-            foo: 'baz'
-          }
-        ]
-      }, {}, function () {
-        var queryFun = {
-          map: function (doc) {
-            emit(doc.foo, doc);
-          }
-        };
-        db.get('volatile', function (_, doc) {
-          db.remove(doc, function () {
-            db.query(queryFun, {
-              include_docs: true,
-              reduce: false
-            }, function (_, res) {
-              res.rows.should.have.length(1, 'Dont include deleted documents');
-              res.total_rows.should.equal(1, 'Include total_rows property.');
-              res.rows.forEach(function (x) {
-                should.exist(x.id);
-                should.exist(x.key);
-                should.exist(x.value._rev);
-                should.exist(x.doc._rev);
-              });
-              done();
-            });
-          });
-        });
-      });
-    });
-
-    it('Test passing just a function', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.bulkDocs({
-        docs: [
-          { foo: 'bar' },
-          {
-            _id: 'volatile',
-            foo: 'baz'
-          }
-        ]
-      }, {}, function () {
-        var queryFun = function (doc) {
+  it('Test basic view', function (done) {
+    var db = new PouchDB(dbs.name);
+    db.bulkDocs({
+      docs: [
+        { foo: 'bar' },
+        {
+          _id: 'volatile',
+          foo: 'baz'
+        }
+      ]
+    }, {}, function () {
+      var queryFun = {
+        map: function (doc) {
           emit(doc.foo, doc);
-        };
-        db.get('volatile', function (_, doc) {
-          db.remove(doc, function () {
-            db.query(queryFun, {
-              include_docs: true,
-              reduce: false
-            }, function (_, res) {
-              res.rows.should.have.length(1, 'Dont include deleted documents');
-              res.rows.forEach(function (x) {
-                should.exist(x.id);
-                should.exist(x.key);
-                should.exist(x.value._rev);
-                should.exist(x.doc._rev);
-              });
-              done();
-            });
-          });
-        });
-      });
-    });
-
-    it('Test opts.startkey/opts.endkey', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.bulkDocs({
-        docs: [
-          { key: 'key1' },
-          { key: 'key2' },
-          { key: 'key3' },
-          { key: 'key4' },
-          { key: 'key5' }
-        ]
-      }, {}, function () {
-        var queryFun = {
-          map: function (doc) {
-            emit(doc.key, doc);
-          }
-        };
-        db.query(queryFun, {
-          reduce: false,
-          startkey: 'key2'
-        }, function (_, res) {
-          res.rows.should.have.length(4, 'Startkey is inclusive');
+        }
+      };
+      db.get('volatile', function (_, doc) {
+        db.remove(doc, function () {
           db.query(queryFun, {
-            reduce: false,
-            endkey: 'key3'
+            include_docs: true,
+            reduce: false
           }, function (_, res) {
-            res.rows.should.have.length(3, 'Endkey is inclusive');
-            db.query(queryFun, {
-              reduce: false,
-              startkey: 'key2',
-              endkey: 'key3'
-            }, function (_, res) {
-              res.rows.should.have.length(2, 'Startkey and endkey together');
-              db.query(queryFun, {
-                reduce: false,
-                startkey: 'key4',
-                endkey: 'key4'
-              }, function (_, res) {
-                res.rows.should.have.length(1, 'Startkey=endkey');
-                done();
-              });
+            res.rows.should.have.length(1, 'Dont include deleted documents');
+            res.total_rows.should.equal(1, 'Include total_rows property.');
+            res.rows.forEach(function (x) {
+              should.exist(x.id);
+              should.exist(x.key);
+              should.exist(x.value._rev);
+              should.exist(x.doc._rev);
             });
-          });
-        });
-      });
-    });
-
-    it('Test opts.key', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.bulkDocs({
-        docs: [
-          { key: 'key1' },
-          { key: 'key2' },
-          { key: 'key3' },
-          { key: 'key3' }
-        ]
-      }, {}, function () {
-        var queryFun = {
-          map: function (doc) {
-            emit(doc.key, doc);
-          }
-        };
-        db.query(queryFun, {
-          reduce: false,
-          key: 'key2'
-        }, function (_, res) {
-          res.rows.should.have.length(1, 'Doc with key');
-          db.query(queryFun, {
-            reduce: false,
-            key: 'key3'
-          }, function (_, res) {
-            res.rows.should.have.length(2, 'Multiple docs with key');
             done();
           });
         });
       });
     });
+  });
 
-    it.skip('Test basic view collation', function (done) {
-      var values = [];
-      // special values sort before all other types
-      values.push(null);
-      values.push(false);
-      values.push(true);
-      // then numbers
-      values.push(1);
-      values.push(2);
-      values.push(3);
-      values.push(4);
-      // then text, case sensitive
-      // currently chrome uses ascii ordering and so wont handle 
-      // capitals properly
-      values.push('a');
-      //values.push("A");
-      values.push('aa');
-      values.push('b');
-      //values.push("B");
-      values.push('ba');
-      values.push('bb');
-      // then arrays. compared element by element until different.
-      // Longer arrays sort after their prefixes
-      values.push(['a']);
-      values.push(['b']);
-      values.push([
-        'b',
-        'c'
-      ]);
-      values.push([
-        'b',
-        'c',
-        'a'
-      ]);
-      values.push([
-        'b',
-        'd'
-      ]);
-      values.push([
-        'b',
-        'd',
-        'e'
-      ]);
-      // then object, compares each key value in the list until different.
-      // larger objects sort after their subset objects.
-      values.push({ a: 1 });
-      values.push({ a: 2 });
-      values.push({ b: 1 });
-      values.push({ b: 2 });
-      values.push({
-        b: 2,
-        a: 1
+  it('Test passing just a function', function (done) {
+    var db = new PouchDB(dbs.name);
+    db.bulkDocs({
+      docs: [
+        { foo: 'bar' },
+        {
+          _id: 'volatile',
+          foo: 'baz'
+        }
+      ]
+    }, {}, function () {
+      var queryFun = function (doc) {
+        emit(doc.foo, doc);
+      };
+      db.get('volatile', function (_, doc) {
+        db.remove(doc, function () {
+          db.query(queryFun, {
+            include_docs: true,
+            reduce: false
+          }, function (_, res) {
+            res.rows.should.have.length(1, 'Dont include deleted documents');
+            res.rows.forEach(function (x) {
+              should.exist(x.id);
+              should.exist(x.key);
+              should.exist(x.value._rev);
+              should.exist(x.doc._rev);
+            });
+            done();
+          });
+        });
       });
-      // Member order does matter for collation.
-      // CouchDB preserves member order
-      // but doesn't require that clients will.
-      // (this test might fail if used with a js engine
-      // that doesn't preserve order)
-      values.push({
-        b: 2,
-        c: 2
+    });
+  });
+
+  it('Test opts.startkey/opts.endkey', function (done) {
+    var db = new PouchDB(dbs.name);
+    db.bulkDocs({
+      docs: [
+        { key: 'key1' },
+        { key: 'key2' },
+        { key: 'key3' },
+        { key: 'key4' },
+        { key: 'key5' }
+      ]
+    }, {}, function () {
+      var queryFun = {
+        map: function (doc) {
+          emit(doc.key, doc);
+        }
+      };
+      db.query(queryFun, {
+        reduce: false,
+        startkey: 'key2'
+      }, function (_, res) {
+        res.rows.should.have.length(4, 'Startkey is inclusive');
+        db.query(queryFun, {
+          reduce: false,
+          endkey: 'key3'
+        }, function (_, res) {
+          res.rows.should.have.length(3, 'Endkey is inclusive');
+          db.query(queryFun, {
+            reduce: false,
+            startkey: 'key2',
+            endkey: 'key3'
+          }, function (_, res) {
+            res.rows.should.have.length(2, 'Startkey and endkey together');
+            db.query(queryFun, {
+              reduce: false,
+              startkey: 'key4',
+              endkey: 'key4'
+            }, function (_, res) {
+              res.rows.should.have.length(1, 'Startkey=endkey');
+              done();
+            });
+          });
+        });
       });
-      var db = new PouchDB(dbs.name);
-      var docs = values.map(function (x, i) {
-        return {
-          _id: i.toString(),
-          foo: x
-        };
+    });
+  });
+
+  it('Test opts.key', function (done) {
+    var db = new PouchDB(dbs.name);
+    db.bulkDocs({
+      docs: [
+        { key: 'key1' },
+        { key: 'key2' },
+        { key: 'key3' },
+        { key: 'key3' }
+      ]
+    }, {}, function () {
+      var queryFun = {
+        map: function (doc) {
+          emit(doc.key, doc);
+        }
+      };
+      db.query(queryFun, {
+        reduce: false,
+        key: 'key2'
+      }, function (_, res) {
+        res.rows.should.have.length(1, 'Doc with key');
+        db.query(queryFun, {
+          reduce: false,
+          key: 'key3'
+        }, function (_, res) {
+          res.rows.should.have.length(2, 'Multiple docs with key');
+          done();
+        });
       });
-      db.bulkDocs({ docs: docs }, {}, function (err) {
-        var queryFun = {
-          map: function (doc) {
-            emit(doc.foo, null);
-          }
-        };
+    });
+  });
+
+  it.skip('Test basic view collation', function (done) {
+    var values = [];
+    // special values sort before all other types
+    values.push(null);
+    values.push(false);
+    values.push(true);
+    // then numbers
+    values.push(1);
+    values.push(2);
+    values.push(3);
+    values.push(4);
+    // then text, case sensitive
+    // currently chrome uses ascii ordering and so wont handle 
+    // capitals properly
+    values.push('a');
+    //values.push("A");
+    values.push('aa');
+    values.push('b');
+    //values.push("B");
+    values.push('ba');
+    values.push('bb');
+    // then arrays. compared element by element until different.
+    // Longer arrays sort after their prefixes
+    values.push(['a']);
+    values.push(['b']);
+    values.push([
+      'b',
+      'c'
+    ]);
+    values.push([
+      'b',
+      'c',
+      'a'
+    ]);
+    values.push([
+      'b',
+      'd'
+    ]);
+    values.push([
+      'b',
+      'd',
+      'e'
+    ]);
+    // then object, compares each key value in the list until different.
+    // larger objects sort after their subset objects.
+    values.push({ a: 1 });
+    values.push({ a: 2 });
+    values.push({ b: 1 });
+    values.push({ b: 2 });
+    values.push({
+      b: 2,
+      a: 1
+    });
+    // Member order does matter for collation.
+    // CouchDB preserves member order
+    // but doesn't require that clients will.
+    // (this test might fail if used with a js engine
+    // that doesn't preserve order)
+    values.push({
+      b: 2,
+      c: 2
+    });
+    var db = new PouchDB(dbs.name);
+    var docs = values.map(function (x, i) {
+      return {
+        _id: i.toString(),
+        foo: x
+      };
+    });
+    db.bulkDocs({ docs: docs }, {}, function (err) {
+      var queryFun = {
+        map: function (doc) {
+          emit(doc.foo, null);
+        }
+      };
+      if (err) {
+        done(err);
+      }
+      db.query(queryFun, { reduce: false }, function (err, res) {
         if (err) {
           done(err);
         }
-        db.query(queryFun, { reduce: false }, function (err, res) {
+        res.rows.forEach(function (x, i) {
+          x.key.should.deep.equal(values[i], 'keys collate');
+        });
+        db.query(queryFun, {
+          descending: true,
+          reduce: false
+        }, function (err, res) {
           if (err) {
             done(err);
           }
           res.rows.forEach(function (x, i) {
-            x.key.should.deep.equal(values[i], 'keys collate');
+            x.key.should.deep
+              .equal(values[values.length - 1 - i],
+                      'keys collate descending');
           });
-          db.query(queryFun, {
-            descending: true,
-            reduce: false
-          }, function (err, res) {
-            if (err) {
-              done(err);
-            }
-            res.rows.forEach(function (x, i) {
-              x.key.should.deep
-                .equal(values[values.length - 1 - i],
-                       'keys collate descending');
-            });
-            done();
-          });
-        });
-      });
-    });
-
-    it('Test joins', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.bulkDocs({
-        docs: [
-          {
-            _id: 'mydoc',
-            foo: 'bar'
-          },
-          { doc_id: 'mydoc' }
-        ]
-      }, {}, function () {
-        var queryFun = {
-          map: function (doc) {
-            if (doc.doc_id) {
-              emit(doc._id, { _id: doc.doc_id });
-            }
-          }
-        };
-        db.query(queryFun, {
-          include_docs: true,
-          reduce: false
-        }, function (_, res) {
-          should.exist(res.rows[0].doc);
-          res.rows[0].doc._id.should.equal('mydoc', 'mydoc included');
           done();
         });
       });
     });
+  });
 
-    it('No reduce function', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.post({ foo: 'bar' }, function () {
-        var queryFun = {
-          map: function () {
-            emit('key', 'val');
-          }
-        };
-        db.query(queryFun, function () {
-          done();
-        });
-      });
-    });
-
-    it('Built in _sum reduce function', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.bulkDocs({
-        docs: [
-          { val: 'bar' },
-          { val: 'bar' },
-          { val: 'baz' }
-        ]
-      }, null, function () {
-        var queryFun = {
-          map: function (doc) {
-            emit(doc.val, 1);
-          },
-          reduce: '_sum'
-        };
-        db.query(queryFun, {
-          reduce: true,
-          group_level: 999
-        }, function (err, res) {
-          res.rows.should.have.length(2);
-          res.rows[0].value.should.equal(2);
-          res.rows[1].value.should.equal(1);
-          done();
-        });
-      });
-    });
-
-    it('Built in _count reduce function', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.bulkDocs({
-        docs: [
-          { val: 'bar' },
-          { val: 'bar' },
-          { val: 'baz' }
-        ]
-      }, null, function () {
-        var queryFun = {
-          map: function (doc) {
-            emit(doc.val, doc.val);
-          },
-          reduce: '_count'
-        };
-        db.query(queryFun, {
-          reduce: true,
-          group_level: 999
-        }, function (err, res) {
-          res.rows.should.have.length(2);
-          res.rows[0].value.should.equal(2);
-          res.rows[1].value.should.equal(1);
-          done();
-        });
-      });
-    });
-
-    it('Built in _stats reduce function', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.bulkDocs({
-        docs: [
-          { val: 'bar' },
-          { val: 'bar' },
-          { val: 'baz' }
-        ]
-      }, null, function () {
-        var queryFun = {
-          map: function (doc) {
-            emit(doc.val, 1);
-          },
-          reduce: '_stats'
-        };
-        db.query(queryFun, {
-          reduce: true,
-          group_level: 999
-        }, function (err, res) {
-          var stats = res.rows[0].value;
-          stats.sum.should.equal(2);
-          stats.count.should.equal(2);
-          stats.min.should.equal(1);
-          stats.max.should.equal(1);
-          stats.sumsqr.should.equal(2);
-          done();
-        });
-      });
-    });
-
-    it('No reduce function, passing just a  function', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.post({ foo: 'bar' }, function () {
-        var queryFun = function () {
-          emit('key', 'val');
-        };
-        db.query(queryFun, function () {
-          done();
-        });
-      });
-    });
-
-    it('Views should include _conflicts', function (done) {
-      var doc1 = {
-        _id: '1',
-        foo: 'bar'
-      };
-      var doc2 = {
-        _id: '1',
-        foo: 'baz'
-      };
-      var queryFun = function (doc) {
-        emit(doc._id, !!doc._conflicts);
-      };
-      var db = new PouchDB(dbs.name);
-      var remote = new PouchDB(dbs.remote);
-      db.post(doc1, function () {
-        remote.post(doc2, function () {
-          db.replicate.from(remote, function () {
-            db.get(doc1._id, { conflicts: true }, function (err, res) {
-              should.exist(res._conflicts);
-              db.query(queryFun, function (err, res) {
-                should.exist(res.rows[0].value);
-                done();
-              });
-            });
-          });
-        });
-      });
-    });
-
-    it('Map only documents with _conflicts (#1000)', function (done) {
-      var docs1 = [
+  it('Test joins', function (done) {
+    var db = new PouchDB(dbs.name);
+    db.bulkDocs({
+      docs: [
         {
-          _id: '1',
+          _id: 'mydoc',
           foo: 'bar'
         },
-        {
-          _id: '2',
-          name: 'two'
-        }
-      ];
-      var doc2 = {
-        _id: '1',
-        foo: 'baz'
-      };
-      var queryFun = function (doc) {
-        if (doc._conflicts) {
-          emit(doc._id, doc._conflicts);
+        { doc_id: 'mydoc' }
+      ]
+    }, {}, function () {
+      var queryFun = {
+        map: function (doc) {
+          if (doc.doc_id) {
+            emit(doc._id, { _id: doc.doc_id });
+          }
         }
       };
-      var db = new PouchDB(dbs.name);
-      var remote = new PouchDB(dbs.remote);
-      db.bulkDocs({ docs: docs1 }, function (err, res) {
-        var revId1 = res[0].rev;
-        remote.post(doc2, function (err, res) {
-          var revId2 = res.rev;
-          db.replicate.from(remote, function () {
-            db.get(docs1[0]._id, { conflicts: true }, function (err, res) {
-              var winner = res._rev;
-              var looser = winner === revId1 ? revId2 : revId1;
-              should.exist(res._conflicts);
-              db.query(queryFun, function (err, res) {
-                res.rows.should.have.length(1, 'One doc with conflicts');
-                res.rows[0].key.should
-                  .equal('1', 'Correct document with conflicts.');
-                res.rows[0].value.should.deep
-                  .equal([looser], 'Correct conflicts included.');
-                done();
-              });
+      db.query(queryFun, {
+        include_docs: true,
+        reduce: false
+      }, function (_, res) {
+        should.exist(res.rows[0].doc);
+        res.rows[0].doc._id.should.equal('mydoc', 'mydoc included');
+        done();
+      });
+    });
+  });
+
+  it('No reduce function', function (done) {
+    var db = new PouchDB(dbs.name);
+    db.post({ foo: 'bar' }, function () {
+      var queryFun = {
+        map: function () {
+          emit('key', 'val');
+        }
+      };
+      db.query(queryFun, function () {
+        done();
+      });
+    });
+  });
+
+  it('Built in _sum reduce function', function (done) {
+    var db = new PouchDB(dbs.name);
+    db.bulkDocs({
+      docs: [
+        { val: 'bar' },
+        { val: 'bar' },
+        { val: 'baz' }
+      ]
+    }, null, function () {
+      var queryFun = {
+        map: function (doc) {
+          emit(doc.val, 1);
+        },
+        reduce: '_sum'
+      };
+      db.query(queryFun, {
+        reduce: true,
+        group_level: 999
+      }, function (err, res) {
+        res.rows.should.have.length(2);
+        res.rows[0].value.should.equal(2);
+        res.rows[1].value.should.equal(1);
+        done();
+      });
+    });
+  });
+
+  it('Built in _count reduce function', function (done) {
+    var db = new PouchDB(dbs.name);
+    db.bulkDocs({
+      docs: [
+        { val: 'bar' },
+        { val: 'bar' },
+        { val: 'baz' }
+      ]
+    }, null, function () {
+      var queryFun = {
+        map: function (doc) {
+          emit(doc.val, doc.val);
+        },
+        reduce: '_count'
+      };
+      db.query(queryFun, {
+        reduce: true,
+        group_level: 999
+      }, function (err, res) {
+        res.rows.should.have.length(2);
+        res.rows[0].value.should.equal(2);
+        res.rows[1].value.should.equal(1);
+        done();
+      });
+    });
+  });
+
+  it('Built in _stats reduce function', function (done) {
+    var db = new PouchDB(dbs.name);
+    db.bulkDocs({
+      docs: [
+        { val: 'bar' },
+        { val: 'bar' },
+        { val: 'baz' }
+      ]
+    }, null, function () {
+      var queryFun = {
+        map: function (doc) {
+          emit(doc.val, 1);
+        },
+        reduce: '_stats'
+      };
+      db.query(queryFun, {
+        reduce: true,
+        group_level: 999
+      }, function (err, res) {
+        var stats = res.rows[0].value;
+        stats.sum.should.equal(2);
+        stats.count.should.equal(2);
+        stats.min.should.equal(1);
+        stats.max.should.equal(1);
+        stats.sumsqr.should.equal(2);
+        done();
+      });
+    });
+  });
+
+  it('No reduce function, passing just a  function', function (done) {
+    var db = new PouchDB(dbs.name);
+    db.post({ foo: 'bar' }, function () {
+      var queryFun = function () {
+        emit('key', 'val');
+      };
+      db.query(queryFun, function () {
+        done();
+      });
+    });
+  });
+
+  it('Views should include _conflicts', function (done) {
+    var doc1 = {
+      _id: '1',
+      foo: 'bar'
+    };
+    var doc2 = {
+      _id: '1',
+      foo: 'baz'
+    };
+    var queryFun = function (doc) {
+      emit(doc._id, !!doc._conflicts);
+    };
+    var db = new PouchDB(dbs.name);
+    var remote = new PouchDB(dbs.remote);
+    db.post(doc1, function () {
+      remote.post(doc2, function () {
+        db.replicate.from(remote, function () {
+          db.get(doc1._id, { conflicts: true }, function (err, res) {
+            should.exist(res._conflicts);
+            db.query(queryFun, function (err, res) {
+              should.exist(res.rows[0].value);
+              done();
             });
           });
         });
       });
     });
+  });
 
-    it('Test view querying with limit option', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.bulkDocs({
-        docs: [
-          { foo: 'bar' },
-          { foo: 'bar' },
-          { foo: 'baz' }
-        ]
-      }, null, function () {
-        db.query(function (doc) {
-          if (doc.foo === 'bar') {
-            emit(doc.foo);
-          }
-        }, { limit: 1 }, function (err, res) {
-          res.total_rows.should.equal(2, 'Correctly returns total rows');
-          res.rows.should.have.length(1, 'Correctly limits returned rows');
-          done();
+  it('Map only documents with _conflicts (#1000)', function (done) {
+    var docs1 = [
+      {
+        _id: '1',
+        foo: 'bar'
+      },
+      {
+        _id: '2',
+        name: 'two'
+      }
+    ];
+    var doc2 = {
+      _id: '1',
+      foo: 'baz'
+    };
+    var queryFun = function (doc) {
+      if (doc._conflicts) {
+        emit(doc._id, doc._conflicts);
+      }
+    };
+    var db = new PouchDB(dbs.name);
+    var remote = new PouchDB(dbs.remote);
+    db.bulkDocs({ docs: docs1 }, function (err, res) {
+      var revId1 = res[0].rev;
+      remote.post(doc2, function (err, res) {
+        var revId2 = res.rev;
+        db.replicate.from(remote, function () {
+          db.get(docs1[0]._id, { conflicts: true }, function (err, res) {
+            var winner = res._rev;
+            var looser = winner === revId1 ? revId2 : revId1;
+            should.exist(res._conflicts);
+            db.query(queryFun, function (err, res) {
+              res.rows.should.have.length(1, 'One doc with conflicts');
+              res.rows[0].key.should
+                .equal('1', 'Correct document with conflicts.');
+              res.rows[0].value.should.deep
+                .equal([looser], 'Correct conflicts included.');
+              done();
+            });
+          });
         });
       });
     });
+  });
 
-    it('Query non existing view returns error', function (done) {
-      var db = new PouchDB(dbs.name);
+  it('Test view querying with limit option', function (done) {
+    var db = new PouchDB(dbs.name);
+    db.bulkDocs({
+      docs: [
+        { foo: 'bar' },
+        { foo: 'bar' },
+        { foo: 'baz' }
+      ]
+    }, null, function () {
+      db.query(function (doc) {
+        if (doc.foo === 'bar') {
+          emit(doc.foo);
+        }
+      }, { limit: 1 }, function (err, res) {
+        res.total_rows.should.equal(2, 'Correctly returns total rows');
+        res.rows.should.have.length(1, 'Correctly limits returned rows');
+        done();
+      });
+    });
+  });
+
+  it('Query non existing view returns error', function (done) {
+    var db = new PouchDB(dbs.name);
+    var doc = {
+      _id: '_design/barbar',
+      views:
+        { scores:
+          { map: 'function (doc) { if (doc.score) ' +
+                  '{ emit(null, doc.score); } }' } }
+    };
+    db.post(doc, function () {
+      db.query('barbar/dontExist', { key: 'bar' }, function (err) {
+        if (!err.name) {
+          err.name = err.error;
+          err.message = err.reason;
+        }
+        err.name.should.be.a('string');
+        err.message.should.be.a('string');
+        done();
+      });
+    });
+  });
+
+  it('Special document member _doc_id_rev', function (done) {
+    var db = new PouchDB(dbs.name);
+    db.bulkDocs({ docs: [{ foo: 'bar' }] }, null, function () {
+      db.query(function (doc) {
+        if (doc.foo === 'bar') {
+          emit(doc.foo);
+        }
+      }, { include_docs: true }, function (err, res) {
+        should.not.exist(res.rows[0].doc._doc_id_rev);
+        done();
+      });
+    });
+  });
+
+  it('If reduce function returns 0', function (done) {
+    var db = new PouchDB(dbs.name);
+    db.bulkDocs({ docs: [{ foo: 'bar' }] }, null, function () {
+      db.query({
+        map: function (doc) {
+          emit(doc.foo);
+        },
+        reduce: function () {
+          return 0;
+        }
+      }, function (err, data) {
+        should.not.equal(data.rows[0].value, null, 'value is null');
+        done();
+      });
+    });
+  });
+
+  it('Testing skip with a view', function (done) {
+    var db = new PouchDB(dbs.name);
+    db.bulkDocs({
+      docs: [
+        { foo: 'bar' },
+        { foo: 'baz' },
+        { foo: 'baf' }
+      ]
+    }, null, function () {
+      db.query(function (doc) {
+        emit(doc.foo, null);
+      }, { skip: 1 }, function (err, data) {
+        should.not.exist(err);
+        data.rows.should.have.length(2);
+        done();
+      });
+    });
+  });
+
+  it('Testing skip with allDocs', function (done) {
+    var db = new PouchDB(dbs.name);
+    db.bulkDocs({
+      docs: [
+        { foo: 'bar' },
+        { foo: 'baz' },
+        { foo: 'baf' }
+      ]
+    }, null, function () {
+      db.allDocs({ skip: 1 }, function (err, data) {
+        should.not.exist(err);
+        data.rows.should.have.length(2);
+        done();
+      });
+    });
+  });
+
+  it('Destroy view when db created with {name: foo}', function () {
+    var db = new PouchDB({name: dbs.name});
+    var doc = {
+      _id: '_design/index',
+      views: {
+        index:
+        { map: 'function (doc) { emit(doc._id); }' }
+      }
+    };
+    return db.put(doc).then(function () {
+      return db.query('index');
+    }).then(function () {
+      return db.destroy();
+    });
+  });
+
+  it('Map documents on 0/null/undefined/empty string', function (done) {
+    var db = new PouchDB(dbs.name);
+    var docs = [
+      {
+        _id: 'doc0',
+        num: 0
+      },
+      {
+        _id: 'doc1',
+        num: 1
+      },
+      { _id: 'doc2' },
+      {
+        _id: 'doc3',
+        num: null
+      },
+      {
+        _id: 'doc4',
+        num: ''
+      }
+    ];
+    db.bulkDocs({ docs: docs }, function () {
+      var mapFunction = function (doc) {
+        emit(doc.num, null);
+      };
+      db.query(mapFunction, {
+        key: 0,
+        include_docs: true
+      }, function (err, data) {
+        data.rows.should.have.length(1);
+        data.rows[0].doc._id.should.equal('doc0');
+      });
+      db.query(mapFunction, {
+        key: null,
+        include_docs: true
+      }, function (err, data) {
+        data.rows.should.have.length(2);
+        data.rows[0].doc._id.should.equal('doc2');
+        data.rows[1].doc._id.should.equal('doc3');
+      });
+      db.query(mapFunction, {
+        key: '',
+        include_docs: true
+      }, function (err, data) {
+        data.rows.should.have.length(1);
+        data.rows[0].doc._id.should.equal('doc4');
+      });
+      db.query(mapFunction, {
+        key: undefined,
+        include_docs: true
+      }, function (err, data) {
+        data.rows.should.have.length(5);
+        // everything
+        done();
+      });
+    });
+  });
+  if (typeof window === 'undefined' && !process.browser) {
+    var fs = require('fs');
+    it.skip("destroy using prototype", function () {
+      var db = new PouchDB(dbs.name + 1);
       var doc = {
         _id: '_design/barbar',
-        views:
-          { scores:
-            { map: 'function (doc) { if (doc.score) ' +
-                   '{ emit(null, doc.score); } }' } }
-      };
-      db.post(doc, function () {
-        db.query('barbar/dontExist', { key: 'bar' }, function (err) {
-          if (!err.name) {
-            err.name = err.error;
-            err.message = err.reason;
-          }
-          err.name.should.be.a('string');
-          err.message.should.be.a('string');
-          done();
-        });
-      });
-    });
-
-    it('Special document member _doc_id_rev', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.bulkDocs({ docs: [{ foo: 'bar' }] }, null, function () {
-        db.query(function (doc) {
-          if (doc.foo === 'bar') {
-            emit(doc.foo);
-          }
-        }, { include_docs: true }, function (err, res) {
-          should.not.exist(res.rows[0].doc._doc_id_rev);
-          done();
-        });
-      });
-    });
-
-    it('If reduce function returns 0', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.bulkDocs({ docs: [{ foo: 'bar' }] }, null, function () {
-        db.query({
-          map: function (doc) {
-            emit(doc.foo);
-          },
-          reduce: function () {
-            return 0;
-          }
-        }, function (err, data) {
-          should.not.equal(data.rows[0].value, null, 'value is null');
-          done();
-        });
-      });
-    });
-
-    it('Testing skip with a view', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.bulkDocs({
-        docs: [
-          { foo: 'bar' },
-          { foo: 'baz' },
-          { foo: 'baf' }
-        ]
-      }, null, function () {
-        db.query(function (doc) {
-          emit(doc.foo, null);
-        }, { skip: 1 }, function (err, data) {
-          should.not.exist(err);
-          data.rows.should.have.length(2);
-          done();
-        });
-      });
-    });
-
-    it('Testing skip with allDocs', function (done) {
-      var db = new PouchDB(dbs.name);
-      db.bulkDocs({
-        docs: [
-          { foo: 'bar' },
-          { foo: 'baz' },
-          { foo: 'baf' }
-        ]
-      }, null, function () {
-        db.allDocs({ skip: 1 }, function (err, data) {
-          should.not.exist(err);
-          data.rows.should.have.length(2);
-          done();
-        });
-      });
-    });
-
-    it('Destroy view when db created with {name: foo}', function () {
-      var db = new PouchDB({name: dbs.name});
-      var doc = {
-        _id: '_design/index',
         views: {
-          index:
-          { map: 'function (doc) { emit(doc._id); }' }
+          scores: {
+            map: function (doc) {
+              if (doc.score) {
+                emit(null, doc.score);
+              }
+            }.toString(),
+            reduce: '_sum'
+          }
         }
       };
-      return db.put(doc).then(function () {
-        return db.query('index');
-      }).then(function () {
+      return db.bulkDocs([doc, {score: 3}, {score: 5}]).then(function () {
+        return db.query('barbar/scores');
+      }).then(function (a) {
+        a.rows[0].value.should.equal(8);
         return db.destroy();
+      }).then(function () {
+        fs.readdirSync('./tmp').should.have.length(0);
       });
     });
-
-    it('Map documents on 0/null/undefined/empty string', function (done) {
-      var db = new PouchDB(dbs.name);
-      var docs = [
-        {
-          _id: 'doc0',
-          num: 0
-        },
-        {
-          _id: 'doc1',
-          num: 1
-        },
-        { _id: 'doc2' },
-        {
-          _id: 'doc3',
-          num: null
-        },
-        {
-          _id: 'doc4',
-          num: ''
-        }
-      ];
-      db.bulkDocs({ docs: docs }, function () {
-        var mapFunction = function (doc) {
-          emit(doc.num, null);
-        };
-        db.query(mapFunction, {
-          key: 0,
-          include_docs: true
-        }, function (err, data) {
-          data.rows.should.have.length(1);
-          data.rows[0].doc._id.should.equal('doc0');
-        });
-        db.query(mapFunction, {
-          key: null,
-          include_docs: true
-        }, function (err, data) {
-          data.rows.should.have.length(2);
-          data.rows[0].doc._id.should.equal('doc2');
-          data.rows[1].doc._id.should.equal('doc3');
-        });
-        db.query(mapFunction, {
-          key: '',
-          include_docs: true
-        }, function (err, data) {
-          data.rows.should.have.length(1);
-          data.rows[0].doc._id.should.equal('doc4');
-        });
-        db.query(mapFunction, {
-          key: undefined,
-          include_docs: true
-        }, function (err, data) {
-          data.rows.should.have.length(5);
-          // everything
-          done();
-        });
-      });
-    });
-    if (typeof window === 'undefined' && !process.browser) {
-      var fs = require('fs');
-      it.skip("destroy using prototype", function () {
-        var db = new PouchDB(dbs.name + 1);
-        var doc = {
-          _id: '_design/barbar',
-          views: {
-            scores: {
-              map: function (doc) {
-                if (doc.score) {
-                  emit(null, doc.score);
-                }
-              }.toString(),
-              reduce: '_sum'
-            }
-          }
-        };
-        return db.bulkDocs([doc, {score: 3}, {score: 5}]).then(function () {
-          return db.query('barbar/scores');
-        }).then(function (a) {
-          a.rows[0].value.should.equal(8);
-          return db.destroy();
-        }).then(function () {
-          fs.readdirSync('./tmp').should.have.length(0);
-        });
-      });
-    }
-  });
+  }
 });


### PR DESCRIPTION
This is another PR relating to the work described in https://github.com/pouchdb/pouchdb/issues/8345. This collection of commits gets the `mapreduce` tests back into working shape. To explain the commits...

First we make the tests run against a single adapter, similar to https://github.com/pouchdb/pouchdb/pull/8359. We have some uncertainty around the test structure here, which is more ambiguous than the `find` tests in terms of the intent of running tests against multiple adapters:

- `test.persistent.js` contains only tests that use design documents for view queries
- `test.views.js` contains only tests that make ad-hoc queries without persistent views/ddocs
- `test.mapreduce.js` contains a mixture of these

Since CouchDB no longer supports temporary views, we've skipped the whole of `test.views.js` for `http` adapters. Some tests in `test.mapreduce.js` are selectively skipped, and the `createView()` function changes behaviour on `http` adapters to define a design doc instead of running an ad-hoc query. We're not sure if this matches the intent of how these tests are organised, but we figured we should still test ad-hoc queries as PouchDB local adapters still support them. So we continue to run `test.views.js` unmodified for local adapters, but we've changed some `test.mapreduce.js` tests to use ddocs instead of ad-hoc queries. We'd appreciate feedback on whether this matches the tests' intent.

Those structural changes are the first three commits. Following those, we have:

- CouchDB can sometimes return a 500 error instead of 400 or 404 so we adjust some tests to allow this
- Fix a bug in `indexeddb` so that a doc with ID `hasOwnProperty` doesn't break `bulkDocs()`
- Stop destroying the DB before tests; this shouldn't be necessary and sometimes makes CouchDB return an error
- Create databases with `q=1` when using `http`. We discovered some inconsistencies in view results when CouchDB has multiple shards, e.g. rows with equal `key`/`id` having undefined sort order, and metadata like `total_rows` being absent. We've filed an [issue against CouchDB](https://github.com/apache/couchdb/issues/3750) relating to this. We also have a commit that we've saved on the branch [`fix/mapreduce-sort-order`](https://github.com/neighbourhoodie/pouchdb/tree/fix/mapreduce-sort-order) that updates tests affected by this, should we later decide to run tests against multi-shard DBs, but it's not included in this PR. We can include this instead of the `q=1` change if desired.
- Generate DB names consistently so that they are URLs when using the `http` adapter and we don't have a mix of local and remote DBs. Again the intent here is unclear -- is it a necessary part of these tests that local vs remote DBs are used, or do we just need to replicate from one DB to another and we don't care what backends those DBs use as long as all of them get tested via CI?
- Update the CI config to list all the configs we want to test.

We'd really appreciate feedback around the ambiguities we've identified.

If/when this gets merged, if we squash-merge it can we make sure author information is retained so my colleagues retain credit on their contributions? :)