### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -2156,7 +2156,7 @@ adapters.forEach(function (adapter) {
             return_docs: true,
             include_docs: true
           }).on('change', function (change) {
-            var i = +change.id.substr(3);
+            var i = +change.id.slice(3);
             if (i === 0) {
               should.not.exist(res.rows[0].doc._attachments,
                                '(onChange) doc0 contains no attachments');

--- a/tests/integration/test.http.js
+++ b/tests/integration/test.http.js
@@ -170,7 +170,7 @@ describe('test.http.js', function () {
 
   it('5814 Ensure prefix has trailing /', function () {
     var index = testUtils.adapterUrl('http', '').lastIndexOf('/');
-    var prefix = testUtils.adapterUrl('http', '').substr(0, index);
+    var prefix = testUtils.adapterUrl('http', '').substring(0, index);
     var db = new PouchDB('test', {prefix: prefix});
     return db.info().then(function () {
       return db.destroy();

--- a/tests/integration/test.replication_events.js
+++ b/tests/integration/test.replication_events.js
@@ -416,17 +416,17 @@ adapters.forEach(function (adapters) {
       const replication = PouchDB.replicate(dbs.remote, dbs.name, {});
       replication.on('checkpoint', result => checkpointEvents.push(result));
       await replication;
-      String(checkpointEvents[0]['pending_batch']).substr(0, 1).should.equal('1');
-      String(checkpointEvents[1]['pending_batch']).substr(0, 1).should.equal('2');
-      String(checkpointEvents[2]['pending_batch']).substr(0, 1).should.equal('3');
-      String(checkpointEvents[3]['start_next_batch']).substr(0, 1).should.equal('3');
+      String(checkpointEvents[0]['pending_batch']).slice(0, 1).should.equal('1');
+      String(checkpointEvents[1]['pending_batch']).slice(0, 1).should.equal('2');
+      String(checkpointEvents[2]['pending_batch']).slice(0, 1).should.equal('3');
+      String(checkpointEvents[3]['start_next_batch']).slice(0, 1).should.equal('3');
       checkpointEvents[4]['revs_diff'].should.have.property('id');
-      String(checkpointEvents[4]['revs_diff']['seq']).substr(0, 1).should.equal('1');
+      String(checkpointEvents[4]['revs_diff']['seq']).slice(0, 1).should.equal('1');
       checkpointEvents[5]['revs_diff'].should.have.property('changes');
-      String(checkpointEvents[5]['revs_diff']['seq']).substr(0, 1).should.equal('2');
+      String(checkpointEvents[5]['revs_diff']['seq']).slice(0, 1).should.equal('2');
       checkpointEvents[6]['revs_diff'].should.have.property('changes');
-      String(checkpointEvents[6]['revs_diff']['seq']).substr(0, 1).should.equal('3');
-      String(checkpointEvents[7]['checkpoint']).substr(0, 1).should.equal('3');
+      String(checkpointEvents[6]['revs_diff']['seq']).slice(0, 1).should.equal('3');
+      String(checkpointEvents[7]['checkpoint']).slice(0, 1).should.equal('3');
       [
         checkpointEvents[4]['revs_diff']['id'],
         checkpointEvents[5]['revs_diff']['id'],

--- a/tests/mapreduce/test.persisted.js
+++ b/tests/mapreduce/test.persisted.js
@@ -428,7 +428,7 @@ describe('test.persisted.js', function () {
       var docs = Array.apply(null, Array(5)).map(function (_, i) {
         return {
           _id: 'doc_' + i,
-          data: Math.random().toString(36).substr(2)
+          data: Math.random().toString(36).slice(2)
         };
       }).concat({
         _id: '_design/test',

--- a/tests/memleak/test.memleak.js
+++ b/tests/memleak/test.memleak.js
@@ -413,7 +413,7 @@ describe('test.memleak.js -- http adapter', function () {
           pool: false
         }
       };
-      var db_name = host+'/goodluck'+Math.random().toString().substr(4,5);
+      var db_name = host+'/goodluck'+Math.random().toString().slice(4,9);
       var db = new PouchDB(db_name,opts);
       function Finally() { return db.close(); }
       db_name = null;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.