### PR TITLE
Purging revs

### DIFF
--- a/docs/_includes/api.html
+++ b/docs/_includes/api.html
@@ -24,6 +24,7 @@
 <li><a href="#revisions_diff">Revision diff</a></li>
 <li><a href="#bulk_get">Bulk get</a></li>
 <li><a href="#close_database">Close database</a></li>
+<li><a href="#purge">Purge doc</a></li>
 <li><a href="#events">Events</a></li>
 <li><a href="#active_tasks">Active tasks</a></li>
 <li><a href="#defaults">Default settings</a></li>

--- a/docs/_includes/api/create_database.html
+++ b/docs/_includes/api/create_database.html
@@ -18,6 +18,7 @@ This method creates a database or opens an existing one. If you use a URL like `
 * `deterministic_revs`: Use a md5 hash to create a deterministic revision number for documents. Setting it to false will mean that the revision number will be a random UUID. Defaults to true.
 * `view_update_changes_batch_size`: Specify how many change records will be consumed at a time when rebuilding view indexes when the `query()` method is used. Defaults to 50.
 * `view_adapter`: Specify a different adapter to store the view index data.
+* `purged_infos_limit`: Specify how many purged revisions we keep track of. Specifying a low value can result in Pouch not delegating older purges down to views. Defaults to `1000`.
 
 **Options for remote databases:**
 

--- a/docs/_includes/api/purge.html
+++ b/docs/_includes/api/purge.html
@@ -1,0 +1,87 @@
+{% include anchor.html edit="true" title="Purge a document rev" hash="purge" %}
+
+{% highlight js %}
+db.purge(docId, rev)
+{% endhighlight %}
+
+Purges a specific revision of a document, specified by `docId` and `rev`. `rev` must be a leaf revision.
+
+Purge permanently removes data from the database. Normal deletion with `db.remove()` does not, it only marks the document as `_deleted=true` and creates a new revision. This behaviour ensures that deletes can be replicated across databases, and deleted documents don’t get undeleted by syncing with a database that still has this document.
+
+`db.purge()` is not intended as a regular method for deleting documents, instead, it is meant as an admin function for cases where some secret was erroneously added to the database and must now be removed completely, eg. a credit card or social security number. Purge effectively puts the database in a state where the offending write never happened.
+
+{% include alert/start.html variant="info"%}
+{% markdown %}
+
+**Purge is currently only implemented in the `indexeddb` adapter**.
+
+Using Purge with any other adapter will throw an error.
+
+{% endmarkdown %}
+{% include alert/end.html%}
+
+#### Example Usage:
+
+{% include code/start.html id="purge1" type="callback" %}
+{% highlight js %}
+db.purge('mydoc', '6-3a24009a9525bde9e4bfa8a99046b00d',
+  function (err, result) {
+    if (err) { return console.log(err); }
+    // handle result
+  }
+);
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="purge1" type="async" %}
+{% highlight js %}
+try {
+  var result = await db.purge('mydoc', '6-3a24009a9525bde9e4bfa8a99046b00d');
+} catch (err) {
+  console.log(err);
+}
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="purge1" type="promise" %}
+{% highlight js %}
+db.purge('mydoc', '6-3a24009a9525bde9e4bfa8a99046b00d')
+  .then(function (doc) {
+    // handle doc
+  }).catch(function (err) {
+    console.log(err);
+  });
+{% endhighlight %}
+{% include code/end.html %}
+
+#### Example Response:
+
+If the document has no conflicts, purging its only leaf rev deletes the document completely, and `purge()` _returns_ (not throws) the same `not_found` error as when trying to fetch a non-existent document. It has internally attempted to fetch the doc, and, as expected with a conflict-free target doc, failed:
+
+{% highlight js %}
+{
+  "status": 404,
+  "name": "not_found",
+  "message": "missing",
+  "error": true,
+  "reason": "missing",
+  "docId": "mydoc"
+}
+{% endhighlight %}
+
+If the document does have conflicts, purging will remove the specified rev and pick a leaf from another rev branch as the winner. Purge will then return the current state of the document with the new winning revision in `_rev`.
+
+{% highlight js %}
+{
+  "_id": "mydoc",
+  "_rev": "6-65e076aa5095b0c6ae4184ea6cf2537a"
+  "title": "Embassy Row"
+}
+{% endhighlight %}
+
+**Notes:**
+
+* The specified `rev` must be a leaf
+* Purges do not sync, they only apply to the database they are performed on
+* If the document has conflicts, purging a leaf will also remove its ancestors up to the next branching rev, and pick a new winning rev
+* Any attachments referenced in the specified rev will also be deleted

--- a/docs/_includes/api/purge.html
+++ b/docs/_includes/api/purge.html
@@ -15,7 +15,7 @@ Purge permanently removes data from the database. Normal deletion with `db.remov
 
 **Purge is currently only implemented in the `indexeddb` adapter**.
 
-Using Purge with any other adapter will throw an error.
+Using Purge with any other adapter will return an error.
 
 {% endmarkdown %}
 {% include alert/end.html%}
@@ -27,8 +27,18 @@ Using Purge with any other adapter will throw an error.
 db.purge('mydoc', '6-3a24009a9525bde9e4bfa8a99046b00d',
   function (err, result) {
     if (err) { return console.log(err); }
-    // handle result
-  }
+    console.log(result)
+    /*
+    Example result:
+    {
+      "ok": true,
+      "deletedRevs": [
+        "6-3a24009a9525bde9e4bfa8a99046b00d",
+        "5-df4a81cd21c75c71974d96e88a68fc2f"
+      ],
+      "documentWasRemovedCompletely": false
+    }
+    */
 );
 {% endhighlight %}
 {% include code/end.html %}
@@ -37,6 +47,18 @@ db.purge('mydoc', '6-3a24009a9525bde9e4bfa8a99046b00d',
 {% highlight js %}
 try {
   var result = await db.purge('mydoc', '6-3a24009a9525bde9e4bfa8a99046b00d');
+  console.log(result)
+  /*
+  Example result:
+  {
+    "ok": true,
+    "deletedRevs": [
+      "6-3a24009a9525bde9e4bfa8a99046b00d",
+      "5-df4a81cd21c75c71974d96e88a68fc2f"
+    ],
+    "documentWasRemovedCompletely": false
+  }
+  */
 } catch (err) {
   console.log(err);
 }
@@ -46,8 +68,19 @@ try {
 {% include code/start.html id="purge1" type="promise" %}
 {% highlight js %}
 db.purge('mydoc', '6-3a24009a9525bde9e4bfa8a99046b00d')
-  .then(function (doc) {
-    // handle doc
+  .then(function (result) {
+    console.log(result)
+    /*
+    Example result:
+    {
+      "ok": true,
+      "deletedRevs": [
+        "6-3a24009a9525bde9e4bfa8a99046b00d",
+        "5-df4a81cd21c75c71974d96e88a68fc2f"
+      ],
+      "documentWasRemovedCompletely": false
+    }
+    */
   }).catch(function (err) {
     console.log(err);
   });
@@ -56,32 +89,13 @@ db.purge('mydoc', '6-3a24009a9525bde9e4bfa8a99046b00d')
 
 #### Example Response:
 
-If the document has no conflicts, purging its only leaf rev deletes the document completely, and `purge()` _returns_ (not throws) the same `not_found` error as when trying to fetch a non-existent document. It has internally attempted to fetch the doc, and, as expected with a conflict-free target doc, failed:
+If the document has no conflicts, purging its only leaf rev deletes the document completely, and `purge()` returns `documentWasRemovedCompletely: true` in its result object.
 
-{% highlight js %}
-{
-  "status": 404,
-  "name": "not_found",
-  "message": "missing",
-  "error": true,
-  "reason": "missing",
-  "docId": "mydoc"
-}
-{% endhighlight %}
-
-If the document does have conflicts, purging will remove the specified rev and pick a leaf from another rev branch as the winner. Purge will then return the current state of the document with the new winning revision in `_rev`.
-
-{% highlight js %}
-{
-  "_id": "mydoc",
-  "_rev": "6-65e076aa5095b0c6ae4184ea6cf2537a"
-  "title": "Embassy Row"
-}
-{% endhighlight %}
+If the document does have conflicts, purging will remove the specified rev and pick a leaf from another rev branch as the winner. Fetching the doc after the purge will return the updated state of the document with the new winning revision in `_rev`.
 
 **Notes:**
 
-* The specified `rev` must be a leaf
+* The `rev` specified for purging must be a leaf, otherwise an error will be returned
 * Purges do not sync, they only apply to the database they are performed on
 * If the document has conflicts, purging a leaf will also remove its ancestors up to the next branching rev, and pick a new winning rev
 * Any attachments referenced in the specified rev will also be deleted

--- a/docs/_includes/api/purge.html
+++ b/docs/_includes/api/purge.html
@@ -27,18 +27,7 @@ Using Purge with any other adapter will return an error.
 db.purge('mydoc', '6-3a24009a9525bde9e4bfa8a99046b00d',
   function (err, result) {
     if (err) { return console.log(err); }
-    console.log(result)
-    /*
-    Example result:
-    {
-      "ok": true,
-      "deletedRevs": [
-        "6-3a24009a9525bde9e4bfa8a99046b00d",
-        "5-df4a81cd21c75c71974d96e88a68fc2f"
-      ],
-      "documentWasRemovedCompletely": false
-    }
-    */
+    // handle result
 );
 {% endhighlight %}
 {% include code/end.html %}
@@ -47,18 +36,7 @@ db.purge('mydoc', '6-3a24009a9525bde9e4bfa8a99046b00d',
 {% highlight js %}
 try {
   var result = await db.purge('mydoc', '6-3a24009a9525bde9e4bfa8a99046b00d');
-  console.log(result)
-  /*
-  Example result:
-  {
-    "ok": true,
-    "deletedRevs": [
-      "6-3a24009a9525bde9e4bfa8a99046b00d",
-      "5-df4a81cd21c75c71974d96e88a68fc2f"
-    ],
-    "documentWasRemovedCompletely": false
-  }
-  */
+  // handle result
 } catch (err) {
   console.log(err);
 }
@@ -69,18 +47,7 @@ try {
 {% highlight js %}
 db.purge('mydoc', '6-3a24009a9525bde9e4bfa8a99046b00d')
   .then(function (result) {
-    console.log(result)
-    /*
-    Example result:
-    {
-      "ok": true,
-      "deletedRevs": [
-        "6-3a24009a9525bde9e4bfa8a99046b00d",
-        "5-df4a81cd21c75c71974d96e88a68fc2f"
-      ],
-      "documentWasRemovedCompletely": false
-    }
-    */
+    // handle result
   }).catch(function (err) {
     console.log(err);
   });
@@ -88,6 +55,17 @@ db.purge('mydoc', '6-3a24009a9525bde9e4bfa8a99046b00d')
 {% include code/end.html %}
 
 #### Example Response:
+
+{% highlight js %}
+  {
+    "ok": true,
+    "deletedRevs": [
+      "6-3a24009a9525bde9e4bfa8a99046b00d",
+      "5-df4a81cd21c75c71974d96e88a68fc2f"
+    ],
+    "documentWasRemovedCompletely": false
+  }
+{% endhighlight %}
 
 If the document has no conflicts, purging its only leaf rev deletes the document completely, and `purge()` returns `documentWasRemovedCompletely: true` in its result object.
 

--- a/docs/api.html
+++ b/docs/api.html
@@ -33,6 +33,7 @@ edit: false
 {% include api/revisions_diff.html %}
 {% include api/bulk_get.html %}
 {% include api/close_database.html %}
+{% include api/purge.html %}
 {% include api/events.html %}
 {% include api/active_tasks.html %}
 {% include api/defaults.html %}

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -452,6 +452,32 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
     });
   }
 
+  function updatePurgeSeq(view) {
+    // with this approach, we just assume to have processed all missing purges and write the latest
+    // purgeSeq into the _local/purgeSeq doc.
+    return view.sourceDB.get('_local/purges').then(function (res) {
+      const purgeSeq = res.purgeSeq;
+      return view.db.get('_local/purgeSeq').then(function (res) {
+        return res._rev;
+      }).catch(function (err) {
+        if (err.status !== 404) {
+          throw err;
+        }
+        return undefined;
+      }).then(function (rev) {
+        return view.db.put({
+          _id: '_local/purgeSeq',
+          _rev: rev,
+          purgeSeq,
+        });
+      });
+    }).catch(function (err) {
+      if (err.status !== 404) {
+        throw err;
+      }
+    });
+  }
+
   // updates all emitted key/value docs and metaDocs in the mrview database
   // for the given batch of documents from the source database
   function saveKeyValues(view, docIdsToChangesAndEmits, seq) {
@@ -468,7 +494,10 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
           docsToPersist.push(lastSeqDoc);
           // write all docs in a single operation, update the seq once
           return view.db.bulkDocs({docs : docsToPersist});
-        });
+        })
+          // TODO: this should be placed somewhere else, probably? we're querying both docs twice
+          //   (first time when getting the actual purges).
+          .then(() => updatePurgeSeq(view));
       });
   }
 
@@ -540,15 +569,83 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
         style: 'all_docs',
         since: currentSeq,
         limit: opts.changes_batch_size
-      }).then(processBatch);
+      }).then(function (response) {
+        return getRecentPurges().then(function (purges) {
+          return processBatch(response, purges);
+        });
+      });
     }
 
