### PR TITLE
fix: add auto_compaction to indexeddb bulkDocs

### DIFF
--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
@@ -15,7 +15,7 @@ import {
 
 import { parseDoc } from 'pouchdb-adapter-utils';
 import { binaryMd5 as md5 } from 'pouchdb-md5';
-import { winningRev as calculateWinningRev, merge } from 'pouchdb-merge';
+import { winningRev as calculateWinningRev, merge, compactTree } from 'pouchdb-merge';
 
 import { DOC_STORE, META_STORE, idbError } from './util';
 
@@ -33,6 +33,7 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
 
   var revsLimit = dbOpts.revs_limit || 1000;
   var rewriteEnabled = dbOpts.name.indexOf("-mrview-") === -1;
+  const autoCompaction = dbOpts.auto_compaction;
 
   // We only need to track 1 revision for local documents
   function docsRevsLimit(doc) {
@@ -190,6 +191,8 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
 
     var theDoc = doc.revs[winningRev].data;
 
+    const isNewDoc = doc.isNewDoc;
+
     if (rewriteEnabled) {
       // doc.data is what we index, so we need to clone and rewrite it, and clean
       // it up for indexability
@@ -228,9 +231,19 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
 
     // If there have been revisions stemmed when merging trees,
     // delete their data
-    if (doc.stemmedRevs) {
-      doc.stemmedRevs.forEach(function (rev) { delete doc.revs[rev]; });
+    let revsToDelete = doc.stemmedRevs || [];
+
+    if (autoCompaction && !isNewDoc) {
+      const result = compactTree(doc);
+      if (result.length) {
+        revsToDelete = revsToDelete.concat(result);
+      }
     }
+
+    if (revsToDelete.length) {
+      revsToDelete.forEach(function (rev) { delete doc.revs[rev]; });
+    }
+
     delete doc.stemmedRevs;
 
     if (!('attachments' in doc)) {


### PR DESCRIPTION
We noticed this functionality was missing in the `indexeddb` adapter. We have also added a test.

Thanks