### PR TITLE
Consistent loading of PouchDB in tests

### DIFF
--- a/tests/common-utils.js
+++ b/tests/common-utils.js
@@ -37,10 +37,12 @@ commonUtils.plugins = function () {
 
 var PLUGIN_ADAPTERS = ['indexeddb', 'localstorage', 'memory', 'node-websql'];
 
-commonUtils.loadPouchDB = function () {
+commonUtils.loadPouchDB = function (opts) {
+  opts = opts || {};
+
   var params = commonUtils.params();
-  var adapters = commonUtils.adapters();
-  var plugins = commonUtils.plugins();
+  var adapters = commonUtils.adapters().concat(opts.adapters || []);
+  var plugins = commonUtils.plugins().concat(opts.plugins || []);
 
   for (let adapter of adapters) {
     if (adapter === 'websql') {

--- a/tests/common-utils.js
+++ b/tests/common-utils.js
@@ -30,6 +30,75 @@ commonUtils.adapters = function () {
   return adapters ? adapters.split(',') : [];
 };
 
+commonUtils.plugins = function () {
+  var plugins = commonUtils.isNode() ? process.env.PLUGINS : commonUtils.params().plugins;
+  return plugins ? plugins.split(',') : [];
+};
+
+commonUtils.loadPouchDB = function () {
+  var scriptPath = '../../packages/node_modules/pouchdb/dist';
+  var pluginAdapters = ['indexeddb', 'localstorage', 'memory'];
+
+  var params = commonUtils.params();
+  var pouchdbSrc = params.src || `${scriptPath}/pouchdb.js`;
+  var adapters = commonUtils.adapters();
+  var plugins = commonUtils.plugins();
+  var scripts = [pouchdbSrc];
+
+  for (let adapter of adapters) {
+    if (pluginAdapters.includes(adapter)) {
+      plugins.push(adapter);
+    }
+  }
+  for (let plugin of plugins) {
+    plugin = plugin.replace(/^pouchdb-/, '');
+    scripts.push(`${scriptPath}/pouchdb.${plugin}.js`);
+  }
+
+  var loadScripts = scripts.reduce((prevScriptLoaded, script) => {
+    return prevScriptLoaded.then(() => commonUtils.asyncLoadScript(script));
+  }, Promise.resolve());
+
+  return loadScripts.then(() => {
+    if (adapters.length > 0) {
+      window.PouchDB.preferredAdapters = adapters;
+    }
+    if ('autoCompaction' in params) {
+      window.PouchDB = window.PouchDB.defaults({ auto_compaction: true });
+    }
+    return window.PouchDB;
+  });
+};
+
+// Thanks to http://engineeredweb.com/blog/simple-async-javascript-loader/
+commonUtils.asyncLoadScript = function (url) {
+  return new commonUtils.Promise(function (resolve) {
+    // Create a new script and setup the basics.
+    var script = document.createElement("script");
+    var firstScript = document.getElementsByTagName('script')[0];
+
+    script.async = true;
+    script.src = url;
+
+    script.onload = function () {
+      resolve();
+
+      // Clear it out to avoid getting called more than once or any
+      // memory leaks.
+      script.onload = script.onreadystatechange = undefined;
+    };
+    script.onreadystatechange = function () {
+      if ("loaded" === script.readyState || "complete" === script.readyState) {
+        script.onload();
+      }
+    };
+
+    // Attach the script tag to the page (before the first script) so the
+    //magic can happen.
+    firstScript.parentNode.insertBefore(script, firstScript);
+  });
+};
+
 commonUtils.couchHost = function () {
   if (typeof window !== 'undefined' && window.cordova) {
     // magic route to localhost on android emulator
@@ -63,5 +132,9 @@ commonUtils.createDocId = function (i) {
   }
   return 'doc_' + intString;
 };
+
+var PouchForCoverage = require('../packages/node_modules/pouchdb-for-coverage');
+var pouchUtils = PouchForCoverage.utils;
+commonUtils.Promise = pouchUtils.Promise;
 
 module.exports = commonUtils;

--- a/tests/common-utils.js
+++ b/tests/common-utils.js
@@ -2,10 +2,14 @@
 
 var commonUtils = {};
 
-// This is a duplicate of the function in integration/utils.js but the
-// current test set up makes it really hard to share that function. Since
-// we are apparently going to refactor the tests for now we'll just copy the
-// function in two places.
+commonUtils.isBrowser = function () {
+  return !commonUtils.isNode();
+};
+
+commonUtils.isNode = function () {
+  return typeof process !== 'undefined' && !process.browser;
+};
+
 commonUtils.params = function () {
   if (commonUtils.isNode()) {
     return process.env;
@@ -19,6 +23,11 @@ commonUtils.params = function () {
     acc[tmp[0]] = decodeURIComponent(tmp[1]) || true;
     return acc;
   }, {});
+};
+
+commonUtils.adapters = function () {
+  var adapters = commonUtils.isNode() ? process.env.ADAPTERS : commonUtils.params().adapters;
+  return adapters ? adapters.split(',') : [];
 };
 
 commonUtils.couchHost = function () {
@@ -53,16 +62,6 @@ commonUtils.createDocId = function (i) {
     intString = '0' + intString;
   }
   return 'doc_' + intString;
-};
-
-commonUtils.isNode = function () {
-  // First part taken from
-  // http://timetler.com/2012/10/13/environment-detection-in-javascript/
-  // The !process.browser check is needed to see if we are in browserify
-  // which actually will pass the first part.
-  return typeof exports !== 'undefined' &&
-          this.exports !== exports &&
-          !process.browser;
 };
 
 module.exports = commonUtils;

--- a/tests/integration/node.setup.js
+++ b/tests/integration/node.setup.js
@@ -19,15 +19,9 @@ exec('mkdir -p ' + testsDir, function () {
   process.on('exit', cleanup);
 });
 global.testUtils = require('./utils.js');
+global.PouchDB = testUtils.loadPouchDB();
 var chai = require('chai');
 chai.use(require('chai-as-promised'));
 global.should = chai.should();
 global.assert = chai.assert;
-
-if (process.env.PLUGINS && !process.env.COVERAGE) {
-  // in coverage, these plugins are explicitly included
-  // in pouchdb-for-coverage
-  process.env.PLUGINS.split(',').forEach(function (plugin) {
-    PouchDB.plugin(require('../../packages/node_modules/' + plugin));
-  });
-}
+require('mkdirp').sync('./tmp');

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -239,7 +239,6 @@ var pouchUtils = PouchForCoverage.utils;
 testUtils.binaryStringToBlob = pouchUtils.binaryStringToBlobOrBuffer;
 testUtils.btoa = pouchUtils.btoa;
 testUtils.atob = pouchUtils.atob;
-testUtils.Promise = pouchUtils.Promise;
 testUtils.ajax = PouchForCoverage.ajax;
 testUtils.uuid = pouchUtils.uuid;
 testUtils.rev = pouchUtils.rev;

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -3,7 +3,7 @@
 'use strict';
 
 var path = require('path');
-var testUtils = {};
+var testUtils = Object.create(require('../common-utils'));
 
 function uniq(list) {
   var map = {};
@@ -18,14 +18,6 @@ testUtils.isCouchMaster = function () {
     testUtils.params().SERVER === 'couchdb-master';
 };
 
-testUtils.isBrowser = function () {
-  return !testUtils.isNode();
-};
-
-testUtils.isNode = function () {
-  return typeof process !== 'undefined' && !process.browser;
-};
-
 testUtils.isIE = function () {
   var ua = (typeof navigator !== 'undefined' && navigator.userAgent) ?
       navigator.userAgent.toLowerCase() : '';
@@ -36,46 +28,7 @@ testUtils.isIE = function () {
 };
 
 testUtils.adapterType = function () {
-  var adapters = testUtils.isNode() ? process.env.ADAPTERS : testUtils.params().adapters;
-  adapters = (adapters || '').split(',');
-  return adapters.indexOf('http') < 0 ? 'local' : 'http';
-};
-
-testUtils.params = function () {
-  if (testUtils.isNode()) {
-    return process.env;
-  }
-  var paramStr = document.location.search.slice(1);
-  return paramStr.split('&').reduce(function (acc, val) {
-    if (!val) {
-      return acc;
-    }
-    var tmp = val.split('=');
-    acc[tmp[0]] = decodeURIComponent(tmp[1]) || true;
-    return acc;
-  }, {});
-};
-
-testUtils.couchHost = function () {
-  if (typeof window !== 'undefined' && window.cordova) {
-    // magic route to localhost on android emulator
-    return 'http://10.0.2.2:5984';
-  }
-
-  if (typeof window !== 'undefined' && window.COUCH_HOST) {
-    return window.COUCH_HOST;
-  }
-
-  if (typeof process !== 'undefined' && process.env.COUCH_HOST) {
-    return process.env.COUCH_HOST;
-  }
-
-  if ('couchHost' in testUtils.params()) {
-    // Remove trailing slash from url if the user defines one
-    return testUtils.params().couchHost.replace(/\/$/, '');
-  }
-
-  return 'http://localhost:5984';
+  return testUtils.adapters().indexOf('http') < 0 ? 'local' : 'http';
 };
 
 testUtils.readBlob = function (blob, callback) {

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -2,7 +2,6 @@
 /* jshint -W079 */
 'use strict';
 
-var path = require('path');
 var testUtils = Object.create(require('../common-utils'));
 
 function uniq(list) {
@@ -304,41 +303,6 @@ testUtils.sortById = function (a, b) {
 };
 
 if (testUtils.isNode()) {
-  if (process.env.COVERAGE) {
-    global.PouchDB = require('../../packages/node_modules/pouchdb-for-coverage');
-  } else { // no need to check for coverage
-    // string addition is to avoid browserify pulling in whole thing
-    global.PouchDB = require('../../packages/' + 'node_modules/pouchdb');
-  }
-
-  if (process.env.AUTO_COMPACTION) {
-    // test autocompaction
-    global.PouchDB = global.PouchDB.defaults({
-      auto_compaction: true,
-      prefix: './tmp/_pouch_'
-    });
-  } else if (process.env.ADAPTERS === 'websql') {
-    // test WebSQL in Node
-    // (the two strings are just to fool Browserify because sqlite3 fails
-    // in Node 0.11-0.12)
-   global.PouchDB.plugin(require('../../packages/node_modules/' +
-      'pouchdb-adapter-node-websql'));
-    global.PouchDB.preferredAdapters = ['websql', 'leveldb'];
-    global.PouchDB = global.PouchDB.defaults({
-      prefix: path.resolve('./tmp/_pouch_')
-    });
-  } else if (process.env.ADAPTERS === 'memory') {
-    global.PouchDB.plugin(require('../../packages/node_modules/' +
-      'pouchdb-adapter-memory'));
-    global.PouchDB.preferredAdapters = ['memory', 'leveldb'];
-  } else {
-    // test regular leveldown in node
-    global.PouchDB = global.PouchDB.defaults({
-      prefix: path.resolve('./tmp/_pouch_')
-    });
-  }
-
-  require('mkdirp').sync('./tmp');
   module.exports = testUtils;
 } else {
   window.testUtils = testUtils;

--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -1,89 +1,14 @@
 /* global mocha: true */
 (function () {
   'use strict';
-  // use query parameter pluginFile if present,
-  // eg: test.html?pluginFile=memory.pouchdb.js
 
   var params = testUtils.params();
-  var plugins = ('plugins' in params) ? params.plugins.split(',') : [];
-  var adapters = ('adapters' in params) ? params.adapters.split(',') : [];
-  var scriptPath = '../../packages/node_modules/pouchdb/dist';
-  var pouchdbSrc = params.src || scriptPath + '/pouchdb.js';
-
-  var scriptsToLoad = [pouchdbSrc];
-  var pluginAdapters = ['indexeddb', 'localstorage', 'memory'];
-
-  adapters.forEach(function (adapter) {
-    if (pluginAdapters.includes(adapter)) {
-      plugins.push(adapter);
-    }
-  });
-  plugins.forEach(function (plugin) {
-    plugin = plugin.replace(/^pouchdb-/, '');
-    scriptsToLoad.push(scriptPath + '/pouchdb.' + plugin + '.js');
-  });
-
   var remote = params.remote === '1';
-
-// Thanks to http://engineeredweb.com/blog/simple-async-javascript-loader/
-  function asyncLoadScript(url, callback) {
-
-    // Create a new script and setup the basics.
-    var script = document.createElement("script"),
-      firstScript = document.getElementsByTagName('script')[0];
-
-    script.async = true;
-    script.src = url;
-
-    // Handle the case where an optional callback was passed in.
-    if ("function" === typeof (callback)) {
-      script.onload = function () {
-        callback();
-
-        // Clear it out to avoid getting called more than once or any
-        // memory leaks.
-        script.onload = script.onreadystatechange = undefined;
-      };
-      script.onreadystatechange = function () {
-        if ("loaded" === script.readyState || "complete" === script.readyState) {
-          script.onload();
-        }
-      };
-    }
-
-    // Attach the script tag to the page (before the first script) so the
-    //magic can happen.
-    firstScript.parentNode.insertBefore(script, firstScript);
-  }
-
-  function modifyGlobals() {
-    if (adapters.length > 0) {
-      window.PouchDB.preferredAdapters = adapters;
-    }
-    if ('autoCompaction' in params) {
-      window.PouchDB = window.PouchDB.defaults({ auto_compaction: true });
-    }
-  }
 
   function loadScripts() {
 
-    function loadNext() {
-      if (scriptsToLoad.length) {
-        var script = scriptsToLoad.shift();
-        asyncLoadScript(script, loadNext);
-      } else {
-        if (document.readyState === 'complete') {
-          startTests();
-        } else {
-          window.addEventListener("load", startTests);
-        }
-      }
-    }
-
     function startTests() {
       window.removeEventListener("load", startTests);
-
-      modifyGlobals();
 
       if (remote) {
         // Capture logs for selenium output
@@ -160,7 +85,13 @@
       mocha.run();
     }
 
-    loadNext();
+    testUtils.loadPouchDB().then(function () {
+      if (document.readyState === 'complete') {
+        startTests();
+      } else {
+        window.addEventListener("load", startTests);
+      }
+    });
   }
 
   loadScripts();

--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -83,7 +83,8 @@
     mocha.run();
   }
 
-  testUtils.loadPouchDB().then(function () {
+  testUtils.loadPouchDB().then(function (PouchDB) {
+    window.PouchDB = PouchDB;
     if (document.readyState === 'complete') {
       startTests();
     } else {

--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -5,95 +5,90 @@
   var params = testUtils.params();
   var remote = params.remote === '1';
 
-  function loadScripts() {
+  function startTests() {
+    window.removeEventListener("load", startTests);
 
-    function startTests() {
-      window.removeEventListener("load", startTests);
+    if (remote) {
+      // Capture logs for selenium output
+      var logs = [];
 
-      if (remote) {
-        // Capture logs for selenium output
-        var logs = [];
+      (function () {
 
-        (function () {
-
-          function serializeLogItem(obj, filter, space) {
-            if (typeof obj === 'string') {
-              return obj;
-            } else if (obj instanceof Error) {
-              return obj.stack;
-            } else {
-              return JSON.stringify(obj, filter, space);
-            }
+        function serializeLogItem(obj, filter, space) {
+          if (typeof obj === 'string') {
+            return obj;
+          } else if (obj instanceof Error) {
+            return obj.stack;
+          } else {
+            return JSON.stringify(obj, filter, space);
           }
+        }
 
-          function wrappedLog(oldLog, type) {
-            return function () {
-              var args = Array.prototype.slice.call(arguments);
-              logs.push({
-                type: type,
-                content: args.map(function (arg) {
-                  return serializeLogItem(arg);
-                }).join(' ')
-              });
-              oldLog.apply(console, arguments);
-            };
-          }
-
-          console.log = wrappedLog(console.log, 'log');
-          console.error = wrappedLog(console.error, 'error');
-
-        })();
-
-        // Capture test events for selenium output
-        var testEventsBuffer = [];
-
-        window.testEvents = function () {
-          var events = testEventsBuffer;
-          testEventsBuffer = [];
-          return events;
-        };
-
-        mocha.reporter(function (runner) {
-          var eventNames = ['start', 'end', 'suite', 'suite end', 'pass', 'pending', 'fail'];
-          eventNames.forEach(function (name) {
-            runner.on(name, function (obj, err) {
-              testEventsBuffer.push({
-                name: name,
-                obj: obj && {
-                  root: obj.root,
-                  title: obj.title,
-                  duration: obj.duration,
-                  slow: typeof obj.slow === 'function' ? obj.slow() : undefined,
-                  fullTitle: typeof obj.fullTitle === 'function' ? obj.fullTitle() : undefined
-                },
-                err: err && {
-                  actual: err.actual,
-                  expected: err.expected,
-                  showDiff: err.showDiff,
-                  message: err.message,
-                  stack: err.stack,
-                  uncaught: err.uncaught
-                },
-                logs: logs
-              });
-              logs = [];
+        function wrappedLog(oldLog, type) {
+          return function () {
+            var args = Array.prototype.slice.call(arguments);
+            logs.push({
+              type: type,
+              content: args.map(function (arg) {
+                return serializeLogItem(arg);
+              }).join(' ')
             });
+            oldLog.apply(console, arguments);
+          };
+        }
+
+        console.log = wrappedLog(console.log, 'log');
+        console.error = wrappedLog(console.error, 'error');
+
+      })();
+
+      // Capture test events for selenium output
+      var testEventsBuffer = [];
+
+      window.testEvents = function () {
+        var events = testEventsBuffer;
+        testEventsBuffer = [];
+        return events;
+      };
+
+      mocha.reporter(function (runner) {
+        var eventNames = ['start', 'end', 'suite', 'suite end', 'pass', 'pending', 'fail'];
+        eventNames.forEach(function (name) {
+          runner.on(name, function (obj, err) {
+            testEventsBuffer.push({
+              name: name,
+              obj: obj && {
+                root: obj.root,
+                title: obj.title,
+                duration: obj.duration,
+                slow: typeof obj.slow === 'function' ? obj.slow() : undefined,
+                fullTitle: typeof obj.fullTitle === 'function' ? obj.fullTitle() : undefined
+              },
+              err: err && {
+                actual: err.actual,
+                expected: err.expected,
+                showDiff: err.showDiff,
+                message: err.message,
+                stack: err.stack,
+                uncaught: err.uncaught
+              },
+              logs: logs
+            });
+            logs = [];
           });
         });
-      }
-
-      mocha.run();
+      });
     }
 
-    testUtils.loadPouchDB().then(function () {
-      if (document.readyState === 'complete') {
-        startTests();
-      } else {
-        window.addEventListener("load", startTests);
-      }
-    });
+    mocha.run();
   }
 
-  loadScripts();
+  testUtils.loadPouchDB().then(function () {
+    if (document.readyState === 'complete') {
+      startTests();
+    } else {
+      window.addEventListener("load", startTests);
+    }
+  });
 
 })();

--- a/tests/performance/index.html
+++ b/tests/performance/index.html
@@ -5,11 +5,6 @@
   </head>
   <body>
     <pre style="width: 100%; height: 100%;" id="output"></pre>
-    <script src="/packages/node_modules/pouchdb/dist/pouchdb.js"></script>
-    <script src="/packages/node_modules/pouchdb/dist/pouchdb-next.js"></script>
-    <script src="/packages/node_modules/pouchdb/dist/pouchdb.find.js"></script>
-    <script src="/packages/node_modules/pouchdb/dist/pouchdb.localstorage.js"></script>
-    <script src="/packages/node_modules/pouchdb/dist/pouchdb.memory.js"></script>
     <script src="../performance-bundle.js"></script>
   </body>
 </html>

--- a/tests/performance/index.js
+++ b/tests/performance/index.js
@@ -1,87 +1,39 @@
-
 'use strict';
 
-var opts = {};
-
-if (typeof process !== 'undefined' && process.env) {
-  if (process.env.ADAPTERS) {
-    opts.adapter = process.env.ADAPTERS;
-  }
-}
+var commonUtils = require('../common-utils');
 
 function runTestSuites(PouchDB) {
+  var adapters = commonUtils.adapters();
 
-  function runTestsNow() {
-    var reporter = require('./perf.reporter');
-    reporter.startAll();
-    reporter.log('Testing PouchDB version ' + PouchDB.version +
-      (opts.adapter ?
-        (', using adapter: ' + opts.adapter) : '') +
-      '\n\n');
+  var reporter = require('./perf.reporter');
+  reporter.startAll();
+  reporter.log('Testing PouchDB version ' + PouchDB.version +
+    (adapters.length > 0 ? (', using adapter: ' + adapters.join(',')) : '') +
+    '\n\n');
 
-    var theAdapterUsed;
-    var count = 0;
-    function checkDone(adapterUsed) {
-      theAdapterUsed = theAdapterUsed || adapterUsed;
-      if (++count === 4) { // number of perf.xxxx.js tests
-        reporter.complete(theAdapterUsed);
-      }
+  var theAdapterUsed;
+  var count = 0;
+  function checkDone(adapterUsed) {
+    theAdapterUsed = theAdapterUsed || adapterUsed;
+    if (++count === 4) { // number of perf.xxxx.js tests
+      reporter.complete(theAdapterUsed);
     }
-
-    require('./perf.basics')(PouchDB, opts, checkDone);
-    require('./perf.views')(PouchDB, opts, checkDone);
-    require('./perf.find')(PouchDB, opts, checkDone);
-    require('./perf.attachments')(PouchDB, opts, checkDone);
   }
 
-  if (typeof process === 'undefined' || process.browser) {
+  require('./perf.basics')(PouchDB, checkDone);
+  require('./perf.views')(PouchDB, checkDone);
+  require('./perf.find')(PouchDB, checkDone);
+  require('./perf.attachments')(PouchDB, checkDone);
+}
+
+var PouchDB = commonUtils.loadPouchDB({ plugins: ['pouchdb-find'] });
+
+if (commonUtils.isBrowser()) {
+  PouchDB.then((PouchDB) => {
     // rendering the initial view has its own costs
     // that interfere with measurements
-    setTimeout(runTestsNow, 1000);
-  } else {
-    runTestsNow();
-  }
-}
-var startNow = true;
-if (global.window && global.window.location && global.window.location.search) {
-
-  var fragment = global.window.location.search.replace(/^\??/, '').split('&');
-  var params = {};
-  fragment.forEach(function (param) {
-    var keyValue = param.split('=');
-    params[keyValue[0]] = decodeURIComponent(keyValue[1]);
+    setTimeout(() => runTestSuites(PouchDB), 1000);
   });
-
-  if ('adapter' in params) {
-    opts.adapter = params.adapter;
-  }
-
-  if ('src' in params) {
-
-    var script = global.document.createElement('script');
-    script.src = params.src;
-    script.onreadystatechange = function () {
-      if ("loaded" === script.readyState || "complete" === script.readyState) {
-        runTestSuites(global.window.PouchDB);
-      }
-    };
-
-    global.document.getElementsByTagName('body')[0].appendChild(script);
-    startNow = false;
-  }
-}
-if (startNow) {
-  var PouchDB;
-  if (process.browser) {
-    PouchDB = window.PouchDB;
-  } else {
-    PouchDB = require('../../packages/node_modules/pouchdb');
-    PouchDB.plugin(require('../../packages/node_modules/' +
-      'pouchdb-find'));
-  }
-  if (!process.browser) {
-    PouchDB.plugin(require('../../packages/node_modules/' +
-      'pouchdb-adapter-memory'));
-  }
+} else {
   runTestSuites(PouchDB);
 }

--- a/tests/performance/perf.attachments.js
+++ b/tests/performance/perf.attachments.js
@@ -28,7 +28,7 @@ function randomBlob(size) {
   }
 }
 
-module.exports = function (PouchDB, opts, callback) {
+module.exports = function (PouchDB, callback) {
 
   var utils = require('./utils');
 
@@ -52,6 +52,6 @@ module.exports = function (PouchDB, opts, callback) {
     }
   ];
 
-  utils.runTests(PouchDB, 'attachments', testCases, opts, callback);
+  utils.runTests(PouchDB, 'attachments', testCases, callback);
 
 };

--- a/tests/performance/perf.basics.js
+++ b/tests/performance/perf.basics.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function (PouchDB, opts, callback) {
+module.exports = function (PouchDB, callback) {
 
   var utils = require('./utils');
   var commonUtils = require('../common-utils.js');
@@ -311,5 +311,5 @@ module.exports = function (PouchDB, opts, callback) {
     }
   ];
 
-  utils.runTests(PouchDB, 'basics', testCases, opts, callback);
+  utils.runTests(PouchDB, 'basics', testCases, callback);
 };

--- a/tests/performance/perf.find.js
+++ b/tests/performance/perf.find.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function (PouchDB, opts, callback) {
+module.exports = function (PouchDB, callback) {
 
   var utils = require('./utils');
 
@@ -161,5 +161,5 @@ module.exports = function (PouchDB, opts, callback) {
     }
   ];
 
-  utils.runTests(PouchDB, 'find', testCases, opts, callback);
+  utils.runTests(PouchDB, 'find', testCases, callback);
 };

--- a/tests/performance/perf.views.js
+++ b/tests/performance/perf.views.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function (PouchDB, opts, callback) {
+module.exports = function (PouchDB, callback) {
 
   var utils = require('./utils');
 
@@ -172,6 +172,6 @@ module.exports = function (PouchDB, opts, callback) {
     }
   ];
 
-  utils.runTests(PouchDB, 'views', testCases, opts, callback);
+  utils.runTests(PouchDB, 'views', testCases, callback);
 
 };

--- a/tests/performance/utils.js
+++ b/tests/performance/utils.js
@@ -20,7 +20,7 @@ if (global.window && global.window.location && global.window.location.search) {
 
 var adapterUsed;
 
-exports.runTests = function (PouchDB, suiteName, testCases, opts, callback) {
+exports.runTests = function (PouchDB, suiteName, testCases, callback) {
 
   testCases = testCases.filter(function (testCase) {
     if (grep && suiteName.indexOf(grep) === -1 &&
@@ -47,8 +47,7 @@ exports.runTests = function (PouchDB, suiteName, testCases, opts, callback) {
       var localDbName = commonUtils.safeRandomDBName();
 
       t.test('setup', function (t) {
-        opts.size = 3000;
-        db = new PouchDB(localDbName, opts);
+        db = new PouchDB(localDbName, { size: 3000 });
         adapterUsed = db.adapter;
         testCase.setup(db, function (err, res) {
           if (err) {
@@ -95,8 +94,7 @@ exports.runTests = function (PouchDB, suiteName, testCases, opts, callback) {
 
         testCaseTeardown.then(function () {
           reporter.end(testCase);
-          var opts = {adapter : db.adapter};
-          return new PouchDB(localDbName, opts).destroy();
+          return new PouchDB(localDbName).destroy();
         }).then(function () {
           t.end();
           if (i === testCases.length - 1) {


### PR DESCRIPTION
One of the challenges of maintaining the test suite is that we have logic in many different places for loading PouchDB and making sure the right adapters/plugins are loaded. This leads to inconsistent behaviour if we fail to update one of these places and means the command-line options have confusing behaviour.

The current mechanism is:

- `bin/run-test.sh` causes either `bin/test-browser.js` or `bin/test-node.sh` to be run, via an `npm` task.
  - `bin/test-browser.js` opens one of the number of HTML files via Selenium and translates environment variables into query string parameters on the loaded page, so that command-line options can be read by it. Most of these pages load a set of Mocha tests followed by `tests/integration/webrunner.js`.
    - `tests/integration/webrunner.js` includes code for loading PouchDB, any required adapters and plugins, and determining which adapter to use. We have already performed some clean-up of this code.
  - `bin/test-node.sh` runs either `tests/performance/index.js` or some collection of Mocha tests with `tests/integration/node.setup.js` uses for initial setup. Environment variables are implicitly passed to child processes.
    - `tests/performance/index.js` is designed to be run on either Node.js or the browser, and includes code for loading PouchDB, any required adapters and plugins, and determining which adapter to use. It uses `tests/common-utils.js` which contains functions copied from `tests/integration/utils.js`.
    - `tests/integration/node.setup.js` loads `tests/integration/utils.js`, which if loaded under Node.js runs code for loading PouchDB, any required adapters, and determining which adapter to use. `node.setup.js` additionally contains code for loading plugins.

We tidy this up by making `tests/integration/utils.js` inherit from `tests/common-utils.js` and moving any shared functions into `common-utils.js`. We then add a function `loadPouchDB()` to this file that performs the following tasks:

- Based on the `POUCHDB_SRC` and `COVERAGE` variables, load PouchDB
- Based on the `ADAPTERS` variable, load any required adapter plugins and set them as preferred
- Based on the `PLUGINS` variable, load any required plugins
- If `AUTO_COMPACTION` is set, turn on auto-compaction
- If running on Node.js, set a prefix

This works the same across all environments and understands how to fetch config either from the environment or the query string parameters. We can then remove all the code from `tests/integration/webrunner.js`, `tests/integration/utils.js`, `tests/integration/node.setup.js`, `tests/performance/index.html` and `tests/performance/index.js` that deals with code loading and configuration, and we can be confident that PouchDB is always configured the same given the same environment variables, no matter which test task we're running.

This also gets the adapters working properly for performance tests so that we can test `indexeddb`.