-    function processBatch(response) {
+    function getRecentPurges() {
+      return view.db.get('_local/purgeSeq').then(function (res) {
+        return res.purgeSeq;
+      }).catch(function (err) {
+        if (err && err.status !== 404) {
+          throw err;
+        }
+        return -1;
+      }).then(function (purgeSeq) {
+        return view.sourceDB.get('_local/purges').then(function (res) {
+          const recentPurges = res.purges.filter(function (purge, index) {
+            return index > purgeSeq;
+          }).map((purge) => purge.docId);
+
+          const uniquePurges = recentPurges.filter(function (docId, index) {
+            return recentPurges.indexOf(docId) === index;
+          });
+
+          return Promise.all(uniquePurges.map(function (docId) {
+            return view.sourceDB.get(docId).then(function (doc) {
+              return { docId, doc };
+            }).catch(function (err) {
+              if (err.status !== 404) {
+                throw err;
+              }
+              return { docId };
+            });
+          }));
+        }).catch(function (err) {
+          if (err && err.status !== 404) {
+            throw err;
+          }
+          return new Map();
+        });
+      });
+    }
+
+    function processBatch(response, purges) {
       var results = response.results;
-      if (!results.length) {
+      if (!results.length && !purges.length) {
         return;
       }
+
+      for (let purge of purges) {
+        const index = results.findIndex(function (change) {
+          return change.id === purge.docId;
+        });
+        if (index < 0) {
+          // mimic a db.remove() on the changes feed
+          const entry = {
+            _id: purge.docId,
+            doc: {
+              _id: purge.docId,
+              _deleted: 1,
+            },
+            changes: [],
+          };
+
+          if (purge.doc) {
+            // update with new winning rev after purge
+            entry.doc = purge.doc;
+            entry.changes.push({ rev: purge.doc._rev });
+          }
+
+          results.push(entry);
+        }
+      }
+
       var docIdsToChangesAndEmits = createDocIdsToChangesAndEmits(results);
+
       queue.add(processChange(docIdsToChangesAndEmits, currentSeq));
 
       indexed_docs = indexed_docs + results.length;

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -608,7 +608,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
           if (err && err.status !== 404) {
             throw err;
           }
-          return new Map();
+          return [];
         });
       });
     }

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
@@ -150,6 +150,19 @@ function IdbPouch(dbOpts, callback) {
     });
   };
 
+  api._purgeRev = function (docId, rev) {
+    // first, let's remove the document from our docs object store and see what happens to the index
+    return this.remove(docId, rev).then(() => {
+      // then, we inspect the meta object stores
+      // then, we check the auxiliary MR index databases. how do we trigger view rebuilds? do we want actual rebuilds or
+      //   something else?
+      // also of interest could be the native indexeddb find indexes - they shouldn't contain anything since they're
+      //   updated automatically? MR-based find indexes should work as above.
+
+      // also, make sure to remove the entire document if we remove the last leaf that has no branched path?
+    });
+  };
+
   // TODO: this setTimeout seems nasty, if its needed lets
   // figure out / explain why
   setTimeout(function () {

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
@@ -14,6 +14,7 @@ import getRevisionTree from './getRevisionTree';
 import doCompaction from './doCompaction';
 import destroy from './destroy';
 import {query, viewCleanup} from './find';
+import purge from './purge';
 
 import { DOC_STORE } from './util';
 
@@ -150,18 +151,7 @@ function IdbPouch(dbOpts, callback) {
     });
   };
 
-  api._purgeRev = function (docId, rev) {
-    // first, let's remove the document from our docs object store and see what happens to the index
-    return this.remove(docId, rev).then(() => {
-      // then, we inspect the meta object stores
-      // then, we check the auxiliary MR index databases. how do we trigger view rebuilds? do we want actual rebuilds or
-      //   something else?
-      // also of interest could be the native indexeddb find indexes - they shouldn't contain anything since they're
-      //   updated automatically? MR-based find indexes should work as above.
-
-      // also, make sure to remove the entire document if we remove the last leaf that has no branched path?
-    });
-  };
+  api._purge = $t(purge, [DOC_STORE], 'readwrite');
 
   // TODO: this setTimeout seems nasty, if its needed lets
   // figure out / explain why

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/purge.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/purge.js
@@ -5,7 +5,7 @@ import { removeLeafFromTree, winningRev } from "pouchdb-merge";
 // operate on an entire path of revs? it could be way cheaper to operate on the
 // doc just once, given that the rev path is correct. but we could verify that
 // during the transaction.
