### PR TITLE
fix: build on tests

### DIFF
--- a/bin/build-node.sh
+++ b/bin/build-node.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# don't bother doing this in travis because it's already been built
-if [ -z $TRAVIS ]; then
+# don't bother doing this in GHA because it's already been built
+if [ -z $GITHUB_REPOSITORY ]; then
   BUILD_NODE=1 npm run build-modules
 fi

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -53,9 +53,9 @@ pouchdb-link-server-modules() {
 }
 
 pouchdb-build-node() {
-  if [[ $BUILD_NODE -ne 0 ]]; then
+  if [[ $BUILD_NODE_DONE -ne 1 ]]; then
     npm run build-node
-    BUILD_NODE=0
+    BUILD_NODE_DONE=1
   fi
 }
 

--- a/bin/test-webpack.sh
+++ b/bin/test-webpack.sh
@@ -12,4 +12,4 @@ node bin/update-package-json-for-publish.js
 ./node_modules/.bin/webpack \
   --output-library PouchDB --output-library-target umd \
   ./packages/node_modules/pouchdb pouchdb-webpack.js
-BUILD_NODE=0 POUCHDB_SRC='../../pouchdb-webpack.js' npm test
+BUILD_NODE_DONE=1 POUCHDB_SRC='../../pouchdb-webpack.js' npm test


### PR DESCRIPTION
`npm test` was not reflecting the latest changes because it was not building the packages. It was not causing issues in our GHA CI because `npm install` builds the packages. We also changed the variable name because it was conflicting with [an existing one](https://github.com/pouchdb/pouchdb/blob/efa56c8ca1a0a5e78671d73405a2684ff407180c/bin/build-pouchdb.js#L182).
This PR is related to [#8393](https://github.com/pouchdb/pouchdb/pull/8393)