### PR TITLE
Docs: update PouchDB on page

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -226,7 +226,7 @@
     <script type="text/javascript" src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="{{ site.baseurl }}/static/js/code.min.js"></script>
     <script type="text/javascript" src="{{ site.baseurl }}/static/js/stickyfill.min.js"></script>
-    <script type="text/javascript" src="//cdn.jsdelivr.net/pouchdb/latest/pouchdb.min.js"></script>
+    <script type="text/javascript" src="//cdn.jsdelivr.net/npm/pouchdb/dist/pouchdb.min.js"></script>
     <script type="text/javascript">
       var $navSidebarWrapper = $('.nav-sidebar-wrapper');
       if ($navSidebarWrapper.length) {

--- a/docs/manifest.appcache
+++ b/docs/manifest.appcache
@@ -19,7 +19,7 @@ CACHE:
 
 http://code.jquery.com/jquery.min.js
 http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js
-http://cdn.jsdelivr.net/pouchdb/latest/pouchdb.min.js
+http://cdn.jsdelivr.net/npm/pouchdb/dist/pouchdb.min.js
 
 http://fonts.googleapis.com/css?family=Lato:400,700|Open+Sans:400,700
 http://fonts.gstatic.com/s/lato/v11/8qcEw_nrk_5HEcCpYdJu8BTbgVql8nDJpwnrE27mub0.woff2

--- a/docs/serviceWorker.js
+++ b/docs/serviceWorker.js
@@ -36,7 +36,7 @@ var nonCriticalAssets =
     '/static/js/code.min.js',
     'https://code.jquery.com/jquery.min.js',
     'https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js',
-    'https://cdn.jsdelivr.net/pouchdb/latest/pouchdb.min.js',
+    'https://cdn.jsdelivr.net/npm/pouchdb/dist/pouchdb.min.js',
   ]
   .concat(pages)
   .filter(function(file) {


### PR DESCRIPTION
Gratulation to the new release!

I was checking on the Page the PouchDB version, but did see that it is still PouchDB v6.2.0.

After some digging I found [where it was loaded](https://github.com/pouchdb/pouchdb/blob/140896cbdff064b5308cc3d55c481f4034855145/docs/_layouts/default.html#L229). It should be always the latest version, but isn't.
On the [JsDeliver Features Site](https://www.jsdelivr.com/features) the used method isn't listed anymore.
So here is my patch: Switch to the always up to date npm based URL.