-function purge(txn, docId, rev, callback) {
+function purge(txn, docId, revs, callback) {
   if (txn.error) {
     return callback(txn.error);
   }
@@ -14,19 +14,23 @@ function purge(txn, docId, rev, callback) {
   docStore.get(docId).onsuccess = (e) => {
     const doc = e.target.result;
 
-    // look into how docs are updated (and hence, how rev trees are updated)
-    // that stuff lives in `bulkDocs`
-    doc.rev_tree = removeLeafFromTree(doc.rev_tree, rev);
+    // we could do a dry run here to check if revs is a proper path towards a leaf in the rev tree
 
-    // assign new revs
-    delete doc.revs[rev];
+    for (const rev of revs) {
+      // purge rev from tree
+      doc.rev_tree = removeLeafFromTree(doc.rev_tree, rev);
+
+      // assign new revs
+      delete doc.revs[revs];
+    }
+
+    if (doc.rev_tree.length === 0) {
+      // if the rev tree is empty, we can delete the entire document
+      docStore.delete(doc.id);
+      return;
+    }
 
     // find new winning rev
-    // do we want to calculate the winning rev for each purged rev? when purging a branch like a-b-c
-    // (c is leaf and previous winning rev), this could mean that during the first rev purge (c) a
-    // winning rev of another branch is calculated. hence, b and c will choose the same winning rev.
-    // considering this, purging an entire with in a single transaction/operation would make even
-    // more sense.
     doc.rev = winningRev(doc);
     doc.data = doc.revs[doc.rev].data;
 

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/purge.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/purge.js
@@ -21,7 +21,7 @@ function purge(txn, docId, revs, callback) {
       doc.rev_tree = removeLeafFromTree(doc.rev_tree, rev);
 
       // assign new revs
-      delete doc.revs[revs];
+      delete doc.revs[rev];
     }
 
     if (doc.rev_tree.length === 0) {

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/purge.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/purge.js
@@ -3,11 +3,13 @@ import { removeLeafFromTree, winningRev } from "pouchdb-merge";
 
 function purgeAttachments(doc, revs) {
   if (!doc.attachments) {
+    // If there are no attachments, doc.attachments is an empty object
     return {};
   }
 
-  for (let k in doc.attachments) {
-    const attachment = doc.attachments[k];
+  // Iterate over all attachments and remove the respective revs
+  for (let key in doc.attachments) {
+    const attachment = doc.attachments[key];
 
     for (let rev of revs) {
       if (attachment.revs[rev]) {
@@ -16,7 +18,7 @@ function purgeAttachments(doc, revs) {
     }
 
     if (Object.keys(attachment.revs).length === 0) {
-      delete doc.attachments[k];
+      delete doc.attachments[key];
     }
   }
 

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/purge.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/purge.js
@@ -33,8 +33,8 @@ function purge(txn, docId, revs, callback) {
   }
 
   const docStore = txn.txn.objectStore(DOC_STORE);
-  const deletedRevs = []
-  let documentWasRemovedCompletely = false
+  const deletedRevs = [];
+  let documentWasRemovedCompletely = false;
   docStore.get(docId).onsuccess = (e) => {
     const doc = e.target.result;
 
@@ -46,7 +46,7 @@ function purge(txn, docId, revs, callback) {
 
       // assign new revs
       delete doc.revs[rev];
-      deletedRevs.push(rev)
+      deletedRevs.push(rev);
     }
 
     if (doc.rev_tree.length === 0) {

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/purge.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/purge.js
@@ -1,6 +1,28 @@
 import { DOC_STORE } from "pouchdb-adapter-indexeddb/src/util";
 import { removeLeafFromTree, winningRev } from "pouchdb-merge";
 
+function purgeAttachments(doc, revs) {
+  if (!doc.attachments) {
+    return {};
+  }
+
+  for (let k in doc.attachments) {
+    const attachment = doc.attachments[k];
+
+    for (let rev of revs) {
+      if (attachment.revs[rev]) {
+        delete attachment.revs[rev];
+      }
+    }
+
+    if (Object.keys(attachment.revs).length === 0) {
+      delete doc.attachments[k];
+    }
+  }
+
+  return doc.attachments;
+}
+
 // do we want to make this function remove just one rev for each call, or rather
 // operate on an entire path of revs? it could be way cheaper to operate on the
 // doc just once, given that the rev path is correct. but we could verify that
@@ -33,6 +55,7 @@ function purge(txn, docId, revs, callback) {
     // find new winning rev
     doc.rev = winningRev(doc);
     doc.data = doc.revs[doc.rev].data;
+    doc.attachments = purgeAttachments(doc, revs);
 
     // finally, write the purged doc
     docStore.put(doc);

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/purge.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/purge.js
@@ -23,10 +23,21 @@ function purgeAttachments(doc, revs) {
   return doc.attachments;
 }
 
-// do we want to make this function remove just one rev for each call, or rather
-// operate on an entire path of revs? it could be way cheaper to operate on the
-// doc just once, given that the rev path is correct. but we could verify that
-// during the transaction.
+// `purge()` expects a path of revisions in its revs argument that:
+// - starts with a leaf rev
+// - continues sequentially with the remaining revs of that leaf’s branch
+//
+// eg. for this rev tree:
+// 1-9692 ▶ 2-37aa ▶ 3-df22 ▶ 4-6e94 ▶ 5-df4a ▶ 6-6a3a ▶ 7-57e5
+//          ┃                 ┗━━━━━━▶ 5-8d8c ▶ 6-65e0
+//          ┗━━━━━━▶ 3-43f6 ▶ 4-a3b4
+//
+// …if you wanted to purge '7-57e5', you would provide ['7-57e5', '6-6a3a', '5-df4a']
+//
+// The purge adapter implementation in `pouchdb-core` uses the helper function `findPathToLeaf`
+// from `pouchdb-merge` to construct this array correctly. Since this purge implementation is
+// only ever called from there, we do no additional checks here as to whether `revs` actually
+// fulfills the criteria above, since `findPathToLeaf` already does these.
 function purge(txn, docId, revs, callback) {
   if (txn.error) {
     return callback(txn.error);

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/purge.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/purge.js
@@ -1,0 +1,42 @@
+import { DOC_STORE } from "pouchdb-adapter-indexeddb/src/util";
+import { removeLeafFromTree, winningRev } from "pouchdb-merge";
+
+// do we want to make this function remove just one rev for each call, or rather
+// operate on an entire path of revs? it could be way cheaper to operate on the
+// doc just once, given that the rev path is correct. but we could verify that
+// during the transaction.
+function purge(txn, docId, rev, callback) {
+  if (txn.error) {
+    return callback(txn.error);
+  }
+
+  const docStore = txn.txn.objectStore(DOC_STORE);
+  docStore.get(docId).onsuccess = (e) => {
+    const doc = e.target.result;
+
+    // look into how docs are updated (and hence, how rev trees are updated)
+    // that stuff lives in `bulkDocs`
+    doc.rev_tree = removeLeafFromTree(doc.rev_tree, rev);
+
+    // assign new revs
+    delete doc.revs[rev];
+
+    // find new winning rev
+    // do we want to calculate the winning rev for each purged rev? when purging a branch like a-b-c
+    // (c is leaf and previous winning rev), this could mean that during the first rev purge (c) a
+    // winning rev of another branch is calculated. hence, b and c will choose the same winning rev.
+    // considering this, purging an entire with in a single transaction/operation would make even
+    // more sense.
+    doc.rev = winningRev(doc);
+    doc.data = doc.revs[doc.rev].data;
+
+    // finally, write the purged doc
+    docStore.put(doc);
+  };
+
+  txn.txn.oncomplete = function () {
+    callback();
+  };
+}
+
+export default purge;

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/purge.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/purge.js
@@ -33,6 +33,8 @@ function purge(txn, docId, revs, callback) {
   }
 
   const docStore = txn.txn.objectStore(DOC_STORE);
+  const deletedRevs = []
+  let documentWasRemovedCompletely = false
   docStore.get(docId).onsuccess = (e) => {
     const doc = e.target.result;
 
@@ -44,11 +46,13 @@ function purge(txn, docId, revs, callback) {
 
       // assign new revs
       delete doc.revs[rev];
+      deletedRevs.push(rev)
     }
 
     if (doc.rev_tree.length === 0) {
       // if the rev tree is empty, we can delete the entire document
       docStore.delete(doc.id);
+      documentWasRemovedCompletely = true;
       return;
     }
 
@@ -62,7 +66,11 @@ function purge(txn, docId, revs, callback) {
   };
 
   txn.txn.oncomplete = function () {
-    callback();
+    callback(null, {
+      ok: true,
+      deletedRevs,
+      documentWasRemovedCompletely
+    });
   };
 }
 

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -20,7 +20,8 @@ import {
   rootToLeaf,
   collectConflicts,
   isDeleted,
-  isLocalId
+  isLocalId,
+  findPathToLeaf
 } from 'pouchdb-merge';
 import {
   MISSING_BULK_DOCS,
@@ -958,5 +959,42 @@ class AbstractPouchDB extends EventEmitter {
     return (typeof this._type === 'function') ? this._type() : this.adapter;
   }
 }
+
+AbstractPouchDB.prototype.purge = adapterFun('_purge', function (docId, rev) {
+  if (typeof this._purge === 'undefined') {
+    throw new Error('Purge is not implemented by the ' + this.adapter + ' adapter.');
+  }
+  var self = this;
+
+  // TODO: this should probably return some information
+  // about the completed purge
+  return new Promise((resolve) => {
+    self._getRevisionTree(docId, async (whatever, revs) => {
+      const path = findPathToLeaf(revs, rev);
+      console.log("purge path", path);
+
+      for (const revHash of path) {
+        await (async () =>
+          new Promise((resolve) =>
+            self._purge(docId, revHash, (err) => {
+              if (err) {
+                console.error("error", err);
+              } else {
+                console.log("purge successful");
+              }
+              resolve();
+            })
+          ))();
+      }
+
+      console.log(
+        "revs_info after purge",
+        await self.get(docId, { revs_info: true })
+      );
+
+      resolve();
+    });
+  });
+});
 
 export default AbstractPouchDB;

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -973,10 +973,9 @@ AbstractPouchDB.prototype.purge = adapterFun('_purge', function (docId, rev) {
       const path = findPathToLeaf(revs, rev);
       console.log("purge path", path);
 
-      for (const revHash of path) {
         await (async () =>
           new Promise((resolve) =>
-            self._purge(docId, revHash, (err) => {
+            self._purge(docId, path, (err) => {
               if (err) {
                 console.error("error", err);
               } else {
@@ -985,12 +984,13 @@ AbstractPouchDB.prototype.purge = adapterFun('_purge', function (docId, rev) {
               resolve();
             })
           ))();
-      }
 
-      console.log(
-        "revs_info after purge",
-        await self.get(docId, { revs_info: true })
-      );
+      try {
+        console.log(
+          "revs_info after purge",
+          await self.get(docId, { revs_info: true })
+        );
+      } catch (err) {}
 
       resolve();
     });

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -974,6 +974,46 @@ AbstractPouchDB.prototype.purge = adapterFun('_purge', function (docId, rev) {
       // `findPathToLeaf` throws if rev is invalid
       const path = findPathToLeaf(revs, rev);
       console.log("purge path", path);
+
+      async function appendPurgeSeq(docId, rev) {
+        let doc;
+
+        try {
+          doc = await self.get('_local/purges');
+          doc.purges.push({
+            docId,
+            rev,
+            purgeSeq: doc.purgeSeq + 1,
+          });
+          doc.purgeSeq += 1;
+        } catch (err) {
+          if (err.status !== 404) {
+            // something else? what could be reasons that this should fail,
+            // and if so, how should be handle it? purging without writing
+            // to purgeSeq could result in incomplete purges where views
+            // still need updating, but the information on how to purge them
+            // is lost when the purgeSeq write failed.
+            console.error(err);
+            return;
+          } else {
+            // we include the current purgeSeq with each record. this is somewhat
+            // redundant, but could help with reordering the list if it would get
+            // corrupted at one point... or is this unnecessary?
+            doc = {
+              _id: '_local/purges',
+              purges: [{
+                docId,
+                rev,
+                purgeSeq: 0,
+              }],
+              purgeSeq: 0,
+            };
+          }
+        }
+
+        await self.put(doc);
+      }
+
       await (async () =>
         new Promise((resolve) =>
           // TODO: The purge itself returns nothing, is that ok?
@@ -983,7 +1023,9 @@ AbstractPouchDB.prototype.purge = adapterFun('_purge', function (docId, rev) {
               console.error("error", err);
             } else {
               console.log("purge successful");
+              appendPurgeSeq(docId, rev);
             }
+
             resolve();
           })
         ))();

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -991,6 +991,8 @@ class AbstractPouchDB extends EventEmitter {
   }
 }
 
+// The abstract purge implementation expects a doc id and the rev of a leaf node in that doc.
+// It will return errors if the rev doesn’t exist or isn’t a leaf.
 AbstractPouchDB.prototype.purge = adapterFun('_purge', function (docId, rev, callback) {
   if (typeof this._purge === 'undefined') {
     return callback('Purge is not implemented by the ' + this.adapter + ' adapter.');

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -985,6 +985,9 @@ AbstractPouchDB.prototype.purge = adapterFun('_purge', function (docId, rev) {
             rev,
             purgeSeq: doc.purgeSeq + 1,
           });
+          if (doc.purges.length > self.purged_infos_limit) {
+            doc.purges.splice(0, doc.purges.length - self.purged_infos_limit);
+          }
           doc.purgeSeq += 1;
         } catch (err) {
           if (err.status !== 404) {

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -966,33 +966,41 @@ AbstractPouchDB.prototype.purge = adapterFun('_purge', function (docId, rev) {
   }
   var self = this;
 
-  // TODO: this should probably return some information
-  // about the completed purge
   return new Promise((resolve) => {
     self._getRevisionTree(docId, async (whatever, revs) => {
+      if (!revs) {
+        throw new Error('The target document doesn’t exist (has no revisions)');
+      }
+      // `findPathToLeaf` throws if rev is invalid
       const path = findPathToLeaf(revs, rev);
       console.log("purge path", path);
-
-        await (async () =>
-          new Promise((resolve) =>
-            self._purge(docId, path, (err) => {
-              if (err) {
-                console.error("error", err);
-              } else {
-                console.log("purge successful");
-              }
-              resolve();
-            })
-          ))();
-
+      await (async () =>
+        new Promise((resolve) =>
+          // TODO: The purge itself returns nothing, is that ok?
+          // CouchDB returns the successfully purged revisions
+          self._purge(docId, path, (err) => {
+            if (err) {
+              console.error("error", err);
+            } else {
+              console.log("purge successful");
+            }
+            resolve();
+          })
+        ))();
+      let result;
       try {
+        // If the doc had conflicts and still exists, return it
+        result = await self.get(docId);
         console.log(
           "revs_info after purge",
           await self.get(docId, { revs_info: true })
         );
-      } catch (err) {}
-
-      resolve();
+      } catch (err) {
+        // If the doc was conflict-free, it is now gone. Return the `not_found` error,
+        // as this is the expected happy path result of a `get()` on a purged doc
+        result = err;
+      }
+      resolve(result);
     });
   });
 });

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -995,7 +995,7 @@ class AbstractPouchDB extends EventEmitter {
 // It will return errors if the rev doesn’t exist or isn’t a leaf.
 AbstractPouchDB.prototype.purge = adapterFun('_purge', function (docId, rev, callback) {
   if (typeof this._purge === 'undefined') {
-    return callback('Purge is not implemented by the ' + this.adapter + ' adapter.');
+    return callback(createError(UNKNOWN_ERROR, 'Purge is not implemented in the ' + this.adapter + ' adapter.'));
   }
   var self = this;
 
@@ -1004,7 +1004,7 @@ AbstractPouchDB.prototype.purge = adapterFun('_purge', function (docId, rev, cal
       return callback(error);
     }
     if (!revs) {
-      return callback('The target document doesn’t exist (has no revisions)');
+      return callback(createError(MISSING_DOC));
     }
     let path;
     try {

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -156,6 +156,37 @@ function doNextCompaction(self) {
   });
 }
 
+function appendPurgeSeq(db, docId, rev) {
+  return db.get('_local/purges').then(function (doc) {
+    const purgeSeq = doc.purgeSeq + 1;
+    doc.purges.push({
+      docId,
+      rev,
+      purgeSeq,
+    });
+    if (doc.purges.length > self.purged_infos_limit) {
+      doc.purges.splice(0, doc.purges.length - self.purged_infos_limit);
+    }
+    doc.purgeSeq = purgeSeq;
+    return doc;
+  }).catch(function (err) {
+    if (err.status !== 404) {
+      throw err;
+    }
+    return {
+      _id: '_local/purges',
+      purges: [{
+        docId,
+        rev,
+        purgeSeq: 0,
+      }],
+      purgeSeq: 0,
+    };
+  }).then(function (doc) {
+    return db.put(doc);
+  });
+}
+
 function attachmentNameError(name) {
   if (name.charAt(0) === '_') {
     return name + ' is not a valid attachment name, attachment ' +
@@ -960,92 +991,33 @@ class AbstractPouchDB extends EventEmitter {
   }
 }
 
-AbstractPouchDB.prototype.purge = adapterFun('_purge', function (docId, rev) {
+AbstractPouchDB.prototype.purge = adapterFun('_purge', function (docId, rev, callback) {
   if (typeof this._purge === 'undefined') {
-    throw new Error('Purge is not implemented by the ' + this.adapter + ' adapter.');
+    return callback('Purge is not implemented by the ' + this.adapter + ' adapter.');
   }
   var self = this;
 
-  return new Promise((resolve) => {
-    self._getRevisionTree(docId, async (whatever, revs) => {
-      if (!revs) {
-        throw new Error('The target document doesn’t exist (has no revisions)');
+  self._getRevisionTree(docId, (error, revs) => {
+    if (error) {
+      return callback(error);
+    }
+    if (!revs) {
+      return callback('The target document doesn’t exist (has no revisions)');
+    }
+    let path;
+    try {
+      path = findPathToLeaf(revs, rev);
+    } catch (error) {
+      return callback(error.message || error);
+    }
+    self._purge(docId, path, (error, result) => {
+      if (error) {
+        return callback(error);
+      } else {
+        appendPurgeSeq(self, docId, rev).then(function () {
+          return callback(null, result);
+        });
       }
-      // `findPathToLeaf` throws if rev is invalid
-      const path = findPathToLeaf(revs, rev);
-      console.log("purge path", path);
-
-      async function appendPurgeSeq(docId, rev) {
-        let doc;
-
-        try {
-          doc = await self.get('_local/purges');
-          doc.purges.push({
-            docId,
-            rev,
-            purgeSeq: doc.purgeSeq + 1,
-          });
-          if (doc.purges.length > self.purged_infos_limit) {
-            doc.purges.splice(0, doc.purges.length - self.purged_infos_limit);
-          }
-          doc.purgeSeq += 1;
-        } catch (err) {
-          if (err.status !== 404) {
-            // something else? what could be reasons that this should fail,
-            // and if so, how should be handle it? purging without writing
-            // to purgeSeq could result in incomplete purges where views
-            // still need updating, but the information on how to purge them
-            // is lost when the purgeSeq write failed.
-            console.error(err);
-            return;
-          } else {
-            // we include the current purgeSeq with each record. this is somewhat
-            // redundant, but could help with reordering the list if it would get
-            // corrupted at one point... or is this unnecessary?
-            doc = {
-              _id: '_local/purges',
-              purges: [{
-                docId,
-                rev,
-                purgeSeq: 0,
-              }],
-              purgeSeq: 0,
-            };
-          }
-        }
-
-        await self.put(doc);
-      }
-
-      await (async () =>
-        new Promise((resolve) =>
-          // TODO: The purge itself returns nothing, is that ok?
-          // CouchDB returns the successfully purged revisions
-          self._purge(docId, path, (err) => {
-            if (err) {
-              console.error("error", err);
-            } else {
-              console.log("purge successful");
-              appendPurgeSeq(docId, rev);
-            }
-
-            resolve();
-          })
-        ))();
-      let result;
-      try {
-        // If the doc had conflicts and still exists, return it
-        result = await self.get(docId);
-        console.log(
-          "revs_info after purge",
-          await self.get(docId, { revs_info: true })
-        );
-      } catch (err) {
-        // If the doc was conflict-free, it is now gone. Return the `not_found` error,
-        // as this is the expected happy path result of a `get()` on a purged doc
-        result = err;
-      }
-      resolve(result);
     });
   });
 });

--- a/packages/node_modules/pouchdb-core/src/constructor.js
+++ b/packages/node_modules/pouchdb-core/src/constructor.js
@@ -56,6 +56,7 @@ class PouchInternal extends Adapter {
     this.__opts = opts = clone(opts);
 
     this.auto_compaction = opts.auto_compaction;
+    this.purged_infos_limit = opts.purged_infos_limit || 1000;
     this.prefix = PouchDB.prefix;
 
     if (typeof name !== 'string') {

--- a/packages/node_modules/pouchdb-merge/src/findPathToLeaf.js
+++ b/packages/node_modules/pouchdb-merge/src/findPathToLeaf.js
@@ -1,6 +1,20 @@
+// `findPathToLeaf()` returns an array of revs that goes from the specified
+// leaf rev to the root of that leaf’s branch.
+//
+// eg. for this rev tree:
+// 1-9692 ▶ 2-37aa ▶ 3-df22 ▶ 4-6e94 ▶ 5-df4a ▶ 6-6a3a ▶ 7-57e5
+//          ┃                 ┗━━━━━━▶ 5-8d8c ▶ 6-65e0
+//          ┗━━━━━━▶ 3-43f6 ▶ 4-a3b4
+//
+// For a `targetRev` of '7-57e5', `findPathToLeaf()` would return ['7-57e5', '6-6a3a', '5-df4a']
+// The `revs` arument has the same structure as what `revs_tree` has on e.g.
+// the IndexedDB representation of the rev tree datastructure. Please refer to
+// tests/unit/test.purge.js for examples of what these look like.
+//
+// This function will throw an error if:
+// - The requested revision does not exist
+// - The requested revision is not a leaf
 function findPathToLeaf(revs, targetRev) {
-  // `revs` has the same structure as what `revs_tree` has on e.g. the IndexedDB representation
-  // of the rev tree datastructure.
   let path = [];
   const toVisit = revs.slice();
 
@@ -23,8 +37,8 @@ function findPathToLeaf(revs, targetRev) {
     }
 
     // this is based on the assumption that after we have a leaf (`branches.length == 0`), we handle the next
-    // branch. this is true for all branches other than the path leading to the winning rev (which is 6-a in
-    // the example below. i've added a reset condition for branching nodes (`branches.length > 1`) as well.
+    // branch. this is true for all branches other than the path leading to the winning rev (which is 7-57e5 in
+    // the example above. i've added a reset condition for branching nodes (`branches.length > 1`) as well.
     if (branches.length === 0 || branches.length > 1) {
       path = [];
     }

--- a/packages/node_modules/pouchdb-merge/src/findPathToLeaf.js
+++ b/packages/node_modules/pouchdb-merge/src/findPathToLeaf.js
@@ -1,0 +1,43 @@
+function findPathToLeaf(revs, targetRev) {
+  // `revs` has the same structure as what `revs_tree` has on e.g. the IndexedDB representation
+  // of the rev tree datastructure.
+  let path = [];
+  const toVisit = revs.slice();
+
+  let node;
+  while ((node = toVisit.pop())) {
+    const { pos, ids: tree } = node;
+    const rev = `${pos}-${tree[0]}`;
+    const branches = tree[2];
+
+    // just assuming we're already working on the path up towards our desired leaf.
+    path.push(rev);
+
+    // we've reached the leaf of our dreams, so return the computed path.
+    if (rev === targetRev) {
+      //…unleeeeess
+      if (branches.length !== 0) {
+        throw new Error('The requested revision is not a leaf');
+      }
+      return path.reverse();
+    }
+
+    // this is based on the assumption that after we have a leaf (`branches.length == 0`), we handle the next
+    // branch. this is true for all branches other than the path leading to the winning rev (which is 6-a in
+    // the example below. i've added a reset condition for branching nodes (`branches.length > 1`) as well.
+    if (branches.length === 0 || branches.length > 1) {
+      path = [];
+    }
+
+    // as a next step, we push the branches of this node to `toVisit` for visiting it during the next iteration
+    for (let i = 0, len = branches.length; i < len; i++) {
+      toVisit.push({ pos: pos + 1, ids: branches[i] });
+    }
+  }
+  if (path.length === 0) {
+    throw new Error('The requested revision does not exist');
+  }
+  return path.reverse();
+}
+
+export default findPathToLeaf;

--- a/packages/node_modules/pouchdb-merge/src/index.js
+++ b/packages/node_modules/pouchdb-merge/src/index.js
@@ -1,7 +1,9 @@
 import collectConflicts from './collectConflicts';
 import collectLeaves from './collectLeaves';
 import compactTree from './compactTree';
+import findPathToLeaf from './findPathToLeaf';
 import merge from './merge';
+import removeLeafFromTree from './removeLeafFromTree';
 import revExists from './revExists';
 import rootToLeaf from './rootToLeaf';
 import traverseRevTree from './traverseRevTree';
@@ -14,9 +16,11 @@ export {
   collectConflicts,
   collectLeaves,
   compactTree,
+  findPathToLeaf,
   isDeleted,
   isLocalId,
   merge,
+  removeLeafFromTree,
   revExists,
   rootToLeaf,
   traverseRevTree,

--- a/packages/node_modules/pouchdb-merge/src/removeLeafFromTree.js
+++ b/packages/node_modules/pouchdb-merge/src/removeLeafFromTree.js
@@ -19,6 +19,11 @@ function removeLeafFromRevTree(tree, leafRev) {
     const hash = `${pos}-${id}`;
 
     if (isLeaf && hash === leafRev) {
+      if (!previousNode) {
+        // FIXME: we're facing the root, and probably shouldn't just return an empty array (object? null?).
+        return [];
+      }
+
       previousNode.ids[2] = previousNode.ids[2].filter(function (branchNode) {
         return branchNode[0] !== id;
       });

--- a/packages/node_modules/pouchdb-merge/src/removeLeafFromTree.js
+++ b/packages/node_modules/pouchdb-merge/src/removeLeafFromTree.js
@@ -4,8 +4,15 @@ import { clone } from 'pouchdb-utils';
 // e.g., by removing an available leaf, it could leave its predecessor as
 // a missing leaf and corrupting the tree.
 function removeLeafFromRevTree(tree, leafRev) {
-  const _tree = clone(tree);
-  const toVisit = _tree.slice();
+  return tree.flatMap((path) => {
+    path = removeLeafFromPath(path, leafRev);
+    return path ? [path] : [];
+  });
+}
+
+function removeLeafFromPath(path, leafRev) {
+  const _tree = clone(path);
+  const toVisit = [_tree];
 
   // we will store branchings (node.branches > 1) as a LIFO stack
   const branchings = [];
@@ -21,7 +28,7 @@ function removeLeafFromRevTree(tree, leafRev) {
     if (isLeaf && hash === leafRev) {
       if (!previousNode) {
         // FIXME: we're facing the root, and probably shouldn't just return an empty array (object? null?).
-        return [];
+        return null;
       }
 
       previousNode.ids[2] = previousNode.ids[2].filter(function (branchNode) {

--- a/packages/node_modules/pouchdb-merge/src/removeLeafFromTree.js
+++ b/packages/node_modules/pouchdb-merge/src/removeLeafFromTree.js
@@ -1,0 +1,32 @@
+import { clone } from 'pouchdb-utils';
+
+function removeLeafFromRevTree(tree, leafRev) {
+  const _tree = clone(tree);
+  const toVisit = _tree.slice();
+
+  let previousNode;
+  let node;
+  while ((node = toVisit.pop())) {
+    const pos = node.pos;
+    const [id, opts, branches] = node.ids;
+    const isLeaf = branches.length === 0;
+    const hash = `${pos}-${id}`;
+
+    if (isLeaf && hash === leafRev && opts.status === "available") {
+      previousNode.ids[2] = previousNode.ids[2].filter(function (branchNode) {
+        return branchNode[0] !== id;
+      });
+      return _tree;
+    }
+    previousNode = node;
+
+    if (branches.length) {
+      for (let i = 0, len = branches.length; i < len; i++) {
+        toVisit.push({pos: pos + 1, ids: branches[i]});
+      }
+    }
+  }
+  return _tree;
+}
+
+export default removeLeafFromRevTree;

--- a/packages/node_modules/pouchdb-merge/src/removeLeafFromTree.js
+++ b/packages/node_modules/pouchdb-merge/src/removeLeafFromTree.js
@@ -1,29 +1,44 @@
 import { clone } from 'pouchdb-utils';
 
+// this method removes a leaf from a rev tree, independent of its status.
+// e.g., by removing an available leaf, it could leave its predecessor as
+// a missing leaf and corrupting the tree.
 function removeLeafFromRevTree(tree, leafRev) {
   const _tree = clone(tree);
   const toVisit = _tree.slice();
+
+  // we will store branchings (node.branches > 1) as a LIFO stack
+  const branchings = [];
 
   let previousNode;
   let node;
   while ((node = toVisit.pop())) {
     const pos = node.pos;
-    const [id, opts, branches] = node.ids;
+    const [id, , branches] = node.ids;
     const isLeaf = branches.length === 0;
     const hash = `${pos}-${id}`;
 
-    if (isLeaf && hash === leafRev && opts.status === "available") {
+    if (isLeaf && hash === leafRev) {
       previousNode.ids[2] = previousNode.ids[2].filter(function (branchNode) {
         return branchNode[0] !== id;
       });
       return _tree;
     }
-    previousNode = node;
 
     if (branches.length) {
+      if (branches.length > 1) {
+        branchings.push(node);
+      }
+
       for (let i = 0, len = branches.length; i < len; i++) {
         toVisit.push({pos: pos + 1, ids: branches[i]});
       }
+    }
+
+    if (branches.length === 0 && branchings.length > 0) {
+      previousNode = branchings.pop();
+    }  else {
+      previousNode = node;
     }
   }
   return _tree;

--- a/packages/node_modules/pouchdb-merge/src/removeLeafFromTree.js
+++ b/packages/node_modules/pouchdb-merge/src/removeLeafFromTree.js
@@ -11,49 +11,32 @@ function removeLeafFromRevTree(tree, leafRev) {
 }
 
 function removeLeafFromPath(path, leafRev) {
-  const _tree = clone(path);
-  const toVisit = [_tree];
-
-  // we will store branchings (node.branches > 1) as a LIFO stack
-  const branchings = [];
-
-  let previousNode;
+  const tree = clone(path);
+  const toVisit = [tree];
   let node;
+
   while ((node = toVisit.pop())) {
-    const pos = node.pos;
-    const [id, , branches] = node.ids;
+    const { pos, ids: [id, , branches], parent } = node;
     const isLeaf = branches.length === 0;
     const hash = `${pos}-${id}`;
 
     if (isLeaf && hash === leafRev) {
-      if (!previousNode) {
+      if (!parent) {
         // FIXME: we're facing the root, and probably shouldn't just return an empty array (object? null?).
         return null;
       }
 
-      previousNode.ids[2] = previousNode.ids[2].filter(function (branchNode) {
+      parent.ids[2] = parent.ids[2].filter(function (branchNode) {
         return branchNode[0] !== id;
       });
-      return _tree;
+      return tree;
     }
 
-    if (branches.length) {
-      if (branches.length > 1) {
-        branchings.push(node);
-      }
-
-      for (let i = 0, len = branches.length; i < len; i++) {
-        toVisit.push({pos: pos + 1, ids: branches[i]});
-      }
-    }
-
-    if (branches.length === 0 && branchings.length > 0) {
-      previousNode = branchings.pop();
-    }  else {
-      previousNode = node;
+    for (let i = 0, len = branches.length; i < len; i++) {
+      toVisit.push({ pos: pos + 1, ids: branches[i], parent: node });
     }
   }
-  return _tree;
+  return tree;
 }
 
 export default removeLeafFromRevTree;

--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -3256,6 +3256,38 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('Test rev purge with attachment', function () {
+      const db = new PouchDB(dbs.name);
+
+      if (typeof db._purge === 'undefined') {
+        console.log('purge is not implemented for adapter', db.adapter);
+        return;
+      }
+
+      const doc = { _id: 'foo' };
+      const base64 =
+        'iVBORw0KGgoAAAANSUhEUgAAAhgAAAJLCAYAAAClnu9J' +
+        'AAAgAElEQVR4Xuy9B7ylZXUu/p62T5nOMAPM0BVJICQi' +
+        'ogjEJN5ohEgQ';
+
+      return db.put(doc).then(function (res) {
+        return db.putAttachment('foo', 'foo.bin', res.rev, base64, 'image/png');
+      }).then(function () {
+        return db.get(doc._id);
+      }).then(function (_doc) {
+        return db.purge(doc._id, _doc._rev);
+      }).then(function () {
+        return db.getAttachment(doc._id, 'foo.bin');
+      }).then(function () {
+        assert.fail('attachment should not exist');
+      }).catch(function (err) {
+        if (!err.status) {
+          throw err;
+        }
+        err.status.should.equal(404, 'attachment should not exist');
+      });
+    });
+
   });
 });
 

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -594,12 +594,12 @@ adapters.forEach(function (adapter) {
         var db = new PouchDB(dbs.name);
         db.post(doc, function (err, resp) {
           should.not.exist(err);
-  
+
           db.get(resp.id, function (err, doc2) {
             should.not.exist(err);
-  
+
             doc2._access.should.eql(['alice']);
-  
+
             done();
           });
         });
@@ -1128,6 +1128,29 @@ adapters.forEach(function (adapter) {
       return db.put(doc).then(function () {
         return doc._id;
       }).then(db.get);
+    });
+
+    it('Test rev purge', function () {
+      const db = new PouchDB(dbs.name);
+
+      if (typeof db._purge === 'undefined') {
+        console.log('purge is not implemented for adapter', db.adapter);
+        return;
+      }
+
+      const doc = { _id: 'foo' };
+      return db.put(doc).then(function (res) {
+        return db.purge(doc._id, res.rev);
+      }).then(function () {
+        return db.get(doc._id);
+      }).then(function () {
+        assert.fail('doc should not exist');
+      }).catch(function (err) {
+        if (!err.status) {
+          throw err;
+        }
+        err.status.should.equal(404, 'doc should not exist');
+      });
     });
 
     if (adapter === 'local') {

--- a/tests/integration/test.design_docs.js
+++ b/tests/integration/test.design_docs.js
@@ -155,5 +155,33 @@ adapters.forEach(function (adapter) {
       });
     });
 
+    it('Test rev purge with a view', function () {
+      const db = new PouchDB(dbs.name);
+
+      if (typeof db._purge === 'undefined') {
+        console.log('purge is not implemented for adapter', db.adapter);
+        return;
+      }
+
+      return db.bulkDocs({
+        docs: [
+          doc,
+          {_id: 'dale', score: 3},
+          {_id: 'mikeal', score: 5},
+        ],
+      }).then(function () {
+        return db.query('foo/scores');
+      }).then(function () {
+        return db.get('dale');
+      }).then(function (_doc) {
+        return db.purge(_doc._id, _doc._rev);
+      }).then(function () {
+        return db.query('foo/scores');
+      }).then(function (res) {
+        res.rows.length.should.equal(1);
+        res.rows[0].value.should.equal(5);
+      });
+    });
+
   });
 });

--- a/tests/unit/test.purge.js
+++ b/tests/unit/test.purge.js
@@ -599,6 +599,22 @@ describe.only('the removeLeafFromTree util', function () {
     tree.should.be.deep.equal(shortConflictedTreeWithout6a5a6c5c);
 
   });
+  it('should return an empty array if the entire tree is being deleted', function () {
+    const smallTree = [
+      {
+        pos: 1,
+        ids: [
+          "df226cb9a2e5bdd3e6be009fd51f47c1",
+          {
+            "status": "available"
+          },
+          []
+        ]
+      }
+    ];
+  let tree = removeLeafFromTree(smallTree, "1-df226cb9a2e5bdd3e6be009fd51f47c1");
+    tree.should.be.deep.equal([]);
+  });
   it('does not remove anything from the tree if the rev is not a leaf', function () {
     const tree = removeLeafFromTree(shortConflictedTree, "5-df4a81cd21c75c71974d96e88a68fc2f");
     tree.should.be.deep.equal(shortConflictedTree);

--- a/tests/unit/test.purge.js
+++ b/tests/unit/test.purge.js
@@ -178,6 +178,190 @@ const shortConflictedTreeWithout6a = [
   }
 ];
 
+// the same as the above shortConflictedTree, but without the 6-a & 5-a leaves
+const shortConflictedTreeWithout6a5a = [
+  {
+    "pos": 1,
+    "ids": [
+      "9692d401ed2d3434827608278bdc36e3",
+      {
+        "status": "available"
+      },
+      [
+        [
+          "37aa033df08c21b4f56f1da2081e9e00",
+          {
+            "status": "available"
+          },
+          [
+            [
+              "43f6d5557d6de39488c64bb2c684ae7c",
+              {
+                "status": "missing"
+              },
+              [
+                [
+                  "a3b44168027079c2692a7d8eb35e9643",
+                  {
+                    "status": "available"
+                  },
+                  []
+                ]
+              ]
+            ],
+            [
+              "df226cb9a2e5bdd3e6be009fd51f47c1",
+              {
+                "status": "available"
+              },
+              [
+                [
+                  "6e94d345514a08620c3176eea080d3ec",
+                  {
+                    "status": "available"
+                  },
+                  [
+                    [
+                      "0b84bfea5508e2020feb07384714a987",
+                      {
+                        "status": "missing"
+                      },
+                      [
+                        [
+                          "2d0ab4f4089a57c95d52bfd2d66b823d",
+                          {
+                            "status": "available"
+                          },
+                          []
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  }
+];
+
+// the same as the above shortConflictedTree, but without the 6-a, 5-a, and 6-c leaves
+const shortConflictedTreeWithout6a5a6c = [
+  {
+    "pos": 1,
+    "ids": [
+      "9692d401ed2d3434827608278bdc36e3",
+      {
+        "status": "available"
+      },
+      [
+        [
+          "37aa033df08c21b4f56f1da2081e9e00",
+          {
+            "status": "available"
+          },
+          [
+            [
+              "43f6d5557d6de39488c64bb2c684ae7c",
+              {
+                "status": "missing"
+              },
+              [
+                [
+                  "a3b44168027079c2692a7d8eb35e9643",
+                  {
+                    "status": "available"
+                  },
+                  []
+                ]
+              ]
+            ],
+            [
+              "df226cb9a2e5bdd3e6be009fd51f47c1",
+              {
+                "status": "available"
+              },
+              [
+                [
+                  "6e94d345514a08620c3176eea080d3ec",
+                  {
+                    "status": "available"
+                  },
+                  [
+                    [
+                      "0b84bfea5508e2020feb07384714a987",
+                      {
+                        "status": "missing"
+                      },
+                      []
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  }
+];
+
+
+// the same as the above shortConflictedTree, but without the 6-a, 5-a, 6-c, and 5-c leaves
+const shortConflictedTreeWithout6a5a6c5c = [
+  {
+    "pos": 1,
+    "ids": [
+      "9692d401ed2d3434827608278bdc36e3",
+      {
+        "status": "available"
+      },
+      [
+        [
+          "37aa033df08c21b4f56f1da2081e9e00",
+          {
+            "status": "available"
+          },
+          [
+            [
+              "43f6d5557d6de39488c64bb2c684ae7c",
+              {
+                "status": "missing"
+              },
+              [
+                [
+                  "a3b44168027079c2692a7d8eb35e9643",
+                  {
+                    "status": "available"
+                  },
+                  []
+                ]
+              ]
+            ],
+            [
+              "df226cb9a2e5bdd3e6be009fd51f47c1",
+              {
+                "status": "available"
+              },
+              [
+                [
+                  "6e94d345514a08620c3176eea080d3ec",
+                  {
+                    "status": "available"
+                  },
+                  []
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  }
+];
+
 /*
   With revs_limit: 4, the shortConflictedTree from above becomes:
   3-a - 4-a - 5-a - 6-a
@@ -405,8 +589,15 @@ describe('the findPathToLeaf util', function () {
 
 describe.only('the removeLeafFromTree util', function () {
   it('removes a leaf from the tree', function () {
-    const tree = removeLeafFromTree(shortConflictedTree, "6-3f7f6c55c27bf54c009b661607a9fe05");
+    let tree = removeLeafFromTree(shortConflictedTree, "6-3f7f6c55c27bf54c009b661607a9fe05");
     tree.should.be.deep.equal(shortConflictedTreeWithout6a);
+    tree = removeLeafFromTree(tree, "5-df4a81cd21c75c71974d96e88a68fc2f");
+    tree.should.be.deep.equal(shortConflictedTreeWithout6a5a);
+    tree = removeLeafFromTree(tree, "6-2d0ab4f4089a57c95d52bfd2d66b823d");
+    tree.should.be.deep.equal(shortConflictedTreeWithout6a5a6c);
+    tree = removeLeafFromTree(tree, "5-0b84bfea5508e2020feb07384714a987");
+    tree.should.be.deep.equal(shortConflictedTreeWithout6a5a6c5c);
+
   });
   it('does not remove anything from the tree if the rev is not a leaf', function () {
     const tree = removeLeafFromTree(shortConflictedTree, "5-df4a81cd21c75c71974d96e88a68fc2f");

--- a/tests/unit/test.purge.js
+++ b/tests/unit/test.purge.js
@@ -572,7 +572,7 @@ describe('the removeLeafFromTree util', function () {
         ]]
       ]]
     }];
-    let purged = removeLeafFromTree(tree, "3-mnop")
+    let purged = removeLeafFromTree(tree, "4-mnop")
     purged.should.deep.equal([{
       "pos": 1,
       "ids": ["abcd", {}, [
@@ -600,34 +600,36 @@ describe('the removeLeafFromTree util', function () {
           ]]
         ]]
       ]]
+    }, {
+      "pos": 3,
+      "ids": [
+        "df226cb9a2e5bdd3e6be009fd51f47c1", {}, [
+          ["6e94d345514a08620c3176eea080d3ec", {}, [
+            ["0b84bfea5508e2020feb07384714a987", {}, []],
+            ["df4a81cd21c75c71974d96e88a68fc2f", {}, []]
+          ]]
+        ]
+      ]
     }]);
   });
   it('should remove respective leafs from a multi-root tree with revs_limit=3', function () {
     // we're creating the tree below:
-    // root1 1-9692 -> 2-37aa -> 3-df22 -> 4-6e94 -> 5-df4a -> 6-3f7f
-    //                 |                   |-------> 5-8d8c -> 6-65e0
-    // root2           |-------> 3-43f6 -> 4-a3b4
+    // root1 4-6e94 -> 5-df4a -> 6-3f7f
+    //       └-------> 5-8d8c -> 6-65e0
+    // root2 4-a3b4
     const limitedTree = [{
-      pos: 1,
-      ids: ["9692", {}, [
-        ["37aa", {}, [
-          ["df22", {}, [
-            ["6e94", {}, [
-              ["df4a", {}, [
-                ["3f7f", {}, []],
-              ]],
-              ["8d8c", {}, [
-                ["65e0", {}, []],
-              ]],
+      pos: 4,
+      ids: ["6e94", {}, [
+            ["df4a", {}, [
+              ["3f7f", {}, []],
+            ]],
+            ["8d8c", {}, [
+              ["65e0", {}, []],
             ]],
           ]],
-        ]],
-      ]],
     }, {
-      pos: 3,
-      ids: ["43f6", {}, [
-        ["a3b4", {}, []],
-      ]],
+      pos: 4,
+      ids: ["a3b4", {}, []],
     }];
 
     const tree = removeLeafFromTree(
@@ -635,18 +637,17 @@ describe('the removeLeafFromTree util', function () {
         limitedTree,
         '6-3f7f'
       ),
-      '6-2d0a'
+      '5-df4a'
     );
-    tree.should.be.deep.equal([{
-      pos: 1,
-      ids: ["9692", {}, [
-        ["37aa", {}, []],
-      ]],
-    }, {
-      pos: 3,
-      ids: ["43f6", {}, [
-        ["a3b4", {}, []],
-      ]],
-    }]);
+    // and we’re expecting this after the purge
+    // root1 4-6e94
+    //       └-------> 5-8d8c -> 6-65e0
+    // root2 4-a3b4
+    tree.should.be.deep.equal([
+      { pos: 4, ids: [ '6e94', {}, [
+        ["8d8c", {}, [["65e0", {}, []]]]
+      ] ] },
+      { pos: 4, ids: [ 'a3b4', {}, [] ] }
+    ]);
   });
 });

--- a/tests/unit/test.purge.js
+++ b/tests/unit/test.purge.js
@@ -560,6 +560,29 @@ describe('the removeLeafFromTree util', function () {
     const tree = removeLeafFromTree(shortConflictedTree, "foobar");
     tree.should.be.deep.equal(shortConflictedTree);
   });
+  it('removes leafs that are the first child of several siblings', function () {
+    let tree = [{
+      "pos": 1,
+      "ids": ["abcd", {}, [
+        ["efgh", {}, [
+          ["ijkl", {}, [
+            ["mnop", {}, []]
+          ]],
+          ["qrst", {}, []]
+        ]]
+      ]]
+    }];
+    let purged = removeLeafFromTree(tree, "3-mnop")
+    purged.should.deep.equal([{
+      "pos": 1,
+      "ids": ["abcd", {}, [
+        ["efgh", {}, [
+          ["ijkl", {}, []],
+          ["qrst", {}, []]
+        ]]
+      ]]
+    }])
+  });
   it('should remove respective leafs from a multi-root tree with revs_limit=4', function () {
     let tree = removeLeafFromTree(
       removeLeafFromTree(

--- a/tests/unit/test.purge.js
+++ b/tests/unit/test.purge.js
@@ -379,91 +379,28 @@ const shortConflictedTreeWithout6a5a6c5c = [
   3-b = 3-43f6d5557d6de39488c64bb2c684ae7c
   4-b = 4-a3b44168027079c2692a7d8eb35e9643 leaf
 */
-const shortConflictedTreeWithTwoRoots = [
-  {
-    "pos": 1,
-    "ids": [
-      "9692d401ed2d3434827608278bdc36e3",
-      {
-        "status": "available"
-      },
-      [
-        [
-          "37aa033df08c21b4f56f1da2081e9e00",
-          {
-            "status": "available"
-          },
-          [
-            [
-              "43f6d5557d6de39488c64bb2c684ae7c",
-              {
-                "status": "missing"
-              },
-              [
-                [
-                  "a3b44168027079c2692a7d8eb35e9643",
-                  {
-                    "status": "available"
-                  },
-                  []
-                ]
-              ]
-            ]
-          ]
-        ]
-      ]
-    ]
-  },
-  {
-    "pos": 3,
-    "ids": [
-      "df226cb9a2e5bdd3e6be009fd51f47c1",
-      {
-        "status": "available"
-      },
-      [
-        [
-          "6e94d345514a08620c3176eea080d3ec",
-          {
-            "status": "available"
-          },
-          [
-            [
-              "0b84bfea5508e2020feb07384714a987",
-              {
-                "status": "missing"
-              },
-              [
-                [
-                  "2d0ab4f4089a57c95d52bfd2d66b823d",
-                  {
-                    "status": "available"
-                  },
-                  []
-                ]
-              ]
-            ],
-            [
-              "df4a81cd21c75c71974d96e88a68fc2f",
-              {
-                "status": "available"
-              },
-              [
-                [
-                  "3f7f6c55c27bf54c009b661607a9fe05",
-                  {
-                    "status": "available"
-                  },
-                  []
-                ]
-              ]
-            ]
-          ]
-        ]
-      ]
-    ]
-  }
-];
+const shortConflictedTreeWithTwoRoots = [{
+  "pos": 1,
+  "ids": ["9692d401ed2d3434827608278bdc36e3", {}, [
+    ["37aa033df08c21b4f56f1da2081e9e00", {}, [
+      ["43f6d5557d6de39488c64bb2c684ae7c", {}, [
+        ["a3b44168027079c2692a7d8eb35e9643", {}, []]
+      ]]
+    ]]
+  ]]
+}, {
+  "pos": 3,
+  "ids": ["df226cb9a2e5bdd3e6be009fd51f47c1", {}, [
+    ["6e94d345514a08620c3176eea080d3ec", {}, [
+      ["0b84bfea5508e2020feb07384714a987", {}, [
+        ["2d0ab4f4089a57c95d52bfd2d66b823d", {}, []]
+      ]],
+      ["df4a81cd21c75c71974d96e88a68fc2f", {}, [
+        ["3f7f6c55c27bf54c009b661607a9fe05", {}, []]
+      ]]
+    ]]
+  ]]
+}];
 
 /*
   With revs_limit: 4, just the main branch
@@ -587,7 +524,7 @@ describe('the findPathToLeaf util', function () {
   });
 });
 
-describe.only('the removeLeafFromTree util', function () {
+describe('the removeLeafFromTree util', function () {
   it('removes a leaf from the tree', function () {
     let tree = removeLeafFromTree(shortConflictedTree, "6-3f7f6c55c27bf54c009b661607a9fe05");
     tree.should.be.deep.equal(shortConflictedTreeWithout6a);
@@ -622,5 +559,71 @@ describe.only('the removeLeafFromTree util', function () {
   it('does not remove anything from the tree if the rev doesn\'t exist', function () {
     const tree = removeLeafFromTree(shortConflictedTree, "foobar");
     tree.should.be.deep.equal(shortConflictedTree);
+  });
+  it('should remove respective leafs from a multi-root tree with revs_limit=4', function () {
+    let tree = removeLeafFromTree(
+      removeLeafFromTree(
+        shortConflictedTreeWithTwoRoots,
+        '6-3f7f6c55c27bf54c009b661607a9fe05'
+      ),
+      '6-2d0ab4f4089a57c95d52bfd2d66b823d'
+    );
+    tree.should.be.deep.equal([{
+      "pos": 1,
+      "ids": ["9692d401ed2d3434827608278bdc36e3", {}, [
+        ["37aa033df08c21b4f56f1da2081e9e00", {}, [
+          ["43f6d5557d6de39488c64bb2c684ae7c", {}, [
+            ["a3b44168027079c2692a7d8eb35e9643", {}, []]
+          ]]
+        ]]
+      ]]
+    }]);
+  });
+  it('should remove respective leafs from a multi-root tree with revs_limit=3', function () {
+    // we're creating the tree below:
+    // root1 1-9692 -> 2-37aa -> 3-df22 -> 4-6e94 -> 5-df4a -> 6-3f7f
+    //                 |                   |-------> 5-8d8c -> 6-65e0
+    // root2           |-------> 3-43f6 -> 4-a3b4
+    const limitedTree = [{
+      pos: 1,
+      ids: ["9692", {}, [
+        ["37aa", {}, [
+          ["df22", {}, [
+            ["6e94", {}, [
+              ["df4a", {}, [
+                ["3f7f", {}, []],
+              ]],
+              ["8d8c", {}, [
+                ["65e0", {}, []],
+              ]],
+            ]],
+          ]],
+        ]],
+      ]],
+    }, {
+      pos: 3,
+      ids: ["43f6", {}, [
+        ["a3b4", {}, []],
+      ]],
+    }];
+
+    const tree = removeLeafFromTree(
+      removeLeafFromTree(
+        limitedTree,
+        '6-3f7f'
+      ),
+      '6-2d0a'
+    );
+    tree.should.be.deep.equal([{
+      pos: 1,
+      ids: ["9692", {}, [
+        ["37aa", {}, []],
+      ]],
+    }, {
+      pos: 3,
+      ids: ["43f6", {}, [
+        ["a3b4", {}, []],
+      ]],
+    }]);
   });
 });

--- a/tests/unit/test.purge.js
+++ b/tests/unit/test.purge.js
@@ -1,64 +1,23 @@
 'use strict';
 
-var should = require('chai').should();
-
-function findPathToLeaf(revs, targetRev) {
-  // `revs` has the same structure as what `revs_tree` has on e.g. the IndexedDB representation
-  // of the rev tree datastructure.
-  let path = [];
-  const toVisit = revs.slice();
-
-  let node;
-  while ((node = toVisit.pop())) {
-    const { pos, ids: tree } = node;
-    const rev = `${pos}-${tree[0]}`;
-    const branches = tree[2];
-
-    // just assuming we're already working on the path up towards our desired leaf.
-    path.push(rev);
-
-    // we've reached the leaf of our dreams, so return the computed path.
-    if (rev === targetRev) {
-      //…unleeeeess
-      if (branches.length !== 0) {
-        throw new Error('The requested revision is not a leaf');
-      }
-      return path.reverse();
-    }
-
-    // this is based on the assumption that after we have a leaf (`branches.length == 0`), we handle the next
-    // branch. this is true for all branches other than the path leading to the winning rev (which is 6-a in
-    // the example below. i've added a reset condition for branching nodes (`branches.length > 1`) as well.
-    if (branches.length === 0 || branches.length > 1) {
-      path = [];
-    }
-
-    // as a next step, we push the branches of this node to `toVisit` for visiting it during the next iteration
-    for (let i = 0, len = branches.length; i < len; i++) {
-      toVisit.push({ pos: pos + 1, ids: branches[i] });
-    }
-  }
-  if (path.length === 0) {
-    throw new Error('The requested revision does not exist');
-  }
-  return path.reverse();
-}
+const should = require('chai').should();
+const { findPathToLeaf, removeLeafFromTree } = require('../../packages/node_modules/pouchdb-merge');
 
 /*
-1-a - 2-a -- 3-a - 4-a - 5-a - 6-a
-          \            \
-           \             5-c - 6-c
-             3-b - 4-b
-1-a = 1-9692d401ed2d3434827608278bdc36e3
-2-a = 2-37aa033df08c21b4f56f1da2081e9e00
-3-a = 3-df226cb9a2e5bdd3e6be009fd51f47c1
-4-a = 4-6e94d345514a08620c3176eea080d3ec
-5-a = 5-df4a81cd21c75c71974d96e88a68fc2f
-6-a = 6-3f7f6c55c27bf54c009b661607a9fe05 leaf
-5-c = 5-0b84bfea5508e2020feb07384714a987
-6-c = 6-2d0ab4f4089a57c95d52bfd2d66b823d leaf
-3-b = 3-43f6d5557d6de39488c64bb2c684ae7c
-4-b = 4-a3b44168027079c2692a7d8eb35e9643 leaf
+  1-a - 2-a -- 3-a - 4-a - 5-a - 6-a
+            \            \
+             \             5-c - 6-c
+               3-b - 4-b
+  1-a = 1-9692d401ed2d3434827608278bdc36e3
+  2-a = 2-37aa033df08c21b4f56f1da2081e9e00
+  3-a = 3-df226cb9a2e5bdd3e6be009fd51f47c1
+  4-a = 4-6e94d345514a08620c3176eea080d3ec
+  5-a = 5-df4a81cd21c75c71974d96e88a68fc2f
+  6-a = 6-3f7f6c55c27bf54c009b661607a9fe05 leaf
+  5-c = 5-0b84bfea5508e2020feb07384714a987
+  6-c = 6-2d0ab4f4089a57c95d52bfd2d66b823d leaf
+  3-b = 3-43f6d5557d6de39488c64bb2c684ae7c
+  4-b = 4-a3b44168027079c2692a7d8eb35e9643 leaf
 */
 const shortConflictedTree = [
   {
@@ -143,22 +102,98 @@ const shortConflictedTree = [
   }
 ];
 
+// the same as the above shortConflictedTree, but without the 6-a leaf
+const shortConflictedTreeWithout6a = [
+  {
+    "pos": 1,
+    "ids": [
+      "9692d401ed2d3434827608278bdc36e3",
+      {
+        "status": "available"
+      },
+      [
+        [
+          "37aa033df08c21b4f56f1da2081e9e00",
+          {
+            "status": "available"
+          },
+          [
+            [
+              "43f6d5557d6de39488c64bb2c684ae7c",
+              {
+                "status": "missing"
+              },
+              [
+                [
+                  "a3b44168027079c2692a7d8eb35e9643",
+                  {
+                    "status": "available"
+                  },
+                  []
+                ]
+              ]
+            ],
+            [
+              "df226cb9a2e5bdd3e6be009fd51f47c1",
+              {
+                "status": "available"
+              },
+              [
+                [
+                  "6e94d345514a08620c3176eea080d3ec",
+                  {
+                    "status": "available"
+                  },
+                  [
+                    [
+                      "0b84bfea5508e2020feb07384714a987",
+                      {
+                        "status": "missing"
+                      },
+                      [
+                        [
+                          "2d0ab4f4089a57c95d52bfd2d66b823d",
+                          {
+                            "status": "available"
+                          },
+                          []
+                        ]
+                      ]
+                    ],
+                    [
+                      "df4a81cd21c75c71974d96e88a68fc2f",
+                      {
+                        "status": "available"
+                      },
+                      []
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  }
+];
+
 /*
-With revs_limit: 4, the shortConflictedTree from above becomes:
-3-a - 4-a - 5-a - 6-a
-          \
-            5-c - 6-c
-1-a - 2-a - 3-b - 4-b
-1-a = 1-9692d401ed2d3434827608278bdc36e3
-2-a = 2-37aa033df08c21b4f56f1da2081e9e00
-3-a = 3-df226cb9a2e5bdd3e6be009fd51f47c1
-4-a = 4-6e94d345514a08620c3176eea080d3ec
-5-a = 5-df4a81cd21c75c71974d96e88a68fc2f
-6-a = 6-3f7f6c55c27bf54c009b661607a9fe05 leaf
-5-c = 5-0b84bfea5508e2020feb07384714a987
-6-c = 6-2d0ab4f4089a57c95d52bfd2d66b823d leaf
-3-b = 3-43f6d5557d6de39488c64bb2c684ae7c
-4-b = 4-a3b44168027079c2692a7d8eb35e9643 leaf
+  With revs_limit: 4, the shortConflictedTree from above becomes:
+  3-a - 4-a - 5-a - 6-a
+            \
+              5-c - 6-c
+  1-a - 2-a - 3-b - 4-b
+  1-a = 1-9692d401ed2d3434827608278bdc36e3
+  2-a = 2-37aa033df08c21b4f56f1da2081e9e00
+  3-a = 3-df226cb9a2e5bdd3e6be009fd51f47c1
+  4-a = 4-6e94d345514a08620c3176eea080d3ec
+  5-a = 5-df4a81cd21c75c71974d96e88a68fc2f
+  6-a = 6-3f7f6c55c27bf54c009b661607a9fe05 leaf
+  5-c = 5-0b84bfea5508e2020feb07384714a987
+  6-c = 6-2d0ab4f4089a57c95d52bfd2d66b823d leaf
+  3-b = 3-43f6d5557d6de39488c64bb2c684ae7c
+  4-b = 4-a3b44168027079c2692a7d8eb35e9643 leaf
 */
 const shortConflictedTreeWithTwoRoots = [
   {
@@ -247,17 +282,17 @@ const shortConflictedTreeWithTwoRoots = [
 ];
 
 /*
-With revs_limit: 4, just the main branch
-(a doc without conflicts):
-1-a - 2-a | 3-a - 4-a - 5-a - 6-a
-truncated ^ here, 1-a - 2-a are missing. This
-is functionally the same as traversing a
-single-branch tree that hasn’t had a revs_limit
-applied, so no need to test that separately.
-3-a = 3-df226cb9a2e5bdd3e6be009fd51f47c1
-4-a = 4-6e94d345514a08620c3176eea080d3ec
-5-a = 5-df4a81cd21c75c71974d96e88a68fc2f
-6-a = 6-3f7f6c55c27bf54c009b661607a9fe05 leaf
+  With revs_limit: 4, just the main branch
+  (a doc without conflicts):
+  1-a - 2-a | 3-a - 4-a - 5-a - 6-a
+  truncated ^ here, 1-a - 2-a are missing. This
+  is functionally the same as traversing a
+  single-branch tree that hasn’t had a revs_limit
+  applied, so no need to test that separately.
+  3-a = 3-df226cb9a2e5bdd3e6be009fd51f47c1
+  4-a = 4-6e94d345514a08620c3176eea080d3ec
+  5-a = 5-df4a81cd21c75c71974d96e88a68fc2f
+  6-a = 6-3f7f6c55c27bf54c009b661607a9fe05 leaf
 */
 const revsLimitedSingleBranchTree = [
   {
@@ -365,5 +400,20 @@ describe.only('the findPathToLeaf util', function () {
     } catch (error) {
       error.message.should.equal("The requested revision is not a leaf");
     }
+  });
+});
+
+describe.only('the removeLeafFromTree util', function () {
+  it('removes a leaf from the tree', function () {
+    const tree = removeLeafFromTree(shortConflictedTree, "6-3f7f6c55c27bf54c009b661607a9fe05");
+    tree.should.be.deep.equal(shortConflictedTreeWithout6a);
+  });
+  it('does not remove anything from the tree if the rev is not a leaf', function () {
+    const tree = removeLeafFromTree(shortConflictedTree, "5-df4a81cd21c75c71974d96e88a68fc2f");
+    tree.should.be.deep.equal(shortConflictedTree);
+  });
+  it('does not remove anything from the tree if the rev doesn\'t exist', function () {
+    const tree = removeLeafFromTree(shortConflictedTree, "foobar");
+    tree.should.be.deep.equal(shortConflictedTree);
   });
 });

--- a/tests/unit/test.purge.js
+++ b/tests/unit/test.purge.js
@@ -572,7 +572,7 @@ describe('the removeLeafFromTree util', function () {
         ]]
       ]]
     }];
-    let purged = removeLeafFromTree(tree, "4-mnop")
+    let purged = removeLeafFromTree(tree, "4-mnop");
     purged.should.deep.equal([{
       "pos": 1,
       "ids": ["abcd", {}, [
@@ -581,7 +581,7 @@ describe('the removeLeafFromTree util', function () {
           ["qrst", {}, []]
         ]]
       ]]
-    }])
+    }]);
   });
   it('should remove respective leafs from a multi-root tree with revs_limit=4', function () {
     let tree = removeLeafFromTree(

--- a/tests/unit/test.purge.js
+++ b/tests/unit/test.purge.js
@@ -331,7 +331,7 @@ const revsLimitedSingleBranchTree = [
   }
 ];
 
-describe.only('the findPathToLeaf util', function () {
+describe('the findPathToLeaf util', function () {
   it('finds the first branch in a conflicted tree', function () {
     const path = findPathToLeaf(shortConflictedTree, '6-3f7f6c55c27bf54c009b661607a9fe05');
     path.should.be.eql([

--- a/tests/unit/test.purge.js
+++ b/tests/unit/test.purge.js
@@ -1,0 +1,369 @@
+'use strict';
+
+var should = require('chai').should();
+
+function findPathToLeaf(revs, targetRev) {
+  // `revs` has the same structure as what `revs_tree` has on e.g. the IndexedDB representation
+  // of the rev tree datastructure.
+  let path = [];
+  const toVisit = revs.slice();
+
+  let node;
+  while ((node = toVisit.pop())) {
+    const { pos, ids: tree } = node;
+    const rev = `${pos}-${tree[0]}`;
+    const branches = tree[2];
+
+    // just assuming we're already working on the path up towards our desired leaf.
+    path.push(rev);
+
+    // we've reached the leaf of our dreams, so return the computed path.
+    if (rev === targetRev) {
+      //…unleeeeess
+      if (branches.length !== 0) {
+        throw new Error('The requested revision is not a leaf');
+      }
+      return path.reverse();
+    }
+
+    // this is based on the assumption that after we have a leaf (`branches.length == 0`), we handle the next
+    // branch. this is true for all branches other than the path leading to the winning rev (which is 6-a in
+    // the example below. i've added a reset condition for branching nodes (`branches.length > 1`) as well.
+    if (branches.length === 0 || branches.length > 1) {
+      path = [];
+    }
+
+    // as a next step, we push the branches of this node to `toVisit` for visiting it during the next iteration
+    for (let i = 0, len = branches.length; i < len; i++) {
+      toVisit.push({ pos: pos + 1, ids: branches[i] });
+    }
+  }
+  if (path.length === 0) {
+    throw new Error('The requested revision does not exist');
+  }
+  return path.reverse();
+}
+
+/*
+1-a - 2-a -- 3-a - 4-a - 5-a - 6-a
+          \            \
+           \             5-c - 6-c
+             3-b - 4-b
+1-a = 1-9692d401ed2d3434827608278bdc36e3
+2-a = 2-37aa033df08c21b4f56f1da2081e9e00
+3-a = 3-df226cb9a2e5bdd3e6be009fd51f47c1
+4-a = 4-6e94d345514a08620c3176eea080d3ec
+5-a = 5-df4a81cd21c75c71974d96e88a68fc2f
+6-a = 6-3f7f6c55c27bf54c009b661607a9fe05 leaf
+5-c = 5-0b84bfea5508e2020feb07384714a987
+6-c = 6-2d0ab4f4089a57c95d52bfd2d66b823d leaf
+3-b = 3-43f6d5557d6de39488c64bb2c684ae7c
+4-b = 4-a3b44168027079c2692a7d8eb35e9643 leaf
+*/
+const shortConflictedTree = [
+  {
+    "pos": 1,
+    "ids": [
+      "9692d401ed2d3434827608278bdc36e3",
+      {
+        "status": "available"
+      },
+      [
+        [
+          "37aa033df08c21b4f56f1da2081e9e00",
+          {
+            "status": "available"
+          },
+          [
+            [
+              "43f6d5557d6de39488c64bb2c684ae7c",
+              {
+                "status": "missing"
+              },
+              [
+                [
+                  "a3b44168027079c2692a7d8eb35e9643",
+                  {
+                    "status": "available"
+                  },
+                  []
+                ]
+              ]
+            ],
+            [
+              "df226cb9a2e5bdd3e6be009fd51f47c1",
+              {
+                "status": "available"
+              },
+              [
+                [
+                  "6e94d345514a08620c3176eea080d3ec",
+                  {
+                    "status": "available"
+                  },
+                  [
+                    [
+                      "0b84bfea5508e2020feb07384714a987",
+                      {
+                        "status": "missing"
+                      },
+                      [
+                        [
+                          "2d0ab4f4089a57c95d52bfd2d66b823d",
+                          {
+                            "status": "available"
+                          },
+                          []
+                        ]
+                      ]
+                    ],
+                    [
+                      "df4a81cd21c75c71974d96e88a68fc2f",
+                      {
+                        "status": "available"
+                      },
+                      [
+                        [
+                          "3f7f6c55c27bf54c009b661607a9fe05",
+                          {
+                            "status": "available"
+                          },
+                          []
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  }
+];
+
+/*
+With revs_limit: 4, the shortConflictedTree from above becomes:
+3-a - 4-a - 5-a - 6-a
+          \
+            5-c - 6-c
+1-a - 2-a - 3-b - 4-b
+1-a = 1-9692d401ed2d3434827608278bdc36e3
+2-a = 2-37aa033df08c21b4f56f1da2081e9e00
+3-a = 3-df226cb9a2e5bdd3e6be009fd51f47c1
+4-a = 4-6e94d345514a08620c3176eea080d3ec
+5-a = 5-df4a81cd21c75c71974d96e88a68fc2f
+6-a = 6-3f7f6c55c27bf54c009b661607a9fe05 leaf
+5-c = 5-0b84bfea5508e2020feb07384714a987
+6-c = 6-2d0ab4f4089a57c95d52bfd2d66b823d leaf
+3-b = 3-43f6d5557d6de39488c64bb2c684ae7c
+4-b = 4-a3b44168027079c2692a7d8eb35e9643 leaf
+*/
+const shortConflictedTreeWithTwoRoots = [
+  {
+    "pos": 1,
+    "ids": [
+      "9692d401ed2d3434827608278bdc36e3",
+      {
+        "status": "available"
+      },
+      [
+        [
+          "37aa033df08c21b4f56f1da2081e9e00",
+          {
+            "status": "available"
+          },
+          [
+            [
+              "43f6d5557d6de39488c64bb2c684ae7c",
+              {
+                "status": "missing"
+              },
+              [
+                [
+                  "a3b44168027079c2692a7d8eb35e9643",
+                  {
+                    "status": "available"
+                  },
+                  []
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  },
+  {
+    "pos": 3,
+    "ids": [
+      "df226cb9a2e5bdd3e6be009fd51f47c1",
+      {
+        "status": "available"
+      },
+      [
+        [
+          "6e94d345514a08620c3176eea080d3ec",
+          {
+            "status": "available"
+          },
+          [
+            [
+              "0b84bfea5508e2020feb07384714a987",
+              {
+                "status": "missing"
+              },
+              [
+                [
+                  "2d0ab4f4089a57c95d52bfd2d66b823d",
+                  {
+                    "status": "available"
+                  },
+                  []
+                ]
+              ]
+            ],
+            [
+              "df4a81cd21c75c71974d96e88a68fc2f",
+              {
+                "status": "available"
+              },
+              [
+                [
+                  "3f7f6c55c27bf54c009b661607a9fe05",
+                  {
+                    "status": "available"
+                  },
+                  []
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  }
+];
+
+/*
+With revs_limit: 4, just the main branch
+(a doc without conflicts):
+1-a - 2-a | 3-a - 4-a - 5-a - 6-a
+truncated ^ here, 1-a - 2-a are missing. This
+is functionally the same as traversing a
+single-branch tree that hasn’t had a revs_limit
+applied, so no need to test that separately.
+3-a = 3-df226cb9a2e5bdd3e6be009fd51f47c1
+4-a = 4-6e94d345514a08620c3176eea080d3ec
+5-a = 5-df4a81cd21c75c71974d96e88a68fc2f
+6-a = 6-3f7f6c55c27bf54c009b661607a9fe05 leaf
+*/
+const revsLimitedSingleBranchTree = [
+  {
+    "pos": 3,
+    "ids": [
+      "df226cb9a2e5bdd3e6be009fd51f47c1",
+      {
+        "status": "available"
+      },
+      [
+        [
+          "6e94d345514a08620c3176eea080d3ec",
+          {
+            "status": "available"
+          },
+          [
+            [
+              "df4a81cd21c75c71974d96e88a68fc2f",
+              {
+                "status": "available"
+              },
+              [
+                [
+                  "3f7f6c55c27bf54c009b661607a9fe05",
+                  {
+                    "status": "available"
+                  },
+                  []
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  }
+];
+
+describe.only('the findPathToLeaf util', function () {
+  it('finds the first branch in a conflicted tree', function () {
+    const path = findPathToLeaf(shortConflictedTree, '6-3f7f6c55c27bf54c009b661607a9fe05');
+    path.should.be.eql([
+      '6-3f7f6c55c27bf54c009b661607a9fe05',
+      '5-df4a81cd21c75c71974d96e88a68fc2f'
+    ]);
+  });
+  it('finds the second branch in a conflicted tree', function () {
+    const path = findPathToLeaf(shortConflictedTree, '6-2d0ab4f4089a57c95d52bfd2d66b823d');
+    path.should.be.eql([
+      '6-2d0ab4f4089a57c95d52bfd2d66b823d',
+      '5-0b84bfea5508e2020feb07384714a987'
+    ]);
+  });
+  it('finds the third branch in a conflicted tree', function () {
+    const path = findPathToLeaf(shortConflictedTree, '4-a3b44168027079c2692a7d8eb35e9643');
+    path.should.be.eql([
+      '4-a3b44168027079c2692a7d8eb35e9643',
+      '3-43f6d5557d6de39488c64bb2c684ae7c'
+    ]);
+  });
+  it('finds the first branch in a multi-root conflicted tree', function () {
+    const path = findPathToLeaf(shortConflictedTreeWithTwoRoots, '6-3f7f6c55c27bf54c009b661607a9fe05');
+    path.should.be.eql([
+      '6-3f7f6c55c27bf54c009b661607a9fe05',
+      '5-df4a81cd21c75c71974d96e88a68fc2f'
+    ]);
+  });
+  it('finds the second branch in a multi-root conflicted tree', function () {
+    const path = findPathToLeaf(shortConflictedTreeWithTwoRoots, '6-2d0ab4f4089a57c95d52bfd2d66b823d');
+    path.should.be.eql([
+      '6-2d0ab4f4089a57c95d52bfd2d66b823d',
+      '5-0b84bfea5508e2020feb07384714a987'
+    ]);
+  });
+  it('finds the third branch in a multi-root conflicted tree and returns the entire subtree', function () {
+    const path = findPathToLeaf(shortConflictedTreeWithTwoRoots, '4-a3b44168027079c2692a7d8eb35e9643');
+    path.should.be.eql([
+      '4-a3b44168027079c2692a7d8eb35e9643',
+      '3-43f6d5557d6de39488c64bb2c684ae7c',
+      '2-37aa033df08c21b4f56f1da2081e9e00',
+      '1-9692d401ed2d3434827608278bdc36e3'
+    ]);
+  });
+  it('returns the entire tree of a single-branch tree (truncated by revs_limit)', function () {
+    const path = findPathToLeaf(revsLimitedSingleBranchTree, '6-3f7f6c55c27bf54c009b661607a9fe05');
+    path.should.be.eql([
+      '6-3f7f6c55c27bf54c009b661607a9fe05',
+      '5-df4a81cd21c75c71974d96e88a68fc2f',
+      '4-6e94d345514a08620c3176eea080d3ec',
+      '3-df226cb9a2e5bdd3e6be009fd51f47c1'
+    ]);
+  });
+  it('throws if the requested rev doesn’t exist', function () {
+    try {
+      findPathToLeaf(shortConflictedTree, '7-009b661607a9fe053f7f6c55c27bf54c');
+      should.fail();
+    } catch (error) {
+      error.message.should.equal("The requested revision does not exist");
+    }
+  });
+  it('throws if the requested rev is not a leaf', function () {
+    try {
+      findPathToLeaf(shortConflictedTree, '3-df226cb9a2e5bdd3e6be009fd51f47c1');
+      should.fail();
+    } catch (error) {
+      error.message.should.equal("The requested revision is not a leaf");
+    }
+  });
+});

--- a/tests/unit/test.purge.js
+++ b/tests/unit/test.purge.js
@@ -19,348 +19,98 @@ const { findPathToLeaf, removeLeafFromTree } = require('../../packages/node_modu
   3-b = 3-43f6d5557d6de39488c64bb2c684ae7c
   4-b = 4-a3b44168027079c2692a7d8eb35e9643 leaf
 */
-const shortConflictedTree = [
-  {
-    "pos": 1,
-    "ids": [
-      "9692d401ed2d3434827608278bdc36e3",
-      {
-        "status": "available"
-      },
-      [
-        [
-          "37aa033df08c21b4f56f1da2081e9e00",
-          {
-            "status": "available"
-          },
-          [
-            [
-              "43f6d5557d6de39488c64bb2c684ae7c",
-              {
-                "status": "missing"
-              },
-              [
-                [
-                  "a3b44168027079c2692a7d8eb35e9643",
-                  {
-                    "status": "available"
-                  },
-                  []
-                ]
-              ]
-            ],
-            [
-              "df226cb9a2e5bdd3e6be009fd51f47c1",
-              {
-                "status": "available"
-              },
-              [
-                [
-                  "6e94d345514a08620c3176eea080d3ec",
-                  {
-                    "status": "available"
-                  },
-                  [
-                    [
-                      "0b84bfea5508e2020feb07384714a987",
-                      {
-                        "status": "missing"
-                      },
-                      [
-                        [
-                          "2d0ab4f4089a57c95d52bfd2d66b823d",
-                          {
-                            "status": "available"
-                          },
-                          []
-                        ]
-                      ]
-                    ],
-                    [
-                      "df4a81cd21c75c71974d96e88a68fc2f",
-                      {
-                        "status": "available"
-                      },
-                      [
-                        [
-                          "3f7f6c55c27bf54c009b661607a9fe05",
-                          {
-                            "status": "available"
-                          },
-                          []
-                        ]
-                      ]
-                    ]
-                  ]
-                ]
-              ]
-            ]
-          ]
-        ]
-      ]
-    ]
-  }
-];
+const shortConflictedTree = [{
+  "pos": 1,
+  "ids": ["9692d401ed2d3434827608278bdc36e3", {}, [
+    ["37aa033df08c21b4f56f1da2081e9e00", {}, [
+      ["43f6d5557d6de39488c64bb2c684ae7c", {}, [
+        ["a3b44168027079c2692a7d8eb35e9643", {}, []]
+      ]],
+      ["df226cb9a2e5bdd3e6be009fd51f47c1", {}, [
+        ["6e94d345514a08620c3176eea080d3ec", {}, [
+          ["0b84bfea5508e2020feb07384714a987", {}, [
+            ["2d0ab4f4089a57c95d52bfd2d66b823d", {}, []]
+          ]],
+          ["df4a81cd21c75c71974d96e88a68fc2f", {}, [
+            ["3f7f6c55c27bf54c009b661607a9fe05", {}, []]
+          ]]
+        ]]
+      ]]
+    ]]
+  ]]
+}];
 
 // the same as the above shortConflictedTree, but without the 6-a leaf
-const shortConflictedTreeWithout6a = [
-  {
-    "pos": 1,
-    "ids": [
-      "9692d401ed2d3434827608278bdc36e3",
-      {
-        "status": "available"
-      },
-      [
-        [
-          "37aa033df08c21b4f56f1da2081e9e00",
-          {
-            "status": "available"
-          },
-          [
-            [
-              "43f6d5557d6de39488c64bb2c684ae7c",
-              {
-                "status": "missing"
-              },
-              [
-                [
-                  "a3b44168027079c2692a7d8eb35e9643",
-                  {
-                    "status": "available"
-                  },
-                  []
-                ]
-              ]
-            ],
-            [
-              "df226cb9a2e5bdd3e6be009fd51f47c1",
-              {
-                "status": "available"
-              },
-              [
-                [
-                  "6e94d345514a08620c3176eea080d3ec",
-                  {
-                    "status": "available"
-                  },
-                  [
-                    [
-                      "0b84bfea5508e2020feb07384714a987",
-                      {
-                        "status": "missing"
-                      },
-                      [
-                        [
-                          "2d0ab4f4089a57c95d52bfd2d66b823d",
-                          {
-                            "status": "available"
-                          },
-                          []
-                        ]
-                      ]
-                    ],
-                    [
-                      "df4a81cd21c75c71974d96e88a68fc2f",
-                      {
-                        "status": "available"
-                      },
-                      []
-                    ]
-                  ]
-                ]
-              ]
-            ]
-          ]
-        ]
-      ]
-    ]
-  }
-];
+const shortConflictedTreeWithout6a = [{
+  "pos": 1,
+  "ids": ["9692d401ed2d3434827608278bdc36e3", {}, [
+    ["37aa033df08c21b4f56f1da2081e9e00", {}, [
+      ["43f6d5557d6de39488c64bb2c684ae7c", {}, [
+        ["a3b44168027079c2692a7d8eb35e9643", {}, []]
+      ]],
+      ["df226cb9a2e5bdd3e6be009fd51f47c1", {}, [
+        ["6e94d345514a08620c3176eea080d3ec", {}, [
+          ["0b84bfea5508e2020feb07384714a987", {}, [
+            ["2d0ab4f4089a57c95d52bfd2d66b823d", {}, []]
+          ]],
+          ["df4a81cd21c75c71974d96e88a68fc2f", {}, []]
+        ]]
+      ]]
+    ]]
+  ]]
+ }];
 
 // the same as the above shortConflictedTree, but without the 6-a & 5-a leaves
-const shortConflictedTreeWithout6a5a = [
-  {
-    "pos": 1,
-    "ids": [
-      "9692d401ed2d3434827608278bdc36e3",
-      {
-        "status": "available"
-      },
-      [
-        [
-          "37aa033df08c21b4f56f1da2081e9e00",
-          {
-            "status": "available"
-          },
-          [
-            [
-              "43f6d5557d6de39488c64bb2c684ae7c",
-              {
-                "status": "missing"
-              },
-              [
-                [
-                  "a3b44168027079c2692a7d8eb35e9643",
-                  {
-                    "status": "available"
-                  },
-                  []
-                ]
-              ]
-            ],
-            [
-              "df226cb9a2e5bdd3e6be009fd51f47c1",
-              {
-                "status": "available"
-              },
-              [
-                [
-                  "6e94d345514a08620c3176eea080d3ec",
-                  {
-                    "status": "available"
-                  },
-                  [
-                    [
-                      "0b84bfea5508e2020feb07384714a987",
-                      {
-                        "status": "missing"
-                      },
-                      [
-                        [
-                          "2d0ab4f4089a57c95d52bfd2d66b823d",
-                          {
-                            "status": "available"
-                          },
-                          []
-                        ]
-                      ]
-                    ]
-                  ]
-                ]
-              ]
-            ]
-          ]
-        ]
-      ]
-    ]
-  }
-];
+const shortConflictedTreeWithout6a5a = [{
+  "pos": 1,
+  "ids": ["9692d401ed2d3434827608278bdc36e3", {}, [
+    ["37aa033df08c21b4f56f1da2081e9e00", {}, [
+      ["43f6d5557d6de39488c64bb2c684ae7c", {}, [
+        ["a3b44168027079c2692a7d8eb35e9643", {}, []]
+      ]],
+      ["df226cb9a2e5bdd3e6be009fd51f47c1", {}, [
+        ["6e94d345514a08620c3176eea080d3ec", {}, [
+          ["0b84bfea5508e2020feb07384714a987", {}, [
+            ["2d0ab4f4089a57c95d52bfd2d66b823d", {}, []]
+          ]]
+        ]]
+      ]]
+    ]]
+  ]]
+}];
 
 // the same as the above shortConflictedTree, but without the 6-a, 5-a, and 6-c leaves
-const shortConflictedTreeWithout6a5a6c = [
-  {
-    "pos": 1,
-    "ids": [
-      "9692d401ed2d3434827608278bdc36e3",
-      {
-        "status": "available"
-      },
-      [
-        [
-          "37aa033df08c21b4f56f1da2081e9e00",
-          {
-            "status": "available"
-          },
-          [
-            [
-              "43f6d5557d6de39488c64bb2c684ae7c",
-              {
-                "status": "missing"
-              },
-              [
-                [
-                  "a3b44168027079c2692a7d8eb35e9643",
-                  {
-                    "status": "available"
-                  },
-                  []
-                ]
-              ]
-            ],
-            [
-              "df226cb9a2e5bdd3e6be009fd51f47c1",
-              {
-                "status": "available"
-              },
-              [
-                [
-                  "6e94d345514a08620c3176eea080d3ec",
-                  {
-                    "status": "available"
-                  },
-                  [
-                    [
-                      "0b84bfea5508e2020feb07384714a987",
-                      {
-                        "status": "missing"
-                      },
-                      []
-                    ]
-                  ]
-                ]
-              ]
-            ]
-          ]
-        ]
-      ]
-    ]
-  }
-];
+const shortConflictedTreeWithout6a5a6c = [{
+  "pos": 1,
+  "ids": ["9692d401ed2d3434827608278bdc36e3", {}, [
+    ["37aa033df08c21b4f56f1da2081e9e00", {}, [
+      ["43f6d5557d6de39488c64bb2c684ae7c", {}, [
+        ["a3b44168027079c2692a7d8eb35e9643", {}, []]
+      ]],
+      ["df226cb9a2e5bdd3e6be009fd51f47c1", {}, [
+        ["6e94d345514a08620c3176eea080d3ec", {}, [
+          ["0b84bfea5508e2020feb07384714a987", {}, []]
+        ]]
+      ]]
+    ]]
+  ]]
+}];
 
 
 // the same as the above shortConflictedTree, but without the 6-a, 5-a, 6-c, and 5-c leaves
-const shortConflictedTreeWithout6a5a6c5c = [
-  {
-    "pos": 1,
-    "ids": [
-      "9692d401ed2d3434827608278bdc36e3",
-      {
-        "status": "available"
-      },
-      [
-        [
-          "37aa033df08c21b4f56f1da2081e9e00",
-          {
-            "status": "available"
-          },
-          [
-            [
-              "43f6d5557d6de39488c64bb2c684ae7c",
-              {
-                "status": "missing"
-              },
-              [
-                [
-                  "a3b44168027079c2692a7d8eb35e9643",
-                  {
-                    "status": "available"
-                  },
-                  []
-                ]
-              ]
-            ],
-            [
-              "df226cb9a2e5bdd3e6be009fd51f47c1",
-              {
-                "status": "available"
-              },
-              [
-                [
-                  "6e94d345514a08620c3176eea080d3ec",
-                  {
-                    "status": "available"
-                  },
-                  []
-                ]
-              ]
-            ]
-          ]
-        ]
-      ]
-    ]
-  }
-];
+const shortConflictedTreeWithout6a5a6c5c = [{
+  "pos": 1,
+  "ids": ["9692d401ed2d3434827608278bdc36e3", {}, [
+    ["37aa033df08c21b4f56f1da2081e9e00", {}, [
+      ["43f6d5557d6de39488c64bb2c684ae7c", {}, [
+        ["a3b44168027079c2692a7d8eb35e9643", {}, []]
+      ]],
+      ["df226cb9a2e5bdd3e6be009fd51f47c1", {}, [
+        ["6e94d345514a08620c3176eea080d3ec", {}, []]
+      ]]
+    ]]
+  ]]
+}];
 
 /*
   With revs_limit: 4, the shortConflictedTree from above becomes:
@@ -415,42 +165,16 @@ const shortConflictedTreeWithTwoRoots = [{
   5-a = 5-df4a81cd21c75c71974d96e88a68fc2f
   6-a = 6-3f7f6c55c27bf54c009b661607a9fe05 leaf
 */
-const revsLimitedSingleBranchTree = [
-  {
-    "pos": 3,
-    "ids": [
-      "df226cb9a2e5bdd3e6be009fd51f47c1",
-      {
-        "status": "available"
-      },
-      [
-        [
-          "6e94d345514a08620c3176eea080d3ec",
-          {
-            "status": "available"
-          },
-          [
-            [
-              "df4a81cd21c75c71974d96e88a68fc2f",
-              {
-                "status": "available"
-              },
-              [
-                [
-                  "3f7f6c55c27bf54c009b661607a9fe05",
-                  {
-                    "status": "available"
-                  },
-                  []
-                ]
-              ]
-            ]
-          ]
-        ]
-      ]
-    ]
-  }
-];
+const revsLimitedSingleBranchTree = [{
+  "pos": 3,
+  "ids": ["df226cb9a2e5bdd3e6be009fd51f47c1", {}, [
+    ["6e94d345514a08620c3176eea080d3ec", {}, [
+      ["df4a81cd21c75c71974d96e88a68fc2f", {}, [
+        ["3f7f6c55c27bf54c009b661607a9fe05", {}, []]
+      ]]
+    ]]
+  ]]
+}];
 
 describe('the findPathToLeaf util', function () {
   it('finds the first branch in a conflicted tree', function () {


### PR DESCRIPTION
This PR will introduce new functionality for [purging documents similar to how CouchDB does it](https://docs.couchdb.org/en/stable/api/database/misc.html#db-purge) from a PouchDB with the `indexeddb` adapter.

### Description
The `db.purge(docId, rev, callback)` function directly updates the IndexedDB document and calculates a new winning rev, as well as updates the respective data fields. You can only purge a leaf revision, and doing so will remove all ancestors of that leaf up to the next branch, just like CouchDB does it. If no revisions remain, the document is removed entirely. Purge will also remove any attachments from the affected revisions, as well as delegate purge removals to views. Purges will trigger view updates as soon as they are queried.

Purge returns either an error (document doesn't exist, revision doesn't exist, revision isn't a leaf node), or a results object with the format:

```js
{
  ok: true,
  deletedRevs: [
    "6-3a24009a9525bde9e4bfa8a99046b00d",
    "5-df4a81cd21c75c71974d96e88a68fc2f"
  ],
  documentWasRemovedCompletely: false
}
```

Purge parameters (`docId`, `rev`) are being stored in a local document, `_local/purges`, alongside a `purgeSeq`. With that, on-demand consumers such as views can reflect the purges at a later time.

A purge should only be considered complete after subsequent database compaction and after view indexes have been updated (the latter is part of this PR).

#### Purge constructor option

[Similar to CouchDB](https://docs.couchdb.org/en/stable/api/database/misc.html#put--db-_purged_infos_limit), we've added a `purged_infos_limit` option to control how many purges PouchDB will keep track off in order to e.g. delegate them to views. This option defaults to `1000` (same as CouchDB).

```js
new PouchDB({
  purged_infos_limit: 1500
})
```

#### Utility functions

There are two new utility functions that operate on a document's rev tree. They are:

* `findPathToLeaf()` to calculate the path from the last branching within a tree up to a leaf in order to determine the path of revs that have to be deleted during a purge. It is called by the new purge implementation in `pouchdb-core`, and passes the resulting array of revisions down to the adapter-specific implementation, which expects them in this format and order. `findPathToLeaf()` does the checks for whether a rev exists and is a leaf, and the adapter-level implementations of `purge` can rely on this. There are explanatory comments in the code
* `removeLeafFromTree()` to then remove a leaf from a rev tree data structure (`revs_info`) from within the adapter-level implementations of `purge` 

Run the new unit tests with `npm run test-unit`.

#### Adapter support

If purge is called on an adapter that doesn't support it, it will throw an error. Currently, it is only supported by the `indexeddb` adapter. This implementation also contains explanatory comments, in case anyone wants to implement this for other adapters.