### PR TITLE
WIP: Add test for broken skip in pouch-find

### DIFF
--- a/tests/find/test-suite-1/test.skip.js
+++ b/tests/find/test-suite-1/test.skip.js
@@ -284,4 +284,41 @@ describe('test.skip.js', function () {
       });
     });
   });
+
+  it('skip 1 should work when an index is used', async function () {
+    const docsData = [
+        {
+            _id: 'dhfgqj2ng8kt',
+            firstName: 'Shakira',
+            lastName: 'Larson',
+            age: 38
+        },
+        {
+            _id: 'fumelxdcqsxn',
+            firstName: 'Christine',
+            lastName: 'Huel',
+            age: 32
+        }
+    ];
+
+    var db = context.db;
+    db.createIndex({
+        index: {
+            fields: ['firstName']
+        }
+    });
+
+    await db.bulkDocs(docsData);
+
+    const resultAll = await db.find({
+        selector: {}
+    });
+    const resultNoFirst = await db.find({
+        selector: {},
+        skip: 1
+    });
+
+    assert.deepEqual(resultAll.length, docsData.length);
+    assert.deepEqual(resultNoFirst.length, docsData.length -1);
+  });
 });


### PR DESCRIPTION
Using the skip option seems to return the wrong amount of documents, if an index is used.