### PR TITLE
Fix tests for local doc IDs

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -53,7 +53,7 @@ function encodeDocId(id) {
   if (/^_design/.test(id)) {
     return '_design/' + encodeURIComponent(id.slice(8));
   }
-  if (/^_local/.test(id)) {
+  if (id.startsWith('_local/')) {
     return '_local/' + encodeURIComponent(id.slice(7));
   }
   return encodeURIComponent(id);

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/allDocs.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/allDocs.js
@@ -204,7 +204,7 @@ export default function (txn, metadata, opts, callback) {
     if (!doc) { return; }
 
     // Skip local docs
-    if (/^_local/.test(doc.id)) {
+    if (doc.id.startsWith('_local/')) {
       return e.target.result.continue();
     }
 

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
@@ -37,7 +37,7 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
 
   // We only need to track 1 revision for local documents
   function docsRevsLimit(doc) {
-    return /^_local/.test(doc.id) ? 1 : revsLimit;
+    return doc.id.startsWith('_local/') ? 1 : revsLimit;
   }
 
   function rootIsMissing(doc) {
@@ -195,7 +195,7 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
     var winningRev = calculateWinningRev(doc);
     // rev of new doc for attachments and to return it
     var writtenRev = doc.rev;
-    var isLocal = /^_local/.test(doc.id);
+    var isLocal = doc.id.startsWith('_local/');
 
     var theDoc = doc.revs[winningRev].data;
 

--- a/packages/node_modules/pouchdb-merge/src/isLocalId.js
+++ b/packages/node_modules/pouchdb-merge/src/isLocalId.js
@@ -1,5 +1,5 @@
 function isLocalId(id) {
-  return (/^_local/).test(id);
+  return typeof id === 'string' && id.startsWith('_local/');
 }
 
 export default isLocalId;


### PR DESCRIPTION
Closes https://github.com/pouchdb/pouchdb/issues/8602

This changes tests for local doc IDs inline with documented behaviour to test that the id starts with "_local/" instead of just "_local".

