### PR TITLE
Fix the race condition when closing one of multiple databases.

### DIFF
--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -1176,7 +1176,7 @@ function LevelPouch(opts, callback) {
 
         var adapterName = functionName(leveldown);
         var adapterStore = dbStores.get(adapterName);
-        var keys = [...adapterStore.keys()].filter(k => k.includes("-mrview-"));
+        var keys = [...adapterStore.keys()].filter(k => k.includes(name)).filter(k => k.includes("-mrview-"));
         keys.forEach(key => {
           var eventEmitter = adapterStore.get(key);
           eventEmitter.removeAllListeners();


### PR DESCRIPTION
Only need disconnect the mrview with right database name, in case multiple databases running.

Issue originally reported here: https://github.com/pubkey/rxdb/pull/3813.

PR with detail reproduce procedure is here: https://github.com/pouchdb/pouchdb/pull/8513


