### PR TITLE
feat: add retries to failed jobs in gha ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,17 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           couchdb-version: ${{ matrix.couchdb }}
-      - run: ${{ matrix.cmd }}
+      - id: test
+        run: ${{ matrix.cmd }}
+        continue-on-error: true
+      - name: First retry
+        id: retry
+        if: steps.test.outcome == 'failure'
+        run: ${{ matrix.cmd }}
+        continue-on-error: true
+      - name: Second retry
+        if: steps.retry.outcome == 'failure'
+        run: ${{ matrix.cmd }}
 
   # Run the integration, find and mapreduce tests against CouchDB in the
   # browser. This should be run against every version of CouchDB we support and
@@ -92,7 +102,17 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           couchdb-version: ${{ matrix.couchdb }}
-      - run: ${{ matrix.cmd }}
+      - id: test
+        run: ${{ matrix.cmd }}
+        continue-on-error: true
+      - name: First retry
+        id: retry
+        if: steps.test.outcome == 'failure'
+        run: ${{ matrix.cmd }}
+        continue-on-error: true
+      - name: Second retry
+        if: steps.retry.outcome == 'failure'
+        run: ${{ matrix.cmd }}
 
   # Run the integration, find and mapreduce tests against all the Node.js
   # PouchDB adapters. This should be run for every adapter on every version of
@@ -118,7 +138,17 @@ jobs:
       - uses: ./.github/actions/install-deps
         with:
           node-version: ${{ matrix.node }}
-      - run: ${{ matrix.cmd }}
+      - id: test
+        run: ${{ matrix.cmd }}
+        continue-on-error: true
+      - name: First retry
+        id: retry
+        if: steps.test.outcome == 'failure'
+        run: ${{ matrix.cmd }}
+        continue-on-error: true
+      - name: Second retry
+        if: steps.retry.outcome == 'failure'
+        run: ${{ matrix.cmd }}
 
   # Run the integration, find and mapreduce tests against all the browser-based
   # adapters. PouchDB adapters. This should be run for every adapter on every
@@ -151,7 +181,17 @@ jobs:
       - uses: ./.github/actions/install-deps
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - run: ${{ matrix.cmd }}
+      - id: test
+        run: ${{ matrix.cmd }}
+        continue-on-error: true
+      - name: First retry
+        id: retry
+        if: steps.test.outcome == 'failure'
+        run: ${{ matrix.cmd }}
+        continue-on-error: true
+      - name: Second retry
+        if: steps.retry.outcome == 'failure'
+        run: ${{ matrix.cmd }}
 
   # Run the integration, find and mapreduce tests using pouchdb-server as the
   # remote adapter. This checks that pouchdb-server works with the current
@@ -184,7 +224,17 @@ jobs:
       - uses: ./.github/actions/install-deps
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - run: ${{ matrix.cmd }}
+      - id: test
+        run: ${{ matrix.cmd }}
+        continue-on-error: true
+      - name: First retry
+        id: retry
+        if: steps.test.outcome == 'failure'
+        run: ${{ matrix.cmd }}
+        continue-on-error: true
+      - name: Second retry
+        if: steps.retry.outcome == 'failure'
+        run: ${{ matrix.cmd }}
 
   # Run all the other testing tasks -- unit tests, and so on. These should be
   # run on every version of Node.js that we support.
@@ -210,4 +260,14 @@ jobs:
       - uses: ./.github/actions/install-deps
         with:
           node-version: ${{ matrix.node }}
-      - run: ${{ matrix.cmd }}
+      - id: test
+        run: ${{ matrix.cmd }}
+        continue-on-error: true
+      - name: First retry
+        id: retry
+        if: steps.test.outcome == 'failure'
+        run: ${{ matrix.cmd }}
+        continue-on-error: true
+      - name: Second retry
+        if: steps.retry.outcome == 'failure'
+        run: ${{ matrix.cmd }}


### PR DESCRIPTION
We have been experiencing many flaky tests in our runs, an unknown cause for now. We have added two retry steps. Ideally, we should turn these steps into a composite action to avoid repetition but at the moment [it does not support](https://github.com/actions/runner/issues/1457) the `continue-on-error` property.

Thanks!