### PR TITLE
fix: active task total items calculation

### DIFF
--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -144,7 +144,7 @@ function replicate(src, target, opts, returnValue, result) {
       }
 
       var completed = task.completed_items || 0;
-      var total_items = info.update_seq - initial_last_seq;
+      var total_items = parseInt(info.update_seq, 10) - parseInt(initial_last_seq, 10);
       src.activeTasks.update(taskId, {
         completed_items: completed + currentBatch.changes.length,
         total_items
@@ -436,8 +436,8 @@ function replicate(src, target, opts, returnValue, result) {
   function createTask(checkpoint) {
     return src.info().then(function (info) {
       var total_items = typeof opts.since === 'undefined' ?
-        info.update_seq - checkpoint :
-        info.update_seq;
+        parseInt(info.update_seq, 10) - parseInt(checkpoint, 10) :
+        parseInt(info.update_seq, 10);
 
       taskId = src.activeTasks.add({
         name: `${continuous ? 'continuous ' : ''}replication from ${info.db_name}` ,


### PR DESCRIPTION
Update sequences can be strings, e.g. `2342-g1AAAACheJzLYWBgYMpgTmEQTM4vTc5ISXIwNDLXMwBCwxyQVB4LkGRoAFL_gSArgzmJgYFlQi5QjN0wydgsMS0Jm1Y8BiYyJNUjTJoGNsnMMC0lLckCm54sAOFdKgw` (and are always strings in clustered CouchDB since v2) and therefore cannot be subtracted. This uses `parseInt(seq, 10)` to get an integer from the sequence number or sequence string. Note that `parseInt` will ignore the appendix (is that even specified anywhere?) and also works with integers.

In reality, this is not even accurate. Because eg changing the `_security` object in an Apache CouchDB database also changes the sequence, even though no document change has been written. Therefore, the sequence arithmetic is insufficient for counting document changes. But normally the active task is used for progress display purposes, so this might suffice as a rough approximation.