### PR TITLE
activeTasks API

### DIFF
--- a/docs/_includes/api.html
+++ b/docs/_includes/api.html
@@ -25,6 +25,7 @@
 <li><a href="#bulk_get">Bulk get</a></li>
 <li><a href="#close_database">Close database</a></li>
 <li><a href="#events">Events</a></li>
+<li><a href="#active_tasks">Active tasks</a></li>
 <li><a href="#defaults">Default settings</a></li>
 <li><a href="#plugins">Plugins</a></li>
 <li><a href="#debug_mode">Debug mode</a></li>

--- a/docs/_includes/api/active_tasks.html
+++ b/docs/_includes/api/active_tasks.html
@@ -1,0 +1,45 @@
+{% include anchor.html edit="true" title="List active tasks" hash="active_tasks" %}
+
+{% highlight js %}
+PouchDB.activeTasks.list()
+{% endhighlight %}
+
+List all active database tasks. There are three types of internal tasks: `database_compaction`, `view_indexing`, and `replication`. PouchDB will report progress of these tasks to the active tasks API and remove tasks as soon as they are completed or have failed.
+
+#### Example Usage:
+
+{% highlight js %}
+var tasks = PouchDB.activeTasks.list()
+{% endhighlight %}
+
+#### Example Result:
+
+{% highlight js %}
+[{
+  "id": "d81fea92-8ce4-42df-bb2b-89a4e67536c3",
+  "name": "database_compaction",
+  "created_at": "2022-02-08T15:38:45.318Z",
+  "total_items": 12,
+  "completed_items": 1,
+  "updated_at": "2022-02-08T15:38:45.821Z"
+}]
+{% endhighlight %}
+
+### Real-time updates
+
+You can use [JavaScript Proxies](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) to monitor calls to the active tasks API. For the `PouchDB.activeTasks.add()` function, which is used internally to announce new tasks to PouchDB, you can monitor calls as follows:
+
+{% highlight js %}
+PouchDB.activeTasks.add = new Proxy(PouchDB.activeTasks.add, {
+  apply: (target, thisArg, argumentsList) => {
+    const task = argumentsList[0];
+    const id = Reflect.apply(
+      target,
+      PouchDB.activeTasks,
+      [task]
+    );
+    console.log('Added task', id, task.name);
+    return id;
+  },
+});
+{% endhighlight %}

--- a/docs/api.html
+++ b/docs/api.html
@@ -34,6 +34,7 @@ edit: false
 {% include api/bulk_get.html %}
 {% include api/close_database.html %}
 {% include api/events.html %}
+{% include api/active_tasks.html %}
 {% include api/defaults.html %}
 {% include api/plugins.html %}
 

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -491,6 +491,8 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
     // bind the emit function once
     var mapResults;
     var doc;
