### PR TITLE
(#8589) fixed querying a view retaining the memory of the return

### DIFF
--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -708,7 +708,7 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       view.seq = currentSeq;
       view.sourceDB.activeTasks.remove(taskId);
     } catch (error) {
-      view.sourceDB.activeTasks.remove(taskId, error);      
+      view.sourceDB.activeTasks.remove(taskId, error);
     }
   }
 
@@ -763,9 +763,11 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
   }
 
   function queryView(view, opts) {
-    return sequentialize(getQueue(view), function () {
+    const queue = getQueue(view);
+    sequentialize(queue, function () {
       return queryViewInQueue(view, opts);
     })();
+    return queue.finish();
   }
 
   async function queryViewInQueue(view, opts) {

--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/taskqueue.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/taskqueue.js
@@ -19,7 +19,9 @@ class TaskQueue {
   }
 
   finish() {
-    return this.promise;
+    const output = this.promise;
+    this.promise = this.promise.then(() => {}); // Release reference to the return value of this.promise so it can be garbage collected
+    return output;
   }
 }
 


### PR DESCRIPTION
Corrected behaviour where `pouchdb.query()` would retain the resultset in memory until another query was executed on the same view

Fixes https://github.com/pouchdb/pouchdb/issues/8589#issue-1558262141