### PR TITLE
Recover if publishing packages fails part-way through

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ tests/integration/utils-bundle.js
 package-lock.json
 yarn.lock
 /.eslintcache
+release-todo.txt

--- a/bin/publish-packages.sh
+++ b/bin/publish-packages.sh
@@ -34,6 +34,9 @@ publish_packages () {
 
   if [[ "$failed" == 'n' ]] ; then
     rm "$todo"
+    return 0
+  else
+    return 1
   fi
 }
 

--- a/bin/publish-packages.sh
+++ b/bin/publish-packages.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -e
+
+publish_packages () {
+  local root_dir="$PWD"
+  local todo="$root_dir/release-todo.txt"
+
+  if [[ ! -e "$todo" ]] ; then
+    echo 'No packages to release, quitting.'
+    return 0
+  fi
+
+  local pkgs=($(cat "$todo"))
+  local failed='n'
+
+  for pkg in "${pkgs[@]}" ; do
+    cd "$root_dir"
+
+    if ! should_publish "$pkg" ; then
+      continue
+    fi
+
+    if [[ "$failed" == 'n' ]] ; then
+      if ! publish_package "$pkg" ; then
+        failed='y'
+        echo "Publishing '$pkg' failed, quitting."
+        echo "$pkg" > "$todo"
+      fi
+    else
+      echo "$pkg" >> "$todo"
+    fi
+  done
+
+  if [[ "$failed" == 'n' ]] ; then
+    rm "$todo"
+  fi
+}
+
+should_publish () {
+  local pkg="$1"
+
+  if [ ! -d "packages/node_modules/$pkg" ]; then
+    return 1
+  elif [ "true" = $(node --eval "console.log(require('./packages/node_modules/$pkg/package.json').private);") ]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+publish_package () {
+  local pkg="$1"
+
+  cd "packages/node_modules/$pkg"
+  echo "Publishing $pkg..."
+
+  if [ -n "$DRY_RUN" ]; then
+    echo "Dry run, not publishing"
+  elif [ -n "$BETA" ]; then
+    if ! npm publish --tag beta ; then
+      return 1
+    fi
+  else
+    if ! npm publish ; then
+      return 1
+    fi
+  fi
+}
+
+publish_packages

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -26,23 +26,8 @@ git checkout -b $BUILD_DIR
 node bin/update-package-json-for-publish.js
 
 # Publish all modules with Lerna
-for pkg in $(ls packages/node_modules); do
-  if [ ! -d "packages/node_modules/$pkg" ]; then
-    continue
-  elif [ "true" = $(node --eval "console.log(require('./packages/node_modules/$pkg/package.json').private);") ]; then
-    continue
-  fi
-  cd packages/node_modules/$pkg
-  echo "Publishing $pkg..."
-  if [ ! -z $DRY_RUN ]; then
-    echo "Dry run, not publishing"
-  elif [ ! -z $BETA ]; then
-    npm publish --tag beta
-  else
-    npm publish
-  fi
-  cd -
-done
+ls packages/node_modules > release-todo.txt
+sh bin/publish-packages.sh
 
 # Create git tag, which is also the Bower/Github release
 rm -fr lib src dist bower.json component.json package.json


### PR DESCRIPTION
This is motivated by some pain that @AlbaHerrerias and I have run into publishing packages since npm started requiring two-factor authentication. Each time we hit an `npm publish` command, we have to type in a two-factor code. If this is rejected, or if anything else goes wrong during publish, the release script halts and the remaining packages need to be published by hand.

This lets us recover from this situation by writing all the package names to disk first. The `publish-packages.sh` script will try to published the items in the "todo" file until it hits an error, at which point it writes the remaining packages back to disk. The script can then be run again to publish the remaining packages, resuming from the one that failed last time.