### PR TITLE
(#7954) - Connection is reopened, with retry, if automatically closed (idb adapter)

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/allDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/allDocs.js
@@ -11,7 +11,6 @@ import {
   decodeMetadata,
   fetchAttachmentsIfNecessary,
   postProcessAttachments,
-  openTransactionSafely,
   idbError
 } from './utils';
 import runBatchedCursor from './runBatchedCursor';
@@ -65,21 +64,21 @@ function createKeyRange(start, end, inclusiveEnd, key, descending) {
   return null;
 }
 
-function idbAllDocs(opts, idb, callback) {
+function idbAllDocs(opts, openTransactionSafely, callback) {
   var start = 'startkey' in opts ? opts.startkey : false;
   var end = 'endkey' in opts ? opts.endkey : false;
   var key = 'key' in opts ? opts.key : false;
-  var keys = 'keys' in opts ? opts.keys : false; 
+  var keys = 'keys' in opts ? opts.keys : false;
   var skip = opts.skip || 0;
   var limit = typeof opts.limit === 'number' ? opts.limit : -1;
   var inclusiveEnd = opts.inclusive_end !== false;
 
-  var keyRange ; 
+  var keyRange;
   var keyRangeError;
   if (!keys) {
     keyRange = createKeyRange(start, end, inclusiveEnd, key, opts.descending);
     keyRangeError = keyRange && keyRange.error;
-    if (keyRangeError && 
+    if (keyRangeError &&
       !(keyRangeError.name === "DataError" && keyRangeError.code === 0)) {
       // DataError with error code 0 indicates start is less than end, so
       // can just do an empty query. Else need to throw
@@ -93,160 +92,161 @@ function idbAllDocs(opts, idb, callback) {
   if (opts.attachments) {
     stores.push(ATTACH_STORE);
   }
-  var txnResult = openTransactionSafely(idb, stores, 'readonly');
-  if (txnResult.error) {
-    return callback(txnResult.error);
-  }
-  var txn = txnResult.txn;
-  txn.oncomplete = onTxnComplete;
-  txn.onabort = idbError(callback);
-  var docStore = txn.objectStore(DOC_STORE);
-  var seqStore = txn.objectStore(BY_SEQ_STORE);
-  var metaStore = txn.objectStore(META_STORE);
-  var docIdRevIndex = seqStore.index('_doc_id_rev');
-  var results = [];
-  var docCount;
-  var updateSeq;
+  openTransactionSafely(stores, 'readonly', function (txnResult) {
+    if (txnResult.error) {
+      return callback(txnResult.error);
+    }
+    var txn = txnResult.txn;
+    txn.oncomplete = onTxnComplete;
+    txn.onabort = idbError(callback);
+    var docStore = txn.objectStore(DOC_STORE);
+    var seqStore = txn.objectStore(BY_SEQ_STORE);
+    var metaStore = txn.objectStore(META_STORE);
+    var docIdRevIndex = seqStore.index('_doc_id_rev');
+    var results = [];
+    var docCount;
+    var updateSeq;
 
-  metaStore.get(META_STORE).onsuccess = function (e) {
-    docCount = e.target.result.docCount;
-  };
+    metaStore.get(META_STORE).onsuccess = function (e) {
+      docCount = e.target.result.docCount;
+    };
 
-  /* istanbul ignore if */
-  if (opts.update_seq) {
-    getMaxUpdateSeq(seqStore, function (e) { 
-      if (e.target.result && e.target.result.length > 0) {
-        updateSeq = e.target.result[0];
-      }
-    });
-  }
-
-  function getMaxUpdateSeq(objectStore, onSuccess) {
-    function onCursor(e) {
-      var cursor = e.target.result;
-      var maxKey = undefined;
-      if (cursor && cursor.key) {
-        maxKey = cursor.key;
-      } 
-      return onSuccess({
-        target: {
-          result: [maxKey]
+    /* istanbul ignore if */
+    if (opts.update_seq) {
+      getMaxUpdateSeq(seqStore, function (e) {
+        if (e.target.result && e.target.result.length > 0) {
+          updateSeq = e.target.result[0];
         }
       });
     }
-    objectStore.openCursor(null, 'prev').onsuccess = onCursor;
-  }
 
-  // if the user specifies include_docs=true, then we don't
-  // want to block the main cursor while we're fetching the doc
-  function fetchDocAsynchronously(metadata, row, winningRev) {
-    var key = metadata.id + "::" + winningRev;
-    docIdRevIndex.get(key).onsuccess =  function onGetDoc(e) {
-      row.doc = decodeDoc(e.target.result) || {};
-      if (opts.conflicts) {
-        var conflicts = collectConflicts(metadata);
-        if (conflicts.length) {
-          row.doc._conflicts = conflicts;
+    function getMaxUpdateSeq(objectStore, onSuccess) {
+      function onCursor(e) {
+        var cursor = e.target.result;
+        var maxKey = undefined;
+        if (cursor && cursor.key) {
+          maxKey = cursor.key;
+        }
+        return onSuccess({
+          target: {
+            result: [maxKey]
+          }
+        });
+      }
+      objectStore.openCursor(null, 'prev').onsuccess = onCursor;
+    }
+
+    // if the user specifies include_docs=true, then we don't
+    // want to block the main cursor while we're fetching the doc
+    function fetchDocAsynchronously(metadata, row, winningRev) {
+      var key = metadata.id + "::" + winningRev;
+      docIdRevIndex.get(key).onsuccess = function onGetDoc(e) {
+        row.doc = decodeDoc(e.target.result) || {};
+        if (opts.conflicts) {
+          var conflicts = collectConflicts(metadata);
+          if (conflicts.length) {
+            row.doc._conflicts = conflicts;
+          }
+        }
+        fetchAttachmentsIfNecessary(row.doc, opts, txn);
+      };
+    }
+
+    function allDocsInner(winningRev, metadata) {
+      var row = {
+        id: metadata.id,
+        key: metadata.id,
+        value: {
+          rev: winningRev
+        }
+      };
+      var deleted = metadata.deleted;
+      if (deleted) {
+        if (keys) {
+          results.push(row);
+          // deleted docs are okay with "keys" requests
+          row.value.deleted = true;
+          row.doc = null;
+        }
+      } else if (skip-- <= 0) {
+        results.push(row);
+        if (opts.include_docs) {
+          fetchDocAsynchronously(metadata, row, winningRev);
         }
       }
-      fetchAttachmentsIfNecessary(row.doc, opts, txn);
-    };
-  }
+    }
 
-  function allDocsInner(winningRev, metadata) {
-    var row = {
-      id: metadata.id,
-      key: metadata.id,
-      value: {
-        rev: winningRev
-      }
-    };
-    var deleted = metadata.deleted;
-    if (deleted) {
-      if (keys) {
-        results.push(row);
-        // deleted docs are okay with "keys" requests
-        row.value.deleted = true;
-        row.doc = null;
-      }
-    } else if (skip-- <= 0) {
-      results.push(row);
-      if (opts.include_docs) {
-        fetchDocAsynchronously(metadata, row, winningRev);
+    function processBatch(batchValues) {
+      for (var i = 0, len = batchValues.length; i < len; i++) {
+        if (results.length === limit) {
+          break;
+        }
+        var batchValue = batchValues[i];
+        if (batchValue.error && keys) {
+          // key was not found with "keys" requests
+          results.push(batchValue);
+          continue;
+        }
+        var metadata = decodeMetadata(batchValue);
+        var winningRev = metadata.winningRev;
+        allDocsInner(winningRev, metadata);
       }
     }
-  }
 
-  function processBatch(batchValues) {
-    for (var i = 0, len = batchValues.length; i < len; i++) {
-      if (results.length === limit) {
-        break;
+    function onBatch(batchKeys, batchValues, cursor) {
+      if (!cursor) {
+        return;
       }
-      var batchValue = batchValues[i];
-      if (batchValue.error && keys) {
-        // key was not found with "keys" requests
-        results.push(batchValue);
-        continue;
+      processBatch(batchValues);
+      if (results.length < limit) {
+        cursor.continue();
       }
-      var metadata = decodeMetadata(batchValue);
-      var winningRev = metadata.winningRev;
-      allDocsInner(winningRev, metadata);
     }
-  }
 
-  function onBatch(batchKeys, batchValues, cursor) {
-    if (!cursor) {
+    function onGetAll(e) {
+      var values = e.target.result;
+      if (opts.descending) {
+        values = values.reverse();
+      }
+      processBatch(values);
+    }
+
+    function onResultsReady() {
+      var returnVal = {
+        total_rows: docCount,
+        offset: opts.skip,
+        rows: results
+      };
+
+      /* istanbul ignore if */
+      if (opts.update_seq && updateSeq !== undefined) {
+        returnVal.update_seq = updateSeq;
+      }
+      callback(null, returnVal);
+    }
+
+    function onTxnComplete() {
+      if (opts.attachments) {
+        postProcessAttachments(results, opts.binary).then(onResultsReady);
+      } else {
+        onResultsReady();
+      }
+    }
+
+    // don't bother doing any requests if start > end or limit === 0
+    if (keyRangeError || limit === 0) {
       return;
     }
-    processBatch(batchValues);
-    if (results.length < limit) {
-      cursor.continue();
+    if (keys) {
+      return allDocsKeys(opts.keys, docStore, onBatch);
     }
-  }
-
-  function onGetAll(e) {
-    var values = e.target.result;
-    if (opts.descending) {
-      values = values.reverse();
+    if (limit === -1) { // just fetch everything
+      return getAll(docStore, keyRange, onGetAll);
     }
-    processBatch(values);
-  }
-
-  function onResultsReady() {
-    var returnVal = {
-      total_rows: docCount,
-      offset: opts.skip,
-      rows: results
-    };
-    
-    /* istanbul ignore if */
-    if (opts.update_seq && updateSeq !== undefined) {
-      returnVal.update_seq = updateSeq;
-    }
-    callback(null, returnVal);
-  }
-
-  function onTxnComplete() {
-    if (opts.attachments) {
-      postProcessAttachments(results, opts.binary).then(onResultsReady);
-    } else {
-      onResultsReady();
-    }
-  }
-
-  // don't bother doing any requests if start > end or limit === 0
-  if (keyRangeError || limit === 0) {
-    return;
-  }
-  if (keys) {
-    return allDocsKeys(opts.keys, docStore, onBatch);
-  }
-  if (limit === -1) { // just fetch everything
-    return getAll(docStore, keyRange, onGetAll);
-  }
-  // else do a cursor
-  // choose a batch size based on the skip, since we'll need to skip that many
-  runBatchedCursor(docStore, keyRange, opts.descending, limit + skip, onBatch);
+    // else do a cursor
+    // choose a batch size based on the skip, since we'll need to skip that many
+    runBatchedCursor(docStore, keyRange, opts.descending, limit + skip, onBatch);
+  });
 }
 
 export default idbAllDocs;

--- a/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
@@ -23,13 +23,12 @@ import {
   compactRevs,
   decodeMetadata,
   encodeMetadata,
-  idbError,
-  openTransactionSafely
+  idbError
 } from './utils';
 
 import changesHandler from './changesHandler';
 
-function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
+function idbBulkDocs(dbOpts, req, opts, api, openTransactionSafely, callback) {
   var docInfos = req.docs;
   var txn;
   var docStore;
@@ -77,31 +76,32 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
       LOCAL_STORE, ATTACH_AND_SEQ_STORE,
       META_STORE
     ];
-    var txnResult = openTransactionSafely(idb, stores, 'readwrite');
-    if (txnResult.error) {
-      return callback(txnResult.error);
-    }
-    txn = txnResult.txn;
-    txn.onabort = idbError(callback);
-    txn.ontimeout = idbError(callback);
-    txn.oncomplete = complete;
-    docStore = txn.objectStore(DOC_STORE);
-    bySeqStore = txn.objectStore(BY_SEQ_STORE);
-    attachStore = txn.objectStore(ATTACH_STORE);
-    attachAndSeqStore = txn.objectStore(ATTACH_AND_SEQ_STORE);
-    metaStore = txn.objectStore(META_STORE);
-
-    metaStore.get(META_STORE).onsuccess = function (e) {
-      metaDoc = e.target.result;
-      updateDocCountIfReady();
-    };
-
-    verifyAttachments(function (err) {
-      if (err) {
-        preconditionErrored = true;
-        return callback(err);
+    openTransactionSafely(stores, 'readwrite', function (txnResult) {
+      if (txnResult.error) {
+        return callback(txnResult.error);
       }
-      fetchExistingDocs();
+      txn = txnResult.txn;
+      txn.onabort = idbError(callback);
+      txn.ontimeout = idbError(callback);
+      txn.oncomplete = complete;
+      docStore = txn.objectStore(DOC_STORE);
+      bySeqStore = txn.objectStore(BY_SEQ_STORE);
+      attachStore = txn.objectStore(ATTACH_STORE);
+      attachAndSeqStore = txn.objectStore(ATTACH_AND_SEQ_STORE);
+      metaStore = txn.objectStore(META_STORE);
+
+      metaStore.get(META_STORE).onsuccess = function (e) {
+        metaDoc = e.target.result;
+        updateDocCountIfReady();
+      };
+
+      verifyAttachments(function (err) {
+        if (err) {
+          preconditionErrored = true;
+          return callback(err);
+        }
+        fetchExistingDocs();
+      });
     });
   }
 
@@ -112,7 +112,7 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
 
   function idbProcessDocs() {
     processDocs(dbOpts.revs_limit, docInfos, api, fetchedDocs,
-                txn, results, writeDoc, opts, onAllDocsProcessed);
+      txn, results, writeDoc, opts, onAllDocsProcessed);
   }
 
   function updateDocCountIfReady() {
@@ -220,7 +220,7 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
   }
 
   function writeDoc(docInfo, winningRev, winningRevIsDeleted, newRevIsDeleted,
-                    isUpdate, delta, resultsIdx, callback) {
+    isUpdate, delta, resultsIdx, callback) {
 
     docInfo.metadata.winningRev = winningRev;
     docInfo.metadata.deleted = winningRevIsDeleted;
@@ -248,7 +248,7 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
   }
 
   function finishDoc(docInfo, winningRev, winningRevIsDeleted,
-                     isUpdate, resultsIdx, callback) {
+    isUpdate, resultsIdx, callback) {
 
     var doc = docInfo.data;
     var metadata = docInfo.metadata;
@@ -306,7 +306,7 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
   }
 
   function writeAttachments(docInfo, winningRev, winningRevIsDeleted,
-                            isUpdate, resultsIdx, callback) {
+    isUpdate, resultsIdx, callback) {
 
 
     var doc = docInfo.data;

--- a/packages/node_modules/pouchdb-adapter-idb/src/changes.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/changes.js
@@ -14,12 +14,11 @@ import {
   decodeMetadata,
   fetchAttachmentsIfNecessary,
   idbError,
-  postProcessAttachments,
-  openTransactionSafely
+  postProcessAttachments
 } from './utils';
 import runBatchedCursor from './runBatchedCursor';
 
-function changes(opts, api, dbName, idb) {
+function changes(opts, api, dbName, openTransactionSafely) {
   opts = clone(opts);
 
   if (opts.continuous) {
@@ -193,22 +192,23 @@ function changes(opts, api, dbName, idb) {
   if (opts.attachments) {
     objectStores.push(ATTACH_STORE);
   }
-  var txnResult = openTransactionSafely(idb, objectStores, 'readonly');
-  if (txnResult.error) {
-    return opts.complete(txnResult.error);
-  }
-  txn = txnResult.txn;
-  txn.onabort = idbError(opts.complete);
-  txn.oncomplete = onTxnComplete;
+  openTransactionSafely(objectStores, 'readonly', function (txnResult) {
+    if (txnResult.error) {
+      return opts.complete(txnResult.error);
+    }
+    txn = txnResult.txn;
+    txn.onabort = idbError(opts.complete);
+    txn.oncomplete = onTxnComplete;
 
-  bySeqStore = txn.objectStore(BY_SEQ_STORE);
-  docStore = txn.objectStore(DOC_STORE);
-  docIdRevIndex = bySeqStore.index('_doc_id_rev');
+    bySeqStore = txn.objectStore(BY_SEQ_STORE);
+    docStore = txn.objectStore(DOC_STORE);
+    docIdRevIndex = bySeqStore.index('_doc_id_rev');
 
-  var keyRange = (opts.since && !opts.descending) ?
-    IDBKeyRange.lowerBound(opts.since, true) : null;
+    var keyRange = (opts.since && !opts.descending) ?
+      IDBKeyRange.lowerBound(opts.since, true) : null;
 
-  runBatchedCursor(bySeqStore, keyRange, opts.descending, limit, onBatch);
+    runBatchedCursor(bySeqStore, keyRange, opts.descending, limit, onBatch);
+  });
 }
 
 export default changes;

--- a/packages/node_modules/pouchdb-adapter-idb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/index.js
@@ -42,13 +42,14 @@ import {
   encodeMetadata,
   idbError,
   readBlobData,
-  openTransactionSafely
 } from './utils';
 
 import { enqueueTask } from './taskQueue';
 
 import changesHandler from './changesHandler';
 import changes from './changes';
+
+var OPEN_TRANSACTION_RETRY = 2;
 
 var cachedDBs = new Map();
 var blobSupportPromise;
@@ -289,6 +290,33 @@ function init(api, opts, callback) {
 
   }
 
+  function openTransactionSafely(stores, mode, callback) {
+    var retry = OPEN_TRANSACTION_RETRY;
+    withRetry(stores, mode, callback);
+    function withRetry(stores, mode, callback) {
+      try {
+        return callback({
+          txn: idb.transaction(stores, mode)
+        });
+      } catch (err) {
+        // reinit and retry, if db is closed by the browser (cachedDBs.has(dbName))
+        // code: 11
+        // message: "Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing."
+        // name: "InvalidStateError"
+        if (!cachedDBs.has(dbName) || err.code !== 11 || retry === 0) {
+          return callback({
+            error: err
+          });
+        }
+        retry--;
+      }
+      
+      // re-initialize if InvalidStateError
+      cachedDBs.delete(dbName);
+      setup(function () { withRetry(stores, mode, callback); });
+    }
+  }
+
   api._remote = false;
   api.type = function () {
     return 'idb';
@@ -299,7 +327,7 @@ function init(api, opts, callback) {
   });
 
   api._bulkDocs = function idb_bulkDocs(req, reqOpts, callback) {
-    idbBulkDocs(opts, req, reqOpts, api, idb, callback);
+    idbBulkDocs(opts, req, reqOpts, api, openTransactionSafely, callback);
   };
 
   // First we look up the metadata in the ids database, then we fetch the
@@ -310,57 +338,63 @@ function init(api, opts, callback) {
     var err;
     var txn = opts.ctx;
     if (!txn) {
-      var txnResult = openTransactionSafely(idb,
-        [DOC_STORE, BY_SEQ_STORE, ATTACH_STORE], 'readonly');
-      if (txnResult.error) {
-        return callback(txnResult.error);
-      }
-      txn = txnResult.txn;
+      openTransactionSafely(
+        [DOC_STORE, BY_SEQ_STORE, ATTACH_STORE], 'readonly', function (txnResult) {
+          if (txnResult.error) {
+            return callback(txnResult.error);
+          }
+          txn = txnResult.txn;
+          getWithTx(txn);
+        });
+      return;
     }
+    getWithTx(txn);
 
-    function finish() {
+    function getWithTx(txn) {
+      function finish() {
       callback(err, {doc: doc, metadata: metadata, ctx: txn});
-    }
-
-    txn.objectStore(DOC_STORE).get(id).onsuccess = function (e) {
-      metadata = decodeMetadata(e.target.result);
-      // we can determine the result here if:
-      // 1. there is no such document
-      // 2. the document is deleted and we don't ask about specific rev
-      // When we ask with opts.rev we expect the answer to be either
-      // doc (possibly with _deleted=true) or missing error
-      if (!metadata) {
-        err = createError(MISSING_DOC, 'missing');
-        return finish();
       }
 
-      var rev;
-      if (!opts.rev) {
-        rev = metadata.winningRev;
-        var deleted = isDeleted(metadata);
-        if (deleted) {
-          err = createError(MISSING_DOC, "deleted");
-          return finish();
-        }
-      } else {
-        rev = opts.latest ? getLatest(opts.rev, metadata) : opts.rev;
-      }
-
-      var objectStore = txn.objectStore(BY_SEQ_STORE);
-      var key = metadata.id + '::' + rev;
-
-      objectStore.index('_doc_id_rev').get(key).onsuccess = function (e) {
-        doc = e.target.result;
-        if (doc) {
-          doc = decodeDoc(doc);
-        }
-        if (!doc) {
+      txn.objectStore(DOC_STORE).get(id).onsuccess = function (e) {
+        metadata = decodeMetadata(e.target.result);
+        // we can determine the result here if:
+        // 1. there is no such document
+        // 2. the document is deleted and we don't ask about specific rev
+        // When we ask with opts.rev we expect the answer to be either
+        // doc (possibly with _deleted=true) or missing error
+        if (!metadata) {
           err = createError(MISSING_DOC, 'missing');
           return finish();
         }
-        finish();
+
+        var rev;
+        if (!opts.rev) {
+          rev = metadata.winningRev;
+          var deleted = isDeleted(metadata);
+          if (deleted) {
+            err = createError(MISSING_DOC, "deleted");
+            return finish();
+          }
+        } else {
+          rev = opts.latest ? getLatest(opts.rev, metadata) : opts.rev;
+        }
+
+        var objectStore = txn.objectStore(BY_SEQ_STORE);
+        var key = metadata.id + '::' + rev;
+
+        objectStore.index('_doc_id_rev').get(key).onsuccess = function (e) {
+          doc = e.target.result;
+          if (doc) {
+            doc = decodeDoc(doc);
+          }
+          if (!doc) {
+            err = createError(MISSING_DOC, 'missing');
+            return finish();
+          }
+          finish();
+        };
       };
-    };
+    }
   };
 
   api._getAttachment = function (docId, attachId, attachment, opts, callback) {
@@ -368,57 +402,66 @@ function init(api, opts, callback) {
     if (opts.ctx) {
       txn = opts.ctx;
     } else {
-      var txnResult = openTransactionSafely(idb,
-        [DOC_STORE, BY_SEQ_STORE, ATTACH_STORE], 'readonly');
-      if (txnResult.error) {
-        return callback(txnResult.error);
-      }
-      txn = txnResult.txn;
-    }
-    var digest = attachment.digest;
-    var type = attachment.content_type;
-
-    txn.objectStore(ATTACH_STORE).get(digest).onsuccess = function (e) {
-      var body = e.target.result.body;
-      readBlobData(body, type, opts.binary, function (blobData) {
-        callback(null, blobData);
+      openTransactionSafely([DOC_STORE, BY_SEQ_STORE, ATTACH_STORE], 'readonly', function (txnResult) {
+        if (txnResult.error) {
+          return callback(txnResult.error);
+        }
+        txn = txnResult.txn;
+        getAttachmentWithTx(txn);
       });
-    };
+      return;
+    }
+    getAttachmentWithTx(txn);
+
+    function getAttachmentWithTx(txn) {
+      var digest = attachment.digest;
+      var type = attachment.content_type;
+
+      txn.objectStore(ATTACH_STORE).get(digest).onsuccess = function (e) {
+        var body = e.target.result.body;
+        readBlobData(body, type, opts.binary, function (blobData) {
+          callback(null, blobData);
+        });
+      };
+    }
   };
 
   api._info = function idb_info(callback) {
     var updateSeq;
     var docCount;
 
-    var txnResult = openTransactionSafely(idb, [META_STORE, BY_SEQ_STORE], 'readonly');
-    if (txnResult.error) {
-      return callback(txnResult.error);
-    }
-    var txn = txnResult.txn;
-    txn.objectStore(META_STORE).get(META_STORE).onsuccess = function (e) {
-      docCount = e.target.result.docCount;
-    };
-    txn.objectStore(BY_SEQ_STORE).openCursor(null, 'prev').onsuccess = function (e) {
-      var cursor = e.target.result;
-      updateSeq = cursor ? cursor.key : 0;
-    };
 
-    txn.oncomplete = function () {
-      callback(null, {
-        doc_count: docCount,
-        update_seq: updateSeq,
-        // for debugging
-        idb_attachment_format: (api._meta.blobSupport ? 'binary' : 'base64')
-      });
-    };
+    openTransactionSafely([META_STORE, BY_SEQ_STORE], 'readonly', function (txnResult) {
+      if (txnResult.error) {
+        return callback(txnResult.error);
+      }
+      var txn = txnResult.txn;
+
+      txn.objectStore(META_STORE).get(META_STORE).onsuccess = function (e) {
+        docCount = e.target.result.docCount;
+      };
+      txn.objectStore(BY_SEQ_STORE).openCursor(null, 'prev').onsuccess = function (e) {
+        var cursor = e.target.result;
+        updateSeq = cursor ? cursor.key : 0;
+      };
+
+      txn.oncomplete = function () {
+        callback(null, {
+          doc_count: docCount,
+          update_seq: updateSeq,
+          // for debugging
+          idb_attachment_format: (api._meta.blobSupport ? 'binary' : 'base64')
+        });
+      };
+    });
   };
 
   api._allDocs = function idb_allDocs(opts, callback) {
-    idbAllDocs(opts, idb, callback);
+    idbAllDocs(opts, openTransactionSafely, callback);
   };
 
   api._changes = function idbChanges(opts) {
-    return changes(opts, api, dbName, idb);
+    return changes(opts, api, dbName, openTransactionSafely);
   };
 
   api._close = function (callback) {
@@ -430,20 +473,21 @@ function init(api, opts, callback) {
   };
 
   api._getRevisionTree = function (docId, callback) {
-    var txnResult = openTransactionSafely(idb, [DOC_STORE], 'readonly');
-    if (txnResult.error) {
-      return callback(txnResult.error);
-    }
-    var txn = txnResult.txn;
-    var req = txn.objectStore(DOC_STORE).get(docId);
-    req.onsuccess = function (event) {
-      var doc = decodeMetadata(event.target.result);
-      if (!doc) {
-        callback(createError(MISSING_DOC));
-      } else {
-        callback(null, doc.rev_tree);
+    openTransactionSafely([DOC_STORE], 'readonly', function (txnResult) {
+      if (txnResult.error) {
+        return callback(txnResult.error);
       }
-    };
+      var txn = txnResult.txn;
+      var req = txn.objectStore(DOC_STORE).get(docId);
+      req.onsuccess = function (event) {
+        var doc = decodeMetadata(event.target.result);
+        if (!doc) {
+          callback(createError(MISSING_DOC));
+        } else {
+          callback(null, doc.rev_tree);
+        }
+      };
+    });
   };
 
   // This function removes revisions of document docId
@@ -456,54 +500,56 @@ function init(api, opts, callback) {
       ATTACH_STORE,
       ATTACH_AND_SEQ_STORE
     ];
-    var txnResult = openTransactionSafely(idb, stores, 'readwrite');
-    if (txnResult.error) {
-      return callback(txnResult.error);
-    }
-    var txn = txnResult.txn;
+    openTransactionSafely(stores, 'readwrite', function (txnResult) {
+      if (txnResult.error) {
+        return callback(txnResult.error);
+      }
+      var txn = txnResult.txn;
 
-    var docStore = txn.objectStore(DOC_STORE);
+      var docStore = txn.objectStore(DOC_STORE);
 
-    docStore.get(docId).onsuccess = function (event) {
-      var metadata = decodeMetadata(event.target.result);
-      traverseRevTree(metadata.rev_tree, function (isLeaf, pos,
-                                                         revHash, ctx, opts) {
-        var rev = pos + '-' + revHash;
-        if (revs.indexOf(rev) !== -1) {
-          opts.status = 'missing';
-        }
-      });
-      compactRevs(revs, docId, txn);
-      var winningRev = metadata.winningRev;
-      var deleted = metadata.deleted;
-      txn.objectStore(DOC_STORE).put(
-        encodeMetadata(metadata, winningRev, deleted));
-    };
-    txn.onabort = idbError(callback);
-    txn.oncomplete = function () {
-      callback();
-    };
+      docStore.get(docId).onsuccess = function (event) {
+        var metadata = decodeMetadata(event.target.result);
+        traverseRevTree(metadata.rev_tree, function (isLeaf, pos,
+          revHash, ctx, opts) {
+          var rev = pos + '-' + revHash;
+          if (revs.indexOf(rev) !== -1) {
+            opts.status = 'missing';
+          }
+        });
+        compactRevs(revs, docId, txn);
+        var winningRev = metadata.winningRev;
+        var deleted = metadata.deleted;
+        txn.objectStore(DOC_STORE).put(
+          encodeMetadata(metadata, winningRev, deleted));
+      };
+      txn.onabort = idbError(callback);
+      txn.oncomplete = function () {
+        callback();
+      };
+    });
   };
 
 
   api._getLocal = function (id, callback) {
-    var txnResult = openTransactionSafely(idb, [LOCAL_STORE], 'readonly');
-    if (txnResult.error) {
-      return callback(txnResult.error);
-    }
-    var tx = txnResult.txn;
-    var req = tx.objectStore(LOCAL_STORE).get(id);
-
-    req.onerror = idbError(callback);
-    req.onsuccess = function (e) {
-      var doc = e.target.result;
-      if (!doc) {
-        callback(createError(MISSING_DOC));
-      } else {
-        delete doc['_doc_id_rev']; // for backwards compat
-        callback(null, doc);
+    openTransactionSafely([LOCAL_STORE], 'readonly', function (txnResult) {
+      if (txnResult.error) {
+        return callback(txnResult.error);
       }
-    };
+      var tx = txnResult.txn;
+      var req = tx.objectStore(LOCAL_STORE).get(id);
+
+      req.onerror = idbError(callback);
+      req.onsuccess = function (e) {
+        var doc = e.target.result;
+        if (!doc) {
+          callback(createError(MISSING_DOC));
+        } else {
+          delete doc['_doc_id_rev']; // for backwards compat
+          callback(null, doc);
+        }
+      };
+    });
   };
 
   api._putLocal = function (doc, opts, callback) {
@@ -523,90 +569,103 @@ function init(api, opts, callback) {
     var tx = opts.ctx;
     var ret;
     if (!tx) {
-      var txnResult = openTransactionSafely(idb, [LOCAL_STORE], 'readwrite');
-      if (txnResult.error) {
-        return callback(txnResult.error);
-      }
-      tx = txnResult.txn;
-      tx.onerror = idbError(callback);
-      tx.oncomplete = function () {
-        if (ret) {
-          callback(null, ret);
+      openTransactionSafely([LOCAL_STORE], 'readwrite', function (txnResult) {
+        if (txnResult.error) {
+          return callback(txnResult.error);
         }
-      };
+        tx = txnResult.txn;
+        tx.onerror = idbError(callback);
+        tx.oncomplete = function () {
+          if (ret) {
+            callback(null, ret);
+          }
+        };
+        putLocalWithTx(tx);
+      });
+      return;
     }
+    putLocalWithTx(tx);
 
-    var oStore = tx.objectStore(LOCAL_STORE);
-    var req;
-    if (oldRev) {
-      req = oStore.get(id);
-      req.onsuccess = function (e) {
-        var oldDoc = e.target.result;
-        if (!oldDoc || oldDoc._rev !== oldRev) {
-          callback(createError(REV_CONFLICT));
-        } else { // update
-          var req = oStore.put(doc);
-          req.onsuccess = function () {
+    function putLocalWithTx(tx) {
+      var oStore = tx.objectStore(LOCAL_STORE);
+      var req;
+      if (oldRev) {
+        req = oStore.get(id);
+        req.onsuccess = function (e) {
+          var oldDoc = e.target.result;
+          if (!oldDoc || oldDoc._rev !== oldRev) {
+            callback(createError(REV_CONFLICT));
+          } else { // update
+            var req = oStore.put(doc);
+            req.onsuccess = function () {
             ret = {ok: true, id: doc._id, rev: doc._rev};
-            if (opts.ctx) { // return immediately
-              callback(null, ret);
-            }
-          };
-        }
-      };
-    } else { // new doc
-      req = oStore.add(doc);
-      req.onerror = function (e) {
-        // constraint error, already exists
-        callback(createError(REV_CONFLICT));
-        e.preventDefault(); // avoid transaction abort
-        e.stopPropagation(); // avoid transaction onerror
-      };
-      req.onsuccess = function () {
+              if (opts.ctx) { // return immediately
+                callback(null, ret);
+              }
+            };
+          }
+        };
+      } else { // new doc
+        req = oStore.add(doc);
+        req.onerror = function (e) {
+          // constraint error, already exists
+          callback(createError(REV_CONFLICT));
+          e.preventDefault(); // avoid transaction abort
+          e.stopPropagation(); // avoid transaction onerror
+        };
+        req.onsuccess = function () {
         ret = {ok: true, id: doc._id, rev: doc._rev};
-        if (opts.ctx) { // return immediately
-          callback(null, ret);
-        }
-      };
+          if (opts.ctx) { // return immediately
+            callback(null, ret);
+          }
+        };
+      }
     }
   };
 
   api._removeLocal = function (doc, opts, callback) {
+    var ret;
     if (typeof opts === 'function') {
       callback = opts;
       opts = {};
     }
     var tx = opts.ctx;
     if (!tx) {
-      var txnResult = openTransactionSafely(idb, [LOCAL_STORE], 'readwrite');
-      if (txnResult.error) {
-        return callback(txnResult.error);
-      }
-      tx = txnResult.txn;
-      tx.oncomplete = function () {
-        if (ret) {
-          callback(null, ret);
+      openTransactionSafely([LOCAL_STORE], 'readwrite', function (txnResult) {
+        if (txnResult.error) {
+          return callback(txnResult.error);
+        }
+        tx = txnResult.txn;
+        tx.oncomplete = function () {
+          if (ret) {
+            callback(null, ret);
+          }
+        };
+        removeLocalWithTx(tx);
+      });
+      return;
+    }
+    removeLocalWithTx(tx);
+
+    function removeLocalWithTx(tx) {
+      var id = doc._id;
+      var oStore = tx.objectStore(LOCAL_STORE);
+      var req = oStore.get(id);
+
+      req.onerror = idbError(callback);
+      req.onsuccess = function (e) {
+        var oldDoc = e.target.result;
+        if (!oldDoc || oldDoc._rev !== doc._rev) {
+          callback(createError(MISSING_DOC));
+        } else {
+          oStore.delete(id);
+        ret = {ok: true, id: id, rev: '0-0'};
+          if (opts.ctx) { // return immediately
+            callback(null, ret);
+          }
         }
       };
     }
-    var ret;
-    var id = doc._id;
-    var oStore = tx.objectStore(LOCAL_STORE);
-    var req = oStore.get(id);
-
-    req.onerror = idbError(callback);
-    req.onsuccess = function (e) {
-      var oldDoc = e.target.result;
-      if (!oldDoc || oldDoc._rev !== doc._rev) {
-        callback(createError(MISSING_DOC));
-      } else {
-        oStore.delete(id);
-        ret = {ok: true, id: id, rev: '0-0'};
-        if (opts.ctx) { // return immediately
-          callback(null, ret);
-        }
-      }
-    };
   };
 
   api._destroy = function (opts, callback) {
@@ -632,172 +691,176 @@ function init(api, opts, callback) {
     req.onerror = idbError(callback);
   };
 
-  var cached = cachedDBs.get(dbName);
+  setup(callback);
 
-  if (cached) {
-    idb = cached.idb;
-    api._meta = cached.global;
-    return nextTick(function () {
-      callback(null, api);
-    });
-  }
+  function setup(callback) {
+    var cached = cachedDBs.get(dbName);
 
-  var req = indexedDB.open(dbName, ADAPTER_VERSION);
-  openReqList.set(dbName, req);
-
-  req.onupgradeneeded = function (e) {
-    var db = e.target.result;
-    if (e.oldVersion < 1) {
-      return createSchema(db); // new db, initial schema
-    }
-    // do migrations
-
-    var txn = e.currentTarget.transaction;
-    // these migrations have to be done in this function, before
-    // control is returned to the event loop, because IndexedDB
-
-    if (e.oldVersion < 3) {
-      createLocalStoreSchema(db); // v2 -> v3
-    }
-    if (e.oldVersion < 4) {
-      addAttachAndSeqStore(db); // v3 -> v4
+    if (cached) {
+      idb = cached.idb;
+      api._meta = cached.global;
+      return nextTick(function () {
+        callback(null, api);
+      });
     }
 
-    var migrations = [
-      addDeletedOrLocalIndex, // v1 -> v2
-      migrateLocalStore,      // v2 -> v3
-      migrateAttsAndSeqs,     // v3 -> v4
-      migrateMetadata         // v4 -> v5
-    ];
+    var req = indexedDB.open(dbName, ADAPTER_VERSION);
+    openReqList.set(dbName, req);
 
-    var i = e.oldVersion;
-
-    function next() {
-      var migration = migrations[i - 1];
-      i++;
-      if (migration) {
-        migration(txn, next);
+    req.onupgradeneeded = function (e) {
+      var db = e.target.result;
+      if (e.oldVersion < 1) {
+        return createSchema(db); // new db, initial schema
       }
-    }
+      // do migrations
 
-    next();
-  };
+      var txn = e.currentTarget.transaction;
+      // these migrations have to be done in this function, before
+      // control is returned to the event loop, because IndexedDB
 
-  req.onsuccess = function (e) {
+      if (e.oldVersion < 3) {
+        createLocalStoreSchema(db); // v2 -> v3
+      }
+      if (e.oldVersion < 4) {
+        addAttachAndSeqStore(db); // v3 -> v4
+      }
 
-    idb = e.target.result;
+      var migrations = [
+        addDeletedOrLocalIndex, // v1 -> v2
+        migrateLocalStore,      // v2 -> v3
+        migrateAttsAndSeqs,     // v3 -> v4
+        migrateMetadata         // v4 -> v5
+      ];
 
-    idb.onversionchange = function () {
-      idb.close();
-      cachedDBs.delete(dbName);
+      var i = e.oldVersion;
+
+      function next() {
+        var migration = migrations[i - 1];
+        i++;
+        if (migration) {
+          migration(txn, next);
+        }
+      }
+
+      next();
     };
 
-    idb.onabort = function (e) {
-      guardedConsole('error', 'Database has a global failure', e.target.error);
-      idb.close();
-      cachedDBs.delete(dbName);
-    };
+    req.onsuccess = function (e) {
 
-    // Do a few setup operations (in parallel as much as possible):
-    // 1. Fetch meta doc
-    // 2. Check blob support
-    // 3. Calculate docCount
-    // 4. Generate an instanceId if necessary
-    // 5. Store docCount and instanceId on meta doc
+      idb = e.target.result;
 
-    var txn = idb.transaction([
-      META_STORE,
-      DETECT_BLOB_SUPPORT_STORE,
-      DOC_STORE
-    ], 'readwrite');
-
-    var storedMetaDoc = false;
-    var metaDoc;
-    var docCount;
-    var blobSupport;
-    var instanceId;
-
-    function completeSetup() {
-      if (typeof blobSupport === 'undefined' || !storedMetaDoc) {
-        return;
-      }
-      api._meta = {
-        name: dbName,
-        instanceId: instanceId,
-        blobSupport: blobSupport
+      idb.onversionchange = function () {
+        idb.close();
+        cachedDBs.delete(dbName);
       };
 
-      cachedDBs.set(dbName, {
-        idb: idb,
-        global: api._meta
+      idb.onabort = function (e) {
+        guardedConsole('error', 'Database has a global failure', e.target.error);
+        idb.close();
+        cachedDBs.delete(dbName);
+      };
+
+      // Do a few setup operations (in parallel as much as possible):
+      // 1. Fetch meta doc
+      // 2. Check blob support
+      // 3. Calculate docCount
+      // 4. Generate an instanceId if necessary
+      // 5. Store docCount and instanceId on meta doc
+
+      var txn = idb.transaction([
+        META_STORE,
+        DETECT_BLOB_SUPPORT_STORE,
+        DOC_STORE
+      ], 'readwrite');
+
+      var storedMetaDoc = false;
+      var metaDoc;
+      var docCount;
+      var blobSupport;
+      var instanceId;
+
+      function completeSetup() {
+        if (typeof blobSupport === 'undefined' || !storedMetaDoc) {
+          return;
+        }
+        api._meta = {
+          name: dbName,
+          instanceId: instanceId,
+          blobSupport: blobSupport
+        };
+
+        cachedDBs.set(dbName, {
+          idb: idb,
+          global: api._meta
+        });
+        callback(null, api);
+      }
+
+      function storeMetaDocIfReady() {
+        if (typeof docCount === 'undefined' || typeof metaDoc === 'undefined') {
+          return;
+        }
+        var instanceKey = dbName + '_id';
+        if (instanceKey in metaDoc) {
+          instanceId = metaDoc[instanceKey];
+        } else {
+          metaDoc[instanceKey] = instanceId = uuid();
+        }
+        metaDoc.docCount = docCount;
+        txn.objectStore(META_STORE).put(metaDoc);
+      }
+
+      //
+      // fetch or generate the instanceId
+      //
+      txn.objectStore(META_STORE).get(META_STORE).onsuccess = function (e) {
+        metaDoc = e.target.result || { id: META_STORE };
+        storeMetaDocIfReady();
+      };
+
+      //
+      // countDocs
+      //
+      countDocs(txn, function (count) {
+        docCount = count;
+        storeMetaDocIfReady();
       });
-      callback(null, api);
-    }
 
-    function storeMetaDocIfReady() {
-      if (typeof docCount === 'undefined' || typeof metaDoc === 'undefined') {
-        return;
+      //
+      // check blob support
+      //
+      if (!blobSupportPromise) {
+        // make sure blob support is only checked once
+        blobSupportPromise = checkBlobSupport(txn);
       }
-      var instanceKey = dbName + '_id';
-      if (instanceKey in metaDoc) {
-        instanceId = metaDoc[instanceKey];
-      } else {
-        metaDoc[instanceKey] = instanceId = uuid();
-      }
-      metaDoc.docCount = docCount;
-      txn.objectStore(META_STORE).put(metaDoc);
-    }
 
-    //
-    // fetch or generate the instanceId
-    //
-    txn.objectStore(META_STORE).get(META_STORE).onsuccess = function (e) {
-      metaDoc = e.target.result || { id: META_STORE };
-      storeMetaDocIfReady();
+      blobSupportPromise.then(function (val) {
+        blobSupport = val;
+        completeSetup();
+      });
+
+      // only when the metadata put transaction has completed,
+      // consider the setup done
+      txn.oncomplete = function () {
+        storedMetaDoc = true;
+        completeSetup();
+      };
+      txn.onabort = idbError(callback);
     };
 
-    //
-    // countDocs
-    //
-    countDocs(txn, function (count) {
-      docCount = count;
-      storeMetaDocIfReady();
-    });
+    req.onerror = function (e) {
+      var msg = e.target.error && e.target.error.message;
 
-    //
-    // check blob support
-    //
-    if (!blobSupportPromise) {
-      // make sure blob support is only checked once
-      blobSupportPromise = checkBlobSupport(txn);
-    }
+      if (!msg) {
+        msg = 'Failed to open indexedDB, are you in private browsing mode?';
+      } else if (msg.indexOf("stored database is a higher version") !== -1) {
+        msg = new Error('This DB was created with the newer "indexeddb" adapter, but you are trying to open it with the older "idb" adapter');
+      }
 
-    blobSupportPromise.then(function (val) {
-      blobSupport = val;
-      completeSetup();
-    });
-
-    // only when the metadata put transaction has completed,
-    // consider the setup done
-    txn.oncomplete = function () {
-      storedMetaDoc = true;
-      completeSetup();
+      guardedConsole('error', msg);
+      callback(createError(IDB_ERROR, msg));
     };
-    txn.onabort = idbError(callback);
-  };
-
-  req.onerror = function (e) {
-    var msg = e.target.error && e.target.error.message;
-
-    if (!msg) {
-      msg = 'Failed to open indexedDB, are you in private browsing mode?';
-    } else if (msg.indexOf("stored database is a higher version") !== -1) {
-      msg = new Error('This DB was created with the newer "indexeddb" adapter, but you are trying to open it with the older "idb" adapter');
-    }
-
-    guardedConsole('error', msg);
-    callback(createError(IDB_ERROR, msg));
-  };
+  }
 }
 
 IdbPouch.valid = function () {

--- a/packages/node_modules/pouchdb-adapter-idb/src/utils.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/utils.js
@@ -214,21 +214,8 @@ function compactRevs(revs, docId, txn) {
   });
 }
 
-function openTransactionSafely(idb, stores, mode) {
-  try {
-    return {
-      txn: idb.transaction(stores, mode)
-    };
-  } catch (err) {
-    return {
-      error: err
-    };
-  }
-}
-
 export {
   fetchAttachmentsIfNecessary,
-  openTransactionSafely,
   compactRevs,
   postProcessAttachments,
   idbError,


### PR DESCRIPTION
- The setup process has been wrapped in the setup() function, so it can be called also in openTransactionSafely()
- The function openTransactionSafely has been moved from utils.js into index.js so it has access to the new setup() function and the data in the adapter (cachedDBs and idb variables).
- The function openTransactionSafely has been changed to be async.
- Instead of passing the current idb, it's passed the adapter contextualized openTransactionSafely() function.