### PR TITLE
chore: remove obsolete replication revision-one optimization

### DIFF
--- a/packages/node_modules/pouchdb-replication/src/getDocs.js
+++ b/packages/node_modules/pouchdb-replication/src/getDocs.js
@@ -1,9 +1,5 @@
 import { clone, flatten, isRemote } from 'pouchdb-utils';
 
-function isGenOne(rev) {
-  return /^1-/.test(rev);
-}
-
 function fileHasChanged(localDoc, remoteDoc, filename) {
   return !localDoc._attachments ||
          !localDoc._attachments[filename] ||
@@ -123,63 +119,11 @@ function getDocs(src, target, diffs, state) {
     });
   }
 
-  function hasAttachments(doc) {
-    return doc._attachments && Object.keys(doc._attachments).length > 0;
-  }
-
-  function hasConflicts(doc) {
-    return doc._conflicts && doc._conflicts.length > 0;
-  }
-
-  function fetchRevisionOneDocs(ids) {
-    // Optimization: fetch gen-1 docs and attachments in
-    // a single request using _all_docs
-    return src.allDocs({
-      keys: ids,
-      include_docs: true,
-      conflicts: true
-    }).then(function (res) {
-      if (state.cancelled) {
-        throw new Error('cancelled');
-      }
-      res.rows.forEach(function (row) {
-        if (row.deleted || !row.doc || !isGenOne(row.value.rev) ||
-            hasAttachments(row.doc) || hasConflicts(row.doc)) {
-          // if any of these conditions apply, we need to fetch using get()
-          return;
-        }
-
-        // strip _conflicts array to appease CSG (#5793)
-        /* istanbul ignore if */
-        if (row.doc._conflicts) {
-          delete row.doc._conflicts;
-        }
-
-        // the doc we got back from allDocs() is sufficient
-        resultDocs.push(row.doc);
-        delete diffs[row.id];
-      });
-    });
-  }
-
-  function getRevisionOneDocs() {
-    // filter out the generation 1 docs and get them
-    // leaving the non-generation one docs to be got otherwise
-    var ids = Object.keys(diffs).filter(function (id) {
-      var missing = diffs[id].missing;
-      return missing.length === 1 && isGenOne(missing[0]);
-    });
-    if (ids.length > 0) {
-      return fetchRevisionOneDocs(ids);
-    }
-  }
-
   function returnResult() {
     return { ok:ok, docs:resultDocs };
   }
 
   return Promise.resolve()
