### PR TITLE
Align active-tasks entries with CouchDB's endpoint response.

### DIFF
--- a/bin/test-webpack.sh
+++ b/bin/test-webpack.sh
@@ -7,9 +7,7 @@
 #
 
 npm run build
-npm install webpack@1.13.1 # do this on-demand to avoid slow installs
+npm i webpack@5.72.1 -D webpack-cli@4.9.2 # do this on-demand to avoid slow installs
 node bin/update-package-json-for-publish.js
-./node_modules/.bin/webpack \
-  --output-library PouchDB --output-library-target umd \
-  ./packages/node_modules/pouchdb pouchdb-webpack.js
-BUILD_NODE_DONE=1 POUCHDB_SRC='../../pouchdb-webpack.js' npm test
+./node_modules/.bin/webpack
+BUILD_NODE_DONE=0 POUCHDB_SRC='../../pouchdb-webpack.js' npm test

--- a/docs/_includes/api/active_tasks.html
+++ b/docs/_includes/api/active_tasks.html
@@ -16,12 +16,13 @@ var tasks = PouchDB.activeTasks.list()
 
 {% highlight js %}
 [{
-  "id": "d81fea92-8ce4-42df-bb2b-89a4e67536c3",
-  "name": "database_compaction",
-  "created_at": "2022-02-08T15:38:45.318Z",
-  "total_items": 12,
-  "completed_items": 1,
-  "updated_at": "2022-02-08T15:38:45.821Z"
+  "pid": Symbol("database_compaction"),
+  "type": "database_compaction",
+  "started_on": 1644334725318,
+  "total_changes": 12,
+  "changes_done": 3,
+  "updated_on": 1644334725821,
+  "progress": 25
 }]
 {% endhighlight %}
 
@@ -33,13 +34,13 @@ You can use [JavaScript Proxies](https://developer.mozilla.org/en-US/docs/Web/Ja
 PouchDB.activeTasks.add = new Proxy(PouchDB.activeTasks.add, {
   apply: (target, thisArg, argumentsList) => {
     const task = argumentsList[0];
-    const id = Reflect.apply(
+    const pid = Reflect.apply(
       target,
       PouchDB.activeTasks,
       [task]
     );
-    console.log('Added task', id, task.name);
-    return id;
+    console.log('Added task', pid, task.type);
+    return pid;
   },
 });
 {% endhighlight %}

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -487,7 +487,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
     })();
   }
 
-  async function updateViewInQueue(view, opts) {
+  function updateViewInQueue(view, opts) {
     // bind the emit function once
     var mapResults;
     var doc;
@@ -610,15 +610,16 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       return indexableKeysToKeyValues;
     }
 
-    await createTask();
-    await processNextBatch();
-    try {
-      await queue.finish();
+    return createTask().then(function () {
+      return processNextBatch();
+    }).then(function () {
+      return queue.finish();
+    }).then(function () {
       view.seq = currentSeq;
-      activeTasks.remove(taskId);
-    } catch (err) {
-      activeTasks.remove(taskId, err);
-    }
+      view.sourceDB.activeTasks.remove(taskId);
+    }).catch(function (err) {
+      view.sourceDB.activeTasks.remove(taskId, err);
+    });
   }
 
   function reduceView(view, results, options) {

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -616,7 +616,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       await queue.finish();
       view.seq = currentSeq;
       activeTasks.remove(taskId);
-    } catch(err) {
+    } catch (err) {
       activeTasks.remove(taskId, err);
     }
   }

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -487,12 +487,14 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
     })();
   }
 
