### PR TITLE
docs: Fix a few typos

### DIFF
--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -24,7 +24,7 @@ var FIREFOX_BIN = process.env.FIREFOX_BIN;
 // BAIL=0 to disable bailing
 var bail = process.env.BAIL !== '0';
 
-// process.env.CLIENT is a colon seperated list of
+// process.env.CLIENT is a colon separated list of
 // (saucelabs|selenium):browserName:browserVerion:platform
 var tmp = (process.env.CLIENT || 'selenium:firefox').split(':');
 var client = {

--- a/docs/_posts/2014-11-27-testing-pouchdb.md
+++ b/docs/_posts/2014-11-27-testing-pouchdb.md
@@ -63,4 +63,4 @@ I expect that to fix this, we will need to run the tests on dedicated hardware a
 
 Hopefully that gives a little insight into the process and issues we have with testing. It's a long and ongoing process, and I am hoping that the work we do to improve our testing infrastructure can be reused by other projects.
 
-We would love to hear more about the tools, techniques and issues that other similiar projects have come across while working on their tests. If you have anything to share, please send it along to [@pouchdb](https://twitter.com/pouchdb).
+We would love to hear more about the tools, techniques and issues that other similar projects have come across while working on their tests. If you have anything to share, please send it along to [@pouchdb](https://twitter.com/pouchdb).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -206,7 +206,7 @@ function sync() {
 }
 {% endhighlight %}
 
-`db.replicate()` tells PouchDB to transfer all the documents `to` or `from` the `remoteCouch`. This can either be a string identifier or a PouchDB object. We call this twice: once to receive remote updates, and once to push local changes. Again, the `live` flag is used to tell PouchDB to carry on doing this indefinitely. The callback will be called whenever this finishes. For live replication, this will mean an error has occured, like losing your connection or you canceled the replication.
+`db.replicate()` tells PouchDB to transfer all the documents `to` or `from` the `remoteCouch`. This can either be a string identifier or a PouchDB object. We call this twice: once to receive remote updates, and once to push local changes. Again, the `live` flag is used to tell PouchDB to carry on doing this indefinitely. The callback will be called whenever this finishes. For live replication, this will mean an error has occurred, like losing your connection or you canceled the replication.
 
 You should be able to open [the todo app](http://127.0.0.1:8000) in another browser and see that the two lists stay in sync with any changes you make to them. You may also want to look at your CouchDB's Futon administration page and see the populated database.
 

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -1065,7 +1065,7 @@ adapters.forEach(function (adapter) {
       return db.put(doc).then(function () {
         return db.get(doc._id);
       }).then(function (savedDoc) {
-        // We shouldnt need to delete from doc here (#4273)
+        // We shouldn't need to delete from doc here (#4273)
         should.not.exist(doc._rev);
         should.not.exist(doc._rev_tree);
 


### PR DESCRIPTION
There are small typos in:
- bin/test-browser.js
- docs/_posts/2014-11-27-testing-pouchdb.md
- docs/getting-started.md
- tests/integration/test.basics.js

Fixes:
- Should read `similar` rather than `similiar`.
- Should read `shouldn't` rather than `shouldnt`.
- Should read `separated` rather than `seperated`.
- Should read `occurred` rather than `occured`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md