### PR TITLE
chore: remove unused dependency js-extend

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "http-server": "0.12.3",
     "istanbul": "0.4.5",
     "istanbul-coveralls": "1.0.3",
-    "js-extend": "1.0.1",
     "less": "3.9.0",
     "lodash.debounce": "4.0.8",
     "lodash.flatten": "4.4.0",


### PR DESCRIPTION
Hello,

We have a few dependabot alerts regarding some packages, `js-extend` being one of them. https://github.com/advisories/GHSA-mh82-55cm-6gfh

I've found out that we are not using the package anyways, as its usage was replaced with `Object.assign`
[in this commit](https://github.com/pouchdb/pouchdb/commit/b325846d23d264121b80ead3f5e7b7567b56b538) (related [PR here](https://github.com/pouchdb/pouchdb/issues/6012)). 

Thank you
