### PR TITLE
Fix: replace replication suite call from www.infiniterequest.com to local down server

### DIFF
--- a/bin/down-server.js
+++ b/bin/down-server.js
@@ -1,0 +1,12 @@
+const http = require('http');
+
+const [port] = process.argv.slice(2);
+
+const server = http.createServer((request, response) => {
+  response.writeHead(500, { 'Content-Type': 'application/json' });
+  response.end('{}');
+});
+
+server.listen(port, () => {
+  console.log(`Down server listening on port ${port}`);
+});

--- a/bin/test-node.sh
+++ b/bin/test-node.sh
@@ -12,6 +12,8 @@ else
 fi
 
 if [ $TYPE = "integration" ]; then
+    node bin/down-server.js 3010 & export DOWN_SERVER_PID=$!
+
     TESTS_PATH="tests/integration/test.*.js"
 fi
 if [ $TYPE = "fuzzy" ]; then
@@ -52,3 +54,8 @@ else
     ./node_modules/.bin/istanbul check-coverage --line 100
 fi
 
+EXIT_STATUS=$?
+if [[ ! -z $DOWN_SERVER_PID ]]; then
+  kill $DOWN_SERVER_PID
+fi
+exit $EXIT_STATUS

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -11,8 +11,6 @@ if ('saucelabs' in testUtils.params()) {
   adapters = [['local', 'http'], ['http', 'local']];
 }
 
-var downAdapters = ['local'];
-
 adapters.forEach(function (adapters) {
   describe('suite2 test.replication.js-' + adapters[0] + '-' + adapters[1], function () {
 
@@ -4270,32 +4268,28 @@ adapters.forEach(function (adapters) {
 
 // This test only needs to run for one configuration, and it slows stuff
 // down
-downAdapters.map(function () {
+describe('suite2 test.replication.js-down-test', function () {
+  let dbs = {};
 
-  describe('suite2 test.replication.js-down-test', function () {
+  beforeEach(function (done) {
+    dbs.name = testUtils.adapterUrl('local', 'testdb');
+    testUtils.cleanup([dbs.name], done);
+  });
 
-    var dbs = {};
+  afterEach(function (done) {
+    testUtils.cleanup([dbs.name], done);
+  });
 
-    beforeEach(function (done) {
-      dbs.name = testUtils.adapterUrl(adapters[0], 'testdb');
-      testUtils.cleanup([dbs.name], done);
+  it('replicate from down server test', async () => {
+    const source = new PouchDB('http://127.0.0.1:3010', {
+      ajax: {timeout: 10}
     });
-
-    afterEach(function (done) {
-      testUtils.cleanup([dbs.name], done);
-    });
-
-    it('replicate from down server test', function (done) {
-      var source = new PouchDB('http://127.0.0.1:3010', {
-        ajax: {timeout: 10}
-      });
-      var target = new PouchDB(dbs.name);
-      source.replicate.to(target, function (err) {
-        should.exist(err);
-        done();
-      });
-    });
-
+    const target = new PouchDB(dbs.name);
+    try {
+      await source.replicate.to(target);
+    } catch (error) {
+      should.exist(error);
+    }
   });
 });
 

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -4286,7 +4286,7 @@ downAdapters.map(function () {
     });
 
     it('replicate from down server test', function (done) {
-      var source = new PouchDB('http://infiniterequest.com', {
+      var source = new PouchDB('http://127.0.0.1:3010', {
         ajax: {timeout: 10}
       });
       var target = new PouchDB(dbs.name);


### PR DESCRIPTION
Hello,

Currently, our Github Actions CI is failing in the following replication test: `suite2 test.replication.js-down-test`. As I understand, this test calls `www.infiniterequest.com` to receive a server error (not an infinite request as the name suggest):
![image (3)](https://user-images.githubusercontent.com/17550046/144077559-066f16bf-cc95-492d-882f-a663f5da11a8.png)


But _sometimes_ the request is successful as it redirects to a domain seller, which break our test:
![image (2)](https://user-images.githubusercontent.com/17550046/144077481-c5832e8e-14e3-4a0e-99aa-7456f1ee677a.png)

For that, we have created a local down server to test against. I also refactored the test to remove unused code and updated it to use modern JS.

Thank you