### PR TITLE
chore: upgrade ua-parser-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "tape": "4.13.0",
     "terser": "4.8.0",
     "throw-max-listeners-error": "1.0.1",
-    "ua-parser-js": "0.7.21",
+    "ua-parser-js": "0.7.24",
     "watch-glob": "0.1.3",
     "wd": "1.11.4"
   },


### PR DESCRIPTION
Hello,

We have a few dependabot alerts regarding some packages, `ua-parser-js` being one of them. These are the alerts:
https://github.com/advisories/GHSA-662x-fhqg-9p8v
https://github.com/advisories/GHSA-78cj-fxph-m83p

The only usage I have found of this package is in this [performance testing file](https://github.com/pouchdb/pouchdb/blob/master/tests/performance/perf.reporter.js#L3), so this upgrade shouldn't break anything.

Thank you