### PR TITLE
Remove argsarray dependency

### DIFF
--- a/bin/build-pouchdb.js
+++ b/bin/build-pouchdb.js
@@ -14,7 +14,6 @@ var rollupPlugins = require('./rollupPlugins');
 var rimraf = denodeify(require('rimraf'));
 var mkdirp = denodeify(require('mkdirp'));
 var all = Promise.all.bind(Promise);
-var argsarray = require('argsarray');
 var buildUtils = require('./build-utils');
 var addPath = buildUtils.addPath;
 var doUglify = buildUtils.doUglify;
@@ -148,7 +147,7 @@ function buildPluginsForBrowser() {
   });
 }
 
-var rimrafMkdirp = argsarray(function (args) {
+var rimrafMkdirp = function (...args) {
   return all(args.map(function (otherPath) {
     return rimraf(addPath('pouchdb', otherPath));
   })).then(function () {
@@ -156,15 +155,15 @@ var rimrafMkdirp = argsarray(function (args) {
       return mkdirp(addPath('pouchdb', otherPath));
     }));
   });
-});
+};
 
-var doAll = argsarray(function (args) {
+var doAll = function (...args) {
   return function () {
     return all(args.map(function (promiseFactory) {
       return promiseFactory();
     }));
   };
-});
+};
 
 function doBuildNode() {
   return mkdirp(addPath('pouchdb', 'lib/plugins'))

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "abort-controller": "3.0.0",
-    "argsarray": "0.0.1",
     "buffer-from": "1.1.2",
     "clone-buffer": "1.0.0",
     "double-ended-queue": "2.1.0-0",
@@ -65,7 +64,6 @@
   },
   "devDependencies": {
     "add-cors-to-couchdb": "0.0.6",
-    "argsarray": "0.0.1",
     "body-parser": "1.19.0",
     "browserify": "16.4.0",
     "browserify-incremental": "3.1.1",

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-import getArguments from 'argsarray';
 import pool from './promise-pool';
 
 import { fetch, Headers, AbortController } from 'pouchdb-fetch';
@@ -190,14 +189,14 @@ function HttpPouch(opts, callback) {
   };
 
   function adapterFun(name, fun) {
-    return coreAdapterFun(name, getArguments(function (args) {
+    return coreAdapterFun(name, function (...args) {
       setup().then(function () {
         return fun.apply(this, args);
       }).catch(function (e) {
         let callback = args.pop();
         callback(e);
       });
-    })).bind(api);
+    }).bind(api);
   }
 
   async function fetchJSON(url, options) {

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -1,7 +1,6 @@
 import levelup from 'levelup';
 import sublevel from 'sublevel-pouchdb';
 import { obj as through } from 'through2';
-import getArguments from 'argsarray';
 import Deque from 'double-ended-queue';
 import bufferFrom from 'buffer-from'; // ponyfill for Node <6
 import PouchDB from 'pouchdb-core';
@@ -293,7 +292,7 @@ function LevelPouch(opts, callback) {
     readTasks.forEach(function (readTask) {
       var args = readTask.args;
       var callback = args[args.length - 1];
-      args[args.length - 1] = getArguments(function (cbArgs) {
+      args[args.length - 1] = function (...cbArgs) {
         callback.apply(null, cbArgs);
         if (++numDone === readTasks.length) {
           nextTick(function () {
@@ -306,7 +305,7 @@ function LevelPouch(opts, callback) {
             }
           });
         }
-      });
+      };
       tryCode(readTask.fun, args);
     });
   }
@@ -314,7 +313,7 @@ function LevelPouch(opts, callback) {
   function runWriteOperation(firstTask) {
     var args = firstTask.args;
     var callback = args[args.length - 1];
-    args[args.length - 1] = getArguments(function (cbArgs) {
+    args[args.length - 1] = function (...cbArgs) {
       callback.apply(null, cbArgs);
       nextTick(function () {
         db._queue.shift();
@@ -322,7 +321,7 @@ function LevelPouch(opts, callback) {
           executeNext();
         }
       });
-    });
+    };
     tryCode(firstTask.fun, args);
   }
 
@@ -331,7 +330,7 @@ function LevelPouch(opts, callback) {
   // as e.g. compaction needing to have a lock on the database while
   // it updates stuff. in the future we can revisit this.
   function writeLock(fun) {
-    return getArguments(function (args) {
+    return function (...args) {
       db._queue.push({
         fun: fun,
         args: args,
@@ -341,12 +340,12 @@ function LevelPouch(opts, callback) {
       if (db._queue.length === 1) {
         nextTick(executeNext);
       }
-    });
+    };
   }
 
   // same as the writelock, but multiple can run at once
   function readLock(fun) {
-    return getArguments(function (args) {
+    return function (...args) {
       db._queue.push({
         fun: fun,
         args: args,
@@ -356,7 +355,7 @@ function LevelPouch(opts, callback) {
       if (db._queue.length === 1) {
         nextTick(executeNext);
       }
-    });
+    };
   }
 
   function formatSeq(n) {

--- a/packages/node_modules/pouchdb-core/src/changes.js
+++ b/packages/node_modules/pouchdb-core/src/changes.js
@@ -1,4 +1,3 @@
-import getArguments from 'argsarray';
 import {
   clone,
   listenerCount,
@@ -199,10 +198,10 @@ class Changes extends EE {
     /* istanbul ignore else */
     if (newPromise && typeof newPromise.cancel === 'function') {
       const cancel = this.cancel;
-      this.cancel = getArguments((args) => {
+      this.cancel = (...args) => {
         newPromise.cancel();
         cancel.apply(this, args);
-      });
+      };
     }
   }
 }

--- a/packages/node_modules/pouchdb-find/src/utils.js
+++ b/packages/node_modules/pouchdb-find/src/utils.js
@@ -8,7 +8,7 @@ import { nextTick } from 'pouchdb-utils';
 
 function once(fun) {
   var called = false;
-  return getArguments(function (args) {
+  return function (...args) {
     if (called) {
       console.trace();
       throw new Error('once called  more than once');
@@ -16,22 +16,11 @@ function once(fun) {
       called = true;
       fun.apply(this, args);
     }
-  });
-}
-function getArguments(fun) {
-  return function () {
-    var len = arguments.length;
-    var args = new Array(len);
-    var i = -1;
-    while (++i < len) {
-      args[i] = arguments[i];
-    }
-    return fun.call(this, args);
   };
 }
 function toPromise(func) {
   //create the function we will be returning
-  return getArguments(function (args) {
+  return function (...args) {
     var self = this;
     var tempCB = (typeof args[args.length - 1] === 'function') ? args.pop() : false;
     // if the last argument is a function, assume its a callback
@@ -72,16 +61,16 @@ function toPromise(func) {
       return this;
     };
     return promise;
-  });
+  };
 }
 
 function callbackify(fun) {
-  return getArguments(function (args) {
+  return function (...args) {
     var cb = args.pop();
     var promise = fun.apply(this, args);
     promisedCallback(promise, cb);
     return promise;
-  });
+  };
 }
 
 function promisedCallback(promise, callback) {
@@ -97,7 +86,7 @@ function promisedCallback(promise, callback) {
   return promise;
 }
 
-var flatten = getArguments(function (args) {
+var flatten = function (...args) {
   var res = [];
   for (var i = 0, len = args.length; i < len; i++) {
     var subArr = args[i];
@@ -108,7 +97,7 @@ var flatten = getArguments(function (args) {
     }
   }
   return res;
-});
+};
 
 function mergeObjects(arr) {
   var res = {};
@@ -221,7 +210,6 @@ export {
   arrayToObject,
   callbackify,
   flatten,
-  getArguments,
   max,
   mergeObjects,
   once,

--- a/packages/node_modules/pouchdb-mapreduce-utils/src/index.js
+++ b/packages/node_modules/pouchdb-mapreduce-utils/src/index.js
@@ -1,4 +1,3 @@
-import argsarray from 'argsarray';
 import { nextTick } from 'pouchdb-utils';
 import {
   QueryParseError,
@@ -22,14 +21,14 @@ function promisedCallback(promise, callback) {
 }
 
 function callbackify(fun) {
-  return argsarray(function (args) {
+  return function (...args) {
     var cb = args.pop();
     var promise = fun.apply(this, args);
     if (typeof cb === 'function') {
       promisedCallback(promise, cb);
     }
     return promise;
-  });
+  };
 }
 
 // Promise finally util similar to Q.finally

--- a/packages/node_modules/pouchdb-utils/src/adapterFun.js
+++ b/packages/node_modules/pouchdb-utils/src/adapterFun.js
@@ -1,5 +1,4 @@
 import toPromise from './toPromise';
-import getArguments from 'argsarray';
 
 function logApiCall(self, name, args) {
   /* istanbul ignore if */
@@ -24,7 +23,7 @@ function logApiCall(self, name, args) {
 }
 
 function adapterFun(name, callback) {
-  return toPromise(getArguments(function (args) {
+  return toPromise(function (...args) {
     if (this._closed) {
       return Promise.reject(new Error('database is closed'));
     }
@@ -45,7 +44,7 @@ function adapterFun(name, callback) {
       });
     }
     return callback.apply(this, args);
-  }));
+  });
 }
 
 export default adapterFun;

--- a/packages/node_modules/pouchdb-utils/src/once.js
+++ b/packages/node_modules/pouchdb-utils/src/once.js
@@ -1,8 +1,6 @@
-import getArguments from 'argsarray';
-
 function once(fun) {
   var called = false;
-  return getArguments(function (args) {
+  return function (...args) {
     /* istanbul ignore if */
     if (called) {
       // this is a smoke test and should never actually happen
@@ -11,7 +9,7 @@ function once(fun) {
       called = true;
       fun.apply(this, args);
     }
-  });
+  };
 }
 
 export default once;

--- a/packages/node_modules/pouchdb-utils/src/toPromise.js
+++ b/packages/node_modules/pouchdb-utils/src/toPromise.js
@@ -1,10 +1,9 @@
-import getArguments from 'argsarray';
 import clone from './clone';
 import once from './once';
 
 function toPromise(func) {
   //create the function we will be returning
-  return getArguments(function (args) {
+  return function (...args) {
     // Clone arguments
     args = clone(args);
     var self = this;
@@ -38,7 +37,7 @@ function toPromise(func) {
       }, usedCB);
     }
     return promise;
-  });
+  };
 }
 
 export default toPromise;


### PR DESCRIPTION
Remove `argsarray` package and use rest parameters instead.

These changes were initially proposed [here](https://github.com/pouchdb/pouchdb/pull/7779), but, as I understand, were rejected due to a CI failure. I tried them again, and the GHA tests passed. 

@lindner, as you were the first to propose these changes, please let me know if you’d like to be a co-author of these commits. 

Also noticed that `packages/node_modules/pouchdb-find/src/utils.js` had an inlined implementation of this dependency, so I removed it and used rest parameters as well.

Thank you.
