### PR TITLE
Documentation for new features in 7.3

### DIFF
--- a/docs/_includes/api/create_index.html
+++ b/docs/_includes/api/create_index.html
@@ -210,9 +210,62 @@ db.createIndex({
 {% endhighlight %}
 {% include code/end.html %}
 
+If you want to index a subset of the documents in the database, you can use `partial_filter_selector`. This has the same syntax as the selector you'd pass to `find()`, and only documents matching the selector will be included in the index.
+
+{% include code/start.html id="create_idx5" type="callback" %}
+{% highlight js %}
+db.createIndex({
+  index: {
+    fields: ['year', 'title'],
+    partial_filter_selector: {
+      year: { $gt: 2010 }
+    }
+  }
+}, function (err, result) {
+  if (err) { return console.log(err); }
+  // handle result
+});
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="create_idx5" type="async" %}
+{% highlight js %}
+try {
+  var result = db.createIndex({
+    index: {
+      fields: ['year', 'title'],
+      partial_filter_selector: {
+        year: { $gt: 2010 }
+      }
+    }
+  });
+} catch (err) {
+  console.log(err);
+}
+{% endhighlight %}
+{% include code/end.html %}
+
+{% include code/start.html id="create_idx5" type="promise" %}
+{% highlight js %}
+db.createIndex({
+  index: {
+    fields: ['year', 'title'],
+    partial_filter_selector: {
+      year: { $gt: 2010 }
+    }
+  }
+}).then(function (result) {
+  // handle result
+}).catch(function (err) {
+  console.log(err);
+});
+{% endhighlight %}
+{% include code/end.html %}
+
 ### Options
 
 * `fields`: a list of fields to index
 * `name` (optional): name of the index, auto-generated if you don't include it
 * `ddoc` (optional): design document name (i.e. the part after `'_design/'`), auto-generated if you don't include it
 * `type` (optional): only supports `'json'`, which is also the default
+* `partial_filter_selector` (optional): a _selector_ used to filter the set of documents included in the index

--- a/docs/_includes/api/create_index.html
+++ b/docs/_includes/api/create_index.html
@@ -269,3 +269,23 @@ db.createIndex({
 * `ddoc` (optional): design document name (i.e. the part after `'_design/'`), auto-generated if you don't include it
 * `type` (optional): only supports `'json'`, which is also the default
 * `partial_filter_selector` (optional): a _selector_ used to filter the set of documents included in the index
+
+When a PouchDB instance updates an index, it emits `indexing` events that include information about the progress of the index update task.
+
+{% highlight js %}
+var db = new PouchDB('my-docs');
+
+db.on('indexing', function (event) {
+  // called when indexes are updated
+});
+{% endhighlight %}
+
+The `event` object contains the following fields:
+
+* `view`: the name of the view that's being updated
+* `indexed_docs`: the total number of document updates processed during the current run
+
+When an index is updated this event is emitted once at the start of the update, with `indexed_docs` equal to `0`. It will then emit further events as batches of changes are processed, and those events will also include these fields:
+
+* `last_seq`: the `seq` value of the last event from the database change feed that's been processed
+* `results_count`: the number of changes in the most recent batch of changes

--- a/docs/_includes/api/replication.html
+++ b/docs/_includes/api/replication.html
@@ -6,7 +6,7 @@ PouchDB.replicate(source, target, [options])
 
 Replicate data from `source` to `target`.  Both the `source` and `target` can be a PouchDB instance or a string representing a CouchDB database URL or the name of a local PouchDB database. If `options.live` is `true`, then this will track future changes and also replicate them automatically. This method returns an object with the method `cancel()`, which you call if you want to cancel live replication.
 
-Replication is an [event emitter][] like [changes()](#changes) and emits the `'complete'`, `'active'`, `'paused'`, `'change'`, `'denied'` and `'error'` events.
+Replication is an [event emitter][] like [changes()](#changes) and emits the `'complete'`, `'active'`, `'paused'`, `'change'`, `'denied'`, `'error'` and `'checkpoint'` events.
 
 ### Options
 
@@ -75,6 +75,7 @@ The `remoteDB` can either be a string or a `PouchDB` object. If you have a fetch
 * __`active`__ - This event fires when the replication starts actively processing changes; e.g. when it recovers from an error or new changes are available.
 * __`denied`__ (`err`) - This event fires if a document failed to replicate due to validation or authorization errors.
 * __`error`__ (`err`) - This event is fired when the replication is stopped due to an unrecoverable failure. If `retry` is `false`, this will also fire when the user goes offline or another network error occurs (so you can handle retries yourself, if you want).
+* __`checkpoint`__ - This event exposes information about the internal steps of the replication process. It includes one of the fields `pending_batch`, `start_next_batch`, `revs_diff` or `checkpoint`.
 
 #### Single-shot
 


### PR DESCRIPTION
This PR adds documentation for a few items mentioned in our [draft release announcement](https://gist.github.com/AlbaHerrerias/140c3410323e47b9f8616f0786d95462) that didn't seem to be documented already. The features I've documented are:

- The `partial_filter_selector` option to `createIndex()`
- The `indexing` event on `PouchDB` instances
- The `checkpoint` event on the value of `PouchDB.replicate()`