### PR TITLE
#8370 Implement skip and limit for keys query

### DIFF
--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -741,6 +741,13 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       }
     }
 
+    function sliceKeysResult(arr) {
+      if (!shouldReduce) {
+        return sliceResults(arr,opts.limit,opts.skip);
+      }
+      return arr;
+    }
+
     if (typeof opts.keys !== 'undefined') {
       var keys = opts.keys;
       var fetchPromises = keys.map(function (key) {
@@ -754,7 +761,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
         }
         return fetchFromView(viewOpts);
       });
-      return Promise.all(fetchPromises).then(flatten).then(onMapResultsReady);
+      return Promise.all(fetchPromises).then(flatten).then(sliceKeysResult).then(onMapResultsReady);
     } else { // normal query, no 'keys'
       var viewOpts = {
         descending : opts.descending


### PR DESCRIPTION
The limit and skip parameters were not implemented for map/reduce
keys queries.