### PR TITLE
_id was mappped to data._id instead of id

### DIFF
--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/util.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/util.js
@@ -71,7 +71,7 @@ function correctIndexFields(fields) {
   // we need to filter out deleted documents.
   return ['deleted'].concat(
     fields.map(function (field) {
-      if (field in ['_id', '_rev', '_deleted', '_attachments']) {
+      if (['_id', '_rev', '_deleted', '_attachments'].includes(field)) {
         // These properties are stored at the top level without the underscore
         return field.substr(1);
       } else {

--- a/tests/find/index.html
+++ b/tests/find/index.html
@@ -59,6 +59,7 @@
     <script src='./test-suite-2/test.kitchen-sink.js'></script>
     <script src='./test-suite-2/test.kitchen-sink-2.js'></script>
     <script src='./test-issues/test.issue7810.js'></script>
+    <script src='./test-issues/test.issue8389.js'></script>
     <script type="text/javascript" src="../integration/webrunner.js"></script>
   </body>
 </html>

--- a/tests/find/test-issues/test.issue8389.js
+++ b/tests/find/test-issues/test.issue8389.js
@@ -1,0 +1,95 @@
+"use strict";
+
+describe("test.issue8389.js", function () {
+  var adapter = testUtils.adapterType();
+  var db = null;
+  var dbName = null;
+  
+  const docData = {
+    _id: "foobar",
+    indexedField: "foobaz",
+  };
+
+  function createIndicesAndPutData() {
+    return Promise.all([
+      db.createIndex({
+        index: {
+          fields: ["indexedField", "_id"],
+        },
+      }),
+      db.put(docData),
+    ]);
+  }
+
+  function assertLengthOf(query, docLen) {
+    return db.find(query).then((results) => {
+      const suffix = docLen === 1 ? '' : 's';
+      results.docs.length.should.equal(docLen, `find should return ${docLen} doc${suffix}`);
+    });
+  }
+
+  beforeEach(function () {
+    dbName = testUtils.adapterUrl(adapter, "issue8389");
+    db = new PouchDB(dbName);
+
+    return createIndicesAndPutData();
+  });
+
+  afterEach(function (done) {
+    testUtils.cleanup([dbName], done);
+  });
+
+  it("Testing issue #8389 _id should work in find index: 0 with nonmatching query", function () {
+    var query = {
+      selector: {
+        indexedField: 'bar',
+        _id: 'bar',
+      },
+    };
+    return assertLengthOf(query, 0);
+  });
+  
+  it("Testing issue #8389 _id should work in find index: 1 with matching query", function () {
+    var query = {
+      selector: {
+        indexedField: 'foobaz',
+        _id: 'foobar',
+      },
+    };
+    return assertLengthOf(query, 1);
+  });
+
+  it("Testing issue #8389 _id should work in find index: 1/2 with multiple docs", function () {
+    var query = {
+      selector: {
+        indexedField: 'foobaz',
+        _id: 'foobar',
+      },
+    };
+    const otherDoc = {
+      _id: "charlie",
+      indexedField: "foobaz",
+    };
+    return db.put(otherDoc).then(function () {
+      return assertLengthOf(query, 1);
+    });
+  });
+  
+  it("Testing issue #8389 _id should work in find index: 2/2 with multiple docs", function () {
+    var query = {
+      selector: {
+        indexedField: 'foobaz',
+        _id: {
+          '$gt': 'a',
+        }
+      },
+    };
+    const otherDoc = {
+      _id: "charlie",
+      indexedField: "foobaz",
+    };
+    return db.put(otherDoc).then(function () {
+      return assertLengthOf(query, 2);
+    });
+  });
+});


### PR DESCRIPTION
Indexes with toplevel fields were mapped incorrectly.
This might need a version upgrade of the index names by going from `_find_idx/...` to `find_idx2/...` in `naturalIndexName` or something if we want to fix existing databases.