### PR TITLE
perf-tests: reporter: make wording clearer for multiple adapters

### DIFF
--- a/tests/performance/index.js
+++ b/tests/performance/index.js
@@ -8,7 +8,7 @@ function runTestSuites(PouchDB) {
   var reporter = require('./perf.reporter');
   reporter.startAll();
   reporter.log('Testing PouchDB version ' + PouchDB.version +
-    (adapters.length > 0 ? (', using adapter: ' + adapters.join(',')) : '') +
+    (adapters.length > 0 ? (', using adapter(s): ' + adapters.join(', ')) : '') +
     '\n\n');
 
   var theAdapterUsed;


### PR DESCRIPTION
Before:

```
Testing PouchDB version 7.0.0-prerelease, using adapter: idb,indexeddb
```

After:

```
Testing PouchDB version 7.0.0-prerelease, using adapter(s): idb, indexeddb
```