+    var taskId;
+
 
     function emit(key, value) {
       var output = {id: doc._id, key: normalizeKey(key)};
@@ -505,6 +507,15 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
     var mapFun = mapper(view.mapFun, emit);
 
     var currentSeq = view.seq || 0;
+
+    function createTask() {
+      return view.sourceDB.info().then(function (info) {
+        taskId = view.sourceDB.activeTasks.add({
+          name: 'view_indexing',
+          total_items: info.update_seq - currentSeq,
+        });
+      });
+    }
 
     function processChange(docIdsToChangesAndEmits, seq) {
       return function () {
@@ -548,8 +559,10 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
         indexed_docs: indexed_docs
       };
       view.sourceDB.emit('indexing', progress);
-      
+      view.sourceDB.activeTasks.update(taskId, {completed_items: indexed_docs});
+
       if (results.length < opts.changes_batch_size) {
+        view.sourceDB.activeTasks.remove(taskId);
         return;
       }
       return processNextBatch();
@@ -594,7 +607,9 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       return indexableKeysToKeyValues;
     }
 
-    return processNextBatch().then(function () {
+    return createTask().then(function () {
+      return processNextBatch();
+    }).then(function () {
       return queue.finish();
     }).then(function () {
       view.seq = currentSeq;

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -562,7 +562,6 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       view.sourceDB.activeTasks.update(taskId, {completed_items: indexed_docs});
 
       if (results.length < opts.changes_batch_size) {
-        view.sourceDB.activeTasks.remove(taskId);
         return;
       }
       return processNextBatch();
@@ -613,6 +612,9 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       return queue.finish();
     }).then(function () {
       view.seq = currentSeq;
+      view.sourceDB.activeTasks.remove(taskId);
+    }).catch(function (err) {
+      view.sourceDB.activeTasks.remove(taskId, err);
     });
   }
 

--- a/packages/node_modules/pouchdb-core/src/active-tasks.js
+++ b/packages/node_modules/pouchdb-core/src/active-tasks.js
@@ -1,0 +1,48 @@
+import {v4 as uuidv4} from "uuid";
+
+export default class ActiveTasks {
+  constructor() {
+    this.tasks = {};
+  }
+
+  list() {
+    return Object.values(this.tasks);
+  }
+
+  add(task) {
+    const id = uuidv4();
+    this.tasks[id] = {
+      id,
+      name: task.name,
+      total_items: task.total_items,
+      created_at: new Date().toJSON()
+    };
+    return id;
+  }
+
+  get(id) {
+    return this.tasks[id];
+  }
+
+  /* eslint-disable no-unused-vars */
+  remove(id, reason) {
+    delete this.tasks[id];
+    return this.tasks;
+  }
+
+  update(id, updatedTask) {
+    const task = this.tasks[id];
+    if (typeof task !== 'undefined') {
+      const mergedTask = {
+        id: task.id,
+        name: task.name,
+        created_at: task.created_at,
+        total_items: updatedTask.total_items || task.total_items,
+        completed_items: updatedTask.completed_items || task.completed_items,
+        updated_at: new Date().toJSON()
+      };
+      this.tasks[id] = mergedTask;
+    }
+    return this.tasks;
+  }
+}

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -210,15 +210,15 @@ class AbstractPouchDB extends EventEmitter {
       } else {
         putDoc(cb);
       }
-    
+
       function transformForceOptionToNewEditsOption() {
         var parts = doc._rev.split('-');
         var oldRevId = parts[1];
         var oldRevNum = parseInt(parts[0], 10);
-    
+
         var newRevNum = oldRevNum + 1;
         var newRevId = rev();
-    
+
         doc._revisions = {
           start: newRevNum,
           ids: [newRevId, oldRevId]
@@ -336,21 +336,21 @@ class AbstractPouchDB extends EventEmitter {
         opts = {};
       }
       var ids = Object.keys(req);
-    
+
       if (!ids.length) {
         return callback(null, {});
       }
-    
+
       var count = 0;
       var missing = new Map();
-    
+
       function addToMissing(id, revId) {
         if (!missing.has(id)) {
           missing.set(id, {missing: []});
         }
         missing.get(id).missing.push(revId);
       }
-    
+
       function processDoc(id, rev_tree) {
         // Is this fast enough? Maybe we should switch to a set simulated by a map
         var missingForId = req[id].slice(0);
@@ -361,21 +361,21 @@ class AbstractPouchDB extends EventEmitter {
             if (idx === -1) {
               return;
             }
-    
+
             missingForId.splice(idx, 1);
             /* istanbul ignore if */
             if (opts.status !== 'available') {
               addToMissing(id, rev);
             }
           });
-    
+
         // Traversing the tree is synchronous, so now `missingForId` contains
         // revisions that were not found in the tree
         missingForId.forEach(function (rev) {
           addToMissing(id, rev);
         });
       }
-    
+
       ids.map(function (id) {
         this._getRevisionTree(id, function (err, rev_tree) {
           if (err && err.status === 404 && err.message === 'missing') {
@@ -386,7 +386,7 @@ class AbstractPouchDB extends EventEmitter {
           } else {
             processDoc(id, rev_tree);
           }
-    
+
           if (++count === ids.length) {
             // convert LazyMap to object
             var missingObj = {};
@@ -427,7 +427,7 @@ class AbstractPouchDB extends EventEmitter {
             candidates.push(rev);
           }
         });
-    
+
         traverseRevTree(revTree, function (isLeaf, pos, revHash, ctx, opts) {
           var rev = pos + '-' + revHash;
           if (opts.status === 'available' && candidates.indexOf(rev) !== -1) {
@@ -445,9 +445,9 @@ class AbstractPouchDB extends EventEmitter {
         callback = opts;
         opts = {};
       }
-    
+
       opts = opts || {};
-    
+
       this._compactionQueue = this._compactionQueue || [];
       this._compactionQueue.push({opts: opts, callback: callback});
       if (this._compactionQueue.length === 1) {
@@ -468,7 +468,7 @@ class AbstractPouchDB extends EventEmitter {
         return this._getLocal(id, cb);
       }
       var leaves = [];
-    
+
       const finishOpenRevs = () => {
         var result = [];
         var count = leaves.length;
@@ -476,7 +476,7 @@ class AbstractPouchDB extends EventEmitter {
         if (!count) {
           return cb(null, result);
         }
-    
+
         // order with open_revs is unspecified
         leaves.forEach((leaf) => {
           this.get(id, {
@@ -508,7 +508,7 @@ class AbstractPouchDB extends EventEmitter {
           });
         });
       };
-    
+
       if (opts.open_revs) {
         if (opts.open_revs === "all") {
           this._getRevisionTree(id, function (err, rev_tree) {
@@ -538,60 +538,60 @@ class AbstractPouchDB extends EventEmitter {
         }
         return; // open_revs does not like other options
       }
-    
+
       return this._get(id, opts, (err, result) => {
         if (err) {
           err.docId = id;
           return cb(err);
         }
-    
+
         var doc = result.doc;
         var metadata = result.metadata;
         var ctx = result.ctx;
-    
+
         if (opts.conflicts) {
           var conflicts = collectConflicts(metadata);
           if (conflicts.length) {
             doc._conflicts = conflicts;
           }
         }
-    
+
         if (isDeleted(metadata, doc._rev)) {
           doc._deleted = true;
         }
-    
+
         if (opts.revs || opts.revs_info) {
           var splittedRev = doc._rev.split('-');
           var revNo       = parseInt(splittedRev[0], 10);
           var revHash     = splittedRev[1];
-    
+
           var paths = rootToLeaf(metadata.rev_tree);
           var path = null;
-    
+
           for (var i = 0; i < paths.length; i++) {
             var currentPath = paths[i];
             var hashIndex = currentPath.ids.map(function (x) { return x.id; })
               .indexOf(revHash);
             var hashFoundAtRevPos = hashIndex === (revNo - 1);
-    
+
             if (hashFoundAtRevPos || (!path && hashIndex !== -1)) {
               path = currentPath;
             }
           }
-    
+
           /* istanbul ignore if */
           if (!path) {
             err = new Error('invalid rev tree');
             err.docId = id;
             return cb(err);
           }
-    
+
           var indexOfRev = path.ids.map(function (x) { return x.id; })
             .indexOf(doc._rev.split('-')[1]) + 1;
           var howMany = path.ids.length - indexOfRev;
           path.ids.splice(indexOfRev, howMany);
           path.ids.reverse();
-    
+
           if (opts.revs) {
             doc._revisions = {
               start: (path.pos + path.ids.length) - 1,
@@ -611,7 +611,7 @@ class AbstractPouchDB extends EventEmitter {
             });
           }
         }
-    
+
         if (opts.attachments && doc._attachments) {
           var attachments = doc._attachments;
           var count = Object.keys(attachments).length;
@@ -707,7 +707,7 @@ class AbstractPouchDB extends EventEmitter {
           }
         }
       }
-    
+
       return this._allDocs(opts, callback);
     }).bind(this);
 
@@ -739,25 +739,25 @@ class AbstractPouchDB extends EventEmitter {
         callback = opts;
         opts = {};
       }
-    
+
       opts = opts || {};
-    
+
       if (Array.isArray(req)) {
         req = {
           docs: req
         };
       }
-    
+
       if (!req || !req.docs || !Array.isArray(req.docs)) {
         return callback(createError(MISSING_BULK_DOCS));
       }
-    
+
       for (var i = 0; i < req.docs.length; ++i) {
         if (typeof req.docs[i] !== 'object' || Array.isArray(req.docs[i])) {
           return callback(createError(NOT_AN_OBJECT));
         }
       }
-    
+
       var attachmentError;
       req.docs.forEach(function (doc) {
         if (doc._attachments) {
@@ -769,11 +769,11 @@ class AbstractPouchDB extends EventEmitter {
           });
         }
       });
-    
+
       if (attachmentError) {
         return callback(createError(BAD_REQUEST, attachmentError));
       }
-    
+
       if (!('new_edits' in opts)) {
         if ('new_edits' in req) {
           opts.new_edits = req.new_edits;
@@ -781,23 +781,23 @@ class AbstractPouchDB extends EventEmitter {
           opts.new_edits = true;
         }
       }
-    
+
       var adapter = this;
       if (!opts.new_edits && !isRemote(adapter)) {
         // ensure revisions of the same doc are sorted, so that
         // the local adapter processes them correctly (#2935)
         req.docs.sort(compareByIdThenRev);
       }
-    
+
       cleanDocs(req.docs);
-    
+
       // in the case of conflicts, we want to return the _ids to the user
       // however, the underlying adapter may destroy the docs array, so
       // create a copy here
       var ids = req.docs.map(function (doc) {
         return doc._id;
       });
-    
+
       return this._bulkDocs(req, opts, function (err, res) {
         if (err) {
           return callback(err);
@@ -814,7 +814,7 @@ class AbstractPouchDB extends EventEmitter {
             res[i].id = res[i].id || ids[i];
           }
         }
-    
+
         callback(null, res);
       });
     }).bind(this);
@@ -824,7 +824,7 @@ class AbstractPouchDB extends EventEmitter {
       if (this.__opts.view_adapter) {
         dbOptions.adapter = this.__opts.view_adapter;
       }
-    
+
       var depDB = new this.constructor(dependentDb, dbOptions);
 
       function diffFun(doc) {
@@ -846,9 +846,9 @@ class AbstractPouchDB extends EventEmitter {
         callback = opts;
         opts = {};
       }
-    
+
       var usePrefix = 'use_prefix' in this ? this.use_prefix : true;
-    
+
       const destroyDb = () => {
         // call destroy method of the particular adaptor
         this._destroy(opts, (err, resp) => {
@@ -860,12 +860,12 @@ class AbstractPouchDB extends EventEmitter {
           callback(null, resp || { 'ok': true });
         });
       };
-    
+
       if (isRemote(this)) {
         // no need to check for dependent DBs if it's a remote DB
         return destroyDb();
       }
-    
+
       this.get('_local/_pouch_dependentDbs', (err, localDoc) => {
         if (err) {
           /* istanbul ignore if */
@@ -895,14 +895,21 @@ class AbstractPouchDB extends EventEmitter {
       last_seq: opts.last_seq || 0
     };
     var promises = [];
-  
+
+    var taskId;
+    var compactedDocs = 0;
+
     const onChange = (row) => {
+      this.activeTasks.update(taskId, {
+        completed_items: ++compactedDocs
+      });
       promises.push(this.compactDocument(row.id, 0));
     };
     const onComplete = (resp) => {
       var lastSeq = resp.last_seq;
       Promise.all(promises).then(() => {
-        return upsert(this, '_local/compaction', function deltaFunc(doc) {
+        return upsert(this, '_local/compaction', (doc) => {
+          this.activeTasks.remove(taskId);
           if (!doc.last_seq || doc.last_seq < lastSeq) {
             doc.last_seq = lastSeq;
             return doc;
@@ -913,10 +920,18 @@ class AbstractPouchDB extends EventEmitter {
         callback(null, {ok: true});
       }).catch(callback);
     };
-    this.changes(changesOpts)
-      .on('change', onChange)
-      .on('complete', onComplete)
-      .on('error', callback);
+
+    this.info().then((info) => {
+      taskId = this.activeTasks.add({
+        name: 'database_compaction',
+        total_items: info.update_seq - changesOpts.last_seq,
+      });
+
+      this.changes(changesOpts)
+        .on('change', onChange)
+        .on('complete', onComplete)
+        .on('error', callback);
+    });
   }
 
   changes(opts, callback) {
@@ -924,20 +939,20 @@ class AbstractPouchDB extends EventEmitter {
       callback = opts;
       opts = {};
     }
-  
+
     opts = opts || {};
-  
+
     // By default set return_docs to false if the caller has opts.live = true,
     // this will prevent us from collecting the set of changes indefinitely
     // resulting in growing memory
     opts.return_docs = ('return_docs' in opts) ? opts.return_docs : !opts.live;
-  
+
     return new Changes(this, opts, callback);
   }
 
   type() {
     return (typeof this._type === 'function') ? this._type() : this.adapter;
   }
-}  
+}
 
 export default AbstractPouchDB;

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -905,20 +905,24 @@ class AbstractPouchDB extends EventEmitter {
       });
       promises.push(this.compactDocument(row.id, 0));
     };
+    const onError = (err) => {
+      this.activeTasks.remove(taskId, err);
+      callback(err);
+    };
     const onComplete = (resp) => {
       var lastSeq = resp.last_seq;
       Promise.all(promises).then(() => {
         return upsert(this, '_local/compaction', (doc) => {
-          this.activeTasks.remove(taskId);
           if (!doc.last_seq || doc.last_seq < lastSeq) {
             doc.last_seq = lastSeq;
             return doc;
           }
           return false; // somebody else got here first, don't update
         });
-      }).then(function () {
+      }).then(() => {
+        this.activeTasks.remove(taskId);
         callback(null, {ok: true});
-      }).catch(callback);
+      }).catch(onError);
     };
 
     this.info().then((info) => {
@@ -930,7 +934,7 @@ class AbstractPouchDB extends EventEmitter {
       this.changes(changesOpts)
         .on('change', onChange)
         .on('complete', onComplete)
-        .on('error', callback);
+        .on('error', onError);
     });
   }
 

--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -123,7 +123,7 @@ PouchDB.fetch = function (url, opts) {
 };
 
 function ActiveTasks() {
-  this.tasks = [];
+  this.tasks = {};
 }
 
 ActiveTasks.prototype.list = function () {
@@ -131,47 +131,37 @@ ActiveTasks.prototype.list = function () {
 };
 
 ActiveTasks.prototype.add = function (task) {
-  var newTask = {
+  var id = uuidv4();
+  this.tasks[id] = {
+    id,
     name: task.name,
     total_items: task.total_items,
-    id: uuidv4(),
     createdAt: new Date().toJSON()
   };
-  this.tasks.push(newTask);
-  return newTask.id;
+  return id;
 };
 
 ActiveTasks.prototype.get = function (id) {
-  var index = this.tasks.findIndex(function (task) {
-    return task.id === id;
-  });
-  return this.tasks[index];
+  return this.tasks[id];
 };
 
 ActiveTasks.prototype.remove = function (id) {
-  var index = this.tasks.findIndex(function (task) {
-    return task.id === id;
-  });
-  if (index !== -1) {
-    this.tasks.splice(index, 1);
-  }
+  delete this.tasks[id];
   return this.tasks;
 };
 
 ActiveTasks.prototype.update = function (id, updatedTask) {
-  var index = this.tasks.findIndex(function (task) {
-    return task.id === id;
-  });
-  if (index !== -1) {
+  var task = this.tasks[id];
+  if (typeof task !== 'undefined') {
     var mergedTask = {
-      id: this.tasks[index].id,
-      name: this.tasks[index].name,
-      createdAt: this.tasks[index].createdAt,
-      total_items: updatedTask.total_items || this.tasks[index].total_items,
-      completed_items: updatedTask.completed_items || this.tasks[index].completed_items,
+      id: task.id,
+      name: task.name,
+      createdAt: task.createdAt,
+      total_items: updatedTask.total_items || task.total_items,
+      completed_items: updatedTask.completed_items || task.completed_items,
       updatedAt: new Date().toJSON()
     };
-    this.tasks.splice(index, 1, mergedTask);
+    this.tasks[id] = mergedTask;
   }
   return this.tasks;
 };

--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -1,9 +1,9 @@
 'use strict';
 
 import PouchDB from './constructor';
-import { v4 as uuidv4 } from 'uuid';
 import EE from 'events';
 import { fetch } from 'pouchdb-fetch';
+import ActiveTasks from './active-tasks';
 import { createClass } from './utils';
 
 PouchDB.adapters = {};
@@ -122,52 +122,6 @@ PouchDB.fetch = function (url, opts) {
   return fetch(url, opts);
 };
 
-function ActiveTasks() {
-  this.tasks = {};
-}
-
-ActiveTasks.prototype.list = function () {
-  return Object.values(this.tasks);
-};
-
-ActiveTasks.prototype.add = function (task) {
-  var id = uuidv4();
-  this.tasks[id] = {
-    id,
-    name: task.name,
-    total_items: task.total_items,
-    created_at: new Date().toJSON()
-  };
-  return id;
-};
-
-ActiveTasks.prototype.get = function (id) {
-  return this.tasks[id];
-};
-
-/* eslint-disable no-unused-vars */
-ActiveTasks.prototype.remove = function (id, reason) {
-  delete this.tasks[id];
-  return this.tasks;
-};
-
-ActiveTasks.prototype.update = function (id, updatedTask) {
-  var task = this.tasks[id];
-  if (typeof task !== 'undefined') {
-    var mergedTask = {
-      id: task.id,
-      name: task.name,
-      created_at: task.created_at,
-      total_items: updatedTask.total_items || task.total_items,
-      completed_items: updatedTask.completed_items || task.completed_items,
-      updated_at: new Date().toJSON()
-    };
-    this.tasks[id] = mergedTask;
-  }
-  return this.tasks;
-};
-
-PouchDB.activeTasks = new ActiveTasks();
-PouchDB.prototype.activeTasks = PouchDB.activeTasks;
+PouchDB.prototype.activeTasks = PouchDB.activeTasks = new ActiveTasks();
 
 export default PouchDB;

--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -167,5 +167,6 @@ ActiveTasks.prototype.update = function (id, updatedTask) {
 };
 
 PouchDB.activeTasks = new ActiveTasks();
+PouchDB.prototype.activeTasks = PouchDB.activeTasks;
 
 export default PouchDB;

--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -127,7 +127,7 @@ function ActiveTasks() {
 }
 
 ActiveTasks.prototype.list = function () {
-  return this.tasks;
+  return Object.values(this.tasks);
 };
 
 ActiveTasks.prototype.add = function (task) {

--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import PouchDB from './constructor';
+import { v4 as uuidv4 } from 'uuid';
 import EE from 'events';
 import { fetch } from 'pouchdb-fetch';
 import { createClass } from './utils';
@@ -120,5 +121,61 @@ PouchDB.defaults = function (defaultOpts) {
 PouchDB.fetch = function (url, opts) {
   return fetch(url, opts);
 };
+
+function ActiveTasks() {
+  this.tasks = [];
+}
+
+ActiveTasks.prototype.list = function () {
+  return this.tasks;
+};
+
+ActiveTasks.prototype.add = function (task) {
+  var newTask = {
+    name: task.name,
+    total_items: task.total_items,
+    id: uuidv4(),
+    createdAt: new Date().toJSON()
+  };
+  this.tasks.push(newTask);
+  return newTask.id;
+};
+
+ActiveTasks.prototype.get = function (id) {
+  var index = this.tasks.findIndex(function (task) {
+    return task.id === id;
+  });
+  return this.tasks[index];
+};
+
+ActiveTasks.prototype.remove = function (id) {
+  var index = this.tasks.findIndex(function (task) {
+    return task.id === id;
+  });
+  if (index !== -1) {
+    this.tasks.splice(index, 1);
+  }
+  return this.tasks;
+};
+
+ActiveTasks.prototype.update = function (id, updatedTask) {
+  var index = this.tasks.findIndex(function (task) {
+    return task.id === id;
+  });
+  if (index !== -1) {
+    var mergedTask = {
+      id: this.tasks[index].id,
+      name: this.tasks[index].name,
+      createdAt: this.tasks[index].createdAt,
+      total_items: updatedTask.total_items || this.tasks[index].total_items,
+      completed_items: updatedTask.completed_items || this.tasks[index].completed_items,
+      updatedAt: new Date().toJSON()
+    };
+    this.tasks.splice(index, 1, mergedTask);
+  }
+  return this.tasks;
+};
+
+PouchDB.activeTasks = new ActiveTasks();
 
 export default PouchDB;

--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -145,7 +145,8 @@ ActiveTasks.prototype.get = function (id) {
   return this.tasks[id];
 };
 
-ActiveTasks.prototype.remove = function (id) {
+/* eslint-disable no-unused-vars */
+ActiveTasks.prototype.remove = function (id, reason) {
   delete this.tasks[id];
   return this.tasks;
 };

--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -136,7 +136,7 @@ ActiveTasks.prototype.add = function (task) {
     id,
     name: task.name,
     total_items: task.total_items,
-    createdAt: new Date().toJSON()
+    created_at: new Date().toJSON()
   };
   return id;
 };
@@ -156,10 +156,10 @@ ActiveTasks.prototype.update = function (id, updatedTask) {
     var mergedTask = {
       id: task.id,
       name: task.name,
-      createdAt: task.createdAt,
+      created_at: task.created_at,
       total_items: updatedTask.total_items || task.total_items,
       completed_items: updatedTask.completed_items || task.completed_items,
-      updatedAt: new Date().toJSON()
+      updated_at: new Date().toJSON()
     };
     this.tasks[id] = mergedTask;
   }

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -137,20 +137,19 @@ function replicate(src, target, opts, returnValue, result) {
     }
     writingCheckpoint = true;
 
-    var task = src.activeTasks.get(taskId);
-    if (task) {
-      src.info().then(function (info) {
-        if (!currentBatch) {
-          return;
-        }
-        var completed = task.completed_items || 0;
-        var total_items = info.update_seq - initial_last_seq;
-        src.activeTasks.update(taskId, {
-          completed_items: completed + currentBatch.changes.length,
-          total_items
-        });
+    src.info().then(function (info) {
+      var task = src.activeTasks.get(taskId);
+      if (!currentBatch || !task) {
+        return;
+      }
+
+      var completed = task.completed_items || 0;
+      var total_items = info.update_seq - initial_last_seq;
+      src.activeTasks.update(taskId, {
+        completed_items: completed + currentBatch.changes.length,
+        total_items
       });
-    }
+    });
 
     return checkpointer.writeCheckpoint(currentBatch.seq,
         session).then(function () {

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -140,6 +140,9 @@ function replicate(src, target, opts, returnValue, result) {
     var task = src.activeTasks.get(taskId);
     if (task) {
       src.info().then(function (info) {
+        if (!currentBatch) {
+          return;
+        }
         var completed = task.completed_items || 0;
         var total_items = info.update_seq - initial_last_seq;
         src.activeTasks.update(taskId, {

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -290,10 +290,7 @@ function replicate(src, target, opts, returnValue, result) {
     result.last_seq = last_seq;
     replicationCompleted = true;
 
-    // TODO fix in relation to continuous/live replication when taskId is undefined
-    if (taskId) {
-      src.activeTasks.remove(taskId);
-    }
+    src.activeTasks.remove(taskId, fatalError);
 
     if (fatalError) {
       // need to extend the error because Firefox considers ".result" read-only

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -29,6 +29,7 @@ function replicate(src, target, opts, returnValue, result) {
   var changedDocs = [];
   // Like couchdb, every replication gets a unique session id
   var session = uuid();
+  var taskId;
 
   result = result || {
     ok: true,
@@ -131,6 +132,16 @@ function replicate(src, target, opts, returnValue, result) {
       returnValue.emit('change', outResult);
     }
     writingCheckpoint = true;
+
+    // TODO fix in relation to continuous/live replication when taskId is undefined
+    var task = src.activeTasks.get(taskId);
+    if (task) {
+      var completed = task.completed_items || 0;
+      src.activeTasks.update(taskId, {
+        completed_items: completed + currentBatch.changes.length
+      });
+    }
+
     return checkpointer.writeCheckpoint(currentBatch.seq,
         session).then(function () {
       returnValue.emit('checkpoint', { 'checkpoint': currentBatch.seq });
@@ -272,6 +283,11 @@ function replicate(src, target, opts, returnValue, result) {
     result.last_seq = last_seq;
     replicationCompleted = true;
 
+    // TODO fix in relation to continuous/live replication when taskId is undefined
+    if (taskId) {
+      src.activeTasks.remove(taskId);
+    }
+
     if (fatalError) {
       // need to extend the error because Firefox considers ".result" read-only
       fatalError = createError(fatalError);
@@ -293,7 +309,6 @@ function replicate(src, target, opts, returnValue, result) {
     }
   }
 
-
   function onChange(change, pending, lastSeq) {
     /* istanbul ignore if */
     if (returnValue.cancelled) {
@@ -307,6 +322,13 @@ function replicate(src, target, opts, returnValue, result) {
 
     var filter = filterChange(opts)(change);
     if (!filter) {
+      // update processed items count by 1
+      if (taskId) {
+        var task = src.activeTasks.get(taskId);
+        // we can assume that task exists here? shouldn't be deleted by here.
+        var completed = task.completed_items || 0;
+        src.activeTasks.update(taskId, { completed_items: ++completed });
+      }
       return;
     }
     pendingBatch.seq = change.seq || lastSeq;
@@ -405,6 +427,24 @@ function replicate(src, target, opts, returnValue, result) {
     }
   }
 
+  function createTask(checkpoint) {
+    if (continuous) {
+      return Promise.resolve(checkpoint);
+    }
+
+    return src.info().then(function (info) {
+      var total_items = typeof opts.since === 'undefined' ?
+        info.update_seq - checkpoint :
+        info.update_seq;
+
+      taskId = src.activeTasks.add({
+        name: 'replication',
+        total_items,
+      });
+
+      return checkpoint;
+    });
+  }
 
   function startChanges() {
     initCheckpointer().then(function () {
@@ -413,7 +453,7 @@ function replicate(src, target, opts, returnValue, result) {
         completeReplication();
         return;
       }
-      return checkpointer.getCheckpoint().then(function (checkpoint) {
+      return checkpointer.getCheckpoint().then(createTask).then(function (checkpoint) {
         last_seq = checkpoint;
         changesOpts = {
           since: last_seq,

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -16,6 +16,10 @@ function replicate(src, target, opts, returnValue, result) {
   var writingCheckpoint = false;  // true while checkpoint is being written
   var changesCompleted = false;   // true when all changes received
   var replicationCompleted = false; // true when replication has completed
+  // initial_last_seq is the state of the source db before
+  // replication started, and it is _not_ updated during
+  // replication or used anywhere else, as opposed to last_seq
+  var initial_last_seq = 0;
   var last_seq = 0;
   var continuous = opts.continuous || opts.live || false;
   var batch_size = opts.batch_size || 100;
@@ -133,12 +137,15 @@ function replicate(src, target, opts, returnValue, result) {
     }
     writingCheckpoint = true;
 
-    // TODO fix in relation to continuous/live replication when taskId is undefined
     var task = src.activeTasks.get(taskId);
     if (task) {
-      var completed = task.completed_items || 0;
-      src.activeTasks.update(taskId, {
-        completed_items: completed + currentBatch.changes.length
+      src.info().then(function (info) {
+        var completed = task.completed_items || 0;
+        var total_items = info.update_seq - initial_last_seq;
+        src.activeTasks.update(taskId, {
+          completed_items: completed + currentBatch.changes.length,
+          total_items
+        });
       });
     }
 
@@ -323,11 +330,11 @@ function replicate(src, target, opts, returnValue, result) {
     var filter = filterChange(opts)(change);
     if (!filter) {
       // update processed items count by 1
-      if (taskId) {
-        var task = src.activeTasks.get(taskId);
+      var task = src.activeTasks.get(taskId);
+      if (task) {
         // we can assume that task exists here? shouldn't be deleted by here.
         var completed = task.completed_items || 0;
-        src.activeTasks.update(taskId, { completed_items: ++completed });
+        src.activeTasks.update(taskId, {completed_items: ++completed});
       }
       return;
     }
@@ -428,17 +435,13 @@ function replicate(src, target, opts, returnValue, result) {
   }
 
   function createTask(checkpoint) {
-    if (continuous) {
-      return Promise.resolve(checkpoint);
-    }
-
     return src.info().then(function (info) {
       var total_items = typeof opts.since === 'undefined' ?
         info.update_seq - checkpoint :
         info.update_seq;
 
       taskId = src.activeTasks.add({
-        name: 'replication',
+        name: `${continuous ? 'continuous ' : ''}replication from ${info.db_name}` ,
         total_items,
       });
 
@@ -455,6 +458,7 @@ function replicate(src, target, opts, returnValue, result) {
       }
       return checkpointer.getCheckpoint().then(createTask).then(function (checkpoint) {
         last_seq = checkpoint;
+        initial_last_seq = checkpoint;
         changesOpts = {
           since: last_seq,
           limit: batch_size,

--- a/tests/integration/test.active_tasks.js
+++ b/tests/integration/test.active_tasks.js
@@ -3,7 +3,7 @@
 describe('test.active_tasks.js', function () {
 
   afterEach(function (done) {
-    PouchDB.activeTasks.tasks = [];
+    PouchDB.activeTasks.tasks = {};
     return done();
   });
 
@@ -27,10 +27,10 @@ describe('test.active_tasks.js', function () {
     const id2 = PouchDB.activeTasks.add(task2);
     PouchDB.activeTasks.update(id1, {"completed_items": 2});
     PouchDB.activeTasks.update(id2, {"completed_items": 213});
-    const list = PouchDB.activeTasks.list();
-    list.length.should.equal(2);
-    list[0]['id'].should.equal(id1);
-    list[1]['id'].should.equal(id2);
+    const tasks = PouchDB.activeTasks.list();
+    Object.keys(tasks).length.should.equal(2);
+    tasks[id1].id.should.equal(id1);
+    tasks[id2].id.should.equal(id2);
   });
 
   it('Can update a task', function () {
@@ -56,7 +56,7 @@ describe('test.active_tasks.js', function () {
     PouchDB.activeTasks.update(id2, {"completed_items": 213});
     PouchDB.activeTasks.remove(id1);
     const got2 = PouchDB.activeTasks.get(id2);
-    PouchDB.activeTasks.tasks.length.should.equal(1);
+    Object.keys(PouchDB.activeTasks.tasks).length.should.equal(1);
     got2['id'].should.equal(id2);
   });
 

--- a/tests/integration/test.active_tasks.js
+++ b/tests/integration/test.active_tasks.js
@@ -28,9 +28,9 @@ describe('test.active_tasks.js', function () {
     PouchDB.activeTasks.update(id1, {"completed_items": 2});
     PouchDB.activeTasks.update(id2, {"completed_items": 213});
     const tasks = PouchDB.activeTasks.list();
-    Object.keys(tasks).length.should.equal(2);
-    tasks[id1].id.should.equal(id1);
-    tasks[id2].id.should.equal(id2);
+    tasks.length.should.equal(2);
+    tasks[0].id.should.equal(id1);
+    tasks[1].id.should.equal(id2);
   });
 
   it('Can update a task', function () {

--- a/tests/integration/test.active_tasks.js
+++ b/tests/integration/test.active_tasks.js
@@ -1,0 +1,64 @@
+'use strict';
+
+describe('test.active_tasks.js', function () {
+
+  afterEach(function (done) {
+    PouchDB.activeTasks.tasks = []
+    return done();
+  });
+
+  it('Can add a task', function () {
+    const task1 = {name: 'lol', total_items: 12}
+    const id1 = PouchDB.activeTasks.add(task1)
+    id1.should.be.a('string')
+  });
+
+  it('Can get tasks by id', function () {
+    const task2 = {name: 'wat', total_items: 546}
+    const id2 = PouchDB.activeTasks.add(task2)
+    const got2 = PouchDB.activeTasks.get(id2)
+    got2['id'].should.equal(id2)
+  });
+
+  it('Can get all tasks', function () {
+    const task1 = {name: 'lol', total_items: 12}
+    const task2 = {name: 'wat', total_items: 546}
+    const id1 = PouchDB.activeTasks.add(task1)
+    const id2 = PouchDB.activeTasks.add(task2)
+    PouchDB.activeTasks.update(id1, {"completed_items": 2})
+    PouchDB.activeTasks.update(id2, {"completed_items": 213})
+    const list = PouchDB.activeTasks.list()
+    const got2 = PouchDB.activeTasks.get(id2)
+    list.length.should.equal(2)
+    list[0]['id'].should.equal(id1)
+    list[1]['id'].should.equal(id2)
+  });
+
+  it('Can update a task', function () {
+    const task1 = {name: 'lol', total_items: 12}
+    const task2 = {name: 'wat', total_items: 546}
+    const id1 = PouchDB.activeTasks.add(task1)
+    const id2 = PouchDB.activeTasks.add(task2)
+    PouchDB.activeTasks.update(id1, {"completed_items": 2})
+    PouchDB.activeTasks.update(id2, {"completed_items": 213})
+    const got1 = PouchDB.activeTasks.get(id1)
+    const got2 = PouchDB.activeTasks.get(id2)
+    got1['completed_items'].should.equal(2)
+    got2['completed_items'].should.equal(213)
+    got2['updatedAt'].should.be.a('string')
+  });
+
+  it('Can remove a task', function () {
+    const task1 = {name: 'lol', total_items: 12}
+    const task2 = {name: 'wat', total_items: 546}
+    const id1 = PouchDB.activeTasks.add(task1)
+    const id2 = PouchDB.activeTasks.add(task2)
+    PouchDB.activeTasks.update(id1, {"completed_items": 2})
+    PouchDB.activeTasks.update(id2, {"completed_items": 213})
+    PouchDB.activeTasks.remove(id1)
+    const got2 = PouchDB.activeTasks.get(id2)
+    PouchDB.activeTasks.tasks.length.should.equal(1)
+    got2['id'].should.equal(id2)
+  });
+
+});

--- a/tests/integration/test.active_tasks.js
+++ b/tests/integration/test.active_tasks.js
@@ -44,7 +44,7 @@ describe('test.active_tasks.js', function () {
     const got2 = PouchDB.activeTasks.get(id2);
     got1['completed_items'].should.equal(2);
     got2['completed_items'].should.equal(213);
-    got2['updatedAt'].should.be.a('string');
+    got2['updated_at'].should.be.a('string');
   });
 
   it('Can remove a task', function () {

--- a/tests/integration/test.active_tasks.js
+++ b/tests/integration/test.active_tasks.js
@@ -3,62 +3,61 @@
 describe('test.active_tasks.js', function () {
 
   afterEach(function (done) {
-    PouchDB.activeTasks.tasks = []
+    PouchDB.activeTasks.tasks = [];
     return done();
   });
 
   it('Can add a task', function () {
-    const task1 = {name: 'lol', total_items: 12}
-    const id1 = PouchDB.activeTasks.add(task1)
-    id1.should.be.a('string')
+    const task1 = {name: 'lol', total_items: 12};
+    const id1 = PouchDB.activeTasks.add(task1);
+    id1.should.be.a('string');
   });
 
   it('Can get tasks by id', function () {
-    const task2 = {name: 'wat', total_items: 546}
-    const id2 = PouchDB.activeTasks.add(task2)
-    const got2 = PouchDB.activeTasks.get(id2)
-    got2['id'].should.equal(id2)
+    const task2 = {name: 'wat', total_items: 546};
+    const id2 = PouchDB.activeTasks.add(task2);
+    const got2 = PouchDB.activeTasks.get(id2);
+    got2['id'].should.equal(id2);
   });
 
   it('Can get all tasks', function () {
-    const task1 = {name: 'lol', total_items: 12}
-    const task2 = {name: 'wat', total_items: 546}
-    const id1 = PouchDB.activeTasks.add(task1)
-    const id2 = PouchDB.activeTasks.add(task2)
-    PouchDB.activeTasks.update(id1, {"completed_items": 2})
-    PouchDB.activeTasks.update(id2, {"completed_items": 213})
-    const list = PouchDB.activeTasks.list()
-    const got2 = PouchDB.activeTasks.get(id2)
-    list.length.should.equal(2)
-    list[0]['id'].should.equal(id1)
-    list[1]['id'].should.equal(id2)
+    const task1 = {name: 'lol', total_items: 12};
+    const task2 = {name: 'wat', total_items: 546};
+    const id1 = PouchDB.activeTasks.add(task1);
+    const id2 = PouchDB.activeTasks.add(task2);
+    PouchDB.activeTasks.update(id1, {"completed_items": 2});
+    PouchDB.activeTasks.update(id2, {"completed_items": 213});
+    const list = PouchDB.activeTasks.list();
+    list.length.should.equal(2);
+    list[0]['id'].should.equal(id1);
+    list[1]['id'].should.equal(id2);
   });
 
   it('Can update a task', function () {
-    const task1 = {name: 'lol', total_items: 12}
-    const task2 = {name: 'wat', total_items: 546}
-    const id1 = PouchDB.activeTasks.add(task1)
-    const id2 = PouchDB.activeTasks.add(task2)
-    PouchDB.activeTasks.update(id1, {"completed_items": 2})
-    PouchDB.activeTasks.update(id2, {"completed_items": 213})
-    const got1 = PouchDB.activeTasks.get(id1)
-    const got2 = PouchDB.activeTasks.get(id2)
-    got1['completed_items'].should.equal(2)
-    got2['completed_items'].should.equal(213)
-    got2['updatedAt'].should.be.a('string')
+    const task1 = {name: 'lol', total_items: 12};
+    const task2 = {name: 'wat', total_items: 546};
+    const id1 = PouchDB.activeTasks.add(task1);
+    const id2 = PouchDB.activeTasks.add(task2);
+    PouchDB.activeTasks.update(id1, {"completed_items": 2});
+    PouchDB.activeTasks.update(id2, {"completed_items": 213});
+    const got1 = PouchDB.activeTasks.get(id1);
+    const got2 = PouchDB.activeTasks.get(id2);
+    got1['completed_items'].should.equal(2);
+    got2['completed_items'].should.equal(213);
+    got2['updatedAt'].should.be.a('string');
   });
 
   it('Can remove a task', function () {
-    const task1 = {name: 'lol', total_items: 12}
-    const task2 = {name: 'wat', total_items: 546}
-    const id1 = PouchDB.activeTasks.add(task1)
-    const id2 = PouchDB.activeTasks.add(task2)
-    PouchDB.activeTasks.update(id1, {"completed_items": 2})
-    PouchDB.activeTasks.update(id2, {"completed_items": 213})
-    PouchDB.activeTasks.remove(id1)
-    const got2 = PouchDB.activeTasks.get(id2)
-    PouchDB.activeTasks.tasks.length.should.equal(1)
-    got2['id'].should.equal(id2)
+    const task1 = {name: 'lol', total_items: 12};
+    const task2 = {name: 'wat', total_items: 546};
+    const id1 = PouchDB.activeTasks.add(task1);
+    const id2 = PouchDB.activeTasks.add(task2);
+    PouchDB.activeTasks.update(id1, {"completed_items": 2});
+    PouchDB.activeTasks.update(id2, {"completed_items": 213});
+    PouchDB.activeTasks.remove(id1);
+    const got2 = PouchDB.activeTasks.get(id2);
+    PouchDB.activeTasks.tasks.length.should.equal(1);
+    got2['id'].should.equal(id2);
   });
 
 });

--- a/tests/integration/test.issue1175.js
+++ b/tests/integration/test.issue1175.js
@@ -31,6 +31,17 @@ function MockDatabase(statusCodeToReturn, dataToReturn) {
   this.put = function () {
     return testUtils.Promise.resolve();
   };
+  this.info = function () {
+    return testUtils.Promise.resolve({
+      update_seq: 0
+    });
+  };
+  this.activeTasks = {
+    add: function () {},
+    get: function () {},
+    update: function () {},
+    remove: function () {},
+  };
 }
 function getCallback(expectError, done) {
   // returns a function which expects to be called within a certain time.


### PR DESCRIPTION
This PR brings an implementation of the activeTasks API sketched in https://github.com/pouchdb/pouchdb/issues/8422, similar to what the `_active_tasks` API does for CouchDB. Further discussion can also be found in our development PR, https://github.com/neighbourhoodie/pouchdb/pull/8.


### Long-running tasks

We made several long-running tasks report to the activeTasks API:

- database compaction
- replication (single & continuous)
- view indexing
- find indexing (via view indexing/`abstract-mapreduce` when not using the `indexeddb` adapter)
  - the `indexeddb` adapter brings its own find indexing/querying implementation based on native IDB indexes, which don't support precise progress monitoring


### Tests

Run tests for this feature: 
```$ GREP="active_tasks" && npm test```


### Demo

We've built a demo application for trying out (and visualizing) the activeTasks API for monitoring long-running tasks, which helps with quickly spinning up dummy databases and running each kind of task: https://github.com/neighbourhoodie/pouchdb-activetasks-demo
