### PR TITLE
perf-tests: catch selenium errors earlier

### DIFF
--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -244,10 +244,18 @@ function startTest() {
   new MochaSpecReporter(runner);
   new BenchmarkReporter(runner);
 
-  sauceClient.init(opts, function () {
+  sauceClient.init(opts, function (err) {
+    if (err) {
+      testError(err);
+      return;
+    }
     console.log('Initialized');
 
-    sauceClient.get(testUrl, function () {
+    sauceClient.get(testUrl, function (err) {
+      if (err) {
+        testError(err);
+        return;
+      }
       console.log('Successfully started');
 
       sauceClient.eval('navigator.userAgent', function (err, userAgent) {


### PR DESCRIPTION
This prevents mystical errors like:

```
Rebuilt PouchDB/test/perf JS bundles
Starting {
  runner: 'selenium',
  browser: 'firefox',
  version: null,
  platform: null
} on http://127.0.0.1:8000/tests/performance/index.html?remote=1&adapters=idb&viewAdapters=memory&couchHost=http%3A%2F%2Fadmin%3Apassword%40localhost%3A5984
Initialized
Successfully started
Error: [eval("navigator.userAgent")] Error response status: 6,  Selenium error: No active session with ID execute
    at exports.newError (/pouchdb/node_modules/wd/lib/utils.js:152:13)
    at /pouchdb/node_modules/wd/lib/callbacks.js:94:19
    at /pouchdb/node_modules/wd/lib/webdriver.js:196:5
    at Request._callback (/pouchdb/node_modules/wd/lib/http-utils.js:89:7)
    at Request.self.callback (/pouchdb/node_modules/wd/node_modules/request/request.js:185:22)
    at Request.emit (events.js:314:20)
    at Request.<anonymous> (/pouchdb/node_modules/wd/node_modules/request/request.js:1161:10)
    at Request.emit (events.js:314:20)
    at IncomingMessage.<anonymous> (/pouchdb/node_modules/wd/node_modules/request/request.js:1083:12)
    at Object.onceWrapper (events.js:420:28)
    at IncomingMessage.emit (events.js:326:22)
    at endReadableNT (_stream_readable.js:1241:12)
    at processTicksAndRejections (internal/process/task_queues.js:84:21) {
  status: 6,
  cause: {
    sessionId: 'execute',
    value: {
      error: 'invalid session id',
      message: 'No active session with ID execute',
      stacktrace: ''
    },  
    status: 6
  },  
  inspect: [Function]
}
Doh, tests failed
```

Converting them to more relevant messages from Selenium, e.g.

```
unknown error: DevToolsActivePort file doesn't exist
...
```