### PR TITLE
Es6 refactor

### DIFF
--- a/bin/test-webpack.sh
+++ b/bin/test-webpack.sh
@@ -7,9 +7,7 @@
 #
 
 npm run build
-npm install webpack@1.13.1 # do this on-demand to avoid slow installs
+npm i webpack@5.66.0 -D webpack-cli@4.9.2 # do this on-demand to avoid slow installs
 node bin/update-package-json-for-publish.js
-./node_modules/.bin/webpack \
-  --output-library PouchDB --output-library-target umd \
-  ./packages/node_modules/pouchdb pouchdb-webpack.js
-BUILD_NODE_DONE=1 POUCHDB_SRC='../../pouchdb-webpack.js' npm test
+./node_modules/.bin/webpack
+BUILD_NODE_DONE=0 POUCHDB_SRC='../../pouchdb-webpack.js' npm test

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/createView.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/createView.js
@@ -2,10 +2,10 @@ import { upsert } from 'pouchdb-utils';
 import { stringMd5 } from 'pouchdb-md5';
 import createViewSignature from './createViewSignature';
 
-function createView(sourceDB, viewName, mapFun, reduceFun, temporary, localDocName) {
-  var viewSignature = createViewSignature(mapFun, reduceFun);
+async function createView(sourceDB, viewName, mapFun, reduceFun, temporary, localDocName) {
+  const viewSignature = createViewSignature(mapFun, reduceFun);
 
-  var cachedViews;
+  let cachedViews;
   if (!temporary) {
     // cache this to ensure we don't try to update the same view twice
     cachedViews = sourceDB._cachedViews = sourceDB._cachedViews || {};
@@ -14,20 +14,19 @@ function createView(sourceDB, viewName, mapFun, reduceFun, temporary, localDocNa
     }
   }
 
-  var promiseForView = sourceDB.info().then(function (info) {
-
-    var depDbName = info.db_name + '-mrview-' +
-      (temporary ? 'temp' : stringMd5(viewSignature));
+  const promiseForView = sourceDB.info().then(async function (info) {
+    const depDbName = info.db_name + '-mrview-' +
+    (temporary ? 'temp' : stringMd5(viewSignature));
 
     // save the view name in the source db so it can be cleaned up if necessary
     // (e.g. when the _design doc is deleted, remove all associated view data)
     function diffFunction(doc) {
       doc.views = doc.views || {};
-      var fullViewName = viewName;
+      let fullViewName = viewName;
       if (fullViewName.indexOf('/') === -1) {
         fullViewName = viewName + '/' + viewName;
       }
-      var depDbs = doc.views[fullViewName] = doc.views[fullViewName] || {};
+      const depDbs = doc.views[fullViewName] = doc.views[fullViewName] || {};
       /* istanbul ignore if */
       if (depDbs[depDbName]) {
         return; // no update necessary
@@ -35,34 +34,36 @@ function createView(sourceDB, viewName, mapFun, reduceFun, temporary, localDocNa
       depDbs[depDbName] = true;
       return doc;
     }
-    return upsert(sourceDB, '_local/' + localDocName, diffFunction).then(function () {
-      return sourceDB.registerDependentDatabase(depDbName).then(function (res) {
-        var db = res.db;
-        db.auto_compaction = true;
-        var view = {
-          name: depDbName,
-          db: db,
-          sourceDB: sourceDB,
-          adapter: sourceDB.adapter,
-          mapFun: mapFun,
-          reduceFun: reduceFun
-        };
-        return view.db.get('_local/lastSeq').catch(function (err) {
-          /* istanbul ignore if */
-          if (err.status !== 404) {
-            throw err;
-          }
-        }).then(function (lastSeqDoc) {
-          view.seq = lastSeqDoc ? lastSeqDoc.seq : 0;
-          if (cachedViews) {
-            view.db.once('destroyed', function () {
-              delete cachedViews[viewSignature];
-            });
-          }
-          return view;
-        });
+    await upsert(sourceDB, '_local/' + localDocName, diffFunction);
+    const res = await sourceDB.registerDependentDatabase(depDbName);
+    const db = res.db;
+    db.auto_compaction = true;
+    const view = {
+      name: depDbName,
+      db: db,
+      sourceDB: sourceDB,
+      adapter: sourceDB.adapter,
+      mapFun: mapFun,
+      reduceFun: reduceFun
+    };
+
+    let lastSeqDoc;
+    try {
+      lastSeqDoc = await view.db.get('_local/lastSeq');
+    } catch (err) {
+        /* istanbul ignore if */
+      if (err.status !== 404) {
+        throw err;
+      }
+    }
+
+    view.seq = lastSeqDoc ? lastSeqDoc.seq : 0;
+    if (cachedViews) {
+      view.db.once('destroyed', function () {
+        delete cachedViews[viewSignature];
       });
-    });
+    }
+    return view;
   });
 
   if (cachedViews) {

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -701,16 +701,15 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       return indexableKeysToKeyValues;
     }
 
-    return createTask().then(function () {
-      return processNextBatch();
-    }).then(function () {
-      return queue.finish();
-    }).then(function () {
+    try {
+      await createTask();
+      await processNextBatch();
+      await queue.finish();
       view.seq = currentSeq;
       view.sourceDB.activeTasks.remove(taskId);
-    }).catch(function (err) {
-      view.sourceDB.activeTasks.remove(taskId, err);
-    });
+    } catch (error) {
+      view.sourceDB.activeTasks.remove(taskId, error);      
+    }
   }
 
   function reduceView(view, results, options) {

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -388,7 +388,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
     const indexableKeysToKeyValues = docData[0];
     const changes = docData[1];
 
-    async function getMetaDoc() {
+    function getMetaDoc() {
       if (isGenOne(changes)) {
         // generation 1, so we can safely assume initial state
         // for performance reasons (avoids unnecessary GETs)

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -113,7 +113,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
   }
 
   function sortByKeyThenValue(x, y) {
-    var keyCompare = collate(x.key, y.key);
+    const keyCompare = collate(x.key, y.key);
     return keyCompare !== 0 ? keyCompare : collate(x.value, y.value);
   }
 
@@ -128,21 +128,21 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
   }
 
   function rowToDocId(row) {
-    var val = row.value;
+    const val = row.value;
     // Users can explicitly specify a joined doc _id, or it
     // defaults to the doc _id that emitted the key/value.
-    var docId = (val && typeof val === 'object' && val._id) || row.id;
+    const docId = (val && typeof val === 'object' && val._id) || row.id;
     return docId;
   }
 
   function readAttachmentsAsBlobOrBuffer(res) {
     res.rows.forEach(function (row) {
-      var atts = row.doc && row.doc._attachments;
+      const atts = row.doc && row.doc._attachments;
       if (!atts) {
         return;
       }
       Object.keys(atts).forEach(function (filename) {
-        var att = atts[filename];
+        const att = atts[filename];
         atts[filename].data = b64ToBluffer(att.data, att.content_type);
       });
     });
@@ -159,7 +159,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
 
   function addHttpParam(paramName, opts, params, asJson) {
     // add an http param from opts to params, optionally json-encoded
-    var val = opts[paramName];
+    let val = opts[paramName];
     if (typeof val !== 'undefined') {
       if (asJson) {
         val = encodeURIComponent(JSON.stringify(val));
@@ -170,7 +170,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
 
   function coerceInteger(integerCandidate) {
     if (typeof integerCandidate !== 'undefined') {
-      var asNumber = Number(integerCandidate);
+      const asNumber = Number(integerCandidate);
       // prevents e.g. '1foo' or '1.1' being coerced to 1
       if (!isNaN(asNumber) && asNumber === parseInt(integerCandidate, 10)) {
         return asNumber;
@@ -190,19 +190,17 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
   function checkPositiveInteger(number) {
     if (number) {
       if (typeof number !== 'number') {
-        return  new QueryParseError('Invalid value for integer: "' +
-          number + '"');
+        return  new QueryParseError(`Invalid value for integer: "${number}"`);
       }
       if (number < 0) {
-        return new QueryParseError('Invalid value for positive integer: ' +
-          '"' + number + '"');
+        return new QueryParseError(`Invalid value for positive integer: "${number}"`);
       }
     }
   }
 
   function checkQueryParseError(options, fun) {
-    var startkeyName = options.descending ? 'endkey' : 'startkey';
-    var endkeyName = options.descending ? 'startkey' : 'endkey';
+    const startkeyName = options.descending ? 'endkey' : 'startkey';
+    const endkeyName = options.descending ? 'startkey' : 'endkey';
 
     if (typeof options[startkeyName] !== 'undefined' &&
       typeof options[endkeyName] !== 'undefined' &&
@@ -219,19 +217,19 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       }
     }
     ['group_level', 'limit', 'skip'].forEach(function (optionName) {
-      var error = checkPositiveInteger(options[optionName]);
+      const error = checkPositiveInteger(options[optionName]);
       if (error) {
         throw error;
       }
     });
   }
 
-  function httpQuery(db, fun, opts) {
+  async function httpQuery(db, fun, opts) {
     // List of parameters to add to the PUT request
-    var params = [];
-    var body;
-    var method = 'GET';
-    var ok, status;
+    let params = [];
+    let body;
+    let method = 'GET';
+    let ok;
 
     // If opts.reduce exists and is defined, then add it to the list
     // of parameters.
@@ -262,12 +260,11 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
     // If keys are supplied, issue a POST to circumvent GET query string limits
     // see http://wiki.apache.org/couchdb/HTTP_view_API#Querying_Options
     if (typeof opts.keys !== 'undefined') {
-      var MAX_URL_LENGTH = 2000;
+      const MAX_URL_LENGTH = 2000;
       // according to http://stackoverflow.com/a/417184/680742,
       // the de facto URL length limit is 2000 characters
 
-      var keysAsString =
-        'keys=' + encodeURIComponent(JSON.stringify(opts.keys));
+      const keysAsString = `keys=${encodeURIComponent(JSON.stringify(opts.keys))}`;
       if (keysAsString.length + params.length + 1 <= MAX_URL_LENGTH) {
         // If the keys are short enough, do a GET. we do this to work around
         // Safari not understanding 304s on POSTs (see pouchdb/pouchdb#1239)
@@ -284,28 +281,32 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
 
     // We are referencing a query defined in the design doc
     if (typeof fun === 'string') {
-      var parts = parseViewName(fun);
-      return db.fetch('_design/' + parts[0] + '/_view/' + parts[1] + params, {
+      const parts = parseViewName(fun);
+
+      const response = await db.fetch('_design/' + parts[0] + '/_view/' + parts[1] + params, {
         headers: new Headers({'Content-Type': 'application/json'}),
         method: method,
         body: JSON.stringify(body)
-      }).then(function (response) {
-        ok = response.ok;
-        status = response.status;
-        return response.json();
-      }).then(function (result) {
-        if (!ok) {
-          result.status = status;
-          throw generateErrorFromResponse(result);
+      });
+      ok = response.ok;
+      // status = response.status;
+      const result = await response.json();
+
+      if (!ok) {
+        result.status = response.status;
+        throw generateErrorFromResponse(result);
+      }
+
+      // fail the entire request if the result contains an error
+      result.rows.forEach(function (row) {
+        /* istanbul ignore if */
+        if (row.value && row.value.error && row.value.error === "builtin_reduce_error") {
+          throw new Error(row.reason);
         }
-        // fail the entire request if the result contains an error
-        result.rows.forEach(function (row) {
-          /* istanbul ignore if */
-          if (row.value && row.value.error && row.value.error === "builtin_reduce_error") {
-            throw new Error(row.reason);
-          }
-        });
-        return result;
+      });
+
+      return new Promise(function (resolve) {
+        resolve(result);
       }).then(postprocessAttachments(opts));
     }
 
@@ -319,20 +320,22 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       }
     });
 
-    return db.fetch('_temp_view' + params, {
+    const response = await db.fetch('_temp_view' + params, {
       headers: new Headers({'Content-Type': 'application/json'}),
       method: 'POST',
       body: JSON.stringify(body)
-    }).then(function (response) {
-        ok = response.ok;
-        status = response.status;
-      return response.json();
-    }).then(function (result) {
-      if (!ok) {
-        result.status = status;
-        throw generateErrorFromResponse(result);
-      }
-      return result;
+    });
+
+    ok = response.ok;
+    // status = response.status;
+    const result = await response.json();
+    if (!ok) {
+      result.status = response.status;
+      throw generateErrorFromResponse(result);
+    }
+
+    return new Promise(function (resolve) {
+      resolve(result);
     }).then(postprocessAttachments(opts));
   }
 
@@ -378,14 +381,14 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
   // returns a promise for a list of docs to update, based on the input docId.
   // the order doesn't matter, because post-3.2.0, bulkDocs
   // is an atomic operation in all three adapters.
-  function getDocsToPersist(docId, view, docIdsToChangesAndEmits) {
-    var metaDocId = '_local/doc_' + docId;
-    var defaultMetaDoc = {_id: metaDocId, keys: []};
-    var docData = docIdsToChangesAndEmits.get(docId);
-    var indexableKeysToKeyValues = docData[0];
-    var changes = docData[1];
+  async function getDocsToPersist(docId, view, docIdsToChangesAndEmits) {
+    const metaDocId = '_local/doc_' + docId;
+    const defaultMetaDoc = {_id: metaDocId, keys: []};
+    const docData = docIdsToChangesAndEmits.get(docId);
+    const indexableKeysToKeyValues = docData[0];
+    const changes = docData[1];
 
-    function getMetaDoc() {
+    async function getMetaDoc() {
       if (isGenOne(changes)) {
         // generation 1, so we can safely assume initial state
         // for performance reasons (avoids unnecessary GETs)
@@ -406,12 +409,12 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
     }
 
     function processKeyValueDocs(metaDoc, kvDocsRes) {
-      var kvDocs = [];
-      var oldKeys = new Set();
+      const kvDocs = [];
+      const oldKeys = new Set();
 
-      for (var i = 0, len = kvDocsRes.rows.length; i < len; i++) {
-        var row = kvDocsRes.rows[i];
-        var doc = row.doc;
+      for (let i = 0, len = kvDocsRes.rows.length; i < len; i++) {
+        const row = kvDocsRes.rows[i];
+        const doc = row.doc;
         if (!doc) { // deleted
           continue;
         }
@@ -419,20 +422,20 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
         oldKeys.add(doc._id);
         doc._deleted = !indexableKeysToKeyValues.has(doc._id);
         if (!doc._deleted) {
-          var keyValue = indexableKeysToKeyValues.get(doc._id);
+          const keyValue = indexableKeysToKeyValues.get(doc._id);
           if ('value' in keyValue) {
             doc.value = keyValue.value;
           }
         }
       }
-      var newKeys = mapToKeysArray(indexableKeysToKeyValues);
+      const newKeys = mapToKeysArray(indexableKeysToKeyValues);
       newKeys.forEach(function (key) {
         if (!oldKeys.has(key)) {
           // new doc
-          var kvDoc = {
+          const kvDoc = {
             _id: key
           };
-          var keyValue = indexableKeysToKeyValues.get(key);
+          const keyValue = indexableKeysToKeyValues.get(key);
           if ('value' in keyValue) {
             kvDoc.value = keyValue.value;
           }
@@ -445,11 +448,9 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       return kvDocs;
     }
 
-    return getMetaDoc().then(function (metaDoc) {
-      return getKeyValueDocs(metaDoc).then(function (kvDocsRes) {
-        return processKeyValueDocs(metaDoc, kvDocsRes);
-      });
-    });
+    const metaDoc = await getMetaDoc();
+    const keyValueDocs = await getKeyValueDocs(metaDoc);
+    return processKeyValueDocs(metaDoc, keyValueDocs);
   }
 
   function updatePurgeSeq(view) {
@@ -502,29 +503,28 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
   }
 
   function getQueue(view) {
-    var viewName = typeof view === 'string' ? view : view.name;
-    var queue = persistentQueues[viewName];
+    const viewName = typeof view === 'string' ? view : view.name;
+    let queue = persistentQueues[viewName];
     if (!queue) {
       queue = persistentQueues[viewName] = new TaskQueue();
     }
     return queue;
   }
 
-  function updateView(view, opts) {
+  async function updateView(view, opts) {
     return sequentialize(getQueue(view), function () {
       return updateViewInQueue(view, opts);
     })();
   }
 
-  function updateViewInQueue(view, opts) {
+  async function updateViewInQueue(view, opts) {
     // bind the emit function once
-    var mapResults;
-    var doc;
-    var taskId;
-
+    let mapResults;
+    let doc;
+    let taskId;
 
     function emit(key, value) {
-      var output = {id: doc._id, key: normalizeKey(key)};
+      const output = {id: doc._id, key: normalizeKey(key)};
       // Don't explicitly store the value unless it's defined and non-null.
       // This saves on storage space, because often people don't use it.
       if (typeof value !== 'undefined' && value !== null) {
@@ -533,9 +533,9 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       mapResults.push(output);
     }
 
-    var mapFun = mapper(view.mapFun, emit);
+    const mapFun = mapper(view.mapFun, emit);
 
-    var currentSeq = view.seq || 0;
+    let currentSeq = view.seq || 0;
 
     function createTask() {
       return view.sourceDB.info().then(function (info) {
@@ -553,27 +553,25 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
     }
 
     let indexed_docs = 0;
-    let progress = {
+    const progress = {
       view: view.name,
       indexed_docs: indexed_docs
     };
     view.sourceDB.emit('indexing', progress);
 
-    var queue = new TaskQueue();
+    const queue = new TaskQueue();
 
-    function processNextBatch() {
-      return view.sourceDB.changes({
+    async function processNextBatch() {
+      const response = await view.sourceDB.changes({
         return_docs: true,
         conflicts: true,
         include_docs: true,
         style: 'all_docs',
         since: currentSeq,
         limit: opts.changes_batch_size
-      }).then(function (response) {
-        return getRecentPurges().then(function (purges) {
-          return processBatch(response, purges);
-        });
       });
+      const purges = await getRecentPurges();
+      return processBatch(response, purges);
     }
 
     function getRecentPurges() {
@@ -649,7 +647,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       queue.add(processChange(docIdsToChangesAndEmits, currentSeq));
 
       indexed_docs = indexed_docs + results.length;
-      let progress = {
+      const progress = {
         view: view.name,
         last_seq: response.last_seq,
         results_count: results.length,
@@ -665,9 +663,9 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
     }
 
     function createDocIdsToChangesAndEmits(results) {
-      var docIdsToChangesAndEmits = new Map();
-      for (var i = 0, len = results.length; i < len; i++) {
-        var change = results[i];
+      const docIdsToChangesAndEmits = new Map();
+      for (let i = 0, len = results.length; i < len; i++) {
+        const change = results[i];
         if (change.doc._id[0] !== '_') {
           mapResults = [];
           doc = change.doc;
@@ -677,7 +675,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
           }
           mapResults.sort(sortByKeyThenValue);
 
-          var indexableKeysToKeyValues = createIndexableKeysToKeyValues(mapResults);
+          const indexableKeysToKeyValues = createIndexableKeysToKeyValues(mapResults);
           docIdsToChangesAndEmits.set(change.doc._id, [
             indexableKeysToKeyValues,
             change.changes
@@ -689,11 +687,11 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
     }
 
     function createIndexableKeysToKeyValues(mapResults) {
-      var indexableKeysToKeyValues = new Map();
-      var lastKey;
-      for (var i = 0, len = mapResults.length; i < len; i++) {
-        var emittedKeyValue = mapResults[i];
-        var complexKey = [emittedKeyValue.key, emittedKeyValue.id];
+      const indexableKeysToKeyValues = new Map();
+      let lastKey;
+      for (let i = 0, len = mapResults.length; i < len; i++) {
+        const emittedKeyValue = mapResults[i];
+        const complexKey = [emittedKeyValue.key, emittedKeyValue.id];
         if (i > 0 && collate(emittedKeyValue.key, lastKey) === 0) {
           complexKey.push(i); // dup key+id, so make it unique
         }
@@ -720,16 +718,16 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       delete options.group_level;
     }
 
-    var shouldGroup = options.group || options.group_level;
+    const shouldGroup = options.group || options.group_level;
 
-    var reduceFun = reducer(view.reduceFun);
+    const reduceFun = reducer(view.reduceFun);
 
-    var groups = [];
-    var lvl = isNaN(options.group_level) ? Number.POSITIVE_INFINITY :
+    const groups = [];
+    const lvl = isNaN(options.group_level) ? Number.POSITIVE_INFINITY :
       options.group_level;
     results.forEach(function (e) {
-      var last = groups[groups.length - 1];
-      var groupKey = shouldGroup ? e.key : null;
+      const last = groups[groups.length - 1];
+      let groupKey = shouldGroup ? e.key : null;
 
       // only set group_level for array keys
       if (shouldGroup && Array.isArray(groupKey)) {
@@ -748,9 +746,9 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       });
     });
     results = [];
-    for (var i = 0, len = groups.length; i < len; i++) {
-      var e = groups[i];
-      var reduceTry = tryReduce(view.sourceDB, reduceFun, e.keys, e.values, false);
+    for (let i = 0, len = groups.length; i < len; i++) {
+      const e = groups[i];
+      const reduceTry = tryReduce(view.sourceDB, reduceFun, e.keys, e.values, false);
       if (reduceTry.error && reduceTry.error instanceof BuiltInError) {
         // CouchDB returns an error if a built-in errors out
         throw reduceTry.error;
@@ -771,49 +769,48 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
     })();
   }
 
-  function queryViewInQueue(view, opts) {
-    var totalRows;
-    var shouldReduce = view.reduceFun && opts.reduce !== false;
-    var skip = opts.skip || 0;
+  async function queryViewInQueue(view, opts) {
+    let totalRows;
+    const shouldReduce = view.reduceFun && opts.reduce !== false;
+    const skip = opts.skip || 0;
     if (typeof opts.keys !== 'undefined' && !opts.keys.length) {
       // equivalent query
       opts.limit = 0;
       delete opts.keys;
     }
 
-    function fetchFromView(viewOpts) {
+    async function fetchFromView(viewOpts) {
       viewOpts.include_docs = true;
-      return view.db.allDocs(viewOpts).then(function (res) {
-        totalRows = res.total_rows;
-        return res.rows.map(function (result) {
+      const res = await view.db.allDocs(viewOpts);
+      totalRows = res.total_rows;
 
-          // implicit migration - in older versions of PouchDB,
-          // we explicitly stored the doc as {id: ..., key: ..., value: ...}
-          // this is tested in a migration test
-          /* istanbul ignore next */
-          if ('value' in result.doc && typeof result.doc.value === 'object' &&
-            result.doc.value !== null) {
-            var keys = Object.keys(result.doc.value).sort();
-            // this detection method is not perfect, but it's unlikely the user
-            // emitted a value which was an object with these 3 exact keys
-            var expectedKeys = ['id', 'key', 'value'];
-            if (!(keys < expectedKeys || keys > expectedKeys)) {
-              return result.doc.value;
-            }
+      return res.rows.map(function (result) {
+        // implicit migration - in older versions of PouchDB,
+        // we explicitly stored the doc as {id: ..., key: ..., value: ...}
+        // this is tested in a migration test
+        /* istanbul ignore next */
+        if ('value' in result.doc && typeof result.doc.value === 'object' &&
+          result.doc.value !== null) {
+          const keys = Object.keys(result.doc.value).sort();
+          // this detection method is not perfect, but it's unlikely the user
+          // emitted a value which was an object with these 3 exact keys
+          const expectedKeys = ['id', 'key', 'value'];
+          if (!(keys < expectedKeys || keys > expectedKeys)) {
+            return result.doc.value;
           }
+        }
 
-          var parsedKeyAndDocId = parseIndexableString(result.doc._id);
-          return {
-            key: parsedKeyAndDocId[0],
-            id: parsedKeyAndDocId[1],
-            value: ('value' in result.doc ? result.doc.value : null)
-          };
-        });
+        const parsedKeyAndDocId = parseIndexableString(result.doc._id);
+        return {
+          key: parsedKeyAndDocId[0],
+          id: parsedKeyAndDocId[1],
+          value: ('value' in result.doc ? result.doc.value : null)
+        };
       });
     }
 
-    function onMapResultsReady(rows) {
-      var finalResults;
+    async function onMapResultsReady(rows) {
+      let finalResults;
       if (shouldReduce) {
         finalResults = reduceView(view, rows, opts);
       } else if (typeof opts.keys === 'undefined') {
@@ -835,37 +832,36 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
         finalResults.update_seq = view.seq;
       }
       if (opts.include_docs) {
-        var docIds = uniq(rows.map(rowToDocId));
+        const docIds = uniq(rows.map(rowToDocId));
 
-        return view.sourceDB.allDocs({
+        const allDocsRes = await view.sourceDB.allDocs({
           keys: docIds,
           include_docs: true,
           conflicts: opts.conflicts,
           attachments: opts.attachments,
           binary: opts.binary
-        }).then(function (allDocsRes) {
-          var docIdsToDocs = new Map();
-          allDocsRes.rows.forEach(function (row) {
-            docIdsToDocs.set(row.id, row.doc);
-          });
-          rows.forEach(function (row) {
-            var docId = rowToDocId(row);
-            var doc = docIdsToDocs.get(docId);
-            if (doc) {
-              row.doc = doc;
-            }
-          });
-          return finalResults;
         });
+        var docIdsToDocs = new Map();
+        allDocsRes.rows.forEach(function (row) {
+          docIdsToDocs.set(row.id, row.doc);
+        });
+        rows.forEach(function (row) {
+          var docId = rowToDocId(row);
+          var doc = docIdsToDocs.get(docId);
+          if (doc) {
+            row.doc = doc;
+          }
+        });
+        return finalResults;
       } else {
         return finalResults;
       }
     }
 
     if (typeof opts.keys !== 'undefined') {
-      var keys = opts.keys;
-      var fetchPromises = keys.map(function (key) {
-        var viewOpts = {
+      const keys = opts.keys;
+      const fetchPromises = keys.map(function (key) {
+        const viewOpts = {
           startkey : toIndexableString([key]),
           endkey   : toIndexableString([key, {}])
         };
@@ -875,17 +871,19 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
         }
         return fetchFromView(viewOpts);
       });
-      return Promise.all(fetchPromises).then(flatten).then(onMapResultsReady);
+      const result = await Promise.all(fetchPromises);
+      const flattenedResult = flatten(result);
+      return onMapResultsReady(flattenedResult);
     } else { // normal query, no 'keys'
-      var viewOpts = {
+      const viewOpts = {
         descending : opts.descending
       };
       /* istanbul ignore if */
       if (opts.update_seq) {
         viewOpts.update_seq = true;
       }
-      var startkey;
-      var endkey;
+      let startkey;
+      let endkey;
       if ('start_key' in opts) {
         startkey = opts.start_key;
       }
@@ -904,7 +902,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
           toIndexableString([startkey]);
       }
       if (typeof endkey !== 'undefined') {
-        var inclusiveEnd = opts.inclusive_end !== false;
+        let inclusiveEnd = opts.inclusive_end !== false;
         if (opts.descending) {
           inclusiveEnd = !inclusiveEnd;
         }
@@ -913,8 +911,8 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
           inclusiveEnd ? [endkey, {}] : [endkey]);
       }
       if (typeof opts.key !== 'undefined') {
-        var keyStart = toIndexableString([opts.key]);
-        var keyEnd = toIndexableString([opts.key, {}]);
+        const keyStart = toIndexableString([opts.key]);
+        const keyEnd = toIndexableString([opts.key, {}]);
         if (viewOpts.descending) {
           viewOpts.endkey = keyStart;
           viewOpts.startkey = keyEnd;
@@ -929,74 +927,86 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
         }
         viewOpts.skip = skip;
       }
-      return fetchFromView(viewOpts).then(onMapResultsReady);
+
+      const result = await fetchFromView(viewOpts);
+      return onMapResultsReady(result);
     }
   }
 
-  function httpViewCleanup(db) {
-    return db.fetch('_view_cleanup', {
+  async function httpViewCleanup(db) {
+    const response = await db.fetch('_view_cleanup', {
       headers: new Headers({'Content-Type': 'application/json'}),
       method: 'POST'
-    }).then(function (response) {
-      return response.json();
     });
+    return response.json();
   }
 
-  function localViewCleanup(db) {
-    return db.get('_local/' + localDocName).then(function (metaDoc) {
-      var docsToViews = new Map();
+  async function localViewCleanup(db) {
+    try {
+      const metaDoc = await db.get('_local/' + localDocName);
+      const docsToViews = new Map();
+
       Object.keys(metaDoc.views).forEach(function (fullViewName) {
-        var parts = parseViewName(fullViewName);
-        var designDocName = '_design/' + parts[0];
-        var viewName = parts[1];
-        var views = docsToViews.get(designDocName);
+        const parts = parseViewName(fullViewName);
+        const designDocName = '_design/' + parts[0];
+        const viewName = parts[1];
+        let views = docsToViews.get(designDocName);
         if (!views) {
           views = new Set();
           docsToViews.set(designDocName, views);
         }
         views.add(viewName);
       });
-      var opts = {
+      const opts = {
         keys : mapToKeysArray(docsToViews),
         include_docs : true
       };
-      return db.allDocs(opts).then(function (res) {
-        var viewsToStatus = {};
-        res.rows.forEach(function (row) {
-          var ddocName = row.key.substring(8); // cuts off '_design/'
-          docsToViews.get(row.key).forEach(function (viewName) {
-            var fullViewName = ddocName + '/' + viewName;
-            /* istanbul ignore if */
-            if (!metaDoc.views[fullViewName]) {
-              // new format, without slashes, to support PouchDB 2.2.0
-              // migration test in pouchdb's browser.migration.js verifies this
-              fullViewName = viewName;
-            }
-            var viewDBNames = Object.keys(metaDoc.views[fullViewName]);
-            // design doc deleted, or view function nonexistent
-            var statusIsGood = row.doc && row.doc.views &&
-              row.doc.views[viewName];
-            viewDBNames.forEach(function (viewDBName) {
-              viewsToStatus[viewDBName] =
-                viewsToStatus[viewDBName] || statusIsGood;
-            });
+
+      const res = await db.allDocs(opts);
+      const viewsToStatus = {};
+      res.rows.forEach(function (row) {
+        const ddocName = row.key.substring(8); // cuts off '_design/'
+        docsToViews.get(row.key).forEach(function (viewName) {
+          let fullViewName = ddocName + '/' + viewName;
+          /* istanbul ignore if */
+          if (!metaDoc.views[fullViewName]) {
+            // new format, without slashes, to support PouchDB 2.2.0
+            // migration test in pouchdb's browser.migration.js verifies this
+            fullViewName = viewName;
+          }
+          const viewDBNames = Object.keys(metaDoc.views[fullViewName]);
+          // design doc deleted, or view function nonexistent
+          const statusIsGood = row.doc && row.doc.views &&
+            row.doc.views[viewName];
+          viewDBNames.forEach(function (viewDBName) {
+            viewsToStatus[viewDBName] =
+              viewsToStatus[viewDBName] || statusIsGood;
           });
         });
-        var dbsToDelete = Object.keys(viewsToStatus).filter(
-          function (viewDBName) { return !viewsToStatus[viewDBName]; });
-        var destroyPromises = dbsToDelete.map(function (viewDBName) {
-          return sequentialize(getQueue(viewDBName), function () {
-            return new db.constructor(viewDBName, db.__opts).destroy();
-          })();
-        });
-        return Promise.all(destroyPromises).then(function () {
-          return {ok: true};
-        });
       });
-    }, defaultsTo({ok: true}));
+
+      const dbsToDelete = Object.keys(viewsToStatus)
+        .filter(function (viewDBName) { return !viewsToStatus[viewDBName]; });
+
+      const destroyPromises = dbsToDelete.map(function (viewDBName) {
+        return sequentialize(getQueue(viewDBName), function () {
+          return new db.constructor(viewDBName, db.__opts).destroy();
+        })();
+      });
+
+      return Promise.all(destroyPromises).then(function () {
+        return {ok: true};
+      });
+    } catch (err) {
+      if (err.status === 404) {
+        return {ok: true};
+      } else {
+        throw err;
+      }
+    }
   }
 
-  function queryPromised(db, fun, opts) {
+  async function queryPromised(db, fun, opts) {
     /* istanbul ignore next */
     if (typeof db._query === 'function') {
       return customQuery(db, fun, opts);
@@ -1005,7 +1015,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       return httpQuery(db, fun, opts);
     }
 
-    var updateViewOpts = {
+    const updateViewOpts = {
       changes_batch_size: db.__opts.view_update_changes_batch_size || CHANGES_BATCH_SIZE
     };
 
@@ -1013,68 +1023,63 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       // temp_view
       checkQueryParseError(opts, fun);
 
-      tempViewQueue.add(function () {
-        var createViewPromise = createView(
+      tempViewQueue.add(async function () {
+        const view = await createView(
           /* sourceDB */ db,
           /* viewName */ 'temp_view/temp_view',
           /* mapFun */ fun.map,
           /* reduceFun */ fun.reduce,
           /* temporary */ true,
           /* localDocName */ localDocName);
-        return createViewPromise.then(function (view) {
-          return fin(updateView(view, updateViewOpts).then(function () {
-            return queryView(view, opts);
-          }), function () {
-            return view.db.destroy();
-          });
-        });
+
+        return fin(updateView(view, updateViewOpts).then(
+          function () { return queryView(view, opts); }),
+          function () { return view.db.destroy(); }
+        );
       });
       return tempViewQueue.finish();
     } else {
       // persistent view
-      var fullViewName = fun;
-      var parts = parseViewName(fullViewName);
-      var designDocName = parts[0];
-      var viewName = parts[1];
-      return db.get('_design/' + designDocName).then(function (doc) {
-        var fun = doc.views && doc.views[viewName];
+      const fullViewName = fun;
+      const parts = parseViewName(fullViewName);
+      const designDocName = parts[0];
+      const viewName = parts[1];
 
-        if (!fun) {
-          // basic validator; it's assumed that every subclass would want this
-          throw new NotFoundError('ddoc ' + doc._id + ' has no view named ' +
-            viewName);
+      const doc = await db.get('_design/' + designDocName);
+      fun = doc.views && doc.views[viewName];
+
+      if (!fun) {
+        // basic validator; it's assumed that every subclass would want this
+        throw new NotFoundError(`ddoc ${doc._id} has no view named ${viewName}`);
+      }
+
+      ddocValidator(doc, viewName);
+      checkQueryParseError(opts, fun);
+
+      const view = await createView(
+        /* sourceDB */ db,
+        /* viewName */ fullViewName,
+        /* mapFun */ fun.map,
+        /* reduceFun */ fun.reduce,
+        /* temporary */ false,
+        /* localDocName */ localDocName);
+
+      if (opts.stale === 'ok' || opts.stale === 'update_after') {
+        if (opts.stale === 'update_after') {
+          nextTick(function () {
+            updateView(view, updateViewOpts);
+          });
         }
-
-        ddocValidator(doc, viewName);
-        checkQueryParseError(opts, fun);
-
-        var createViewPromise = createView(
-          /* sourceDB */ db,
-          /* viewName */ fullViewName,
-          /* mapFun */ fun.map,
-          /* reduceFun */ fun.reduce,
-          /* temporary */ false,
-          /* localDocName */ localDocName);
-        return createViewPromise.then(function (view) {
-          if (opts.stale === 'ok' || opts.stale === 'update_after') {
-            if (opts.stale === 'update_after') {
-              nextTick(function () {
-                updateView(view, updateViewOpts);
-              });
-            }
-            return queryView(view, opts);
-          } else { // stale not ok
-            return updateView(view, updateViewOpts).then(function () {
-              return queryView(view, opts);
-            });
-          }
-        });
-      });
+        return queryView(view, opts);
+      } else { // stale not ok
+        await updateView(view, updateViewOpts);
+        return queryView(view, opts);
+      }
     }
   }
 
   function abstractQuery(fun, opts, callback) {
-    var db = this;
+    const db = this;
     if (typeof opts === 'function') {
       callback = opts;
       opts = {};
@@ -1085,15 +1090,15 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       fun = {map : fun};
     }
 
-    var promise = Promise.resolve().then(function () {
+    const promise = Promise.resolve().then(function () {
       return queryPromised(db, fun, opts);
     });
     promisedCallback(promise, callback);
     return promise;
   }
 
-  var abstractViewCleanup = callbackify(function () {
-    var db = this;
+  const abstractViewCleanup = callbackify(function () {
+    const db = this;
     /* istanbul ignore next */
     if (typeof db._viewCleanup === 'function') {
       return customViewCleanup(db);

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -31,21 +31,21 @@ import {
   blobOrBufferToBase64 as blufferToBase64
 } from 'pouchdb-binary-utils';
 
-var CHANGES_BATCH_SIZE = 25;
-var MAX_SIMULTANEOUS_REVS = 50;
-var CHANGES_TIMEOUT_BUFFER = 5000;
-var DEFAULT_HEARTBEAT = 10000;
+const CHANGES_BATCH_SIZE = 25;
+const MAX_SIMULTANEOUS_REVS = 50;
+const CHANGES_TIMEOUT_BUFFER = 5000;
+const DEFAULT_HEARTBEAT = 10000;
 
-var supportsBulkGetMap = {};
+let supportsBulkGetMap = {};
 
 function readAttachmentsAsBlobOrBuffer(row) {
-  var doc = row.doc || row.ok;
-  var atts = doc && doc._attachments;
+  let doc = row.doc || row.ok;
+  let atts = doc && doc._attachments;
   if (!atts) {
     return;
   }
   Object.keys(atts).forEach(function (filename) {
-    var att = atts[filename];
+    let att = atts[filename];
     att.data = b64StringToBluffer(att.data, att.content_type);
   });
 }
@@ -66,7 +66,7 @@ function preprocessAttachments(doc) {
   }
 
   return Promise.all(Object.keys(doc._attachments).map(function (key) {
-    var attachment = doc._attachments[key];
+    let attachment = doc._attachments[key];
     if (attachment.data && typeof attachment.data !== 'string') {
       return new Promise(function (resolve) {
         blufferToBase64(attachment.data, resolve);
@@ -81,7 +81,7 @@ function hasUrlPrefix(opts) {
   if (!opts.prefix) {
     return false;
   }
-  var protocol = parseUri(opts.prefix).protocol;
+  let protocol = parseUri(opts.prefix).protocol;
   return protocol === 'http' || protocol === 'https';
 }
 
@@ -90,20 +90,20 @@ function hasUrlPrefix(opts) {
 function getHost(name, opts) {
   // encode db name if opts.prefix is a url (#5574)
   if (hasUrlPrefix(opts)) {
-    var dbName = opts.name.substr(opts.prefix.length);
+    let dbName = opts.name.substr(opts.prefix.length);
     // Ensure prefix has a trailing slash
-    var prefix = opts.prefix.replace(/\/?$/, '/');
+    let prefix = opts.prefix.replace(/\/?$/, '/');
     name = prefix + encodeURIComponent(dbName);
   }
 
-  var uri = parseUri(name);
+  let uri = parseUri(name);
   if (uri.user || uri.password) {
     uri.auth = {username: uri.user, password: uri.password};
   }
 
   // Split the path part of the URI into parts using '/' as the delimiter
   // after removing any leading '/' and any trailing '/'
-  var parts = uri.path.replace(/(^\/|\/$)/g, '').split('/');
+  let parts = uri.path.replace(/(^\/|\/$)/g, '').split('/');
 
   uri.db = parts.pop();
   // Prevent double encoding of URI component
@@ -125,7 +125,7 @@ function genDBUrl(opts, path) {
 function genUrl(opts, path) {
   // If the host already has a path, then we need to have a path delimiter
   // Otherwise, the path delimiter is the empty string
-  var pathDel = !opts.path ? '' : '/';
+  let pathDel = !opts.path ? '' : '/';
 
   // If the host already has a path, then we need to have a path delimiter
   // Otherwise, the path delimiter is the empty string
@@ -141,12 +141,12 @@ function paramsToStr(params) {
 }
 
 function shouldCacheBust(opts) {
-  var ua = (typeof navigator !== 'undefined' && navigator.userAgent) ?
+  let ua = (typeof navigator !== 'undefined' && navigator.userAgent) ?
       navigator.userAgent.toLowerCase() : '';
-  var isIE = ua.indexOf('msie') !== -1;
-  var isTrident = ua.indexOf('trident') !== -1;
-  var isEdge = ua.indexOf('edge') !== -1;
-  var isGET = !('method' in opts) || opts.method === 'GET';
+  let isIE = ua.indexOf('msie') !== -1;
+  let isTrident = ua.indexOf('trident') !== -1;
+  let isEdge = ua.indexOf('edge') !== -1;
+  let isGET = !('method' in opts) || opts.method === 'GET';
   return (isIE || isTrident || isEdge) && isGET;
 }
 
@@ -154,14 +154,14 @@ function shouldCacheBust(opts) {
 function HttpPouch(opts, callback) {
 
   // The functions that will be publicly available for HttpPouch
-  var api = this;
+  let api = this;
 
-  var host = getHost(opts.name, opts);
-  var dbUrl = genDBUrl(host, '');
+  let host = getHost(opts.name, opts);
+  let dbUrl = genDBUrl(host, '');
 
   opts = clone(opts);
 
-  var ourFetch = function (url, options) {
+  const ourFetch = async function (url, options) {
 
     options = options || {};
     options.headers = options.headers || new Headers();
@@ -169,13 +169,13 @@ function HttpPouch(opts, callback) {
     options.credentials = 'include';
 
     if (opts.auth || host.auth) {
-      var nAuth = opts.auth || host.auth;
-      var str = nAuth.username + ':' + nAuth.password;
-      var token = btoa(unescape(encodeURIComponent(str)));
+      let nAuth = opts.auth || host.auth;
+      let str = nAuth.username + ':' + nAuth.password;
+      let token = btoa(unescape(encodeURIComponent(str)));
       options.headers.set('Authorization', 'Basic ' + token);
     }
 
-    var headers = opts.headers || {};
+    let headers = opts.headers || {};
     Object.keys(headers).forEach(function (key) {
       options.headers.append(key, headers[key]);
     });
@@ -185,8 +185,8 @@ function HttpPouch(opts, callback) {
       url += (url.indexOf('?') === -1 ? '?' : '&') + '_nonce=' + Date.now();
     }
 
-    var fetchFun = opts.fetch || fetch;
-    return fetchFun(url, options);
+    let fetchFun = opts.fetch || fetch;
+    return await fetchFun(url, options);
   };
 
   function adapterFun(name, fun) {
@@ -194,15 +194,15 @@ function HttpPouch(opts, callback) {
       setup().then(function () {
         return fun.apply(this, args);
       }).catch(function (e) {
-        var callback = args.pop();
+        let callback = args.pop();
         callback(e);
       });
     })).bind(api);
   }
 
-  function fetchJSON(url, options, callback) {
+  async function fetchJSON(url, options) {
 
-    var result = {};
+    let result = {};
 
     options = options || {};
     options.headers = options.headers || new Headers();
@@ -214,43 +214,34 @@ function HttpPouch(opts, callback) {
       options.headers.set('Accept', 'application/json');
     }
 
-    return ourFetch(url, options).then(function (response) {
-      result.ok = response.ok;
-      result.status = response.status;
-      return response.json();
-    }).then(function (json) {
-      result.data = json;
-      if (!result.ok) {
-        result.data.status = result.status;
-        var err = generateErrorFromResponse(result.data);
-        if (callback) {
-          return callback(err);
+    const response = await ourFetch(url, options);
+    result.ok = response.ok;
+    result.status = response.status;
+    const json = await response.json();
+
+    result.data = json;
+    if (!result.ok) {
+      result.data.status = result.status;
+      let err = generateErrorFromResponse(result.data);
+      throw err;
+    }
+
+    if (Array.isArray(result.data)) {
+      result.data = result.data.map(function (v) {
+        if (v.error || v.missing) {
+          return generateErrorFromResponse(v);
         } else {
-          throw err;
+          return v;
         }
-      }
+      });
+    }
 
-      if (Array.isArray(result.data)) {
-        result.data = result.data.map(function (v) {
-          if (v.error || v.missing) {
-            return generateErrorFromResponse(v);
-          } else {
-            return v;
-          }
-        });
-      }
-
-      if (callback) {
-        callback(null, result.data);
-      } else {
-        return result;
-      }
-    });
+    return result;
   }
 
-  var setupPromise;
+  let setupPromise;
 
-  function setup() {
+  async function setup() {
     if (opts.skip_setup) {
       return Promise.resolve();
     }
@@ -298,51 +289,52 @@ function HttpPouch(opts, callback) {
     return 'http';
   };
 
-  api.id = adapterFun('id', function (callback) {
-    ourFetch(genUrl(host, '')).then(function (response) {
-      return response.json();
-    }).catch(function () {
-      return {};
-    }).then(function (result) {
-      // Bad response or missing `uuid` should not prevent ID generation.
-      var uuid = (result && result.uuid) ?
-          (result.uuid + host.db) : genDBUrl(host, '');
-      callback(null, uuid);
-    });
+  api.id = adapterFun('id', async function (callback) {
+    let result;
+    try {
+      const response = await ourFetch(genUrl(host, ''));
+      result = await response.json();
+    } catch (err) {
+      result = {};
+    }
+
+    // Bad response or missing `uuid` should not prevent ID generation.
+    let uuid = (result && result.uuid) ? (result.uuid + host.db) : genDBUrl(host, '');
+    callback(null, uuid);
   });
 
   // Sends a POST request to the host calling the couchdb _compact function
   //    version: The version of CouchDB it is running
-  api.compact = adapterFun('compact', function (opts, callback) {
+  api.compact = adapterFun('compact', async function (opts, callback) {
     if (typeof opts === 'function') {
       callback = opts;
       opts = {};
     }
     opts = clone(opts);
 
-    fetchJSON(genDBUrl(host, '_compact'), {method: 'POST'}).then(function () {
-      function ping() {
-        api.info(function (err, res) {
-          // CouchDB may send a "compact_running:true" if it's
-          // already compacting. PouchDB Server doesn't.
-          /* istanbul ignore else */
-          if (res && !res.compact_running) {
-            callback(null, {ok: true});
-          } else {
-            setTimeout(ping, opts.interval || 200);
-          }
-        });
-      }
-      // Ping the http if it's finished compaction
-      ping();
-    });
+    await fetchJSON(genDBUrl(host, '_compact'), {method: 'POST'});
+
+    function ping() {
+      api.info(function (err, res) {
+        // CouchDB may send a "compact_running:true" if it's
+        // already compacting. PouchDB Server doesn't.
+        /* istanbul ignore else */
+        if (res && !res.compact_running) {
+          callback(null, {ok: true});
+        } else {
+          setTimeout(ping, opts.interval || 200);
+        }
+      });
+    }
+    // Ping the http if it's finished compaction
+    ping();
   });
 
   api.bulkGet = coreAdapterFun('bulkGet', function (opts, callback) {
-    var self = this;
+    let self = this;
 
-    function doBulkGet(cb) {
-      var params = {};
+    async function doBulkGet(cb) {
+      let params = {};
       if (opts.revs) {
         params.revs = true;
       }
@@ -353,26 +345,30 @@ function HttpPouch(opts, callback) {
       if (opts.latest) {
         params.latest = true;
       }
-      fetchJSON(genDBUrl(host, '_bulk_get' + paramsToStr(params)), {
-        method: 'POST',
-        body: JSON.stringify({ docs: opts.docs})
-      }).then(function (result) {
+      try {
+        const result = await fetchJSON(genDBUrl(host, '_bulk_get' + paramsToStr(params)), {
+          method: 'POST',
+          body: JSON.stringify({ docs: opts.docs})
+        });
+
         if (opts.attachments && opts.binary) {
           result.data.results.forEach(function (res) {
             res.docs.forEach(readAttachmentsAsBlobOrBuffer);
           });
         }
         cb(null, result.data);
-      }).catch(cb);
+      } catch (error) {
+        cb(error);
+      }
     }
 
     /* istanbul ignore next */
     function doBulkGetShim() {
       // avoid "url too long error" by splitting up into multiple requests
-      var batchSize = MAX_SIMULTANEOUS_REVS;
-      var numBatches = Math.ceil(opts.docs.length / batchSize);
-      var numDone = 0;
-      var results = new Array(numBatches);
+      let batchSize = MAX_SIMULTANEOUS_REVS;
+      let numBatches = Math.ceil(opts.docs.length / batchSize);
+      let numDone = 0;
+      let results = new Array(numBatches);
 
       function onResult(batchNum) {
         return function (err, res) {
@@ -384,8 +380,8 @@ function HttpPouch(opts, callback) {
         };
       }
 
-      for (var i = 0; i < numBatches; i++) {
-        var subOpts = pick(opts, ['revs', 'attachments', 'binary', 'latest']);
+      for (let i = 0; i < numBatches; i++) {
+        let subOpts = pick(opts, ['revs', 'attachments', 'binary', 'latest']);
         subOpts.docs = opts.docs.slice(i * batchSize,
           Math.min(opts.docs.length, (i + 1) * batchSize));
         bulkGetShim(self, subOpts, onResult(i));
@@ -393,8 +389,8 @@ function HttpPouch(opts, callback) {
     }
 
     // mark the whole database as either supporting or not supporting _bulk_get
-    var dbUrl = genUrl(host, '');
-    var supportsBulkGet = supportsBulkGetMap[dbUrl];
+    let dbUrl = genUrl(host, '');
+    let supportsBulkGet = supportsBulkGetMap[dbUrl];
 
     /* istanbul ignore next */
     if (typeof supportsBulkGet !== 'boolean') {
@@ -423,30 +419,30 @@ function HttpPouch(opts, callback) {
   // Calls GET on the host, which gets back a JSON string containing
   //    couchdb: A welcome string
   //    version: The version of CouchDB it is running
-  api._info = function (callback) {
-    setup().then(function () {
-      return ourFetch(genDBUrl(host, ''));
-    }).then(function (response) {
-      return response.json();
-    }).then(function (info) {
+  api._info = async function (callback) {
+    try {
+      await setup();
+      const response = await ourFetch(genDBUrl(host, ''));
+      const info = await response.json();
       info.host = genDBUrl(host, '');
       callback(null, info);
-    }).catch(callback);
+    } catch (err) {
+      callback(err);
+    }
   };
 
-  api.fetch = function (path, options) {
-    return setup().then(function () {
-      var url = path.substring(0, 1) === '/' ?
-        genUrl(host, path.substring(1)) :
-        genDBUrl(host, path);
-      return ourFetch(url, options);
-    });
+  api.fetch = async function (path, options) {
+    await setup();
+    const url = path.substring(0, 1) === '/' ?
+    genUrl(host, path.substring(1)) :
+    genDBUrl(host, path);
+    return ourFetch(url, options);
   };
 
   // Get the document with the given id from the database given by host.
   // The id could be solely the _id in the database, or it may be a
   // _design/ID or _local/ID path
-  api.get = adapterFun('get', function (id, opts, callback) {
+  api.get = adapterFun('get', async function (id, opts, callback) {
     // If no options were given, set the callback to the second parameter
     if (typeof opts === 'function') {
       callback = opts;
@@ -455,7 +451,7 @@ function HttpPouch(opts, callback) {
     opts = clone(opts);
 
     // List of parameters to add to the GET request
-    var params = {};
+    let params = {};
 
     if (opts.revs) {
       params.revs = true;
@@ -492,8 +488,8 @@ function HttpPouch(opts, callback) {
     id = encodeDocId(id);
 
     function fetchAttachments(doc) {
-      var atts = doc._attachments;
-      var filenames = atts && Object.keys(atts);
+      let atts = doc._attachments;
+      let filenames = atts && Object.keys(atts);
       if (!atts || !filenames.length) {
         return;
       }
@@ -501,36 +497,40 @@ function HttpPouch(opts, callback) {
       // Sync Gateway would normally send it back as multipart/mixed,
       // which we cannot parse. Also, this is more efficient than
       // receiving attachments as base64-encoded strings.
-      function fetchData(filename) {
-        var att = atts[filename];
-        var path = encodeDocId(doc._id) + '/' + encodeAttachmentId(filename) +
+      async function fetchData(filename) {
+        const att = atts[filename];
+        const path = encodeDocId(doc._id) + '/' + encodeAttachmentId(filename) +
             '?rev=' + doc._rev;
-        return ourFetch(genDBUrl(host, path)).then(function (response) {
-          if ('buffer' in response) {
-            return response.buffer();
-          } else {
-            /* istanbul ignore next */
-            return response.blob();
+
+        const response = await ourFetch(genDBUrl(host, path));
+
+        let blob;
+        if ('buffer' in response) {
+          blob = await response.buffer();
+        } else {
+          /* istanbul ignore next */
+          blob = await response.blob();
+        }
+
+        let data;
+        if (opts.binary) {
+          let typeFieldDescriptor = Object.getOwnPropertyDescriptor(blob.__proto__, 'type');
+          if (!typeFieldDescriptor || typeFieldDescriptor.set) {
+            blob.type = att.content_type;
           }
-        }).then(function (blob) {
-          if (opts.binary) {
-            var typeFieldDescriptor = Object.getOwnPropertyDescriptor(blob.__proto__, 'type');
-            if (!typeFieldDescriptor || typeFieldDescriptor.set) {
-              blob.type = att.content_type;
-            }
-            return blob;
-          }
-          return new Promise(function (resolve) {
+          data = blob;
+        } else {
+          data = await new Promise(function (resolve) {
             blufferToBase64(blob, resolve);
           });
-        }).then(function (data) {
-          delete att.stub;
-          delete att.length;
-          att.data = data;
-        });
+        }
+
+        delete att.stub;
+        delete att.length;
+        att.data = data;
       }
 
-      var promiseFactories = filenames.map(function (filename) {
+      let promiseFactories = filenames.map(function (filename) {
         return function () {
           return fetchData(filename);
         };
@@ -552,25 +552,23 @@ function HttpPouch(opts, callback) {
       return fetchAttachments(docOrDocs);
     }
 
-    var url = genDBUrl(host, id + paramsToStr(params));
-    fetchJSON(url).then(function (res) {
-      return Promise.resolve().then(function () {
-        if (opts.attachments) {
-          return fetchAllAttachments(res.data);
-        }
-      }).then(function () {
-        callback(null, res.data);
-      });
-    }).catch(function (e) {
-      e.docId = id;
-      callback(e);
-    });
+    const url = genDBUrl(host, id + paramsToStr(params));
+    try {
+      const res = await fetchJSON(url);
+      if (opts.attachments) {
+        await fetchAllAttachments(res.data);
+      }
+      callback(null, res.data);
+    } catch (error) {
+      error.docId = id;
+      callback(error);
+    }
   });
 
 
   // Delete the document given by doc from the database given by host.
-  api.remove = adapterFun('remove', function (docOrId, optsOrRev, opts, cb) {
-    var doc;
+  api.remove = adapterFun('remove', async function (docOrId, optsOrRev, opts, cb) {
+    let doc;
     if (typeof optsOrRev === 'string') {
       // id, rev, opts, callback style
       doc = {
@@ -593,10 +591,15 @@ function HttpPouch(opts, callback) {
       }
     }
 
-    var rev = (doc._rev || opts.rev);
-    var url = genDBUrl(host, encodeDocId(doc._id)) + '?rev=' + rev;
+    const rev = (doc._rev || opts.rev);
+    const url = genDBUrl(host, encodeDocId(doc._id)) + '?rev=' + rev;
 
-    fetchJSON(url, {method: 'DELETE'}, cb).catch(cb);
+    try {
+      const result = await fetchJSON(url, {method: 'DELETE'});
+      cb(null, result.data);
+    } catch (error) {
+      cb(error);
+    }
   });
 
   function encodeAttachmentId(attachmentId) {
@@ -604,29 +607,32 @@ function HttpPouch(opts, callback) {
   }
 
   // Get the attachment
-  api.getAttachment = adapterFun('getAttachment', function (docId, attachmentId,
+  api.getAttachment = adapterFun('getAttachment', async function (docId, attachmentId,
                                                             opts, callback) {
     if (typeof opts === 'function') {
       callback = opts;
       opts = {};
     }
-    var params = opts.rev ? ('?rev=' + opts.rev) : '';
-    var url = genDBUrl(host, encodeDocId(docId)) + '/' +
+    const params = opts.rev ? ('?rev=' + opts.rev) : '';
+    const url = genDBUrl(host, encodeDocId(docId)) + '/' +
         encodeAttachmentId(attachmentId) + params;
-    var contentType;
-    ourFetch(url, {method: 'GET'}).then(function (response) {
-      contentType = response.headers.get('content-type');
+    let contentType;
+    try {
+      const response = await ourFetch(url, {method: 'GET'});
+
       if (!response.ok) {
         throw response;
-      } else {
-        if (typeof process !== 'undefined' && !process.browser && typeof response.buffer === 'function') {
-          return response.buffer();
-        } else {
-          /* istanbul ignore next */
-          return response.blob();
-        }
       }
-    }).then(function (blob) {
+
+      contentType = response.headers.get('content-type');
+      let blob;
+      if (typeof process !== 'undefined' && !process.browser && typeof response.buffer === 'function') {
+        blob = await response.buffer();
+      } else {
+        /* istanbul ignore next */
+        blob = await response.blob();
+      }
+
       // TODO: also remove
       if (typeof process !== 'undefined' && !process.browser) {
         var typeFieldDescriptor = Object.getOwnPropertyDescriptor(blob.__proto__, 'type');
@@ -635,42 +641,54 @@ function HttpPouch(opts, callback) {
         }
       }
       callback(null, blob);
-    }).catch(function (err) {
+    } catch (err) {
       callback(err);
-    });
+    }
   });
 
   // Remove the attachment given by the id and rev
-  api.removeAttachment =  adapterFun('removeAttachment', function (docId,
-                                                                   attachmentId,
-                                                                   rev,
-                                                                   callback) {
-    var url = genDBUrl(host, encodeDocId(docId) + '/' +
-                       encodeAttachmentId(attachmentId)) + '?rev=' + rev;
-    fetchJSON(url, {method: 'DELETE'}, callback).catch(callback);
+  api.removeAttachment =  adapterFun('removeAttachment', async function (
+    docId,
+    attachmentId,
+    rev,
+    callback,
+  ) {
+    const url = genDBUrl(host, encodeDocId(docId) + '/' + encodeAttachmentId(attachmentId)) + '?rev=' + rev;
+
+    try {
+      const result = await fetchJSON(url, {method: 'DELETE'});
+      callback(null, result.data);
+    } catch (error) {
+      callback(error);
+    }
   });
 
   // Add the attachment given by blob and its contentType property
   // to the document with the given id, the revision given by rev, and
   // add it to the database given by host.
-  api.putAttachment = adapterFun('putAttachment', function (docId, attachmentId,
-                                                            rev, blob,
-                                                            type, callback) {
+  api.putAttachment = adapterFun('putAttachment', async function (
+    docId,
+    attachmentId,
+    rev,
+    blob,
+    type,
+    callback,
+  ) {
     if (typeof type === 'function') {
       callback = type;
       type = blob;
       blob = rev;
       rev = null;
     }
-    var id = encodeDocId(docId) + '/' + encodeAttachmentId(attachmentId);
-    var url = genDBUrl(host, id);
+    const id = encodeDocId(docId) + '/' + encodeAttachmentId(attachmentId);
+    let url = genDBUrl(host, id);
     if (rev) {
       url += '?rev=' + rev;
     }
 
     if (typeof blob === 'string') {
       // input is assumed to be a base64 string
-      var binary;
+      let binary;
       try {
         binary = atob(blob);
       } catch (err) {
@@ -680,55 +698,59 @@ function HttpPouch(opts, callback) {
       blob = binary ? binStringToBluffer(binary, type) : '';
     }
 
-    // Add the attachment
-    fetchJSON(url, {
-      headers: new Headers({'Content-Type': type}),
-      method: 'PUT',
-      body: blob
-    }, callback).catch(callback);
+    try {
+      // Add the attachment
+      const result = await fetchJSON(url, {
+        headers: new Headers({'Content-Type': type}),
+        method: 'PUT',
+        body: blob
+      });
+      callback(null, result.data);
+    } catch (error) {
+      callback(error);
+    }
   });
 
   // Update/create multiple documents given by req in the database
   // given by host.
-  api._bulkDocs = function (req, opts, callback) {
+  api._bulkDocs = adapterFun('_bulkDocs', async function (req, opts, callback) {
     // If new_edits=false then it prevents the database from creating
     // new revision numbers for the documents. Instead it just uses
     // the old ones. This is used in database replication.
     req.new_edits = opts.new_edits;
 
-    setup().then(function () {
-      return Promise.all(req.docs.map(preprocessAttachments));
-    }).then(function () {
+    await Promise.all(req.docs.map(preprocessAttachments));
       // Update/create the documents
-      return fetchJSON(genDBUrl(host, '_bulk_docs'), {
-        method: 'POST',
-        body: JSON.stringify(req)
-      }, callback);
-    }).catch(callback);
-  };
+    const result = await fetchJSON(genDBUrl(host, '_bulk_docs'), {
+      method: 'POST',
+      body: JSON.stringify(req)
+    });
+
+    callback(null, result.data);
+  });
 
 
   // Update/create document
-  api._put = function (doc, opts, callback) {
-    setup().then(function () {
-      return preprocessAttachments(doc);
-    }).then(function () {
-      return fetchJSON(genDBUrl(host, encodeDocId(doc._id)), {
+  api._put = async function (doc, opts, callback) {
+    try {
+      await setup();
+      await preprocessAttachments(doc);
+
+      const result = await fetchJSON(genDBUrl(host, encodeDocId(doc._id)), {
         method: 'PUT',
         body: JSON.stringify(doc)
       });
-    }).then(function (result) {
       callback(null, result.data);
-    }).catch(function (err) {
-      err.docId = doc && doc._id;
-      callback(err);
-    });
+    } catch (error) {
+      error.docId = doc && doc._id;
+      callback(error);
+    }
   };
 
 
   // Get a listing of the documents in the database given
   // by host and ordered by increasing id.
-  api.allDocs = adapterFun('allDocs', function (opts, callback) {
+  api.allDocs = adapterFun('allDocs', async function (opts, callback) {
     if (typeof opts === 'function') {
       callback = opts;
       opts = {};
@@ -736,9 +758,9 @@ function HttpPouch(opts, callback) {
     opts = clone(opts);
 
     // List of parameters to add to the GET request
-    var params = {};
-    var body;
-    var method = 'GET';
+    let params = {};
+    let body;
+    let method = 'GET';
 
     if (opts.conflicts) {
       params.conflicts = true;
@@ -794,22 +816,25 @@ function HttpPouch(opts, callback) {
       params.skip = opts.skip;
     }
 
-    var paramStr = paramsToStr(params);
+    let paramStr = paramsToStr(params);
 
     if (typeof opts.keys !== 'undefined') {
       method = 'POST';
       body = {keys: opts.keys};
     }
 
-    fetchJSON(genDBUrl(host, '_all_docs' + paramStr), {
-       method: method,
-      body: JSON.stringify(body)
-    }).then(function (result) {
+    try {
+      const result = await fetchJSON(genDBUrl(host, '_all_docs' + paramStr), {
+        method: method,
+        body: JSON.stringify(body)
+      });
       if (opts.include_docs && opts.attachments && opts.binary) {
         result.data.rows.forEach(readAttachmentsAsBlobOrBuffer);
       }
       callback(null, result.data);
-    }).catch(callback);
+    } catch (error) {
+      callback(error);
+    }
   });
 
   // Get a list of changes made to documents in the database given by host.
@@ -821,7 +846,7 @@ function HttpPouch(opts, callback) {
     // if there is a large set of changes to be returned we can start
     // processing them quicker instead of waiting on the entire
     // set of changes to return and attempting to process them at once
-    var batchSize = 'batch_size' in opts ? opts.batch_size : CHANGES_BATCH_SIZE;
+    let batchSize = 'batch_size' in opts ? opts.batch_size : CHANGES_BATCH_SIZE;
 
     opts = clone(opts);
 
@@ -829,7 +854,7 @@ function HttpPouch(opts, callback) {
       opts.heartbeat = DEFAULT_HEARTBEAT;
     }
 
-    var requestTimeout = ('timeout' in opts) ? opts.timeout : 30 * 1000;
+    let requestTimeout = ('timeout' in opts) ? opts.timeout : 30 * 1000;
 
     // ensure CHANGES_TIMEOUT_BUFFER applies
     if ('timeout' in opts && opts.timeout &&
@@ -843,13 +868,13 @@ function HttpPouch(opts, callback) {
         requestTimeout = opts.heartbeat + CHANGES_TIMEOUT_BUFFER;
     }
 
-    var params = {};
+    let params = {};
     if ('timeout' in opts && opts.timeout) {
       params.timeout = opts.timeout;
     }
 
-    var limit = (typeof opts.limit !== 'undefined') ? opts.limit : false;
-    var leftToFetch = limit;
+    let limit = (typeof opts.limit !== 'undefined') ? opts.limit : false;
+    let leftToFetch = limit;
 
     if (opts.style) {
       params.style = opts.style;
@@ -903,7 +928,7 @@ function HttpPouch(opts, callback) {
     // If opts.query_params exists, pass it through to the changes request.
     // These parameters may be used by the filter on the source database.
     if (opts.query_params && typeof opts.query_params === 'object') {
-      for (var param_name in opts.query_params) {
+      for (let param_name in opts.query_params) {
         /* istanbul ignore else */
         if (Object.prototype.hasOwnProperty.call(opts.query_params, param_name)) {
           params[param_name] = opts.query_params[param_name];
@@ -911,8 +936,8 @@ function HttpPouch(opts, callback) {
       }
     }
 
-    var method = 'GET';
-    var body;
+    let method = 'GET';
+    let body;
 
     if (opts.doc_ids) {
       // set this automagically for the user; it's annoying that couchdb
@@ -929,12 +954,12 @@ function HttpPouch(opts, callback) {
       body = {selector: opts.selector };
     }
 
-    var controller = new AbortController();
-    var lastFetchedSeq;
+    let controller = new AbortController();
+    let lastFetchedSeq;
 
     // Get all the changes starting wtih the one immediately after the
     // sequence number given by since.
-    var fetchData = function (since, callback) {
+    const fetchData = async function (since, callback) {
       if (opts.aborted) {
         return;
       }
@@ -955,8 +980,8 @@ function HttpPouch(opts, callback) {
       }
 
       // Set the options for the ajax call
-      var url = genDBUrl(host, '_changes' + paramsToStr(params));
-      var fetchOpts = {
+      let url = genDBUrl(host, '_changes' + paramsToStr(params));
+      let fetchOpts = {
         signal: controller.signal,
         method: method,
         body: JSON.stringify(body)
@@ -969,27 +994,31 @@ function HttpPouch(opts, callback) {
       }
 
       // Get the changes
-      setup().then(function () {
-        return fetchJSON(url, fetchOpts, callback);
-      }).catch(callback);
+      try {
+        await setup();
+        const result = await fetchJSON(url, fetchOpts);
+        callback(null, result.data);
+      } catch (error) {
+        callback(error);
+      }
     };
 
     // If opts.since exists, get all the changes from the sequence
     // number given by opts.since. Otherwise, get all the changes
     // from the sequence number 0.
-    var results = {results: []};
+    let results = {results: []};
 
-    var fetched = function (err, res) {
+    const fetched = function (err, res) {
       if (opts.aborted) {
         return;
       }
-      var raw_results_length = 0;
+      let raw_results_length = 0;
       // If the result of the ajax call (res) contains changes (res.results)
       if (res && res.results) {
         raw_results_length = res.results.length;
         results.last_seq = res.last_seq;
-        var pending = null;
-        var lastSeq = null;
+        let pending = null;
+        let lastSeq = null;
         // Attach 'pending' property if server supports it (CouchDB 2.0+)
         /* istanbul ignore if */
         if (typeof res.pending === 'number') {
@@ -999,11 +1028,11 @@ function HttpPouch(opts, callback) {
           lastSeq = results.last_seq;
         }
         // For each change
-        var req = {};
+        let req = {};
         req.query = opts.query_params;
         res.results = res.results.filter(function (c) {
           leftToFetch--;
-          var ret = filterChange(opts)(c);
+          let ret = filterChange(opts)(c);
           if (ret) {
             if (opts.include_docs && opts.attachments && opts.binary) {
               readAttachmentsAsBlobOrBuffer(c);
@@ -1029,7 +1058,7 @@ function HttpPouch(opts, callback) {
         lastFetchedSeq = res.last_seq;
       }
 
-      var finished = (limit && leftToFetch <= 0) ||
+      let finished = (limit && leftToFetch <= 0) ||
         (res && raw_results_length < batchSize) ||
         (opts.descending);
 
@@ -1056,35 +1085,40 @@ function HttpPouch(opts, callback) {
   // Given a set of document/revision IDs (given by req), tets the subset of
   // those that do NOT correspond to revisions stored in the database.
   // See http://wiki.apache.org/couchdb/HttpPostRevsDiff
-  api.revsDiff = adapterFun('revsDiff', function (req, opts, callback) {
+  api.revsDiff = adapterFun('revsDiff', async function (req, opts, callback) {
     // If no options were given, set the callback to be the second parameter
     if (typeof opts === 'function') {
       callback = opts;
       opts = {};
     }
 
-    // Get the missing document/revision IDs
-    fetchJSON(genDBUrl(host, '_revs_diff'), {
-      method: 'POST',
-      body: JSON.stringify(req)
-    }, callback).catch(callback);
+    try {
+      // Get the missing document/revision IDs
+      const result = await fetchJSON(genDBUrl(host, '_revs_diff'), {
+        method: 'POST',
+        body: JSON.stringify(req)
+      });
+      callback(null, result.data);
+    } catch (error) {
+      callback(error);
+    }
   });
 
   api._close = function (callback) {
     callback();
   };
 
-  api._destroy = function (options, callback) {
-    fetchJSON(genDBUrl(host, ''), {method: 'DELETE'}).then(function (json) {
+  api._destroy = async function (options, callback) {
+    try {
+      const json = await fetchJSON(genDBUrl(host, ''), {method: 'DELETE'});
       callback(null, json);
-    }).catch(function (err) {
-      /* istanbul ignore if */
-      if (err.status === 404) {
+    } catch (error) {
+      if (error.status === 404) {
         callback(null, {ok: true});
       } else {
-        callback(err);
+        callback(error);
       }
-    });
+    }
   };
 }
 

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -713,22 +713,26 @@ function HttpPouch(opts, callback) {
 
   // Update/create multiple documents given by req in the database
   // given by host.
-  api._bulkDocs = adapterFun('_bulkDocs', async function (req, opts, callback) {
+  api._bulkDocs = async function (req, opts, callback) {
     // If new_edits=false then it prevents the database from creating
     // new revision numbers for the documents. Instead it just uses
     // the old ones. This is used in database replication.
     req.new_edits = opts.new_edits;
 
-    await Promise.all(req.docs.map(preprocessAttachments));
+    try {
+      await setup();
+      await Promise.all(req.docs.map(preprocessAttachments));
+
       // Update/create the documents
-    const result = await fetchJSON(genDBUrl(host, '_bulk_docs'), {
-      method: 'POST',
-      body: JSON.stringify(req)
-    });
-
-    callback(null, result.data);
-  });
-
+      const result = await fetchJSON(genDBUrl(host, '_bulk_docs'), {
+        method: 'POST',
+        body: JSON.stringify(req)
+      });
+      callback(null, result.data);
+    } catch (error) {
+      callback(error);
+    }
+  };
 
   // Update/create document
   api._put = async function (doc, opts, callback) {

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -830,7 +830,7 @@ class AbstractPouchDB extends EventEmitter {
         return doc._id;
       });
 
-      return this._bulkDocs(req, opts, function (err, res) {
+      this._bulkDocs(req, opts, function (err, res) {
         if (err) {
           return callback(err);
         }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+module.exports = {
+  entry: './packages/node_modules/pouchdb',
+  mode: 'production',
+  resolve: {
+    fallback: {
+      "stream-browserify": false,
+      "crypto": false,
+      "path": false ,
+      "vm": false,
+      "stream": false,
+      "os": false,
+      "fs": false,
+    },
+  },
+  output: {
+    library: {
+      name: 'PouchDB',
+      export: 'default',
+      type: 'umd',
+    },
+    globalObject: 'this',
+    path: path.resolve(__dirname, '.'),
+    filename: 'pouchdb-webpack.js',
+  },
+};


### PR DESCRIPTION
In an effort to modernize the codebase we started doing some refactors in the `http-adapter` and `abstract-mapreduce`. We also needed to modify the webpack testing to be able to use `async/await` in the codebase.

More context in https://github.com/pouchdb/pouchdb/issues/8451