### PR TITLE
eslint: use cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ tests/integration/utils-bundle.js
 /pouchdb-server-install
 package-lock.json
 yarn.lock
+/.eslintcache

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test-fuzzy": "TYPE=fuzzy npm run test",
     "test-browser": "npm run build-test && node ./bin/test-browser.js",
     "test-memleak": "mocha -gc tests/memleak",
-    "eslint": "eslint bin/ packages/node_modules/**/src tests/",
+    "eslint": "eslint --cache bin/ packages/node_modules/**/src tests/",
     "dev": "bash bin/run-dev.sh",
     "launch-dev-server": "node ./bin/dev-server.js",
     "test": "bash bin/run-test.sh",


### PR DESCRIPTION
For me this speeds up `npm run eslint` from 10+ seconds to ~1 second.