### PR TITLE
BUG: Querying with $gt over a nested field returns the wrong results

### DIFF
--- a/tests/find/test-suite-1/test.ltgt.js
+++ b/tests/find/test-suite-1/test.ltgt.js
@@ -411,6 +411,69 @@ describe('test.ltgt.js', function () {
     });
   });
 
+  it('$gt on nested field', function(){
+    var db = context.db;
+    return db.createIndex({
+      name: 'nestedIndex',
+      ddoc: 'nestedIndex',
+      index: {
+          fields: ['nes.ted']
+      }
+    }).then(function(){
+      return db.put({
+        _id: 'ninetynine',
+        nr: 99,
+        nes: {
+            ted: 99
+        }
+      });
+    }).then(function(){
+      return db.put({
+        _id: 'hundred',
+        nr: 100,
+        nes: {
+            ted: 100
+        }
+      });
+    }).then(function(){
+      return db.put({
+        _id: 'hundredOne',
+        nr: 101,
+        nes: {
+            ted: 101
+        }
+      });
+    }).then(function(){
+      return db.find({
+        selector: {
+            nr: {
+                $gt: 100
+            }
+        },
+        sort: [{ nr: 'asc' }]
+      })
+    }).then(function(topLevelResult) {
+      if(topLevelResult.docs[0].nes.ted !== 101) {
+        throw new Error('querying top level field has the wrong result')
+      }
+    }).then(function(){
+      return db.find({
+        selector: {
+            'nes.ted': {
+                $gt: 100
+            }
+        },
+        sort: [{ 'nes.ted': 'asc' }]
+      })
+    }).then(function(subLevelResult){
+      if(subLevelResult.docs[0].nes.ted !== 101) {
+        console.dir(subLevelResult);
+        throw new Error('querying sub level field has the wrong result')
+      }
+    })
+  });
+
+
   it('bunch of equivalent queries', function () {
     var db = context.db;
 

--- a/tests/find/test-suite-1/test.ltgt.js
+++ b/tests/find/test-suite-1/test.ltgt.js
@@ -420,6 +420,14 @@ describe('test.ltgt.js', function () {
           fields: ['nes.ted']
       }
     }).then(function () {
+      return db.createIndex({
+        name: 'topLevelIndex',
+        ddoc: 'topLevelIndex',
+        index: {
+            fields: ['nr']
+        }
+      });
+    }).then(function () {
       return db.put({
         _id: 'ninetynine',
         nr: 99,

--- a/tests/find/test-suite-1/test.ltgt.js
+++ b/tests/find/test-suite-1/test.ltgt.js
@@ -451,10 +451,10 @@ describe('test.ltgt.js', function () {
             }
         },
         sort: [{ nr: 'asc' }]
-      })
+      });
     }).then(function(topLevelResult) {
       if(topLevelResult.docs[0].nes.ted !== 101) {
-        throw new Error('querying top level field has the wrong result')
+        throw new Error('querying top level field has the wrong result');
       }
     }).then(function(){
       return db.find({
@@ -464,16 +464,14 @@ describe('test.ltgt.js', function () {
             }
         },
         sort: [{ 'nes.ted': 'asc' }]
-      })
+      });
     }).then(function(subLevelResult){
       if(subLevelResult.docs[0].nes.ted !== 101) {
         console.dir(subLevelResult);
-        throw new Error('querying sub level field has the wrong result')
+        throw new Error('querying sub level field has the wrong result');
       }
     })
   });
-
-
   it('bunch of equivalent queries', function () {
     var db = context.db;
 

--- a/tests/find/test-suite-1/test.ltgt.js
+++ b/tests/find/test-suite-1/test.ltgt.js
@@ -475,7 +475,7 @@ describe('test.ltgt.js', function () {
       });
     }).then(function (subLevelResult) {
       if (subLevelResult.docs[0].nes.ted !== 101) {
-        console.dir(subLevelResult);
+        console.log(JSON.stringify(subLevelResult, null, 4));
         throw new Error('querying sub level field has the wrong result');
       }
     });

--- a/tests/find/test-suite-1/test.ltgt.js
+++ b/tests/find/test-suite-1/test.ltgt.js
@@ -411,7 +411,7 @@ describe('test.ltgt.js', function () {
     });
   });
 
-  it('$gt on nested field', function(){
+  it('$gt on nested field', function () {
     var db = context.db;
     return db.createIndex({
       name: 'nestedIndex',
@@ -419,7 +419,7 @@ describe('test.ltgt.js', function () {
       index: {
           fields: ['nes.ted']
       }
-    }).then(function(){
+    }).then(function () {
       return db.put({
         _id: 'ninetynine',
         nr: 99,
@@ -427,7 +427,7 @@ describe('test.ltgt.js', function () {
             ted: 99
         }
       });
-    }).then(function(){
+    }).then(function () {
       return db.put({
         _id: 'hundred',
         nr: 100,
@@ -435,7 +435,7 @@ describe('test.ltgt.js', function () {
             ted: 100
         }
       });
-    }).then(function(){
+    }).then(function () {
       return db.put({
         _id: 'hundredOne',
         nr: 101,
@@ -443,7 +443,7 @@ describe('test.ltgt.js', function () {
             ted: 101
         }
       });
-    }).then(function(){
+    }).then(function () {
       return db.find({
         selector: {
             nr: {
@@ -452,11 +452,11 @@ describe('test.ltgt.js', function () {
         },
         sort: [{ nr: 'asc' }]
       });
-    }).then(function(topLevelResult) {
-      if(topLevelResult.docs[0].nes.ted !== 101) {
+    }).then(function (topLevelResult) {
+      if (topLevelResult.docs[0].nes.ted !== 101) {
         throw new Error('querying top level field has the wrong result');
       }
-    }).then(function(){
+    }).then(function () {
       return db.find({
         selector: {
             'nes.ted': {
@@ -465,12 +465,12 @@ describe('test.ltgt.js', function () {
         },
         sort: [{ 'nes.ted': 'asc' }]
       });
-    }).then(function(subLevelResult){
-      if(subLevelResult.docs[0].nes.ted !== 101) {
+    }).then(function (subLevelResult) {
+      if (subLevelResult.docs[0].nes.ted !== 101) {
         console.dir(subLevelResult);
         throw new Error('querying sub level field has the wrong result');
       }
-    })
+    });
   });
   it('bunch of equivalent queries', function () {
     var db = context.db;


### PR DESCRIPTION
This PR contains a test case to reproduce a bug in the pouch-find plugin.

Using the `$gt` operator over a nested field will return the wrong query results.

```js

await pouch.put({
    _id: 'hundred',
    nr: 100,
    nes: {
        ted: 100
    }
  });

const result = await pouch.find({
        selector: {
            'nes.ted': {
                $gt: 100
            }
        },
        sort: [{ 'nes.ted': 'asc' }]
    });
```

Because we have `$gt` in the query, the document with `nes: {ted: 100}` must not be part of the query result because 100 is not `$gt` 100.
The problem does not appear when querying with `$gt` over a top-level field.