### PR TITLE
fix: upgrade leveldown from 5.6.0 to 6.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "level": "6.0.1",
     "level-codec": "9.0.2",
     "level-write-stream": "1.0.0",
-    "leveldown": "5.6.0",
+    "leveldown": "6.1.1",
     "levelup": "4.4.0",
     "localstorage-down": "0.6.7",
     "ltgt": "2.2.1",


### PR DESCRIPTION
Fix PouchDB not working on arm64 Apple Silicon machines (#8416)