### PR TITLE
Add script to create new -postfixed.js bundles

### DIFF
--- a/tests/integration/deps/get-postfixed-pouchdb-build.sh
+++ b/tests/integration/deps/get-postfixed-pouchdb-build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eu
+
+# Download a pouchdb production build for testing inter-version migrations in
+# tests/integration/browser.migration.js
+
+log() {
+  echo "[get-postfixed-pouchdb-build] $*"
+}
+
+# Recently, postfixed JS files have been added in minified form.
+infix=".min"
+while [[ $# -gt 1 ]]; do
+  if [[ $1 = --no-minify ]]; then
+    infix=""
+  else
+    echo "!!! Unrecognised arg: $1"
+    exit 1
+  fi
+  shift
+done
+
+version="$1"
+target="./pouchdb-$version-postfixed.js"
+nodots="$(tr -d . <<<"$version")"
+tmp="$(mktemp)"
+
+log "Fetching minified pouch build..."
+wget "https://github.com/pouchdb/pouchdb/releases/download/$version/pouchdb-${version}${infix}.js" --output-document="$tmp"
+
+log "Converting globals..."
+sed "s/PouchDB/PouchDBVersion$nodots/g" "$tmp" > "$target"
+
+log "Completed OK."


### PR DESCRIPTION
Tested with existing `-postfixed.js` builds, the only differences are in `pouchdb-1.1.0-postfixed.js`, and all whitespace:

```diff
$ git diff
diff --git a/tests/integration/deps/pouchdb-1.1.0-postfixed.js b/tests/integration/deps/pouchdb-1.1.0-postfixed.js
index b832ce49..296bedb5 100644
--- a/tests/integration/deps/pouchdb-1.1.0-postfixed.js
+++ b/tests/integration/deps/pouchdb-1.1.0-postfixed.js
@@ -4068,7 +4068,7 @@ exports.MD5 = function (string) {
     return   wordToHexValue;
   }
 
-  //**  function Utf8Encode(string) removed. Aready defined in pidcrypt_utils.js
+  //** function Utf8Encode(string) removed. Aready defined in pidcrypt_utils.js
 
   var x = [];
   var k, AA, BB, CC, DD, a, b, c, d;
@@ -4077,7 +4077,7 @@ exports.MD5 = function (string) {
   var S31 = 4, S32 = 11, S33 = 16, S34 = 23;
   var S41 = 6, S42 = 10, S43 = 15, S44 = 21;
 
-  //  string = Utf8Encode(string); #function call removed
+  //   string = Utf8Encode(string); #function call removed
 
   x = convertToWordArray(string);
 
@@ -5889,4 +5889,4 @@ function pouchCollate(a, b) {
 };;
 },{}]},{},[12])
 (12)
-});
+});
\ No newline at end of file
```