-    .then(getRevisionOneDocs)
     .then(getAllDocs)
     .then(returnResult);
 }

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -378,7 +378,12 @@ function replicate(src, target, opts, returnValue, result) {
             session).then(function () {
           writingCheckpoint = false;
           result.last_seq = last_seq = changes.last_seq;
-          complete();
+          if (returnValue.cancelled) {
+            completeReplication();
+            throw new Error('cancelled');
+          } else {
+            complete();
+          }
         })
         .catch(onCheckpointError);
       } else {

--- a/tests/integration/test.retry.js
+++ b/tests/integration/test.retry.js
@@ -29,17 +29,17 @@ adapters.forEach(function (adapters) {
     it('retry stuff', function (done) {
       var remote = new PouchDB(dbs.remote);
       var Promise = testUtils.Promise;
-      var allDocs = remote.allDocs;
+      var bulkGet = remote.bulkGet;
 
       // Reject attempting to write 'foo' 3 times, then let it succeed
       var i = 0;
-      remote.allDocs = function (opts) {
-        if (opts.keys[0] === 'foo') {
+      remote.bulkGet = function (opts) {
+        if (opts.docs[0].id === 'foo') {
           if (++i !== 3) {
             return Promise.reject(new Error('flunking you'));
           }
         }
-        return allDocs.apply(remote, arguments);
+        return bulkGet.apply(remote, arguments);
       };
 
       var db = new PouchDB(dbs.name);
@@ -152,14 +152,14 @@ adapters.forEach(function (adapters) {
       var remote = new PouchDB(dbs.remote);
       var Promise = testUtils.Promise;
 
-      var origGet = remote.get;
+      var bulkGet = remote.bulkGet;
       var i = 0;
-      remote.get = function () {
+      remote.bulkGet = function () {
         // Reject three times, every 5th time
         if ((++i % 5 === 0) && i <= 15) {
           return Promise.reject(new Error('flunking you'));
         }
-        return origGet.apply(remote, arguments);
+        return bulkGet.apply(remote, arguments);
       };
 
       var rep = db.replicate.from(remote, {
@@ -224,14 +224,14 @@ adapters.forEach(function (adapters) {
       var remote = new PouchDB(dbs.remote);
       var Promise = testUtils.Promise;
 
-      var origGet = remote.get;
+      var remoteBulkGet = remote.bulkGet;
       var i = 0;
-      remote.get = function () {
+      remote.bulkGet = function () {
         // Reject three times, every 5th time
         if ((++i % 5 === 0) && i <= 15) {
           return Promise.reject(new Error('flunking you'));
         }
-        return origGet.apply(remote, arguments);
+        return remoteBulkGet.apply(remote, arguments);
       };
 
       var rep = db.replicate.from(remote, {
@@ -307,14 +307,14 @@ adapters.forEach(function (adapters) {
         var remote = new PouchDB(dbs.remote);
         var Promise = testUtils.Promise;
 
-        var origGet = remote.get;
+        var remoteBulkGet = remote.bulkGet;
         var i = 0;
-        remote.get = function () {
+        remote.bulkGet = function () {
           // Reject three times, every 5th time
           if ((++i % 5 === 0) && i <= 15) {
             return Promise.reject(new Error('flunking you'));
           }
-          return origGet.apply(remote, arguments);
+          return remoteBulkGet.apply(remote, arguments);
         };
 
         var rep = db.replicate.from(remote, {
@@ -383,14 +383,14 @@ adapters.forEach(function (adapters) {
       var remote = new PouchDB(dbs.remote);
       var Promise = testUtils.Promise;
 
-      var origGet = remote.get;
+      var remoteBulkGet = remote.bulkGet;
       var i = 0;
-      remote.get = function () {
+      remote.bulkGet = function () {
         // Reject three times, every 5th time
         if ((++i % 5 === 0) && i <= 15) {
           return Promise.reject(new Error('flunking you'));
         }
-        return origGet.apply(remote, arguments);
+        return remoteBulkGet.apply(remote, arguments);
       };
 
       var rep = db.replicate.from(remote, {
@@ -456,15 +456,15 @@ adapters.forEach(function (adapters) {
       var Promise = testUtils.Promise;
 
       var flunked = 0;
-      var origGet = remote.get;
+      var remoteBulkGet = remote.bulkGet;
       var i = 0;
-      remote.get = function () {
+      remote.bulkGet = function () {
         // Reject five times, every 5th time
         if ((++i % 5 === 0) && i <= 25) {
           flunked++;
           return Promise.reject(new Error('flunking you'));
         }
-        return origGet.apply(remote, arguments);
+        return remoteBulkGet.apply(remote, arguments);
       };
 
       var rep = db.replicate.from(remote, {

--- a/tests/integration/test.sync.js
+++ b/tests/integration/test.sync.js
@@ -848,7 +848,6 @@ adapters.forEach(function (adapters) {
         }
         var cancelling = toCancel.shift();
         cancelling.on('complete', complete);
-        console.log(11, '> 5997 sync 2 databases, cancel');
         cancelling.cancel();
       }
     });

--- a/tests/integration/test.sync.js
+++ b/tests/integration/test.sync.js
@@ -62,7 +62,7 @@ adapters.forEach(function (adapters) {
       var remote = new PouchDB(dbs.remote);
 
       // intentionally throw an error during replication
-      remote.allDocs = function () {
+      remote.bulkGet = function () {
         return testUtils.Promise.reject(new Error('flunking you'));
       };
 
@@ -91,7 +91,7 @@ adapters.forEach(function (adapters) {
       var remote = new PouchDB(dbs.remote);
 
       // intentionally throw an error during replication
-      remote.allDocs = function () {
+      remote.bulkGet = function () {
         return testUtils.Promise.reject(new Error('flunking you'));
       };
 
@@ -124,7 +124,7 @@ adapters.forEach(function (adapters) {
       var remote = new PouchDB(dbs.remote);
 
       // intentionally throw an error during replication
-      remote.allDocs = function () {
+      remote.bulkGet = function () {
         return testUtils.Promise.reject(new Error('flunking you'));
       };
 
@@ -153,7 +153,7 @@ adapters.forEach(function (adapters) {
       var remote = new PouchDB(dbs.remote);
 
       // intentionally throw an error during replication
-      remote.allDocs = function () {
+      remote.bulkGet = function () {
         return testUtils.Promise.reject(new Error('flunking you'));
       };
 


### PR DESCRIPTION
With #993, we introduced an optimization to retrieve documents via `_all_docs` if they had a revision of 1, since there was no `_bulk_get` API at that time. This optimization allowed us to retrieve many revision-one documents with a single request, instead of requesting each document individually. Documents with higher revisions still had to be fetched one by one.

Since then, `_bulk_get` has been implemented in CouchDB and is used by PouchDB's replicator, so this optimization is no longer necessary. On the contrary, it now leads to additional requests that slow down replication, although not that much.

This PR removes this optimization. The tests have also been adjusted.