### PR TITLE
(#8440) - bump node-fetch to 2.6.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "localstorage-down": "0.6.7",
     "ltgt": "2.2.1",
     "memdown": "1.4.1",
-    "node-fetch": "2.6.4",
+    "node-fetch": "2.6.7",
     "promise-polyfill": "8.1.3",
     "readable-stream": "1.1.14",
     "request": "2.88.2",


### PR DESCRIPTION
Resolves a vulnerability present in versions of node-fetch less than 2.6.7