-  function updateViewInQueue(view, opts) {
+  async function updateViewInQueue(view, opts) {
     // bind the emit function once
     var mapResults;
     var doc;
-    var taskId;
-
+    /** @type {import("pouchdb-core/src/active-tasks").default} */
+    const activeTasks = view.sourceDB.activeTasks;
+    /** @type { symbol } */
+    let taskId;
 
     function emit(key, value) {
       var output = {id: doc._id, key: normalizeKey(key)};
@@ -508,12 +510,14 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
 
     var currentSeq = view.seq || 0;
 
-    function createTask() {
-      return view.sourceDB.info().then(function (info) {
-        taskId = view.sourceDB.activeTasks.add({
-          name: 'view_indexing',
-          total_items: info.update_seq - currentSeq,
-        });
+    async function createTask() {
+      const info = await view.sourceDB.info();
+      taskId = activeTasks.add({
+        type: 'indexer',
+        database: info.db_name,
+        total_changes: info.update_seq,
+        changes_done: currentSeq,
+        design_document: view.name
       });
     }
 
@@ -559,7 +563,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
         indexed_docs: indexed_docs
       };
       view.sourceDB.emit('indexing', progress);
-      view.sourceDB.activeTasks.update(taskId, {completed_items: indexed_docs});
+      activeTasks.update(taskId, { changes_done: indexed_docs });
 
       if (results.length < opts.changes_batch_size) {
         return;
@@ -606,16 +610,15 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       return indexableKeysToKeyValues;
     }
 
-    return createTask().then(function () {
-      return processNextBatch();
-    }).then(function () {
-      return queue.finish();
-    }).then(function () {
+    await createTask();
+    await processNextBatch();
+    try {
+      await queue.finish();
       view.seq = currentSeq;
-      view.sourceDB.activeTasks.remove(taskId);
-    }).catch(function (err) {
-      view.sourceDB.activeTasks.remove(taskId, err);
-    });
+      activeTasks.remove(taskId);
+    } catch(err) {
+      activeTasks.remove(taskId, err);
+    }
   }
 
   function reduceView(view, results, options) {

--- a/packages/node_modules/pouchdb-core/src/active-tasks.js
+++ b/packages/node_modules/pouchdb-core/src/active-tasks.js
@@ -267,14 +267,14 @@ function createViewCompactionTask(task) {
  * @returns { ActiveTask & ReplicationTask }
  */
 function createReplicationTask(task) {
-  const baseTask = Object.assign({
+  const baseTask = createBaseTask(Object.assign({
     doc_id: null,
     doc_write_failures: 0,
     docs_read: 0,
     docs_written: 0,
     missing_revisions_found: 0,
     revisions_checked: 0
-  }, createBaseTask(task));
+  }, task));
 
   const activeTask = Object.defineProperties( baseTask, {
     type: {

--- a/packages/node_modules/pouchdb-core/src/active-tasks.js
+++ b/packages/node_modules/pouchdb-core/src/active-tasks.js
@@ -86,30 +86,30 @@ export default class ActiveTasks {
    * @throws { Error } if type is unknown
    */
   add(task) {
-    if(typeof task.type !== "string") {
+    if (typeof task.type !== "string") {
       throw new Error("type of Task.type must be string");
     }
 
-    if(typeof task.database !== "string") {
+    if (typeof task.database !== "string") {
       throw new Error("database is not a string");
     }
 
-    if(typeof task.total_changes !== "number") {
+    if (typeof task.total_changes !== "number") {
       throw new Error("total_changes is not a number");
     }
 
     /** @type { ActiveTask } */
     let entry;
-    if(task.type === "database_compaction") {
+    if (task.type === "database_compaction") {
       entry = createDatabaseCompactionTask(task);
     }
-    else if(task.type === "indexer") {
+    else if (task.type === "indexer") {
       entry = createIndexerTask(task);
     }
-    else if(task.type === "replication") {
+    else if (task.type === "replication") {
       entry = createReplicationTask(task);
     }
-    else if(task.type === "view_compaction") {
+    else if (task.type === "view_compaction") {
       entry = createViewCompactionTask(task);
     }
     else {
@@ -172,18 +172,27 @@ function createBaseTask(task) {
   const pid = Symbol(type);
   const updated_on = Date.now();
 
-  const activeTask = {
-    changes_done: 0,
-    started_on: updated_on,
-    ...task,
-    pid,
-    database,
-    total_changes,
-    updated_on,
-    get progress() {
+  const activeTask = Object.assign(
+    {
+      changes_done: 0,
+      started_on: updated_on,
+      progress: 0,
+    },
+    task,
+    {
+      pid,
+      database,
+      total_changes,
+      updated_on
+    }
+  );
+
+  Object.defineProperty(activeTask, "progress", {
+    enumerable: true,
+    get() {
       return this.changes_done / this.total_changes * 100;
     }
-  };
+  });
 
   return activeTask;
 }
@@ -256,15 +265,14 @@ function createViewCompactionTask(task) {
  * @returns { ActiveTask & ReplicationTask }
  */
 function createReplicationTask(task) {
-  const baseTask = {
+  const baseTask = Object.assign({
     doc_id: null,
     doc_write_failures: 0,
     docs_read: 0,
     docs_written: 0,
     missing_revisions_found: 0,
-    revisions_checked: 0,
-    ...createBaseTask(task)
-  };
+    revisions_checked: 0
+  }, createBaseTask(task));
 
   const activeTask = Object.defineProperties( baseTask, {
     type: {

--- a/packages/node_modules/pouchdb-core/src/active-tasks.js
+++ b/packages/node_modules/pouchdb-core/src/active-tasks.js
@@ -1,48 +1,331 @@
-import {v4 as uuidv4} from "uuid";
+// #region Type definitions
 
+/**
+ * @typedef { ActiveTaskProperties & Required<Task> } ActiveTask
+ * 
+ * @typedef ActiveTaskProperties
+ * @property { symbol } pid Unique Process identifier
+ * @property { number } updated_on Unix timestamp of last operation update
+ * @property { number } progress Current percentage progress
+ */
+
+/**
+ * @typedef { TaskProperties & (DatabaseCompactionTask | IndexerTask | ReplicationTask | ViewCompactionTask) } Task
+ * 
+ * @typedef TaskProperties
+ * @property { "database_compaction" | "indexer" | "replication" | "view_compaction" } type Task type identifier
+ * @property { string } database Database name
+ * @property { number } total_changes Total changes to process
+ * @property { number } [started_on] Task start time as unix timestamp
+ * @property { number } [changes_done] Processed changes
+ */
+
+/**
+ * @typedef DatabaseCompactionTask
+ * @property { "database_compaction" } type Task type identifier "database_compaction"
+ */
+
+/**
+ * @typedef IndexerTask
+ * @property { "indexer" } type Task type identifier "indexer"
+ * @property { string } design_document Design document's _id
+ */
+
+/**
+ * !Note: For convenience "changes_done" and "total_changes" are also set by baseTask.
+ * 
+ * @typedef ReplicationTask
+ * @property { "replication" } type Task type identifier "replication"
+ * @property { boolean } continuous Replication runs continuously
+ * @property { number } checkpointed_source_seq Sequence number of source checkpoint
+ * @property { string|null } [doc_id] 
+ * @property { number } [doc_write_failures] Count of failed document writes
+ * @property { number } [docs_read] Count of documents
+ * @property { number } [docs_written] Count of documents
+ * @property { number } [missing_revisions_found]
+ * @property { string } replication_id Replication id
+ * @property { number } [revisions_checked] Revisions count
+ * @property { string } source Replication source database name
+ * @property { number } source_seq Replication sequence number on source
+ * @property { string } target Replication target
+ */
+
+/**
+ * @typedef ViewCompactionTask
+ * @property { "view_compaction" } type Task type identifier "view_compaction"
+ * @property { string } design_document Design document's _id
+ */
+// #endregion
+
+/**
+ * Implementation of CouchDB's _active_tasks.
+ * 
+ * Tasks properties are aligned with CouchDB's
+ * {@link https://docs.couchdb.org/en/latest/api/server/common.html#active-tasks /_active_tasks} response reference.
+ */
 export default class ActiveTasks {
   constructor() {
-    this.tasks = {};
+    /** @type { Map<symbol, ActiveTask> } */
+    this.tasks = new Map();
   }
 
+  /**
+   * Get a list of active tasks.
+   * 
+   * @returns { ActiveTask[] } array of active tasks
+   */
   list() {
-    return Object.values(this.tasks);
+    return Array.from(this.tasks.values());
   }
 
+  /**
+   * Register a task.
+   * 
+   * @param { Task } task 
+   * @returns { symbol } Process reference symbol
+   * @throws { Error } if type is unknown
+   */
   add(task) {
-    const id = uuidv4();
-    this.tasks[id] = {
-      id,
-      name: task.name,
-      total_items: task.total_items,
-      created_at: new Date().toJSON()
-    };
-    return id;
-  }
-
-  get(id) {
-    return this.tasks[id];
-  }
-
-  /* eslint-disable no-unused-vars */
-  remove(id, reason) {
-    delete this.tasks[id];
-    return this.tasks;
-  }
-
-  update(id, updatedTask) {
-    const task = this.tasks[id];
-    if (typeof task !== 'undefined') {
-      const mergedTask = {
-        id: task.id,
-        name: task.name,
-        created_at: task.created_at,
-        total_items: updatedTask.total_items || task.total_items,
-        completed_items: updatedTask.completed_items || task.completed_items,
-        updated_at: new Date().toJSON()
-      };
-      this.tasks[id] = mergedTask;
+    if(typeof task.type !== "string") {
+      throw new Error("type of Task.type must be string");
     }
-    return this.tasks;
+
+    if(typeof task.database !== "string") {
+      throw new Error("database is not a string");
+    }
+
+    if(typeof task.total_changes !== "number") {
+      throw new Error("total_changes is not a number");
+    }
+
+    /** @type { ActiveTask } */
+    let entry;
+    if(task.type === "database_compaction") {
+      entry = createDatabaseCompactionTask(task);
+    }
+    else if(task.type === "indexer") {
+      entry = createIndexerTask(task);
+    }
+    else if(task.type === "replication") {
+      entry = createReplicationTask(task);
+    }
+    else if(task.type === "view_compaction") {
+      entry = createViewCompactionTask(task);
+    }
+    else {
+      throw new Error("Task type is not supported");
+    }
+
+    const activeTask = Object.seal(entry);
+    this.tasks.set(activeTask.pid, entry);
+    return activeTask.pid;
   }
+
+  /**
+   * Get an active task.
+   * 
+   * @param { symbol } pid Process reference
+   * @returns { ActiveTask | undefined } or undefined if the task is removed
+   */
+  get(pid) {
+    return this.tasks.get(pid);
+  }
+
+  /**
+   * Remove a task from active tasks list.
+   * 
+   * @param { symbol } pid  Process reference
+   * @param { Error } [_reason] Reason of failure
+   */
+  /* eslint-disable no-unused-vars */
+  remove(pid, _reason) {
+    this.tasks.delete(pid);
+  }
+
+  /**
+   * Update task's properties.
+   * 
+   * @param { symbol} pid Process reference
+   * @param { Partial<ActiveTask> } taskUpdate 
+   */
+  update(pid, taskUpdate) {
+    const task = this.tasks.get(pid);
+    if (task && taskUpdate && typeof taskUpdate === "object") {
+      Object.assign(task, Object.fromEntries(
+        Object.entries(taskUpdate)
+        .filter(([key]) => key !== "progress" && key !== "pid")
+      ));
+      task.updated_on = Date.now();
+    }
+  }
+}
+
+/**
+ * Create the base task.
+ * 
+ * @template T
+ * @param { T & TaskProperties } task 
+ * @returns { T & Required<TaskProperties> & ActiveTaskProperties }
+ */
+function createBaseTask(task) {
+  const { type, database, total_changes } = task;
+  const pid = Symbol(type);
+  const updated_on = Date.now();
+
+  const activeTask = {
+    changes_done: 0,
+    started_on: updated_on,
+    ...task,
+    pid,
+    database,
+    total_changes,
+    updated_on,
+    get progress() {
+      return this.changes_done / this.total_changes * 100;
+    }
+  };
+
+  return activeTask;
+}
+
+/**
+ * 
+ * @param { TaskProperties & DatabaseCompactionTask } task 
+ * @returns { ActiveTask & DatabaseCompactionTask }
+ */
+function createDatabaseCompactionTask(task) {
+  const baseTask = createBaseTask(task);
+
+  const activeTask = Object.defineProperties( baseTask, {
+    type: {
+      enumerable: true,
+      value: "database_compaction"
+    }
+  });
+
+  return activeTask;
+}
+
+/**
+ * 
+ * @param { TaskProperties & IndexerTask } task 
+ * @returns { ActiveTask & IndexerTask }
+ */
+function createIndexerTask(task) {
+  const baseTask = createBaseTask(task);
+
+  const activeTask = Object.defineProperties( baseTask, {
+    type: {
+      enumerable: true,
+      value: "indexer"
+    },
+    design_document: {
+      enumerable: true,
+      value: task.design_document
+    }
+  });
+
+  return activeTask;
+}
+
+/**
+ * 
+ * @param { TaskProperties & ViewCompactionTask } task 
+ * @returns { ActiveTask & ViewCompactionTask }
+ */
+function createViewCompactionTask(task) {
+  const baseTask = createBaseTask(task);
+
+  const activeTask = Object.defineProperties( baseTask, {
+    type: {
+      enumerable: true,
+      value: "view_compaction"
+    },
+    design_document: {
+      enumerable: true,
+      value: task.design_document
+    }
+  });
+
+  return activeTask;
+}
+
+/**
+ * 
+ * @param { TaskProperties & ReplicationTask } task 
+ * @returns { ActiveTask & ReplicationTask }
+ */
+function createReplicationTask(task) {
+  const baseTask = {
+    doc_id: null,
+    doc_write_failures: 0,
+    docs_read: 0,
+    docs_written: 0,
+    missing_revisions_found: 0,
+    revisions_checked: 0,
+    ...createBaseTask(task)
+  };
+
+  const activeTask = Object.defineProperties( baseTask, {
+    type: {
+      enumerable: true,
+      value: "replication"
+    },
+    continuous: {
+      enumerable: true,
+      value: baseTask.continuous
+    },
+    checkpointed_source_seq: {
+      enumerable: true,
+      value: baseTask.checkpointed_source_seq
+    },
+    replication_id: {
+      enumerable: true,
+      value: baseTask.replication_id
+    },
+    doc_id: {
+      enumerable: true,
+      writable: true,
+      value: baseTask.doc_id
+    },
+    doc_write_failures: {
+      enumerable: true,
+      writable: true,
+      value: baseTask.doc_write_failures
+    },
+    docs_read: {
+      enumerable: true,
+      writable: true,
+      value: baseTask.docs_read
+    },
+    docs_written: {
+      enumerable: true,
+      writable: true,
+      value: baseTask.docs_written
+    },
+    missing_revisions_found: {
+      enumerable: true,
+      writable: true,
+      value: baseTask.missing_revisions_found
+    },
+    revisions_checked: {
+      enumerable: true,
+      writable: true,
+      value: baseTask.revisions_checked
+    },
+    source: {
+      enumerable: true,
+      value: baseTask.source
+    },
+    source_seq: {
+      enumerable: true,
+      value: baseTask.source_seq
+    },
+    target: {
+      enumerable: true,
+      value: baseTask.target
+    }
+  });
+
+  return activeTask;
 }

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -896,17 +896,22 @@ class AbstractPouchDB extends EventEmitter {
     };
     var promises = [];
 
-    var taskId;
-    var compactedDocs = 0;
+    /** @type {import("pouchdb-core/src/active-tasks").default} */
+    // @ts-ignore context of PouchInternal isn't known here
+    const activeTasks = this.activeTasks;
+    /** @type { symbol } */
+    let taskId;
+    let changes_done = 0;
+    const started_on = Date.now();
 
     const onChange = (row) => {
-      this.activeTasks.update(taskId, {
-        completed_items: ++compactedDocs
+      activeTasks.update(taskId, {
+        changes_done: ++changes_done
       });
       promises.push(this.compactDocument(row.id, 0));
     };
     const onError = (err) => {
-      this.activeTasks.remove(taskId, err);
+      activeTasks.remove(taskId, err);
       callback(err);
     };
     const onComplete = (resp) => {
@@ -920,15 +925,17 @@ class AbstractPouchDB extends EventEmitter {
           return false; // somebody else got here first, don't update
         });
       }).then(() => {
-        this.activeTasks.remove(taskId);
+        activeTasks.remove(taskId);
         callback(null, {ok: true});
       }).catch(onError);
     };
 
     this.info().then((info) => {
-      taskId = this.activeTasks.add({
-        name: 'database_compaction',
-        total_items: info.update_seq - changesOpts.last_seq,
+      taskId = activeTasks.add({
+        type: 'database_compaction',
+        total_changes: info.update_seq - changesOpts.last_seq,
+        database: info.db_name,
+        started_on
       });
 
       this.changes(changesOpts)

--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -33,7 +33,8 @@ function replicate(src, target, opts, returnValue, result) {
   var changedDocs = [];
   // Like couchdb, every replication gets a unique session id
   var session = uuid();
-  var taskId;
+  /** @type { symbol } */
+  let taskId;
 
   result = result || {
     ok: true,
@@ -46,6 +47,9 @@ function replicate(src, target, opts, returnValue, result) {
 
   var changesOpts = {};
   returnValue.ready(src, target);
+
+  /** @type { import("pouchdb-core/src/active-tasks").default } */
+  const activeTasks = src.activeTasks;
 
   function initCheckpointer() {
     if (checkpointer) {
@@ -137,19 +141,21 @@ function replicate(src, target, opts, returnValue, result) {
     }
     writingCheckpoint = true;
 
-    src.info().then(function (info) {
-      var task = src.activeTasks.get(taskId);
-      if (!currentBatch || !task) {
-        return;
-      }
-
-      var completed = task.completed_items || 0;
-      var total_items = info.update_seq - initial_last_seq;
-      src.activeTasks.update(taskId, {
-        completed_items: completed + currentBatch.changes.length,
-        total_items
+    const task = activeTasks.get(taskId);
+    if (task) {
+      const pending = typeof outResult.pending == "number" ? outResult.pending : 0;
+      const total_changes = (pending + result.docs_read) - initial_last_seq;
+      const changes_done = total_changes - pending;
+      activeTasks.update(taskId, {
+        changes_done,
+        total_changes,
+        docs_read: result.docs_read,
+        docs_written: result.docs_written,
+        doc_write_failures: result.doc_write_failures,
+        missing_revisions_found: 0,
+        doc_id: null
       });
-    });
+    }
 
     return checkpointer.writeCheckpoint(currentBatch.seq,
         session).then(function () {
@@ -292,7 +298,7 @@ function replicate(src, target, opts, returnValue, result) {
     result.last_seq = last_seq;
     replicationCompleted = true;
 
-    src.activeTasks.remove(taskId, fatalError);
+    activeTasks.remove(taskId, fatalError);
 
     if (fatalError) {
       // need to extend the error because Firefox considers ".result" read-only
@@ -326,14 +332,14 @@ function replicate(src, target, opts, returnValue, result) {
       pendingBatch.pending = pending;
     }
 
-    var filter = filterChange(opts)(change);
+    const filter = filterChange(opts)(change);
     if (!filter) {
       // update processed items count by 1
-      var task = src.activeTasks.get(taskId);
+      const task = activeTasks.get(taskId);
       if (task) {
         // we can assume that task exists here? shouldn't be deleted by here.
-        var completed = task.completed_items || 0;
-        src.activeTasks.update(taskId, {completed_items: ++completed});
+        const changes_done = task.changes_done + 1;
+        activeTasks.update(taskId, { changes_done });
       }
       return;
     }
@@ -433,19 +439,27 @@ function replicate(src, target, opts, returnValue, result) {
     }
   }
 
-  function createTask(checkpoint) {
-    return src.info().then(function (info) {
-      var total_items = typeof opts.since === 'undefined' ?
-        info.update_seq - checkpoint :
-        info.update_seq;
+  async function createTask(checkpoint) {
+    const info = await src.info();
+    const updateSeqNum = parseInt(info.update_seq, 10);
+    const checkpointNum = parseInt(checkpoint, 10);
+    const total_changes = typeof opts.since === 'undefined' ?
+      updateSeqNum - checkpointNum :
+      updateSeqNum;
 
-      taskId = src.activeTasks.add({
-        name: `${continuous ? 'continuous ' : ''}replication from ${info.db_name}` ,
-        total_items,
-      });
-
-      return checkpoint;
+    taskId = activeTasks.add({
+      type: "replication",
+      continuous,
+      total_changes,
+      checkpointed_source_seq: checkpoint,
+      database: info.db_name,
+      replication_id: repId,
+      source: src.name,
+      source_seq: info.update_seq,
+      target: target.name
     });
+
+    return checkpoint;
   }
 
   function startChanges() {

--- a/tests/integration/test.active_tasks.js
+++ b/tests/integration/test.active_tasks.js
@@ -24,7 +24,7 @@ describe('test.active_tasks.js', function () {
     }
   });
 
-  it('Throws when task database not a string', function () {
+  it('Throws when task database is not a string', function () {
     try {
       const task = {type: 'database_compaction', total_changes: 12};
       PouchDB.activeTasks.add(task);

--- a/tests/integration/test.active_tasks.js
+++ b/tests/integration/test.active_tasks.js
@@ -11,14 +11,14 @@ describe('test.active_tasks.js', function () {
     try {
       const task = {database: 'test', total_changes: 12};
       PouchDB.activeTasks.add(task);
-    } catch(err) {
+    } catch (err) {
       should.exist(err);
       err.should.be.instanceof(Error);
     }
     try {
       const task = {type: 'undefined', database: 'test', total_changes: 12};
       PouchDB.activeTasks.add(task);
-    } catch(err) {
+    } catch (err) {
       should.exist(err);
       err.should.be.instanceof(Error);
     }
@@ -28,7 +28,7 @@ describe('test.active_tasks.js', function () {
     try {
       const task = {type: 'database_compaction', total_changes: 12};
       PouchDB.activeTasks.add(task);
-    } catch(err) {
+    } catch (err) {
       should.exist(err);
       err.should.be.instanceof(Error);
     }
@@ -36,7 +36,7 @@ describe('test.active_tasks.js', function () {
     try {
       const task = {type: 'database_compaction', database: 55, total_changes: 12};
       PouchDB.activeTasks.add(task);
-    } catch(err) {
+    } catch (err) {
       should.exist(err);
       err.should.be.instanceof(Error);
     }
@@ -46,7 +46,7 @@ describe('test.active_tasks.js', function () {
     try {
       const task = {type: 'database_compaction', database: "test"};
       PouchDB.activeTasks.add(task);
-    } catch(err) {
+    } catch (err) {
       should.exist(err);
       err.should.be.instanceof(Error);
     }
@@ -54,7 +54,7 @@ describe('test.active_tasks.js', function () {
     try {
       const task = {type: 'database_compaction', database: "test", total_changes: null};
       PouchDB.activeTasks.add(task);
-    } catch(err) {
+    } catch (err) {
       should.exist(err);
       err.should.be.instanceof(Error);
     }
@@ -118,7 +118,7 @@ describe('test.active_tasks.js', function () {
     PouchDB.activeTasks.remove(id1);
     const got2 = PouchDB.activeTasks.get(id2);
     PouchDB.activeTasks.tasks.size.should.equal(1);
-    assert.equal(got2.pid, id2);;
+    assert.equal(got2.pid, id2);
   });
 
 });

--- a/tests/integration/test.active_tasks.js
+++ b/tests/integration/test.active_tasks.js
@@ -81,7 +81,6 @@ describe('test.active_tasks.js', function () {
     PouchDB.activeTasks.update(id1, {"changes_done": 2});
     PouchDB.activeTasks.update(id2, {"changes_done": 213});
     const tasks = PouchDB.activeTasks.list();
-    console.log("tasks: ", tasks);
     assert.equal(tasks.length, 2);
     assert.equal(tasks[0].pid, id1);
     assert.equal(tasks[1].pid, id2);

--- a/tests/integration/test.active_tasks.js
+++ b/tests/integration/test.active_tasks.js
@@ -3,61 +3,122 @@
 describe('test.active_tasks.js', function () {
 
   afterEach(function (done) {
-    PouchDB.activeTasks.tasks = {};
+    PouchDB.activeTasks.tasks = new Map();
     return done();
   });
 
+  it('Throws when task type is wrong', function () {
+    try {
+      const task = {database: 'test', total_changes: 12};
+      PouchDB.activeTasks.add(task);
+    } catch(err) {
+      should.exist(err);
+      err.should.be.instanceof(Error);
+    }
+    try {
+      const task = {type: 'undefined', database: 'test', total_changes: 12};
+      PouchDB.activeTasks.add(task);
+    } catch(err) {
+      should.exist(err);
+      err.should.be.instanceof(Error);
+    }
+  });
+
+  it('Throws when task database not a string', function () {
+    try {
+      const task = {type: 'database_compaction', total_changes: 12};
+      PouchDB.activeTasks.add(task);
+    } catch(err) {
+      should.exist(err);
+      err.should.be.instanceof(Error);
+    }
+
+    try {
+      const task = {type: 'database_compaction', database: 55, total_changes: 12};
+      PouchDB.activeTasks.add(task);
+    } catch(err) {
+      should.exist(err);
+      err.should.be.instanceof(Error);
+    }
+  });
+
+  it('Throws when task total_changes is not a number', function () {
+    try {
+      const task = {type: 'database_compaction', database: "test"};
+      PouchDB.activeTasks.add(task);
+    } catch(err) {
+      should.exist(err);
+      err.should.be.instanceof(Error);
+    }
+
+    try {
+      const task = {type: 'database_compaction', database: "test", total_changes: null};
+      PouchDB.activeTasks.add(task);
+    } catch(err) {
+      should.exist(err);
+      err.should.be.instanceof(Error);
+    }
+  });
+
   it('Can add a task', function () {
-    const task1 = {name: 'lol', total_items: 12};
+    const task1 = {type: 'database_compaction', database: 'test', total_changes: 12};
     const id1 = PouchDB.activeTasks.add(task1);
-    id1.should.be.a('string');
+    assert.typeOf(id1, 'symbol');
   });
 
   it('Can get tasks by id', function () {
-    const task2 = {name: 'wat', total_items: 546};
+    const task2 = {type: 'database_compaction', database: 'test', total_changes: 546};
     const id2 = PouchDB.activeTasks.add(task2);
     const got2 = PouchDB.activeTasks.get(id2);
-    got2['id'].should.equal(id2);
+    assert.equal(got2['pid'], id2);
   });
 
   it('Can get all tasks', function () {
-    const task1 = {name: 'lol', total_items: 12};
-    const task2 = {name: 'wat', total_items: 546};
+    const task1 = {type: 'database_compaction', database: 'test', total_changes: 12};
+    const task2 = {type: 'database_compaction', database: 'test', total_changes: 546};
     const id1 = PouchDB.activeTasks.add(task1);
     const id2 = PouchDB.activeTasks.add(task2);
-    PouchDB.activeTasks.update(id1, {"completed_items": 2});
-    PouchDB.activeTasks.update(id2, {"completed_items": 213});
+    PouchDB.activeTasks.update(id1, {"changes_done": 2});
+    PouchDB.activeTasks.update(id2, {"changes_done": 213});
     const tasks = PouchDB.activeTasks.list();
-    tasks.length.should.equal(2);
-    tasks[0].id.should.equal(id1);
-    tasks[1].id.should.equal(id2);
+    console.log("tasks: ", tasks);
+    assert.equal(tasks.length, 2);
+    assert.equal(tasks[0].pid, id1);
+    assert.equal(tasks[1].pid, id2);
+  });
+
+  it('Can get task progress', function () {
+    const task = {type: 'database_compaction', database: 'test', total_changes: 2, changes_done: 1};
+    const id = PouchDB.activeTasks.add(task);
+    const got = PouchDB.activeTasks.get(id);
+    assert.equal(got.progress, 50);
   });
 
   it('Can update a task', function () {
-    const task1 = {name: 'lol', total_items: 12};
-    const task2 = {name: 'wat', total_items: 546};
+    const task1 = {type: 'database_compaction', database: 'test', total_changes: 12};
+    const task2 = {type: 'database_compaction', database: 'test', total_changes: 546};
     const id1 = PouchDB.activeTasks.add(task1);
     const id2 = PouchDB.activeTasks.add(task2);
-    PouchDB.activeTasks.update(id1, {"completed_items": 2});
-    PouchDB.activeTasks.update(id2, {"completed_items": 213});
+    PouchDB.activeTasks.update(id1, {"changes_done": 2});
+    PouchDB.activeTasks.update(id2, {"changes_done": 213});
     const got1 = PouchDB.activeTasks.get(id1);
     const got2 = PouchDB.activeTasks.get(id2);
-    got1['completed_items'].should.equal(2);
-    got2['completed_items'].should.equal(213);
-    got2['updated_at'].should.be.a('string');
+    got1['changes_done'].should.equal(2);
+    got2['changes_done'].should.equal(213);
+    got2['updated_on'].should.be.a('number');
   });
 
   it('Can remove a task', function () {
-    const task1 = {name: 'lol', total_items: 12};
-    const task2 = {name: 'wat', total_items: 546};
+    const task1 = {type: 'database_compaction', database: 'test', total_changes: 12};
+    const task2 = {type: 'database_compaction', database: 'test', total_changes: 546};
     const id1 = PouchDB.activeTasks.add(task1);
     const id2 = PouchDB.activeTasks.add(task2);
-    PouchDB.activeTasks.update(id1, {"completed_items": 2});
-    PouchDB.activeTasks.update(id2, {"completed_items": 213});
+    PouchDB.activeTasks.update(id1, {"changes_done": 2});
+    PouchDB.activeTasks.update(id2, {"changes_done": 213});
     PouchDB.activeTasks.remove(id1);
     const got2 = PouchDB.activeTasks.get(id2);
-    Object.keys(PouchDB.activeTasks.tasks).length.should.equal(1);
-    got2['id'].should.equal(id2);
+    PouchDB.activeTasks.tasks.size.should.equal(1);
+    assert.equal(got2.pid, id2);;
   });
 
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+module.exports = {
+  entry: './packages/node_modules/pouchdb',
+  mode: 'production',
+  resolve: {
+    fallback: {
+      "stream-browserify": false,
+      "crypto": false,
+      "path": false ,
+      "vm": false,
+      "stream": false,
+      "os": false,
+      "fs": false,
+    },
+  },
+  output: {
+    library: {
+      name: 'PouchDB',
+      export: 'default',
+      type: 'umd',
+    },
+    globalObject: 'this',
+    path: path.resolve(__dirname, '.'),
+    filename: 'pouchdb-webpack.js',
+  },
+};


### PR DESCRIPTION
I refactored the ActiveTasks class so it matches more the `/_active_tasks` endpoint response of CouchDB.

For `pid` i chose `Symbol` to mimic the uniqueness of couchdb's response (there should no need for custom uuid-string generation).