### PR TITLE
Fix writing erroneous attachment rev references in bulkDocs

### DIFF
--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
@@ -74,6 +74,14 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
     });
   }
 
+  function revHasAttachment(doc, rev, digest) {
+    return doc.revs[rev] &&
+      doc.revs[rev].data._attachments &&
+      Object.values(doc.revs[rev].data._attachments).find(function (att) {
+        return att.digest === digest;
+      });
+  }
+
   function processDocs(txn, docs, oldDocs) {
 
     docs.forEach(function (doc, i) {
@@ -262,7 +270,9 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
             return;
           }
 
-          doc.attachments[attachment.digest].revs[writtenRev] = true;
+          if (revHasAttachment(doc, writtenRev, attachment.digest)) {
+            doc.attachments[attachment.digest].revs[writtenRev] = true;
+          }
 
         } else {
 


### PR DESCRIPTION
This PR fixes an issue where `bulkDocs()` would write rev references in attachments to non-winning revs that have been received during replication, documented in #8456. By checking whether these revs themselves have references to the respective attachment, we can fix this behaviour.

The test included in this PR show this behavior by creating two conflicting nodes, `3a` and `2b`. `3a` has an attachment while `2b` will be erroneously referenced by the attachment due to the bug described in #8456. When we remove `3a` and subsequently run compaction, `2b` will become the winning rev and the attachment should be removed, which it isn't without the supplied bugfix. This is shown by adding an attachment stub to `2b` and successfully retrieving the attachment.