### PR TITLE
fix: replication cancelling race condition

### DIFF
--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -378,7 +378,12 @@ function replicate(src, target, opts, returnValue, result) {
             session).then(function () {
           writingCheckpoint = false;
           result.last_seq = last_seq = changes.last_seq;
-          complete();
+          if (returnValue.cancelled) {
+            completeReplication();
+            throw new Error('cancelled');
+          } else {
+            complete();
+          }
         })
         .catch(onCheckpointError);
       } else {


### PR DESCRIPTION
This fixes a race condition that was observed in a presumed flaky test that was ultimately not flaky: If a replication is aborted at the exact time when a checkpoint was written at the end of a changes batch without changes, then the replication was not really aborted.