### PR TITLE
(#8463) - check if docFieldValue is also null value.

### DIFF
--- a/packages/node_modules/pouchdb-selector-core/src/in-memory-filter.js
+++ b/packages/node_modules/pouchdb-selector-core/src/in-memory-filter.js
@@ -219,7 +219,7 @@ var matchers = {
       return false;
     }
 
-    if (typeof docFieldValue[0] === 'object') {
+    if (typeof docFieldValue[0] === 'object' &&  docFieldValue[0] !== null) {
       return docFieldValue.some(function (val) {
         return rowFilter(val, userValue, Object.keys(userValue));
       });
@@ -240,7 +240,7 @@ var matchers = {
       return false;
     }
 
-    if (typeof docFieldValue[0] === 'object') {
+    if (typeof docFieldValue[0] === 'object' &&  docFieldValue[0] !== null) {
       return docFieldValue.every(function (val) {
         return rowFilter(val, userValue, Object.keys(userValue));
       });

--- a/tests/find/test-suite-1/test.array.js
+++ b/tests/find/test-suite-1/test.array.js
@@ -728,5 +728,27 @@ describe('test.array.js', function () {
         err.message.should.eq('Query operator $allMatch must be an object. Received string: a');
       });
     });
+        
+    it('with null value in array', function () {
+      var db = context.db;
+      var docs = [
+        {_id: '1', values: [null, null]},
+        {_id: '2', values: [1, null, 3]},
+        {_id: '3', values: [1, 2, 3]}
+      ];
+
+      return db.bulkDocs(docs).then(function () {
+        return db.find({
+          selector: {
+            values: {$allMatch: {$eq: null}},
+          },
+          fields: ['_id']
+        }).then(function (resp) {
+          resp.docs.map(function (doc) {
+            return doc._id;
+          }).should.deep.equal(['1']);
+        });
+      });
+    });
   });
 });

--- a/tests/find/test-suite-1/test.elem-match.js
+++ b/tests/find/test-suite-1/test.elem-match.js
@@ -98,4 +98,26 @@ describe('test.elem-match.js', function () {
       err.message.should.eq('Query operator $elemMatch must be an object. Received : null');
     });
   });
+    
+  it('with null value in array', function () {
+    var db = context.db;
+    var docs = [
+      {_id: '1', values: [null]},
+      {_id: '2', values: [1, null, 3]},
+      {_id: '3', values: [1, 2, 3]}
+    ];
+
+    return db.bulkDocs(docs).then(function () {
+      return db.find({
+        selector: {
+          values: {$elemMatch: {$eq: null}},
+        },
+        fields: ['_id']
+      }).then(function (resp) {
+        resp.docs.map(function (doc) {
+          return doc._id;
+        }).should.deep.equal(['1', '2']);
+      });
+    });
+  });
 });


### PR DESCRIPTION
The fix checks if docFieldValue is also null value.
typeof null returns object in javasctipy. Fixes a bug when querying against and array with a null value, $elemMatch and $allMatch.
Two tests are added for this case. One for $elemMatch and one for $allMatch

Related issue: https://github.com/pouchdb/pouchdb/issues/8463