### PR TITLE
(#8444) Refactor: use es6 classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "fetch-cookie": "0.11.0",
     "fruitdown": "1.0.2",
     "immediate": "3.3.0",
-    "inherits": "2.0.4",
     "level": "6.0.1",
     "level-codec": "9.0.2",
     "level-write-stream": "1.0.0",

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/taskqueue.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/taskqueue.js
@@ -4,19 +4,23 @@
  */
 
 
-function TaskQueue() {
-  this.promise = new Promise(function (fulfill) {fulfill(); });
+class TaskQueue {
+  constructor() {
+    this.promise = new Promise(function (fulfill) {fulfill(); });
+  }
+
+  add(promiseFactory) {
+    this.promise = this.promise.catch(function () {
+      // just recover
+    }).then(function () {
+      return promiseFactory();
+    });
+    return this.promise;
+  }
+
+  finish() {
+    return this.promise;
+  }
 }
-TaskQueue.prototype.add = function (promiseFactory) {
-  this.promise = this.promise.catch(function () {
-    // just recover
-  }).then(function () {
-    return promiseFactory();
-  });
-  return this.promise;
-};
-TaskQueue.prototype.finish = function () {
-  return this.promise;
-};
 
 export default TaskQueue;

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/transaction.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/transaction.js
@@ -16,69 +16,70 @@ function getCacheFor(transaction, store) {
   return subCache;
 }
 
-function LevelTransaction() {
-  this._batch = [];
-  this._cache = new Map();
-}
-
-LevelTransaction.prototype.get = function (store, key, callback) {
-  var cache = getCacheFor(this, store);
-  var exists = cache.get(key);
-  if (exists) {
-    return nextTick(function () {
-      callback(null, exists);
-    });
-  } else if (exists === null) { // deleted marker
-    /* istanbul ignore next */
-    return nextTick(function () {
-      callback({name: 'NotFoundError'});
-    });
+class LevelTransaction {
+  constructor() {
+    this._batch = [];
+    this._cache = new Map();
   }
-  store.get(key, function (err, res) {
-    if (err) {
-      /* istanbul ignore else */
-      if (err.name === 'NotFoundError') {
-        cache.set(key, null);
+
+  get(store, key, callback) {
+    var cache = getCacheFor(this, store);
+    var exists = cache.get(key);
+    if (exists) {
+      return nextTick(function () {
+        callback(null, exists);
+      });
+    } else if (exists === null) { // deleted marker
+      /* istanbul ignore next */
+      return nextTick(function () {
+        callback({name: 'NotFoundError'});
+      });
+    }
+    store.get(key, function (err, res) {
+      if (err) {
+        /* istanbul ignore else */
+        if (err.name === 'NotFoundError') {
+          cache.set(key, null);
+        }
+        return callback(err);
       }
-      return callback(err);
-    }
-    cache.set(key, res);
-    callback(null, res);
-  });
-};
-
-LevelTransaction.prototype.batch = function (batch) {
-  for (var i = 0, len = batch.length; i < len; i++) {
-    var operation = batch[i];
-
-    var cache = getCacheFor(this, operation.prefix);
-
-    if (operation.type === 'put') {
-      cache.set(operation.key, operation.value);
-    } else {
-      cache.set(operation.key, null);
-    }
-  }
-  this._batch = this._batch.concat(batch);
-};
-
-LevelTransaction.prototype.execute = function (db, callback) {
-
-  var keys = new Set();
-  var uniqBatches = [];
-
-  // remove duplicates; last one wins
-  for (var i = this._batch.length - 1; i >= 0; i--) {
-    var operation = this._batch[i];
-    var lookupKey = operation.prefix.prefix()[0] + '\xff' + operation.key;
-    if (keys.has(lookupKey)) {
-      continue;
-    }
-    keys.add(lookupKey);
-    uniqBatches.push(operation);
+      cache.set(key, res);
+      callback(null, res);
+    });
   }
 
-  db.batch(uniqBatches, callback);
-};
+  batch(batch) {
+    for (var i = 0, len = batch.length; i < len; i++) {
+      var operation = batch[i];
+
+      var cache = getCacheFor(this, operation.prefix);
+
+      if (operation.type === 'put') {
+        cache.set(operation.key, operation.value);
+      } else {
+        cache.set(operation.key, null);
+      }
+    }
+    this._batch = this._batch.concat(batch);
+  }
+
+  execute(db, callback) {
+    var keys = new Set();
+    var uniqBatches = [];
+
+    // remove duplicates; last one wins
+    for (var i = this._batch.length - 1; i >= 0; i--) {
+      var operation = this._batch[i];
+      var lookupKey = operation.prefix.prefix()[0] + '\xff' + operation.key;
+      if (keys.has(lookupKey)) {
+        continue;
+      }
+      keys.add(lookupKey);
+      uniqBatches.push(operation);
+    }
+
+    db.batch(uniqBatches, callback);
+  }
+}
 
 export default LevelTransaction;

--- a/packages/node_modules/pouchdb-checkpointer/src/index.js
+++ b/packages/node_modules/pouchdb-checkpointer/src/index.js
@@ -72,46 +72,114 @@ function updateCheckpoint(db, id, checkpoint, session, returnValue) {
   });
 }
 
-function Checkpointer(src, target, id, returnValue, opts) {
-  this.src = src;
-  this.target = target;
-  this.id = id;
-  this.returnValue = returnValue;
-  this.opts = opts || {};
-}
-
-Checkpointer.prototype.writeCheckpoint = function (checkpoint, session) {
-  var self = this;
-  return this.updateTarget(checkpoint, session).then(function () {
-    return self.updateSource(checkpoint, session);
-  });
-};
-
-Checkpointer.prototype.updateTarget = function (checkpoint, session) {
-  if (this.opts.writeTargetCheckpoint) {
-    return updateCheckpoint(this.target, this.id, checkpoint,
-      session, this.returnValue);
-  } else {
-    return Promise.resolve(true);
+class CheckpointerInternal {
+  constructor(src, target, id, returnValue, opts) {
+    this.src = src;
+    this.target = target;
+    this.id = id;
+    this.returnValue = returnValue;
+    this.opts = opts || {};
   }
-};
 
-Checkpointer.prototype.updateSource = function (checkpoint, session) {
-  if (this.opts.writeSourceCheckpoint) {
+  writeCheckpoint(checkpoint, session) {
     var self = this;
-    return updateCheckpoint(this.src, this.id, checkpoint,
-      session, this.returnValue)
-      .catch(function (err) {
-        if (isForbiddenError(err)) {
-          self.opts.writeSourceCheckpoint = false;
-          return true;
+    return this.updateTarget(checkpoint, session).then(function () {
+      return self.updateSource(checkpoint, session);
+    });
+  }
+
+  updateTarget(checkpoint, session) {
+    if (this.opts.writeTargetCheckpoint) {
+      return updateCheckpoint(this.target, this.id, checkpoint,
+        session, this.returnValue);
+    } else {
+      return Promise.resolve(true);
+    }
+  }
+
+  updateSource(checkpoint, session) {
+    if (this.opts.writeSourceCheckpoint) {
+      var self = this;
+      return updateCheckpoint(this.src, this.id, checkpoint,
+        session, this.returnValue)
+        .catch(function (err) {
+          if (isForbiddenError(err)) {
+            self.opts.writeSourceCheckpoint = false;
+            return true;
+          }
+          throw err;
+        });
+    } else {
+      return Promise.resolve(true);
+    }
+  }
+
+  getCheckpoint() {
+    var self = this;
+  
+    if (self.opts && self.opts.writeSourceCheckpoint && !self.opts.writeTargetCheckpoint) {
+      return self.src.get(self.id).then(function (sourceDoc) {
+        return sourceDoc.last_seq || LOWEST_SEQ;
+      }).catch(function (err) {
+        /* istanbul ignore if */
+        if (err.status !== 404) {
+          throw err;
+        }
+        return LOWEST_SEQ;
+      });
+    }
+  
+    return self.target.get(self.id).then(function (targetDoc) {
+      if (self.opts && self.opts.writeTargetCheckpoint && !self.opts.writeSourceCheckpoint) {
+        return targetDoc.last_seq || LOWEST_SEQ;
+      }
+  
+      return self.src.get(self.id).then(function (sourceDoc) {
+        // Since we can't migrate an old version doc to a new one
+        // (no session id), we just go with the lowest seq in this case
+        /* istanbul ignore if */
+        if (targetDoc.version !== sourceDoc.version) {
+          return LOWEST_SEQ;
+        }
+  
+        var version;
+        if (targetDoc.version) {
+          version = targetDoc.version.toString();
+        } else {
+          version = "undefined";
+        }
+  
+        if (version in comparisons) {
+          return comparisons[version](targetDoc, sourceDoc);
+        }
+        /* istanbul ignore next */
+        return LOWEST_SEQ;
+      }, function (err) {
+        if (err.status === 404 && targetDoc.last_seq) {
+          return self.src.put({
+            _id: self.id,
+            last_seq: LOWEST_SEQ
+          }).then(function () {
+            return LOWEST_SEQ;
+          }, function (err) {
+            if (isForbiddenError(err)) {
+              self.opts.writeSourceCheckpoint = false;
+              return targetDoc.last_seq;
+            }
+            /* istanbul ignore next */
+            return LOWEST_SEQ;
+          });
         }
         throw err;
       });
-  } else {
-    return Promise.resolve(true);
+    }).catch(function (err) {
+      if (err.status !== 404) {
+        throw err;
+      }
+      return LOWEST_SEQ;
+    });
   }
-};
+}
 
 var comparisons = {
   "undefined": function (targetDoc, sourceDoc) {
@@ -128,71 +196,6 @@ var comparisons = {
   }
 };
 
-Checkpointer.prototype.getCheckpoint = function () {
-  var self = this;
-
-  if (self.opts && self.opts.writeSourceCheckpoint && !self.opts.writeTargetCheckpoint) {
-    return self.src.get(self.id).then(function (sourceDoc) {
-      return sourceDoc.last_seq || LOWEST_SEQ;
-    }).catch(function (err) {
-      /* istanbul ignore if */
-      if (err.status !== 404) {
-        throw err;
-      }
-      return LOWEST_SEQ;
-    });
-  }
-
-  return self.target.get(self.id).then(function (targetDoc) {
-    if (self.opts && self.opts.writeTargetCheckpoint && !self.opts.writeSourceCheckpoint) {
-      return targetDoc.last_seq || LOWEST_SEQ;
-    }
-
-    return self.src.get(self.id).then(function (sourceDoc) {
-      // Since we can't migrate an old version doc to a new one
-      // (no session id), we just go with the lowest seq in this case
-      /* istanbul ignore if */
-      if (targetDoc.version !== sourceDoc.version) {
-        return LOWEST_SEQ;
-      }
-
-      var version;
-      if (targetDoc.version) {
-        version = targetDoc.version.toString();
-      } else {
-        version = "undefined";
-      }
-
-      if (version in comparisons) {
-        return comparisons[version](targetDoc, sourceDoc);
-      }
-      /* istanbul ignore next */
-      return LOWEST_SEQ;
-    }, function (err) {
-      if (err.status === 404 && targetDoc.last_seq) {
-        return self.src.put({
-          _id: self.id,
-          last_seq: LOWEST_SEQ
-        }).then(function () {
-          return LOWEST_SEQ;
-        }, function (err) {
-          if (isForbiddenError(err)) {
-            self.opts.writeSourceCheckpoint = false;
-            return targetDoc.last_seq;
-          }
-          /* istanbul ignore next */
-          return LOWEST_SEQ;
-        });
-      }
-      throw err;
-    });
-  }).catch(function (err) {
-    if (err.status !== 404) {
-      throw err;
-    }
-    return LOWEST_SEQ;
-  });
-};
 // This checkpoint comparison is ported from CouchDBs source
 // they come from here:
 // https://github.com/apache/couchdb-couch-replicator/blob/master/src/couch_replicator.erl#L863-L906
@@ -262,5 +265,11 @@ function isForbiddenError(err) {
   return typeof err.status === 'number' && Math.floor(err.status / 100) === 4;
 }
 
+function Checkpointer(src, target, id, returnValue, opts) {
+  if (!(this instanceof CheckpointerInternal)) {
+    return new CheckpointerInternal(src, target, id, returnValue, opts);
+  }
+  return Checkpointer;
+}
 
 export default Checkpointer;

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -4,7 +4,6 @@ import {
   isRemote
 } from 'pouchdb-utils';
 import EventEmitter from 'events';
-import inherits from 'inherits';
 import Changes from './changes';
 import {
   pick,
@@ -164,814 +163,781 @@ function attachmentNameError(name) {
   return false;
 }
 
-inherits(AbstractPouchDB, EventEmitter);
+class AbstractPouchDB extends EventEmitter {
+  _setup() {
+    this.post = adapterFun('post', function (doc, opts, callback) {
+      if (typeof opts === 'function') {
+        callback = opts;
+        opts = {};
+      }
+      if (typeof doc !== 'object' || Array.isArray(doc)) {
+        return callback(createError(NOT_AN_OBJECT));
+      }
+      this.bulkDocs({docs: [doc]}, opts, yankError(callback, doc._id));
+    }).bind(this);
 
-function AbstractPouchDB() {
-  EventEmitter.call(this);
+    this.put = adapterFun('put', function (doc, opts, cb) {
+      if (typeof opts === 'function') {
+        cb = opts;
+        opts = {};
+      }
+      if (typeof doc !== 'object' || Array.isArray(doc)) {
+        return cb(createError(NOT_AN_OBJECT));
+      }
+      invalidIdError(doc._id);
+      if (isLocalId(doc._id) && typeof this._putLocal === 'function') {
+        if (doc._deleted) {
+          return this._removeLocal(doc, cb);
+        } else {
+          return this._putLocal(doc, cb);
+        }
+      }
 
-  // re-bind prototyped methods
-  for (var p in AbstractPouchDB.prototype) {
-    if (typeof this[p] === 'function') {
-      this[p] = this[p].bind(this);
-    }
-  }
-}
+      const putDoc = (next) => {
+        if (typeof this._put === 'function' && opts.new_edits !== false) {
+          this._put(doc, opts, next);
+        } else {
+          this.bulkDocs({docs: [doc]}, opts, yankError(next, doc._id));
+        }
+      };
 
-AbstractPouchDB.prototype.post =
-  adapterFun('post', function (doc, opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-  if (typeof doc !== 'object' || Array.isArray(doc)) {
-    return callback(createError(NOT_AN_OBJECT));
-  }
-  this.bulkDocs({docs: [doc]}, opts, yankError(callback, doc._id));
-});
+      if (opts.force && doc._rev) {
+        transformForceOptionToNewEditsOption();
+        putDoc(function (err) {
+          var result = err ? null : {ok: true, id: doc._id, rev: doc._rev};
+          cb(err, result);
+        });
+      } else {
+        putDoc(cb);
+      }
+    
+      function transformForceOptionToNewEditsOption() {
+        var parts = doc._rev.split('-');
+        var oldRevId = parts[1];
+        var oldRevNum = parseInt(parts[0], 10);
+    
+        var newRevNum = oldRevNum + 1;
+        var newRevId = rev();
+    
+        doc._revisions = {
+          start: newRevNum,
+          ids: [newRevId, oldRevId]
+        };
+        doc._rev = newRevNum + '-' + newRevId;
+        opts.new_edits = false;
+      }
+    }).bind(this);
 
-AbstractPouchDB.prototype.put = adapterFun('put', function (doc, opts, cb) {
-  if (typeof opts === 'function') {
-    cb = opts;
-    opts = {};
-  }
-  if (typeof doc !== 'object' || Array.isArray(doc)) {
-    return cb(createError(NOT_AN_OBJECT));
-  }
-  invalidIdError(doc._id);
-  if (isLocalId(doc._id) && typeof this._putLocal === 'function') {
-    if (doc._deleted) {
-      return this._removeLocal(doc, cb);
-    } else {
-      return this._putLocal(doc, cb);
-    }
-  }
-  var self = this;
-  if (opts.force && doc._rev) {
-    transformForceOptionToNewEditsOption();
-    putDoc(function (err) {
-      var result = err ? null : {ok: true, id: doc._id, rev: doc._rev};
-      cb(err, result);
-    });
-  } else {
-    putDoc(cb);
+    this.putAttachment = adapterFun('putAttachment', function (docId, attachmentId, rev, blob, type) {
+      var api = this;
+      if (typeof type === 'function') {
+        type = blob;
+        blob = rev;
+        rev = null;
+      }
+      // Lets fix in https://github.com/pouchdb/pouchdb/issues/3267
+      /* istanbul ignore if */
+      if (typeof type === 'undefined') {
+        type = blob;
+        blob = rev;
+        rev = null;
+      }
+      if (!type) {
+        guardedConsole('warn', 'Attachment', attachmentId, 'on document', docId, 'is missing content_type');
+      }
+
+      function createAttachment(doc) {
+        var prevrevpos = '_rev' in doc ? parseInt(doc._rev, 10) : 0;
+        doc._attachments = doc._attachments || {};
+        doc._attachments[attachmentId] = {
+          content_type: type,
+          data: blob,
+          revpos: ++prevrevpos
+        };
+        return api.put(doc);
+      }
+
+      return api.get(docId).then(function (doc) {
+        if (doc._rev !== rev) {
+          throw createError(REV_CONFLICT);
+        }
+
+        return createAttachment(doc);
+      }, function (err) {
+        // create new doc
+        /* istanbul ignore else */
+        if (err.reason === MISSING_DOC.message) {
+          return createAttachment({_id: docId});
+        } else {
+          throw err;
+        }
+      });
+    }).bind(this);
+
+    this.removeAttachment = adapterFun('removeAttachment', function (docId, attachmentId, rev, callback) {
+      this.get(docId, (err, obj) => {
+        /* istanbul ignore if */
+        if (err) {
+          callback(err);
+          return;
+        }
+        if (obj._rev !== rev) {
+          callback(createError(REV_CONFLICT));
+          return;
+        }
+        /* istanbul ignore if */
+        if (!obj._attachments) {
+          return callback();
+        }
+        delete obj._attachments[attachmentId];
+        if (Object.keys(obj._attachments).length === 0) {
+          delete obj._attachments;
+        }
+        this.put(obj, callback);
+      });
+    }).bind(this);
+
+    this.remove = adapterFun('remove', function (docOrId, optsOrRev, opts, callback) {
+      var doc;
+      if (typeof optsOrRev === 'string') {
+        // id, rev, opts, callback style
+        doc = {
+          _id: docOrId,
+          _rev: optsOrRev
+        };
+        if (typeof opts === 'function') {
+          callback = opts;
+          opts = {};
+        }
+      } else {
+        // doc, opts, callback style
+        doc = docOrId;
+        if (typeof optsOrRev === 'function') {
+          callback = optsOrRev;
+          opts = {};
+        } else {
+          callback = opts;
+          opts = optsOrRev;
+        }
+      }
+      opts = opts || {};
+      opts.was_delete = true;
+      var newDoc = {_id: doc._id, _rev: (doc._rev || opts.rev)};
+      newDoc._deleted = true;
+      if (isLocalId(newDoc._id) && typeof this._removeLocal === 'function') {
+        return this._removeLocal(doc, callback);
+      }
+      this.bulkDocs({docs: [newDoc]}, opts, yankError(callback, newDoc._id));
+    }).bind(this);
+
+    this.revsDiff = adapterFun('revsDiff', function (req, opts, callback) {
+      if (typeof opts === 'function') {
+        callback = opts;
+        opts = {};
+      }
+      var ids = Object.keys(req);
+    
+      if (!ids.length) {
+        return callback(null, {});
+      }
+    
+      var count = 0;
+      var missing = new Map();
+    
+      function addToMissing(id, revId) {
+        if (!missing.has(id)) {
+          missing.set(id, {missing: []});
+        }
+        missing.get(id).missing.push(revId);
+      }
+    
+      function processDoc(id, rev_tree) {
+        // Is this fast enough? Maybe we should switch to a set simulated by a map
+        var missingForId = req[id].slice(0);
+        traverseRevTree(rev_tree, function (isLeaf, pos, revHash, ctx,
+          opts) {
+            var rev = pos + '-' + revHash;
+            var idx = missingForId.indexOf(rev);
+            if (idx === -1) {
+              return;
+            }
+    
+            missingForId.splice(idx, 1);
+            /* istanbul ignore if */
+            if (opts.status !== 'available') {
+              addToMissing(id, rev);
+            }
+          });
+    
+        // Traversing the tree is synchronous, so now `missingForId` contains
+        // revisions that were not found in the tree
+        missingForId.forEach(function (rev) {
+          addToMissing(id, rev);
+        });
+      }
+    
+      ids.map(function (id) {
+        this._getRevisionTree(id, function (err, rev_tree) {
+          if (err && err.status === 404 && err.message === 'missing') {
+            missing.set(id, {missing: req[id]});
+          } else if (err) {
+            /* istanbul ignore next */
+            return callback(err);
+          } else {
+            processDoc(id, rev_tree);
+          }
+    
+          if (++count === ids.length) {
+            // convert LazyMap to object
+            var missingObj = {};
+            missing.forEach(function (value, key) {
+              missingObj[key] = value;
+            });
+            return callback(null, missingObj);
+          }
+        });
+      }, this);
+    }).bind(this);
+
+    // _bulk_get API for faster replication, as described in
+    // https://github.com/apache/couchdb-chttpd/pull/33
+    // At the "abstract" level, it will just run multiple get()s in
+    // parallel, because this isn't much of a performance cost
+    // for local databases (except the cost of multiple transactions, which is
+    // small). The http adapter overrides this in order
+    // to do a more efficient single HTTP request.
+    this.bulkGet = adapterFun('bulkGet', function (opts, callback) {
+      bulkGetShim(this, opts, callback);
+    }).bind(this);
+
+    // compact one document and fire callback
+    // by compacting we mean removing all revisions which
+    // are further from the leaf in revision tree than max_height
+    this.compactDocument = adapterFun('compactDocument', function (docId, maxHeight, callback) {
+      this._getRevisionTree(docId, (err, revTree) => {
+        /* istanbul ignore if */
+        if (err) {
+          return callback(err);
+        }
+        var height = computeHeight(revTree);
+        var candidates = [];
+        var revs = [];
+        Object.keys(height).forEach(function (rev) {
+          if (height[rev] > maxHeight) {
+            candidates.push(rev);
+          }
+        });
+    
+        traverseRevTree(revTree, function (isLeaf, pos, revHash, ctx, opts) {
+          var rev = pos + '-' + revHash;
+          if (opts.status === 'available' && candidates.indexOf(rev) !== -1) {
+            revs.push(rev);
+          }
+        });
+        this._doCompaction(docId, revs, callback);
+      });
+    }).bind(this);
+
+    // compact the whole database using single document
+    // compaction
+    this.compact = adapterFun('compact', function (opts, callback) {
+      if (typeof opts === 'function') {
+        callback = opts;
+        opts = {};
+      }
+    
+      opts = opts || {};
+    
+      this._compactionQueue = this._compactionQueue || [];
+      this._compactionQueue.push({opts: opts, callback: callback});
+      if (this._compactionQueue.length === 1) {
+        doNextCompaction(this);
+      }
+    }).bind(this);
+
+    /* Begin api wrappers. Specific functionality to storage belongs in the _[method] */
+    this.get = adapterFun('get', function (id, opts, cb) {
+      if (typeof opts === 'function') {
+        cb = opts;
+        opts = {};
+      }
+      if (typeof id !== 'string') {
+        return cb(createError(INVALID_ID));
+      }
+      if (isLocalId(id) && typeof this._getLocal === 'function') {
+        return this._getLocal(id, cb);
+      }
+      var leaves = [];
+    
+      const finishOpenRevs = () => {
+        var result = [];
+        var count = leaves.length;
+        /* istanbul ignore if */
+        if (!count) {
+          return cb(null, result);
+        }
+    
+        // order with open_revs is unspecified
+        leaves.forEach((leaf) => {
+          this.get(id, {
+            rev: leaf,
+            revs: opts.revs,
+            latest: opts.latest,
+            attachments: opts.attachments,
+            binary: opts.binary
+          }, function (err, doc) {
+            if (!err) {
+              // using latest=true can produce duplicates
+              var existing;
+              for (var i = 0, l = result.length; i < l; i++) {
+                if (result[i].ok && result[i].ok._rev === doc._rev) {
+                  existing = true;
+                  break;
+                }
+              }
+              if (!existing) {
+                result.push({ok: doc});
+              }
+            } else {
+              result.push({missing: leaf});
+            }
+            count--;
+            if (!count) {
+              cb(null, result);
+            }
+          });
+        });
+      };
+    
+      if (opts.open_revs) {
+        if (opts.open_revs === "all") {
+          this._getRevisionTree(id, function (err, rev_tree) {
+            /* istanbul ignore if */
+            if (err) {
+              return cb(err);
+            }
+            leaves = collectLeaves(rev_tree).map(function (leaf) {
+              return leaf.rev;
+            });
+            finishOpenRevs();
+          });
+        } else {
+          if (Array.isArray(opts.open_revs)) {
+            leaves = opts.open_revs;
+            for (var i = 0; i < leaves.length; i++) {
+              var l = leaves[i];
+              // looks like it's the only thing couchdb checks
+              if (!(typeof (l) === "string" && /^\d+-/.test(l))) {
+                return cb(createError(INVALID_REV));
+              }
+            }
+            finishOpenRevs();
+          } else {
+            return cb(createError(UNKNOWN_ERROR, 'function_clause'));
+          }
+        }
+        return; // open_revs does not like other options
+      }
+    
+      return this._get(id, opts, (err, result) => {
+        if (err) {
+          err.docId = id;
+          return cb(err);
+        }
+    
+        var doc = result.doc;
+        var metadata = result.metadata;
+        var ctx = result.ctx;
+    
+        if (opts.conflicts) {
+          var conflicts = collectConflicts(metadata);
+          if (conflicts.length) {
+            doc._conflicts = conflicts;
+          }
+        }
+    
+        if (isDeleted(metadata, doc._rev)) {
+          doc._deleted = true;
+        }
+    
+        if (opts.revs || opts.revs_info) {
+          var splittedRev = doc._rev.split('-');
+          var revNo       = parseInt(splittedRev[0], 10);
+          var revHash     = splittedRev[1];
+    
+          var paths = rootToLeaf(metadata.rev_tree);
+          var path = null;
+    
+          for (var i = 0; i < paths.length; i++) {
+            var currentPath = paths[i];
+            var hashIndex = currentPath.ids.map(function (x) { return x.id; })
+              .indexOf(revHash);
+            var hashFoundAtRevPos = hashIndex === (revNo - 1);
+    
+            if (hashFoundAtRevPos || (!path && hashIndex !== -1)) {
+              path = currentPath;
+            }
+          }
+    
+          /* istanbul ignore if */
+          if (!path) {
+            err = new Error('invalid rev tree');
+            err.docId = id;
+            return cb(err);
+          }
+    
+          var indexOfRev = path.ids.map(function (x) { return x.id; })
+            .indexOf(doc._rev.split('-')[1]) + 1;
+          var howMany = path.ids.length - indexOfRev;
+          path.ids.splice(indexOfRev, howMany);
+          path.ids.reverse();
+    
+          if (opts.revs) {
+            doc._revisions = {
+              start: (path.pos + path.ids.length) - 1,
+              ids: path.ids.map(function (rev) {
+                return rev.id;
+              })
+            };
+          }
+          if (opts.revs_info) {
+            var pos =  path.pos + path.ids.length;
+            doc._revs_info = path.ids.map(function (rev) {
+              pos--;
+              return {
+                rev: pos + '-' + rev.id,
+                status: rev.opts.status
+              };
+            });
+          }
+        }
+    
+        if (opts.attachments && doc._attachments) {
+          var attachments = doc._attachments;
+          var count = Object.keys(attachments).length;
+          if (count === 0) {
+            return cb(null, doc);
+          }
+          Object.keys(attachments).forEach((key) => {
+            this._getAttachment(doc._id, key, attachments[key], {
+              // Previously the revision handling was done in adapter.js
+              // getAttachment, however since idb-next doesnt we need to
+              // pass the rev through
+              rev: doc._rev,
+              binary: opts.binary,
+              ctx: ctx
+            }, function (err, data) {
+              var att = doc._attachments[key];
+              att.data = data;
+              delete att.stub;
+              delete att.length;
+              if (!--count) {
+                cb(null, doc);
+              }
+            });
+          });
+        } else {
+          if (doc._attachments) {
+            for (var key in doc._attachments) {
+              /* istanbul ignore else */
+              if (Object.prototype.hasOwnProperty.call(doc._attachments, key)) {
+                doc._attachments[key].stub = true;
+              }
+            }
+          }
+          cb(null, doc);
+        }
+      });
+    }).bind(this);
+
+    // TODO: I dont like this, it forces an extra read for every
+    // attachment read and enforces a confusing api between
+    // adapter.js and the adapter implementation
+    this.getAttachment = adapterFun('getAttachment', function (docId, attachmentId, opts, callback) {
+      if (opts instanceof Function) {
+        callback = opts;
+        opts = {};
+      }
+      this._get(docId, opts, (err, res) => {
+        if (err) {
+          return callback(err);
+        }
+        if (res.doc._attachments && res.doc._attachments[attachmentId]) {
+          opts.ctx = res.ctx;
+          opts.binary = true;
+          this._getAttachment(docId, attachmentId,
+                              res.doc._attachments[attachmentId], opts, callback);
+        } else {
+          return callback(createError(MISSING_DOC));
+        }
+      });
+    }).bind(this);
+
+    this.allDocs = adapterFun('allDocs', function (opts, callback) {
+      if (typeof opts === 'function') {
+        callback = opts;
+        opts = {};
+      }
+      opts.skip = typeof opts.skip !== 'undefined' ? opts.skip : 0;
+      if (opts.start_key) {
+        opts.startkey = opts.start_key;
+      }
+      if (opts.end_key) {
+        opts.endkey = opts.end_key;
+      }
+      if ('keys' in opts) {
+        if (!Array.isArray(opts.keys)) {
+          return callback(new TypeError('options.keys must be an array'));
+        }
+        var incompatibleOpt =
+          ['startkey', 'endkey', 'key'].filter(function (incompatibleOpt) {
+          return incompatibleOpt in opts;
+        })[0];
+        if (incompatibleOpt) {
+          callback(createError(QUERY_PARSE_ERROR,
+            'Query parameter `' + incompatibleOpt +
+            '` is not compatible with multi-get'
+          ));
+          return;
+        }
+        if (!isRemote(this)) {
+          allDocsKeysParse(opts);
+          if (opts.keys.length === 0) {
+            return this._allDocs({limit: 0}, callback);
+          }
+        }
+      }
+    
+      return this._allDocs(opts, callback);
+    }).bind(this);
+
+    this.close = adapterFun('close', function (callback) {
+      this._closed = true;
+      this.emit('closed');
+      return this._close(callback);
+    }).bind(this);
+
+    this.info = adapterFun('info', function (callback) {
+      this._info((err, info) => {
+        if (err) {
+          return callback(err);
+        }
+        // assume we know better than the adapter, unless it informs us
+        info.db_name = info.db_name || this.name;
+        info.auto_compaction = !!(this.auto_compaction && !isRemote(this));
+        info.adapter = this.adapter;
+        callback(null, info);
+      });
+    }).bind(this);
+
+    this.id = adapterFun('id', function (callback) {
+      return this._id(callback);
+    }).bind(this);
+
+    this.bulkDocs = adapterFun('bulkDocs', function (req, opts, callback) {
+      if (typeof opts === 'function') {
+        callback = opts;
+        opts = {};
+      }
+    
+      opts = opts || {};
+    
+      if (Array.isArray(req)) {
+        req = {
+          docs: req
+        };
+      }
+    
+      if (!req || !req.docs || !Array.isArray(req.docs)) {
+        return callback(createError(MISSING_BULK_DOCS));
+      }
+    
+      for (var i = 0; i < req.docs.length; ++i) {
+        if (typeof req.docs[i] !== 'object' || Array.isArray(req.docs[i])) {
+          return callback(createError(NOT_AN_OBJECT));
+        }
+      }
+    
+      var attachmentError;
+      req.docs.forEach(function (doc) {
+        if (doc._attachments) {
+          Object.keys(doc._attachments).forEach(function (name) {
+            attachmentError = attachmentError || attachmentNameError(name);
+            if (!doc._attachments[name].content_type) {
+              guardedConsole('warn', 'Attachment', name, 'on document', doc._id, 'is missing content_type');
+            }
+          });
+        }
+      });
+    
+      if (attachmentError) {
+        return callback(createError(BAD_REQUEST, attachmentError));
+      }
+    
+      if (!('new_edits' in opts)) {
+        if ('new_edits' in req) {
+          opts.new_edits = req.new_edits;
+        } else {
+          opts.new_edits = true;
+        }
+      }
+    
+      var adapter = this;
+      if (!opts.new_edits && !isRemote(adapter)) {
+        // ensure revisions of the same doc are sorted, so that
+        // the local adapter processes them correctly (#2935)
+        req.docs.sort(compareByIdThenRev);
+      }
+    
+      cleanDocs(req.docs);
+    
+      // in the case of conflicts, we want to return the _ids to the user
+      // however, the underlying adapter may destroy the docs array, so
+      // create a copy here
+      var ids = req.docs.map(function (doc) {
+        return doc._id;
+      });
+    
+      return this._bulkDocs(req, opts, function (err, res) {
+        if (err) {
+          return callback(err);
+        }
+        if (!opts.new_edits) {
+          // this is what couch does when new_edits is false
+          res = res.filter(function (x) {
+            return x.error;
+          });
+        }
+        // add ids for error/conflict responses (not required for CouchDB)
+        if (!isRemote(adapter)) {
+          for (var i = 0, l = res.length; i < l; i++) {
+            res[i].id = res[i].id || ids[i];
+          }
+        }
+    
+        callback(null, res);
+      });
+    }).bind(this);
+
+    this.registerDependentDatabase = adapterFun('registerDependentDatabase', function (dependentDb, callback) {
+      var dbOptions = clone(this.__opts);
+      if (this.__opts.view_adapter) {
+        dbOptions.adapter = this.__opts.view_adapter;
+      }
+    
+      var depDB = new this.constructor(dependentDb, dbOptions);
+
+      function diffFun(doc) {
+        doc.dependentDbs = doc.dependentDbs || {};
+        if (doc.dependentDbs[dependentDb]) {
+          return false; // no update required
+        }
+        doc.dependentDbs[dependentDb] = true;
+        return doc;
+      }
+      upsert(this, '_local/_pouch_dependentDbs', diffFun).then(function () {
+        callback(null, {db: depDB});
+      }).catch(callback);
+    }).bind(this);
+
+    this.destroy = adapterFun('destroy', function (opts, callback) {
+
+      if (typeof opts === 'function') {
+        callback = opts;
+        opts = {};
+      }
+    
+      var usePrefix = 'use_prefix' in this ? this.use_prefix : true;
+    
+      const destroyDb = () => {
+        // call destroy method of the particular adaptor
+        this._destroy(opts, (err, resp) => {
+          if (err) {
+            return callback(err);
+          }
+          this._destroyed = true;
+          this.emit('destroyed');
+          callback(null, resp || { 'ok': true });
+        });
+      };
+    
+      if (isRemote(this)) {
+        // no need to check for dependent DBs if it's a remote DB
+        return destroyDb();
+      }
+    
+      this.get('_local/_pouch_dependentDbs', (err, localDoc) => {
+        if (err) {
+          /* istanbul ignore if */
+          if (err.status !== 404) {
+            return callback(err);
+          } else { // no dependencies
+            return destroyDb();
+          }
+        }
+        var dependentDbs = localDoc.dependentDbs;
+        var PouchDB = this.constructor;
+        var deletedMap = Object.keys(dependentDbs).map((name) => {
+          // use_prefix is only false in the browser
+          /* istanbul ignore next */
+          var trueName = usePrefix ?
+            name.replace(new RegExp('^' + PouchDB.prefix), '') : name;
+          return new PouchDB(trueName, this.__opts).destroy();
+        });
+        Promise.all(deletedMap).then(destroyDb, callback);
+      });
+    }).bind(this);
   }
 
-  function transformForceOptionToNewEditsOption() {
-    var parts = doc._rev.split('-');
-    var oldRevId = parts[1];
-    var oldRevNum = parseInt(parts[0], 10);
-
-    var newRevNum = oldRevNum + 1;
-    var newRevId = rev();
-
-    doc._revisions = {
-      start: newRevNum,
-      ids: [newRevId, oldRevId]
+  _compact(opts, callback) {
+    var changesOpts = {
+      return_docs: false,
+      last_seq: opts.last_seq || 0
     };
-    doc._rev = newRevNum + '-' + newRevId;
-    opts.new_edits = false;
-  }
-  function putDoc(next) {
-    if (typeof self._put === 'function' && opts.new_edits !== false) {
-      self._put(doc, opts, next);
-    } else {
-      self.bulkDocs({docs: [doc]}, opts, yankError(next, doc._id));
-    }
-  }
-});
-
-AbstractPouchDB.prototype.putAttachment =
-  adapterFun('putAttachment', function (docId, attachmentId, rev,
-                                              blob, type) {
-  var api = this;
-  if (typeof type === 'function') {
-    type = blob;
-    blob = rev;
-    rev = null;
-  }
-  // Lets fix in https://github.com/pouchdb/pouchdb/issues/3267
-  /* istanbul ignore if */
-  if (typeof type === 'undefined') {
-    type = blob;
-    blob = rev;
-    rev = null;
-  }
-  if (!type) {
-    guardedConsole('warn', 'Attachment', attachmentId, 'on document', docId, 'is missing content_type');
-  }
-
-  function createAttachment(doc) {
-    var prevrevpos = '_rev' in doc ? parseInt(doc._rev, 10) : 0;
-    doc._attachments = doc._attachments || {};
-    doc._attachments[attachmentId] = {
-      content_type: type,
-      data: blob,
-      revpos: ++prevrevpos
+    var promises = [];
+  
+    const onChange = (row) => {
+      promises.push(this.compactDocument(row.id, 0));
     };
-    return api.put(doc);
+    const onComplete = (resp) => {
+      var lastSeq = resp.last_seq;
+      Promise.all(promises).then(() => {
+        return upsert(this, '_local/compaction', function deltaFunc(doc) {
+          if (!doc.last_seq || doc.last_seq < lastSeq) {
+            doc.last_seq = lastSeq;
+            return doc;
+          }
+          return false; // somebody else got here first, don't update
+        });
+      }).then(function () {
+        callback(null, {ok: true});
+      }).catch(callback);
+    };
+    this.changes(changesOpts)
+      .on('change', onChange)
+      .on('complete', onComplete)
+      .on('error', callback);
   }
 
-  return api.get(docId).then(function (doc) {
-    if (doc._rev !== rev) {
-      throw createError(REV_CONFLICT);
-    }
-
-    return createAttachment(doc);
-  }, function (err) {
-     // create new doc
-    /* istanbul ignore else */
-    if (err.reason === MISSING_DOC.message) {
-      return createAttachment({_id: docId});
-    } else {
-      throw err;
-    }
-  });
-});
-
-AbstractPouchDB.prototype.removeAttachment =
-  adapterFun('removeAttachment', function (docId, attachmentId, rev,
-                                                 callback) {
-  var self = this;
-  self.get(docId, function (err, obj) {
-    /* istanbul ignore if */
-    if (err) {
-      callback(err);
-      return;
-    }
-    if (obj._rev !== rev) {
-      callback(createError(REV_CONFLICT));
-      return;
-    }
-    /* istanbul ignore if */
-    if (!obj._attachments) {
-      return callback();
-    }
-    delete obj._attachments[attachmentId];
-    if (Object.keys(obj._attachments).length === 0) {
-      delete obj._attachments;
-    }
-    self.put(obj, callback);
-  });
-});
-
-AbstractPouchDB.prototype.remove =
-  adapterFun('remove', function (docOrId, optsOrRev, opts, callback) {
-  var doc;
-  if (typeof optsOrRev === 'string') {
-    // id, rev, opts, callback style
-    doc = {
-      _id: docOrId,
-      _rev: optsOrRev
-    };
+  changes(opts, callback) {
     if (typeof opts === 'function') {
       callback = opts;
       opts = {};
     }
-  } else {
-    // doc, opts, callback style
-    doc = docOrId;
-    if (typeof optsOrRev === 'function') {
-      callback = optsOrRev;
-      opts = {};
-    } else {
-      callback = opts;
-      opts = optsOrRev;
-    }
-  }
-  opts = opts || {};
-  opts.was_delete = true;
-  var newDoc = {_id: doc._id, _rev: (doc._rev || opts.rev)};
-  newDoc._deleted = true;
-  if (isLocalId(newDoc._id) && typeof this._removeLocal === 'function') {
-    return this._removeLocal(doc, callback);
-  }
-  this.bulkDocs({docs: [newDoc]}, opts, yankError(callback, newDoc._id));
-});
-
-AbstractPouchDB.prototype.revsDiff =
-  adapterFun('revsDiff', function (req, opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-  var ids = Object.keys(req);
-
-  if (!ids.length) {
-    return callback(null, {});
+  
+    opts = opts || {};
+  
+    // By default set return_docs to false if the caller has opts.live = true,
+    // this will prevent us from collecting the set of changes indefinitely
+    // resulting in growing memory
+    opts.return_docs = ('return_docs' in opts) ? opts.return_docs : !opts.live;
+  
+    return new Changes(this, opts, callback);
   }
 
-  var count = 0;
-  var missing = new Map();
-
-  function addToMissing(id, revId) {
-    if (!missing.has(id)) {
-      missing.set(id, {missing: []});
-    }
-    missing.get(id).missing.push(revId);
+  type() {
+    return (typeof this._type === 'function') ? this._type() : this.adapter;
   }
-
-  function processDoc(id, rev_tree) {
-    // Is this fast enough? Maybe we should switch to a set simulated by a map
-    var missingForId = req[id].slice(0);
-    traverseRevTree(rev_tree, function (isLeaf, pos, revHash, ctx,
-      opts) {
-        var rev = pos + '-' + revHash;
-        var idx = missingForId.indexOf(rev);
-        if (idx === -1) {
-          return;
-        }
-
-        missingForId.splice(idx, 1);
-        /* istanbul ignore if */
-        if (opts.status !== 'available') {
-          addToMissing(id, rev);
-        }
-      });
-
-    // Traversing the tree is synchronous, so now `missingForId` contains
-    // revisions that were not found in the tree
-    missingForId.forEach(function (rev) {
-      addToMissing(id, rev);
-    });
-  }
-
-  ids.map(function (id) {
-    this._getRevisionTree(id, function (err, rev_tree) {
-      if (err && err.status === 404 && err.message === 'missing') {
-        missing.set(id, {missing: req[id]});
-      } else if (err) {
-        /* istanbul ignore next */
-        return callback(err);
-      } else {
-        processDoc(id, rev_tree);
-      }
-
-      if (++count === ids.length) {
-        // convert LazyMap to object
-        var missingObj = {};
-        missing.forEach(function (value, key) {
-          missingObj[key] = value;
-        });
-        return callback(null, missingObj);
-      }
-    });
-  }, this);
-});
-
-// _bulk_get API for faster replication, as described in
-// https://github.com/apache/couchdb-chttpd/pull/33
-// At the "abstract" level, it will just run multiple get()s in
-// parallel, because this isn't much of a performance cost
-// for local databases (except the cost of multiple transactions, which is
-// small). The http adapter overrides this in order
-// to do a more efficient single HTTP request.
-AbstractPouchDB.prototype.bulkGet =
-  adapterFun('bulkGet', function (opts, callback) {
-  bulkGetShim(this, opts, callback);
-});
-
-// compact one document and fire callback
-// by compacting we mean removing all revisions which
-// are further from the leaf in revision tree than max_height
-AbstractPouchDB.prototype.compactDocument =
-  adapterFun('compactDocument', function (docId, maxHeight, callback) {
-  var self = this;
-  this._getRevisionTree(docId, function (err, revTree) {
-    /* istanbul ignore if */
-    if (err) {
-      return callback(err);
-    }
-    var height = computeHeight(revTree);
-    var candidates = [];
-    var revs = [];
-    Object.keys(height).forEach(function (rev) {
-      if (height[rev] > maxHeight) {
-        candidates.push(rev);
-      }
-    });
-
-    traverseRevTree(revTree, function (isLeaf, pos, revHash, ctx, opts) {
-      var rev = pos + '-' + revHash;
-      if (opts.status === 'available' && candidates.indexOf(rev) !== -1) {
-        revs.push(rev);
-      }
-    });
-    self._doCompaction(docId, revs, callback);
-  });
-});
-
-// compact the whole database using single document
-// compaction
-AbstractPouchDB.prototype.compact =
-  adapterFun('compact', function (opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-
-  var self = this;
-  opts = opts || {};
-
-  self._compactionQueue = self._compactionQueue || [];
-  self._compactionQueue.push({opts: opts, callback: callback});
-  if (self._compactionQueue.length === 1) {
-    doNextCompaction(self);
-  }
-});
-AbstractPouchDB.prototype._compact = function (opts, callback) {
-  var self = this;
-  var changesOpts = {
-    return_docs: false,
-    last_seq: opts.last_seq || 0
-  };
-  var promises = [];
-
-  function onChange(row) {
-    promises.push(self.compactDocument(row.id, 0));
-  }
-  function onComplete(resp) {
-    var lastSeq = resp.last_seq;
-    Promise.all(promises).then(function () {
-      return upsert(self, '_local/compaction', function deltaFunc(doc) {
-        if (!doc.last_seq || doc.last_seq < lastSeq) {
-          doc.last_seq = lastSeq;
-          return doc;
-        }
-        return false; // somebody else got here first, don't update
-      });
-    }).then(function () {
-      callback(null, {ok: true});
-    }).catch(callback);
-  }
-  self.changes(changesOpts)
-    .on('change', onChange)
-    .on('complete', onComplete)
-    .on('error', callback);
-};
-
-/* Begin api wrappers. Specific functionality to storage belongs in the
-   _[method] */
-AbstractPouchDB.prototype.get = adapterFun('get', function (id, opts, cb) {
-  if (typeof opts === 'function') {
-    cb = opts;
-    opts = {};
-  }
-  if (typeof id !== 'string') {
-    return cb(createError(INVALID_ID));
-  }
-  if (isLocalId(id) && typeof this._getLocal === 'function') {
-    return this._getLocal(id, cb);
-  }
-  var leaves = [], self = this;
-
-  function finishOpenRevs() {
-    var result = [];
-    var count = leaves.length;
-    /* istanbul ignore if */
-    if (!count) {
-      return cb(null, result);
-    }
-
-    // order with open_revs is unspecified
-    leaves.forEach(function (leaf) {
-      self.get(id, {
-        rev: leaf,
-        revs: opts.revs,
-        latest: opts.latest,
-        attachments: opts.attachments,
-        binary: opts.binary
-      }, function (err, doc) {
-        if (!err) {
-          // using latest=true can produce duplicates
-          var existing;
-          for (var i = 0, l = result.length; i < l; i++) {
-            if (result[i].ok && result[i].ok._rev === doc._rev) {
-              existing = true;
-              break;
-            }
-          }
-          if (!existing) {
-            result.push({ok: doc});
-          }
-        } else {
-          result.push({missing: leaf});
-        }
-        count--;
-        if (!count) {
-          cb(null, result);
-        }
-      });
-    });
-  }
-
-  if (opts.open_revs) {
-    if (opts.open_revs === "all") {
-      this._getRevisionTree(id, function (err, rev_tree) {
-        /* istanbul ignore if */
-        if (err) {
-          return cb(err);
-        }
-        leaves = collectLeaves(rev_tree).map(function (leaf) {
-          return leaf.rev;
-        });
-        finishOpenRevs();
-      });
-    } else {
-      if (Array.isArray(opts.open_revs)) {
-        leaves = opts.open_revs;
-        for (var i = 0; i < leaves.length; i++) {
-          var l = leaves[i];
-          // looks like it's the only thing couchdb checks
-          if (!(typeof (l) === "string" && /^\d+-/.test(l))) {
-            return cb(createError(INVALID_REV));
-          }
-        }
-        finishOpenRevs();
-      } else {
-        return cb(createError(UNKNOWN_ERROR, 'function_clause'));
-      }
-    }
-    return; // open_revs does not like other options
-  }
-
-  return this._get(id, opts, function (err, result) {
-    if (err) {
-      err.docId = id;
-      return cb(err);
-    }
-
-    var doc = result.doc;
-    var metadata = result.metadata;
-    var ctx = result.ctx;
-
-    if (opts.conflicts) {
-      var conflicts = collectConflicts(metadata);
-      if (conflicts.length) {
-        doc._conflicts = conflicts;
-      }
-    }
-
-    if (isDeleted(metadata, doc._rev)) {
-      doc._deleted = true;
-    }
-
-    if (opts.revs || opts.revs_info) {
-      var splittedRev = doc._rev.split('-');
-      var revNo       = parseInt(splittedRev[0], 10);
-      var revHash     = splittedRev[1];
-
-      var paths = rootToLeaf(metadata.rev_tree);
-      var path = null;
-
-      for (var i = 0; i < paths.length; i++) {
-        var currentPath = paths[i];
-        var hashIndex = currentPath.ids.map(function (x) { return x.id; })
-          .indexOf(revHash);
-        var hashFoundAtRevPos = hashIndex === (revNo - 1);
-
-        if (hashFoundAtRevPos || (!path && hashIndex !== -1)) {
-          path = currentPath;
-        }
-      }
-
-      /* istanbul ignore if */
-      if (!path) {
-        err = new Error('invalid rev tree');
-        err.docId = id;
-        return cb(err);
-      }
-
-      var indexOfRev = path.ids.map(function (x) { return x.id; })
-        .indexOf(doc._rev.split('-')[1]) + 1;
-      var howMany = path.ids.length - indexOfRev;
-      path.ids.splice(indexOfRev, howMany);
-      path.ids.reverse();
-
-      if (opts.revs) {
-        doc._revisions = {
-          start: (path.pos + path.ids.length) - 1,
-          ids: path.ids.map(function (rev) {
-            return rev.id;
-          })
-        };
-      }
-      if (opts.revs_info) {
-        var pos =  path.pos + path.ids.length;
-        doc._revs_info = path.ids.map(function (rev) {
-          pos--;
-          return {
-            rev: pos + '-' + rev.id,
-            status: rev.opts.status
-          };
-        });
-      }
-    }
-
-    if (opts.attachments && doc._attachments) {
-      var attachments = doc._attachments;
-      var count = Object.keys(attachments).length;
-      if (count === 0) {
-        return cb(null, doc);
-      }
-      Object.keys(attachments).forEach(function (key) {
-        this._getAttachment(doc._id, key, attachments[key], {
-          // Previously the revision handling was done in adapter.js
-          // getAttachment, however since idb-next doesnt we need to
-          // pass the rev through
-          rev: doc._rev,
-          binary: opts.binary,
-          ctx: ctx
-        }, function (err, data) {
-          var att = doc._attachments[key];
-          att.data = data;
-          delete att.stub;
-          delete att.length;
-          if (!--count) {
-            cb(null, doc);
-          }
-        });
-      }, self);
-    } else {
-      if (doc._attachments) {
-        for (var key in doc._attachments) {
-          /* istanbul ignore else */
-          if (Object.prototype.hasOwnProperty.call(doc._attachments, key)) {
-            doc._attachments[key].stub = true;
-          }
-        }
-      }
-      cb(null, doc);
-    }
-  });
-});
-
-// TODO: I dont like this, it forces an extra read for every
-// attachment read and enforces a confusing api between
-// adapter.js and the adapter implementation
-AbstractPouchDB.prototype.getAttachment =
-  adapterFun('getAttachment', function (docId, attachmentId, opts, callback) {
-  var self = this;
-  if (opts instanceof Function) {
-    callback = opts;
-    opts = {};
-  }
-  this._get(docId, opts, function (err, res) {
-    if (err) {
-      return callback(err);
-    }
-    if (res.doc._attachments && res.doc._attachments[attachmentId]) {
-      opts.ctx = res.ctx;
-      opts.binary = true;
-      self._getAttachment(docId, attachmentId,
-                          res.doc._attachments[attachmentId], opts, callback);
-    } else {
-      return callback(createError(MISSING_DOC));
-    }
-  });
-});
-
-AbstractPouchDB.prototype.allDocs =
-  adapterFun('allDocs', function (opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-  opts.skip = typeof opts.skip !== 'undefined' ? opts.skip : 0;
-  if (opts.start_key) {
-    opts.startkey = opts.start_key;
-  }
-  if (opts.end_key) {
-    opts.endkey = opts.end_key;
-  }
-  if ('keys' in opts) {
-    if (!Array.isArray(opts.keys)) {
-      return callback(new TypeError('options.keys must be an array'));
-    }
-    var incompatibleOpt =
-      ['startkey', 'endkey', 'key'].filter(function (incompatibleOpt) {
-      return incompatibleOpt in opts;
-    })[0];
-    if (incompatibleOpt) {
-      callback(createError(QUERY_PARSE_ERROR,
-        'Query parameter `' + incompatibleOpt +
-        '` is not compatible with multi-get'
-      ));
-      return;
-    }
-    if (!isRemote(this)) {
-      allDocsKeysParse(opts);
-      if (opts.keys.length === 0) {
-        return this._allDocs({limit: 0}, callback);
-      }
-    }
-  }
-
-  return this._allDocs(opts, callback);
-});
-
-AbstractPouchDB.prototype.changes = function (opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-
-  opts = opts || {};
-
-  // By default set return_docs to false if the caller has opts.live = true,
-  // this will prevent us from collecting the set of changes indefinitely
-  // resulting in growing memory
-  opts.return_docs = ('return_docs' in opts) ? opts.return_docs : !opts.live;
-
-  return new Changes(this, opts, callback);
-};
-
-AbstractPouchDB.prototype.close = adapterFun('close', function (callback) {
-  this._closed = true;
-  this.emit('closed');
-  return this._close(callback);
-});
-
-AbstractPouchDB.prototype.info = adapterFun('info', function (callback) {
-  var self = this;
-  this._info(function (err, info) {
-    if (err) {
-      return callback(err);
-    }
-    // assume we know better than the adapter, unless it informs us
-    info.db_name = info.db_name || self.name;
-    info.auto_compaction = !!(self.auto_compaction && !isRemote(self));
-    info.adapter = self.adapter;
-    callback(null, info);
-  });
-});
-
-AbstractPouchDB.prototype.id = adapterFun('id', function (callback) {
-  return this._id(callback);
-});
-
-/* istanbul ignore next */
-AbstractPouchDB.prototype.type = function () {
-  return (typeof this._type === 'function') ? this._type() : this.adapter;
-};
-
-AbstractPouchDB.prototype.bulkDocs =
-  adapterFun('bulkDocs', function (req, opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-
-  opts = opts || {};
-
-  if (Array.isArray(req)) {
-    req = {
-      docs: req
-    };
-  }
-
-  if (!req || !req.docs || !Array.isArray(req.docs)) {
-    return callback(createError(MISSING_BULK_DOCS));
-  }
-
-  for (var i = 0; i < req.docs.length; ++i) {
-    if (typeof req.docs[i] !== 'object' || Array.isArray(req.docs[i])) {
-      return callback(createError(NOT_AN_OBJECT));
-    }
-  }
-
-  var attachmentError;
-  req.docs.forEach(function (doc) {
-    if (doc._attachments) {
-      Object.keys(doc._attachments).forEach(function (name) {
-        attachmentError = attachmentError || attachmentNameError(name);
-        if (!doc._attachments[name].content_type) {
-          guardedConsole('warn', 'Attachment', name, 'on document', doc._id, 'is missing content_type');
-        }
-      });
-    }
-  });
-
-  if (attachmentError) {
-    return callback(createError(BAD_REQUEST, attachmentError));
-  }
-
-  if (!('new_edits' in opts)) {
-    if ('new_edits' in req) {
-      opts.new_edits = req.new_edits;
-    } else {
-      opts.new_edits = true;
-    }
-  }
-
-  var adapter = this;
-  if (!opts.new_edits && !isRemote(adapter)) {
-    // ensure revisions of the same doc are sorted, so that
-    // the local adapter processes them correctly (#2935)
-    req.docs.sort(compareByIdThenRev);
-  }
-
-  cleanDocs(req.docs);
-
-  // in the case of conflicts, we want to return the _ids to the user
-  // however, the underlying adapter may destroy the docs array, so
-  // create a copy here
-  var ids = req.docs.map(function (doc) {
-    return doc._id;
-  });
-
-  return this._bulkDocs(req, opts, function (err, res) {
-    if (err) {
-      return callback(err);
-    }
-    if (!opts.new_edits) {
-      // this is what couch does when new_edits is false
-      res = res.filter(function (x) {
-        return x.error;
-      });
-    }
-    // add ids for error/conflict responses (not required for CouchDB)
-    if (!isRemote(adapter)) {
-      for (var i = 0, l = res.length; i < l; i++) {
-        res[i].id = res[i].id || ids[i];
-      }
-    }
-
-    callback(null, res);
-  });
-});
-
-AbstractPouchDB.prototype.registerDependentDatabase =
-  adapterFun('registerDependentDatabase', function (dependentDb,
-                                                          callback) {
-  var dbOptions = clone(this.__opts);
-  if (this.__opts.view_adapter) {
-    dbOptions.adapter = this.__opts.view_adapter;
-  }
-
-  var depDB = new this.constructor(dependentDb, dbOptions);
-
-  function diffFun(doc) {
-    doc.dependentDbs = doc.dependentDbs || {};
-    if (doc.dependentDbs[dependentDb]) {
-      return false; // no update required
-    }
-    doc.dependentDbs[dependentDb] = true;
-    return doc;
-  }
-  upsert(this, '_local/_pouch_dependentDbs', diffFun)
-    .then(function () {
-      callback(null, {db: depDB});
-    }).catch(callback);
-});
-
-AbstractPouchDB.prototype.destroy =
-  adapterFun('destroy', function (opts, callback) {
-
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-
-  var self = this;
-  var usePrefix = 'use_prefix' in self ? self.use_prefix : true;
-
-  function destroyDb() {
-    // call destroy method of the particular adaptor
-    self._destroy(opts, function (err, resp) {
-      if (err) {
-        return callback(err);
-      }
-      self._destroyed = true;
-      self.emit('destroyed');
-      callback(null, resp || { 'ok': true });
-    });
-  }
-
-  if (isRemote(self)) {
-    // no need to check for dependent DBs if it's a remote DB
-    return destroyDb();
-  }
-
-  self.get('_local/_pouch_dependentDbs', function (err, localDoc) {
-    if (err) {
-      /* istanbul ignore if */
-      if (err.status !== 404) {
-        return callback(err);
-      } else { // no dependencies
-        return destroyDb();
-      }
-    }
-    var dependentDbs = localDoc.dependentDbs;
-    var PouchDB = self.constructor;
-    var deletedMap = Object.keys(dependentDbs).map(function (name) {
-      // use_prefix is only false in the browser
-      /* istanbul ignore next */
-      var trueName = usePrefix ?
-        name.replace(new RegExp('^' + PouchDB.prefix), '') : name;
-      return new PouchDB(trueName, self.__opts).destroy();
-    });
-    Promise.all(deletedMap).then(destroyDb, callback);
-  });
-});
+}  
 
 export default AbstractPouchDB;

--- a/packages/node_modules/pouchdb-core/src/changes.js
+++ b/packages/node_modules/pouchdb-core/src/changes.js
@@ -10,13 +10,10 @@ import {
   collectLeaves,
   collectConflicts
 } from 'pouchdb-merge';
-import inherits from 'inherits';
 import EE from 'events';
 
 
 import PouchDB from './setup';
-
-inherits(Changes, EE);
 
 function tryCatchInChangeListener(self, change, pending, lastSeq) {
   // isolate try/catches to avoid V8 deoptimizations
@@ -27,82 +24,6 @@ function tryCatchInChangeListener(self, change, pending, lastSeq) {
   }
 }
 
-function Changes(db, opts, callback) {
-  EE.call(this);
-  var self = this;
-  this.db = db;
-  opts = opts ? clone(opts) : {};
-  var complete = opts.complete = once(function (err, resp) {
-    if (err) {
-      if (listenerCount(self, 'error') > 0) {
-        self.emit('error', err);
-      }
-    } else {
-      self.emit('complete', resp);
-    }
-    self.removeAllListeners();
-    db.removeListener('destroyed', onDestroy);
-  });
-  if (callback) {
-    self.on('complete', function (resp) {
-      callback(null, resp);
-    });
-    self.on('error', callback);
-  }
-  function onDestroy() {
-    self.cancel();
-  }
-  db.once('destroyed', onDestroy);
-
-  opts.onChange = function (change, pending, lastSeq) {
-    /* istanbul ignore if */
-    if (self.isCancelled) {
-      return;
-    }
-    tryCatchInChangeListener(self, change, pending, lastSeq);
-  };
-
-  var promise = new Promise(function (fulfill, reject) {
-    opts.complete = function (err, res) {
-      if (err) {
-        reject(err);
-      } else {
-        fulfill(res);
-      }
-    };
-  });
-  self.once('cancel', function () {
-    db.removeListener('destroyed', onDestroy);
-    opts.complete(null, {status: 'cancelled'});
-  });
-  this.then = promise.then.bind(promise);
-  this['catch'] = promise['catch'].bind(promise);
-  this.then(function (result) {
-    complete(null, result);
-  }, complete);
-
-
-
-  if (!db.taskqueue.isReady) {
-    db.taskqueue.addTask(function (failed) {
-      if (failed) {
-        opts.complete(failed);
-      } else if (self.isCancelled) {
-        self.emit('cancel');
-      } else {
-        self.validateChanges(opts);
-      }
-    });
-  } else {
-    self.validateChanges(opts);
-  }
-}
-Changes.prototype.cancel = function () {
-  this.isCancelled = true;
-  if (this.db.taskqueue.isReady) {
-    this.emit('cancel');
-  }
-};
 function processChange(doc, metadata, opts) {
   var changeList = [{rev: doc._rev}];
   if (opts.style === 'all_docs') {
@@ -127,86 +48,163 @@ function processChange(doc, metadata, opts) {
   return change;
 }
 
-Changes.prototype.validateChanges = function (opts) {
-  var callback = opts.complete;
-  var self = this;
-
-  /* istanbul ignore else */
-  if (PouchDB._changesFilterPlugin) {
-    PouchDB._changesFilterPlugin.validate(opts, function (err) {
+class Changes extends EE {
+  constructor(db, opts, callback) {
+    super();
+    this.db = db;
+    opts = opts ? clone(opts) : {};
+    var complete = opts.complete = once((err, resp) => {
       if (err) {
-        return callback(err);
+        if (listenerCount(this, 'error') > 0) {
+          this.emit('error', err);
+        }
+      } else {
+        this.emit('complete', resp);
       }
-      self.doChanges(opts);
+      this.removeAllListeners();
+      db.removeListener('destroyed', onDestroy);
     });
-  } else {
-    self.doChanges(opts);
-  }
-};
-
-Changes.prototype.doChanges = function (opts) {
-  var self = this;
-  var callback = opts.complete;
-
-  opts = clone(opts);
-  if ('live' in opts && !('continuous' in opts)) {
-    opts.continuous = opts.live;
-  }
-  opts.processChange = processChange;
-
-  if (opts.since === 'latest') {
-    opts.since = 'now';
-  }
-  if (!opts.since) {
-    opts.since = 0;
-  }
-  if (opts.since === 'now') {
-    this.db.info().then(function (info) {
+    if (callback) {
+      this.on('complete', function (resp) {
+        callback(null, resp);
+      });
+      this.on('error', callback);
+    }
+    const onDestroy = () => {
+      this.cancel();
+    };
+    db.once('destroyed', onDestroy);
+  
+    opts.onChange = (change, pending, lastSeq) => {
       /* istanbul ignore if */
-      if (self.isCancelled) {
-        callback(null, {status: 'cancelled'});
+      if (this.isCancelled) {
         return;
       }
-      opts.since = info.update_seq;
-      self.doChanges(opts);
-    }, callback);
-    return;
-  }
-
-  /* istanbul ignore else */
-  if (PouchDB._changesFilterPlugin) {
-    PouchDB._changesFilterPlugin.normalize(opts);
-    if (PouchDB._changesFilterPlugin.shouldFilter(this, opts)) {
-      return PouchDB._changesFilterPlugin.filter(this, opts);
+      tryCatchInChangeListener(this, change, pending, lastSeq);
+    };
+  
+    var promise = new Promise(function (fulfill, reject) {
+      opts.complete = function (err, res) {
+        if (err) {
+          reject(err);
+        } else {
+          fulfill(res);
+        }
+      };
+    });
+    this.once('cancel', function () {
+      db.removeListener('destroyed', onDestroy);
+      opts.complete(null, {status: 'cancelled'});
+    });
+    this.then = promise.then.bind(promise);
+    this['catch'] = promise['catch'].bind(promise);
+    this.then(function (result) {
+      complete(null, result);
+    }, complete);
+  
+  
+  
+    if (!db.taskqueue.isReady) {
+      db.taskqueue.addTask((failed) => {
+        if (failed) {
+          opts.complete(failed);
+        } else if (this.isCancelled) {
+          this.emit('cancel');
+        } else {
+          this.validateChanges(opts);
+        }
+      });
+    } else {
+      this.validateChanges(opts);
     }
-  } else {
-    ['doc_ids', 'filter', 'selector', 'view'].forEach(function (key) {
-      if (key in opts) {
-        guardedConsole('warn',
-          'The "' + key + '" option was passed in to changes/replicate, ' +
-          'but pouchdb-changes-filter plugin is not installed, so it ' +
-          'was ignored. Please install the plugin to enable filtering.'
-        );
+  }
+
+  cancel() {
+    this.isCancelled = true;
+    if (this.db.taskqueue.isReady) {
+      this.emit('cancel');
+    }
+  }
+
+  validateChanges(opts) {
+    var callback = opts.complete;
+  
+    /* istanbul ignore else */
+    if (PouchDB._changesFilterPlugin) {
+      PouchDB._changesFilterPlugin.validate(opts, (err) => {
+        if (err) {
+          return callback(err);
+        }
+        this.doChanges(opts);
+      });
+    } else {
+      this.doChanges(opts);
+    }
+  }
+
+  doChanges(opts) {
+    var callback = opts.complete;
+  
+    opts = clone(opts);
+    if ('live' in opts && !('continuous' in opts)) {
+      opts.continuous = opts.live;
+    }
+    opts.processChange = processChange;
+  
+    if (opts.since === 'latest') {
+      opts.since = 'now';
+    }
+    if (!opts.since) {
+      opts.since = 0;
+    }
+    if (opts.since === 'now') {
+      this.db.info().then((info) => {
+        /* istanbul ignore if */
+        if (this.isCancelled) {
+          callback(null, {status: 'cancelled'});
+          return;
+        }
+        opts.since = info.update_seq;
+        this.doChanges(opts);
+      }, callback);
+      return;
+    }
+  
+    /* istanbul ignore else */
+    if (PouchDB._changesFilterPlugin) {
+      PouchDB._changesFilterPlugin.normalize(opts);
+      if (PouchDB._changesFilterPlugin.shouldFilter(this, opts)) {
+        return PouchDB._changesFilterPlugin.filter(this, opts);
       }
-    });
+    } else {
+      ['doc_ids', 'filter', 'selector', 'view'].forEach(function (key) {
+        if (key in opts) {
+          guardedConsole('warn',
+            'The "' + key + '" option was passed in to changes/replicate, ' +
+            'but pouchdb-changes-filter plugin is not installed, so it ' +
+            'was ignored. Please install the plugin to enable filtering.'
+          );
+        }
+      });
+    }
+  
+    if (!('descending' in opts)) {
+      opts.descending = false;
+    }
+  
+    // 0 and 1 should return 1 document
+    opts.limit = opts.limit === 0 ? 1 : opts.limit;
+    opts.complete = callback;
+    var newPromise = this.db._changes(opts);
+    /* istanbul ignore else */
+    if (newPromise && typeof newPromise.cancel === 'function') {
+      const cancel = this.cancel;
+      this.cancel = getArguments((args) => {
+        newPromise.cancel();
+        cancel.apply(this, args);
+      });
+    }
   }
-
-  if (!('descending' in opts)) {
-    opts.descending = false;
-  }
-
-  // 0 and 1 should return 1 document
-  opts.limit = opts.limit === 0 ? 1 : opts.limit;
-  opts.complete = callback;
-  var newPromise = this.db._changes(opts);
-  /* istanbul ignore else */
-  if (newPromise && typeof newPromise.cancel === 'function') {
-    var cancel = self.cancel;
-    self.cancel = getArguments(function (args) {
-      newPromise.cancel();
-      cancel.apply(this, args);
-    });
-  }
-};
+}
 
 export default Changes;

--- a/packages/node_modules/pouchdb-core/src/constructor.js
+++ b/packages/node_modules/pouchdb-core/src/constructor.js
@@ -1,8 +1,8 @@
-import inherits from 'inherits';
 import Adapter from './adapter';
 import TaskQueue from './taskqueue';
 import { clone } from 'pouchdb-utils';
 import parseAdapter from './parseAdapter';
+import { createClass } from './utils';
 
 // OK, so here's the deal. Consider this code:
 //     var db1 = new PouchDB('foo');
@@ -33,74 +33,76 @@ function prepareForDestruction(self) {
   self.constructor.emit('ref', self);
 }
 
-inherits(PouchDB, Adapter);
-function PouchDB(name, opts) {
-  // In Node our test suite only tests this for PouchAlt unfortunately
-  /* istanbul ignore if */
-  if (!(this instanceof PouchDB)) {
-    return new PouchDB(name, opts);
+class PouchInternal extends Adapter {
+  constructor(name, opts) {
+    super();
+    this._setup(name, opts);
   }
 
-  var self = this;
-  opts = opts || {};
+  _setup(name, opts) {
+    super._setup();
+    opts = opts || {};
 
-  if (name && typeof name === 'object') {
-    opts = name;
-    name = opts.name;
-    delete opts.name;
-  }
-
-  if (opts.deterministic_revs === undefined) {
-    opts.deterministic_revs = true;
-  }
-
-  this.__opts = opts = clone(opts);
-
-  self.auto_compaction = opts.auto_compaction;
-  self.prefix = PouchDB.prefix;
-
-  if (typeof name !== 'string') {
-    throw new Error('Missing/invalid DB name');
-  }
-
-  var prefixedName = (opts.prefix || '') + name;
-  var backend = parseAdapter(prefixedName, opts);
-
-  opts.name = backend.name;
-  opts.adapter = opts.adapter || backend.adapter;
-
-  self.name = name;
-  self._adapter = opts.adapter;
-  PouchDB.emit('debug', ['adapter', 'Picked adapter: ', opts.adapter]);
-
-  if (!PouchDB.adapters[opts.adapter] ||
-      !PouchDB.adapters[opts.adapter].valid()) {
-    throw new Error('Invalid Adapter: ' + opts.adapter);
-  }
-
-  if (opts.view_adapter) {
-    if (!PouchDB.adapters[opts.view_adapter] ||
-        !PouchDB.adapters[opts.view_adapter].valid()) {
-      throw new Error('Invalid View Adapter: ' + opts.view_adapter);
+    if (name && typeof name === 'object') {
+      opts = name;
+      name = opts.name;
+      delete opts.name;
     }
-  }
 
-  Adapter.call(self);
-  self.taskqueue = new TaskQueue();
-
-  self.adapter = opts.adapter;
-
-  PouchDB.adapters[opts.adapter].call(self, opts, function (err) {
-    if (err) {
-      return self.taskqueue.fail(err);
+    if (opts.deterministic_revs === undefined) {
+      opts.deterministic_revs = true;
     }
-    prepareForDestruction(self);
 
-    self.emit('created', self);
-    PouchDB.emit('created', self.name);
-    self.taskqueue.ready(self);
-  });
+    this.__opts = opts = clone(opts);
 
+    this.auto_compaction = opts.auto_compaction;
+    this.prefix = PouchDB.prefix;
+
+    if (typeof name !== 'string') {
+      throw new Error('Missing/invalid DB name');
+    }
+
+    var prefixedName = (opts.prefix || '') + name;
+    var backend = parseAdapter(prefixedName, opts);
+
+    opts.name = backend.name;
+    opts.adapter = opts.adapter || backend.adapter;
+
+    this.name = name;
+    this._adapter = opts.adapter;
+    PouchDB.emit('debug', ['adapter', 'Picked adapter: ', opts.adapter]);
+
+    if (!PouchDB.adapters[opts.adapter] ||
+        !PouchDB.adapters[opts.adapter].valid()) {
+      throw new Error('Invalid Adapter: ' + opts.adapter);
+    }
+
+    if (opts.view_adapter) {
+      if (!PouchDB.adapters[opts.view_adapter] ||
+          !PouchDB.adapters[opts.view_adapter].valid()) {
+        throw new Error('Invalid View Adapter: ' + opts.view_adapter);
+      }
+    }
+
+    this.taskqueue = new TaskQueue();
+
+    this.adapter = opts.adapter;
+
+    PouchDB.adapters[opts.adapter].call(this, opts, (err) => {
+      if (err) {
+        return this.taskqueue.fail(err);
+      }
+      prepareForDestruction(this);
+
+      this.emit('created', this);
+      PouchDB.emit('created', this.name);
+      this.taskqueue.ready(this);
+    });
+  }
 }
+
+const PouchDB = createClass(PouchInternal, function (name, opts) {
+  PouchInternal.prototype._setup.call(this, name, opts);
+});
 
 export default PouchDB;

--- a/packages/node_modules/pouchdb-core/src/setup.js
+++ b/packages/node_modules/pouchdb-core/src/setup.js
@@ -1,9 +1,9 @@
 'use strict';
 
 import PouchDB from './constructor';
-import inherits from 'inherits';
 import EE from 'events';
 import { fetch } from 'pouchdb-fetch';
+import { createClass } from './utils';
 
 PouchDB.adapters = {};
 PouchDB.preferredAdapters = [];
@@ -90,11 +90,7 @@ PouchDB.plugin = function (obj) {
 };
 
 PouchDB.defaults = function (defaultOpts) {
-  function PouchAlt(name, opts) {
-    if (!(this instanceof PouchAlt)) {
-      return new PouchAlt(name, opts);
-    }
-
+  let PouchWithDefaults = createClass(PouchDB, function (name, opts) {
     opts = opts || {};
 
     if (name && typeof name === 'object') {
@@ -103,24 +99,22 @@ PouchDB.defaults = function (defaultOpts) {
       delete opts.name;
     }
 
-    opts = Object.assign({}, PouchAlt.__defaults, opts);
+    opts = Object.assign({}, PouchWithDefaults.__defaults, opts);
     PouchDB.call(this, name, opts);
-  }
+  });
 
-  inherits(PouchAlt, PouchDB);
-
-  PouchAlt.preferredAdapters = PouchDB.preferredAdapters.slice();
+  PouchWithDefaults.preferredAdapters = PouchDB.preferredAdapters.slice();
   Object.keys(PouchDB).forEach(function (key) {
-    if (!(key in PouchAlt)) {
-      PouchAlt[key] = PouchDB[key];
+    if (!(key in PouchWithDefaults)) {
+      PouchWithDefaults[key] = PouchDB[key];
     }
   });
 
   // make default options transitive
   // https://github.com/pouchdb/pouchdb/issues/5922
-  PouchAlt.__defaults = Object.assign({}, this.__defaults, defaultOpts);
+  PouchWithDefaults.__defaults = Object.assign({}, this.__defaults, defaultOpts);
 
-  return PouchAlt;
+  return PouchWithDefaults;
 };
 
 PouchDB.fetch = function (url, opts) {

--- a/packages/node_modules/pouchdb-core/src/taskqueue.js
+++ b/packages/node_modules/pouchdb-core/src/taskqueue.js
@@ -1,38 +1,38 @@
-export default TaskQueue;
+export default class TaskQueue {
+  constructor() {
+    this.isReady = false;
+    this.failed = false;
+    this.queue = [];
+  }
 
-function TaskQueue() {
-  this.isReady = false;
-  this.failed = false;
-  this.queue = [];
-}
-
-TaskQueue.prototype.execute = function () {
-  var fun;
-  if (this.failed) {
-    while ((fun = this.queue.shift())) {
-      fun(this.failed);
-    }
-  } else {
-    while ((fun = this.queue.shift())) {
-      fun();
+  execute() {
+    var fun;
+    if (this.failed) {
+      while ((fun = this.queue.shift())) {
+        fun(this.failed);
+      }
+    } else {
+      while ((fun = this.queue.shift())) {
+        fun();
+      }
     }
   }
-};
 
-TaskQueue.prototype.fail = function (err) {
-  this.failed = err;
-  this.execute();
-};
-
-TaskQueue.prototype.ready = function (db) {
-  this.isReady = true;
-  this.db = db;
-  this.execute();
-};
-
-TaskQueue.prototype.addTask = function (fun) {
-  this.queue.push(fun);
-  if (this.failed) {
+  fail(err) {
+    this.failed = err;
     this.execute();
   }
-};
+
+  ready(db) {
+    this.isReady = true;
+    this.db = db;
+    this.execute();
+  }
+
+  addTask(fun) {
+    this.queue.push(fun);
+    if (this.failed) {
+      this.execute();
+    }
+  }
+}

--- a/packages/node_modules/pouchdb-core/src/utils.js
+++ b/packages/node_modules/pouchdb-core/src/utils.js
@@ -1,0 +1,16 @@
+function inherits(A, B) {
+  A.prototype = Object.create(B.prototype, {
+    constructor: { value: A }
+  });
+}
+
+export function createClass(parent, init) {
+  let klass = function (...args) {
+    if (!(this instanceof klass)) {
+      return new klass(...args);
+    }
+    init.apply(this, args);
+  };
+  inherits(klass, parent);
+  return klass;
+}

--- a/packages/node_modules/pouchdb-errors/src/index.js
+++ b/packages/node_modules/pouchdb-errors/src/index.js
@@ -1,22 +1,22 @@
-import inherits from 'inherits';
-inherits(PouchError, Error);
+class PouchError extends Error {
+  constructor(status, error, reason) {
+    super();
+    Error(reason);
+    this.status = status;
+    this.name = error;
+    this.message = reason;
+    this.error = true;
+  }
 
-function PouchError(status, error, reason) {
-  Error.call(this, reason);
-  this.status = status;
-  this.name = error;
-  this.message = reason;
-  this.error = true;
+  toString() {
+    return JSON.stringify({
+      status: this.status,
+      name: this.name,
+      message: this.message,
+      reason: this.reason
+    });
+  }
 }
-
-PouchError.prototype.toString = function () {
-  return JSON.stringify({
-    status: this.status,
-    name: this.name,
-    message: this.message,
-    reason: this.reason
-  });
-};
 
 var UNAUTHORIZED = new PouchError(401, 'unauthorized', "Name or password is incorrect.");
 var MISSING_BULK_DOCS = new PouchError(400, 'bad_request', "Missing JSON list of 'docs'");

--- a/packages/node_modules/pouchdb-mapreduce-utils/src/errors.js
+++ b/packages/node_modules/pouchdb-mapreduce-utils/src/errors.js
@@ -1,40 +1,42 @@
-import inherits from 'inherits';
 
-function QueryParseError(message) {
-  this.status = 400;
-  this.name = 'query_parse_error';
-  this.message = message;
-  this.error = true;
-  try {
-    Error.captureStackTrace(this, QueryParseError);
-  } catch (e) {}
+class QueryParseError extends Error {
+  constructor(message) {
+    super();
+    this.status = 400;
+    this.name = 'query_parse_error';
+    this.message = message;
+    this.error = true;
+    try {
+      Error.captureStackTrace(this, QueryParseError);
+    } catch (e) {}
+  }
 }
 
-inherits(QueryParseError, Error);
-
-function NotFoundError(message) {
-  this.status = 404;
-  this.name = 'not_found';
-  this.message = message;
-  this.error = true;
-  try {
-    Error.captureStackTrace(this, NotFoundError);
-  } catch (e) {}
+class NotFoundError extends Error {
+  constructor(message) {
+    super();
+    this.status = 404;
+    this.name = 'not_found';
+    this.message = message;
+    this.error = true;
+    try {
+      Error.captureStackTrace(this, NotFoundError);
+    } catch (e) {}
+  }
 }
 
-inherits(NotFoundError, Error);
-
-function BuiltInError(message) {
-  this.status = 500;
-  this.name = 'invalid_value';
-  this.message = message;
-  this.error = true;
-  try {
-    Error.captureStackTrace(this, BuiltInError);
-  } catch (e) {}
+class BuiltInError extends Error {
+  constructor(message) {
+    super();
+    this.status = 500;
+    this.name = 'invalid_value';
+    this.message = message;
+    this.error = true;
+    try {
+      Error.captureStackTrace(this, BuiltInError);
+    } catch (e) {}
+  }
 }
-
-inherits(BuiltInError, Error);
 
 export {
   QueryParseError,

--- a/packages/node_modules/pouchdb-replication/src/replication.js
+++ b/packages/node_modules/pouchdb-replication/src/replication.js
@@ -1,53 +1,51 @@
 import EE from 'events';
-import inherits from 'inherits';
 
 // We create a basic promise so the caller can cancel the replication possibly
 // before we have actually started listening to changes etc
-inherits(Replication, EE);
-function Replication() {
-  EE.call(this);
-  this.cancelled = false;
-  this.state = 'pending';
-  var self = this;
-  var promise = new Promise(function (fulfill, reject) {
-    self.once('complete', fulfill);
-    self.once('error', reject);
-  });
-  self.then = function (resolve, reject) {
-    return promise.then(resolve, reject);
-  };
-  self.catch = function (reject) {
-    return promise.catch(reject);
-  };
-  // As we allow error handling via "error" event as well,
-  // put a stub in here so that rejecting never throws UnhandledError.
-  self.catch(function () {});
+class Replication extends EE {
+  constructor() {
+    super();
+    this.cancelled = false;
+    this.state = 'pending';
+    const promise = new Promise((fulfill, reject) => {
+      this.once('complete', fulfill);
+      this.once('error', reject);
+    });
+    this.then = function (resolve, reject) {
+      return promise.then(resolve, reject);
+    };
+    this.catch = function (reject) {
+      return promise.catch(reject);
+    };
+    // As we allow error handling via "error" event as well,
+    // put a stub in here so that rejecting never throws UnhandledError.
+    this.catch(function () {});
+  }
+
+  cancel() {
+    this.cancelled = true;
+    this.state = 'cancelled';
+    this.emit('cancel');
+  }
+
+  ready(src, target) {
+    if (this._readyCalled) {
+      return;
+    }
+    this._readyCalled = true;
+  
+    const onDestroy = () => {
+      this.cancel();
+    };
+    src.once('destroyed', onDestroy);
+    target.once('destroyed', onDestroy);
+    function cleanup() {
+      src.removeListener('destroyed', onDestroy);
+      target.removeListener('destroyed', onDestroy);
+    }
+    this.once('complete', cleanup);
+    this.once('error', cleanup);
+  }
 }
-
-Replication.prototype.cancel = function () {
-  this.cancelled = true;
-  this.state = 'cancelled';
-  this.emit('cancel');
-};
-
-Replication.prototype.ready = function (src, target) {
-  var self = this;
-  if (self._readyCalled) {
-    return;
-  }
-  self._readyCalled = true;
-
-  function onDestroy() {
-    self.cancel();
-  }
-  src.once('destroyed', onDestroy);
-  target.once('destroyed', onDestroy);
-  function cleanup() {
-    src.removeListener('destroyed', onDestroy);
-    target.removeListener('destroyed', onDestroy);
-  }
-  self.once('complete', cleanup);
-  self.once('error', cleanup);
-};
 
 export default Replication;

--- a/packages/node_modules/pouchdb-replication/src/sync.js
+++ b/packages/node_modules/pouchdb-replication/src/sync.js
@@ -3,11 +3,9 @@ import {
   replicate,
   toPouch
 } from './replicateWrapper';
-import inherits from 'inherits';
 import EE from 'events';
 import { clone } from 'pouchdb-utils';
 
-inherits(Sync, EE);
 export default sync;
 function sync(src, target, opts, callback) {
   if (typeof opts === 'function') {
@@ -25,194 +23,196 @@ function sync(src, target, opts, callback) {
   return new Sync(src, target, opts, callback);
 }
 
-function Sync(src, target, opts, callback) {
-  var self = this;
-  this.canceled = false;
+class Sync extends EE {
+  constructor(src, target, opts, callback) {
+    super();
+    this.canceled = false;
 
-  var optsPush = opts.push ? Object.assign({}, opts, opts.push) : opts;
-  var optsPull = opts.pull ? Object.assign({}, opts, opts.pull) : opts;
+    const optsPush = opts.push ? Object.assign({}, opts, opts.push) : opts;
+    const optsPull = opts.pull ? Object.assign({}, opts, opts.pull) : opts;
 
-  this.push = replicate(src, target, optsPush);
-  this.pull = replicate(target, src, optsPull);
+    this.push = replicate(src, target, optsPush);
+    this.pull = replicate(target, src, optsPull);
 
-  this.pushPaused = true;
-  this.pullPaused = true;
+    this.pushPaused = true;
+    this.pullPaused = true;
 
-  function pullChange(change) {
-    self.emit('change', {
-      direction: 'pull',
-      change: change
-    });
-  }
-  function pushChange(change) {
-    self.emit('change', {
-      direction: 'push',
-      change: change
-    });
-  }
-  function pushDenied(doc) {
-    self.emit('denied', {
-      direction: 'push',
-      doc: doc
-    });
-  }
-  function pullDenied(doc) {
-    self.emit('denied', {
-      direction: 'pull',
-      doc: doc
-    });
-  }
-  function pushPaused() {
-    self.pushPaused = true;
-    /* istanbul ignore if */
-    if (self.pullPaused) {
-      self.emit('paused');
-    }
-  }
-  function pullPaused() {
-    self.pullPaused = true;
-    /* istanbul ignore if */
-    if (self.pushPaused) {
-      self.emit('paused');
-    }
-  }
-  function pushActive() {
-    self.pushPaused = false;
-    /* istanbul ignore if */
-    if (self.pullPaused) {
-      self.emit('active', {
-        direction: 'push'
+    const pullChange = (change) => {
+      this.emit('change', {
+        direction: 'pull',
+        change: change
       });
-    }
-  }
-  function pullActive() {
-    self.pullPaused = false;
-    /* istanbul ignore if */
-    if (self.pushPaused) {
-      self.emit('active', {
-        direction: 'pull'
+    };
+    const pushChange = (change) => {
+      this.emit('change', {
+        direction: 'push',
+        change: change
       });
-    }
-  }
-
-  var removed = {};
-
-  function removeAll(type) { // type is 'push' or 'pull'
-    return function (event, func) {
-      var isChange = event === 'change' &&
-        (func === pullChange || func === pushChange);
-      var isDenied = event === 'denied' &&
-        (func === pullDenied || func === pushDenied);
-      var isPaused = event === 'paused' &&
-        (func === pullPaused || func === pushPaused);
-      var isActive = event === 'active' &&
-        (func === pullActive || func === pushActive);
-
-      if (isChange || isDenied || isPaused || isActive) {
-        if (!(event in removed)) {
-          removed[event] = {};
-        }
-        removed[event][type] = true;
-        if (Object.keys(removed[event]).length === 2) {
-          // both push and pull have asked to be removed
-          self.removeAllListeners(event);
-        }
+    };
+    const pushDenied = (doc) => {
+      this.emit('denied', {
+        direction: 'push',
+        doc: doc
+      });
+    };
+    const pullDenied = (doc) => {
+      this.emit('denied', {
+        direction: 'pull',
+        doc: doc
+      });
+    };
+    const pushPaused = () => {
+      this.pushPaused = true;
+      /* istanbul ignore if */
+      if (this.pullPaused) {
+        this.emit('paused');
       }
     };
-  }
-
-  if (opts.live) {
-    this.push.on('complete', self.pull.cancel.bind(self.pull));
-    this.pull.on('complete', self.push.cancel.bind(self.push));
-  }
-
-  function addOneListener(ee, event, listener) {
-    if (ee.listeners(event).indexOf(listener) == -1) {
-      ee.on(event, listener);
-    }
-  }
-
-  this.on('newListener', function (event) {
-    if (event === 'change') {
-      addOneListener(self.pull, 'change', pullChange);
-      addOneListener(self.push, 'change', pushChange);
-    } else if (event === 'denied') {
-      addOneListener(self.pull, 'denied', pullDenied);
-      addOneListener(self.push, 'denied', pushDenied);
-    } else if (event === 'active') {
-      addOneListener(self.pull, 'active', pullActive);
-      addOneListener(self.push, 'active', pushActive);
-    } else if (event === 'paused') {
-      addOneListener(self.pull, 'paused', pullPaused);
-      addOneListener(self.push, 'paused', pushPaused);
-    }
-  });
-
-  this.on('removeListener', function (event) {
-    if (event === 'change') {
-      self.pull.removeListener('change', pullChange);
-      self.push.removeListener('change', pushChange);
-    } else if (event === 'denied') {
-      self.pull.removeListener('denied', pullDenied);
-      self.push.removeListener('denied', pushDenied);
-    } else if (event === 'active') {
-      self.pull.removeListener('active', pullActive);
-      self.push.removeListener('active', pushActive);
-    } else if (event === 'paused') {
-      self.pull.removeListener('paused', pullPaused);
-      self.push.removeListener('paused', pushPaused);
-    }
-  });
-
-  this.pull.on('removeListener', removeAll('pull'));
-  this.push.on('removeListener', removeAll('push'));
-
-  var promise = Promise.all([
-    this.push,
-    this.pull
-  ]).then(function (resp) {
-    var out = {
-      push: resp[0],
-      pull: resp[1]
+    const pullPaused = () => {
+      this.pullPaused = true;
+      /* istanbul ignore if */
+      if (this.pushPaused) {
+        this.emit('paused');
+      }
     };
-    self.emit('complete', out);
-    if (callback) {
-      callback(null, out);
-    }
-    self.removeAllListeners();
-    return out;
-  }, function (err) {
-    self.cancel();
-    if (callback) {
-      // if there's a callback, then the callback can receive
-      // the error event
-      callback(err);
-    } else {
-      // if there's no callback, then we're safe to emit an error
-      // event, which would otherwise throw an unhandled error
-      // due to 'error' being a special event in EventEmitters
-      self.emit('error', err);
-    }
-    self.removeAllListeners();
-    if (callback) {
-      // no sense throwing if we're already emitting an 'error' event
-      throw err;
-    }
-  });
+    const pushActive = () => {
+      this.pushPaused = false;
+      /* istanbul ignore if */
+      if (this.pullPaused) {
+        this.emit('active', {
+          direction: 'push'
+        });
+      }
+    };
+    const pullActive = () => {
+      this.pullPaused = false;
+      /* istanbul ignore if */
+      if (this.pushPaused) {
+        this.emit('active', {
+          direction: 'pull'
+        });
+      }
+    };
 
-  this.then = function (success, err) {
-    return promise.then(success, err);
-  };
+    let removed = {};
 
-  this.catch = function (err) {
-    return promise.catch(err);
-  };
-}
+    const removeAll = (type) => { // type is 'push' or 'pull'
+      return (event, func) => {
+        const isChange = event === 'change' &&
+          (func === pullChange || func === pushChange);
+        const isDenied = event === 'denied' &&
+          (func === pullDenied || func === pushDenied);
+        const isPaused = event === 'paused' &&
+          (func === pullPaused || func === pushPaused);
+        const isActive = event === 'active' &&
+          (func === pullActive || func === pushActive);
 
-Sync.prototype.cancel = function () {
-  if (!this.canceled) {
-    this.canceled = true;
-    this.push.cancel();
-    this.pull.cancel();
+        if (isChange || isDenied || isPaused || isActive) {
+          if (!(event in removed)) {
+            removed[event] = {};
+          }
+          removed[event][type] = true;
+          if (Object.keys(removed[event]).length === 2) {
+            // both push and pull have asked to be removed
+            this.removeAllListeners(event);
+          }
+        }
+      };
+    };
+
+    if (opts.live) {
+      this.push.on('complete', this.pull.cancel.bind(this.pull));
+      this.pull.on('complete', this.push.cancel.bind(this.push));
+    }
+
+    function addOneListener(ee, event, listener) {
+      if (ee.listeners(event).indexOf(listener) == -1) {
+        ee.on(event, listener);
+      }
+    }
+
+    this.on('newListener', function (event) {
+      if (event === 'change') {
+        addOneListener(this.pull, 'change', pullChange);
+        addOneListener(this.push, 'change', pushChange);
+      } else if (event === 'denied') {
+        addOneListener(this.pull, 'denied', pullDenied);
+        addOneListener(this.push, 'denied', pushDenied);
+      } else if (event === 'active') {
+        addOneListener(this.pull, 'active', pullActive);
+        addOneListener(this.push, 'active', pushActive);
+      } else if (event === 'paused') {
+        addOneListener(this.pull, 'paused', pullPaused);
+        addOneListener(this.push, 'paused', pushPaused);
+      }
+    });
+
+    this.on('removeListener', function (event) {
+      if (event === 'change') {
+        this.pull.removeListener('change', pullChange);
+        this.push.removeListener('change', pushChange);
+      } else if (event === 'denied') {
+        this.pull.removeListener('denied', pullDenied);
+        this.push.removeListener('denied', pushDenied);
+      } else if (event === 'active') {
+        this.pull.removeListener('active', pullActive);
+        this.push.removeListener('active', pushActive);
+      } else if (event === 'paused') {
+        this.pull.removeListener('paused', pullPaused);
+        this.push.removeListener('paused', pushPaused);
+      }
+    });
+
+    this.pull.on('removeListener', removeAll('pull'));
+    this.push.on('removeListener', removeAll('push'));
+
+    const promise = Promise.all([
+      this.push,
+      this.pull
+    ]).then((resp) => {
+      const out = {
+        push: resp[0],
+        pull: resp[1]
+      };
+      this.emit('complete', out);
+      if (callback) {
+        callback(null, out);
+      }
+      this.removeAllListeners();
+      return out;
+    }, (err) => {
+      this.cancel();
+      if (callback) {
+        // if there's a callback, then the callback can receive
+        // the error event
+        callback(err);
+      } else {
+        // if there's no callback, then we're safe to emit an error
+        // event, which would otherwise throw an unhandled error
+        // due to 'error' being a special event in EventEmitters
+        this.emit('error', err);
+      }
+      this.removeAllListeners();
+      if (callback) {
+        // no sense throwing if we're already emitting an 'error' event
+        throw err;
+      }
+    });
+
+    this.then = function (success, err) {
+      return promise.then(success, err);
+    };
+
+    this.catch = function (err) {
+      return promise.catch(err);
+    };
   }
-};
+
+  cancel() {
+    if (!this.canceled) {
+      this.canceled = true;
+      this.push.cancel();
+      this.pull.cancel();
+    }
+  }
+}

--- a/packages/node_modules/pouchdb-utils/src/changesHandler.js
+++ b/packages/node_modules/pouchdb-utils/src/changesHandler.js
@@ -1,92 +1,79 @@
 import EventEmitter from 'events';
-import inherits from 'inherits';
 import hasLocalStorage from './env/hasLocalStorage';
 import pick from './pick';
 import nextTick from './nextTick';
 
-inherits(Changes, EventEmitter);
-
-/* istanbul ignore next */
-function attachBrowserEvents(self) {
-  if (hasLocalStorage()) {
-    addEventListener("storage", function (e) {
-      self.emit(e.key);
-    });
+export default class Changes extends EventEmitter {
+  constructor() {
+    super();
+    
+    this._listeners = {};
+    
+    if (hasLocalStorage()) {
+      addEventListener("storage", function (e) {
+        this.emit(e.key);
+      });
+    }
   }
-}
 
-function Changes() {
-  EventEmitter.call(this);
-  this._listeners = {};
-
-  attachBrowserEvents(this);
-}
-Changes.prototype.addListener = function (dbName, id, db, opts) {
-  /* istanbul ignore if */
-  if (this._listeners[id]) {
-    return;
-  }
-  var self = this;
-  var inprogress = false;
-  function eventFunction() {
-    /* istanbul ignore if */
-    if (!self._listeners[id]) {
+  addListener(dbName, id, db, opts) {
+    if (this._listeners[id]) {
       return;
     }
-    if (inprogress) {
-      inprogress = 'waiting';
+    var inprogress = false;
+    var self = this;
+    function eventFunction() {
+      if (!self._listeners[id]) {
+        return;
+      }
+      if (inprogress) {
+        inprogress = 'waiting';
+        return;
+      }
+      inprogress = true;
+      var changesOpts = pick(opts, [
+        'style', 'include_docs', 'attachments', 'conflicts', 'filter',
+        'doc_ids', 'view', 'since', 'query_params', 'binary', 'return_docs'
+      ]);
+  
+      function onError() {
+        inprogress = false;
+      }
+  
+      db.changes(changesOpts).on('change', function (c) {
+        if (c.seq > opts.since && !opts.cancelled) {
+          opts.since = c.seq;
+          opts.onChange(c);
+        }
+      }).on('complete', function () {
+        if (inprogress === 'waiting') {
+          nextTick(eventFunction);
+        }
+        inprogress = false;
+      }).on('error', onError);
+    }
+    this._listeners[id] = eventFunction;
+    this.on(dbName, eventFunction);
+  }
+  
+  removeListener(dbName, id) {
+    if (!(id in this._listeners)) {
       return;
     }
-    inprogress = true;
-    var changesOpts = pick(opts, [
-      'style', 'include_docs', 'attachments', 'conflicts', 'filter',
-      'doc_ids', 'view', 'since', 'query_params', 'binary', 'return_docs'
-    ]);
-
-    /* istanbul ignore next */
-    function onError() {
-      inprogress = false;
+    super.removeListener(dbName, this._listeners[id]);
+    delete this._listeners[id];
+  }
+  
+  notifyLocalWindows(dbName) {
+    //do a useless change on a storage thing
+    //in order to get other windows's listeners to activate
+    if (hasLocalStorage()) {
+      localStorage[dbName] = (localStorage[dbName] === "a") ? "b" : "a";
     }
-
-    db.changes(changesOpts).on('change', function (c) {
-      if (c.seq > opts.since && !opts.cancelled) {
-        opts.since = c.seq;
-        opts.onChange(c);
-      }
-    }).on('complete', function () {
-      if (inprogress === 'waiting') {
-        nextTick(eventFunction);
-      }
-      inprogress = false;
-    }).on('error', onError);
   }
-  this._listeners[id] = eventFunction;
-  this.on(dbName, eventFunction);
-};
-
-Changes.prototype.removeListener = function (dbName, id) {
-  /* istanbul ignore if */
-  if (!(id in this._listeners)) {
-    return;
+  
+  notify(dbName) {
+    this.emit(dbName);
+    this.notifyLocalWindows(dbName);
   }
-  EventEmitter.prototype.removeListener.call(this, dbName,
-    this._listeners[id]);
-  delete this._listeners[id];
-};
-
-
-/* istanbul ignore next */
-Changes.prototype.notifyLocalWindows = function (dbName) {
-  //do a useless change on a storage thing
-  //in order to get other windows's listeners to activate
-  if (hasLocalStorage()) {
-    localStorage[dbName] = (localStorage[dbName] === "a") ? "b" : "a";
-  }
-};
-
-Changes.prototype.notify = function (dbName) {
-  this.emit(dbName);
-  this.notifyLocalWindows(dbName);
-};
-
-export default Changes;
+}

--- a/packages/node_modules/sublevel-pouchdb/src/NotFoundError.js
+++ b/packages/node_modules/sublevel-pouchdb/src/NotFoundError.js
@@ -1,11 +1,8 @@
-import inherits from 'inherits';
-
-function NotFoundError() {
-  Error.call(this);
+class NotFoundError extends Error {
+  constructor() {
+    super();
+    this.name = 'NotFoundError';
+  }
 }
-
-inherits(NotFoundError, Error);
-
-NotFoundError.prototype.name = 'NotFoundError';
 
 export default NotFoundError;

--- a/packages/node_modules/sublevel-pouchdb/src/readStream.js
+++ b/packages/node_modules/sublevel-pouchdb/src/readStream.js
@@ -6,94 +6,110 @@
 // NOTE: we are fixed to readable-stream@1.0.x for now
 // for pure Streams2 across Node versions
 import ReadableStreamCore from 'readable-stream';
-import inherits from 'inherits';
 
 var Readable = ReadableStreamCore.Readable;
 
-function ReadStream(options, makeData) {
-  if (!(this instanceof ReadStream)) {
-    return new ReadStream(options, makeData);
-  }
-
-  Readable.call(this, { objectMode: true, highWaterMark: options.highWaterMark });
-
-  // purely to keep `db` around until we're done so it's not GCed if the user doesn't keep a ref
-
-  this._waiting = false;
-  this._options = options;
-  this._makeData = makeData;
+function createClass(parent, init) {
+  let klass = function (...args) {
+    if (!(this instanceof klass)) {
+      return new klass(...args);
+    }
+    init.apply(this, args);
+  };
+  klass.prototype = Object.create(parent.prototype, {
+    constructor: { value: klass }
+  });
+  return klass;
 }
 
-inherits(ReadStream, Readable);
-
-ReadStream.prototype.setIterator = function (it) {
-  this._iterator = it;
-  /* istanbul ignore if */
-  if (this._destroyed) {
-    return it.end(function () {});
+class ReadStreamInternal extends Readable {
+  constructor(options, makeData) {
+    super({ objectMode: true, highWaterMark: options.highWaterMark });
+    this._setup(options, makeData);
   }
-  /* istanbul ignore if */
-  if (this._waiting) {
+
+  _setup(options, makeData) {
+    super.constructor({ objectMode: true, highWaterMark: options.highWaterMark });
+
+    // purely to keep `db` around until we're done so it's not GCed if the user doesn't keep a ref
     this._waiting = false;
-    return this._read();
-  }
-  return this;
-};
-
-ReadStream.prototype._read = function read() {
-  var self = this;
-  /* istanbul ignore if */
-  if (self._destroyed) {
-    return;
-  }
-  /* istanbul ignore if */
-  if (!self._iterator) {
-    return this._waiting = true;
+    this._options = options;
+    this._makeData = makeData;
   }
 
-  self._iterator.next(function (err, key, value) {
-    if (err || (key === undefined && value === undefined)) {
-      if (!err && !self._destroyed) {
-        self.push(null);
-      }
-      return self._cleanup(err);
+  setIterator(it) {
+    this._iterator = it;
+    /* istanbul ignore if */
+    if (this._destroyed) {
+      return it.end(function () {});
     }
-
-
-    value = self._makeData(key, value);
-    if (!self._destroyed) {
-      self.push(value);
+    /* istanbul ignore if */
+    if (this._waiting) {
+      this._waiting = false;
+      return this._read();
     }
-  });
-};
-
-ReadStream.prototype._cleanup = function (err) {
-  if (this._destroyed) {
-    return;
+    return this;
   }
 
-  this._destroyed = true;
-
-  var self = this;
-  /* istanbul ignore if */
-  if (err && err.message !== 'iterator has ended') {
-    self.emit('error', err);
-  }
-
-  /* istanbul ignore else */
-  if (self._iterator) {
-    self._iterator.end(function () {
-      self._iterator = null;
+  _cleanup(err) {
+    if (this._destroyed) {
+      return;
+    }
+  
+    this._destroyed = true;
+  
+    var self = this;
+    /* istanbul ignore if */
+    if (err && err.message !== 'iterator has ended') {
+      self.emit('error', err);
+    }
+  
+    /* istanbul ignore else */
+    if (self._iterator) {
+      self._iterator.end(function () {
+        self._iterator = null;
+        self.emit('close');
+      });
+    } else {
       self.emit('close');
-    });
-  } else {
-    self.emit('close');
+    }
   }
-};
 
-ReadStream.prototype.destroy = function () {
-  this._cleanup();
-};
+  destroy() {
+    this._cleanup();
+  }
+  
+  _read() {
+    var self = this;
+    /* istanbul ignore if */
+    if (self._destroyed) {
+      return;
+    }
+    /* istanbul ignore if */
+    if (!self._iterator) {
+      return this._waiting = true;
+    }
+  
+    self._iterator.next(function (err, key, value) {
+      if (err || (key === undefined && value === undefined)) {
+        if (!err && !self._destroyed) {
+          self.push(null);
+        }
+        return self._cleanup(err);
+      }
+  
+  
+      value = self._makeData(key, value);
+      if (!self._destroyed) {
+        self.push(value);
+      }
+    });
+  }
+}
+
+const ReadStream = createClass(ReadStreamInternal, function (options, makeData) {
+  ReadStreamInternal.prototype._setup.call(this, options, makeData);
+});
 
 export default ReadStream;
 


### PR DESCRIPTION
Please read more info in this related issue #8444

* Use `classes` instead of `prototypes` when possible
* Deprecate the usage of the package `inherits` and use ES6 classes instead. 