### PR TITLE
ci: upgrade github actions to v3

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -8,11 +8,11 @@ runs:
   using: composite
 
   steps:
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/install-deps
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -51,7 +51,7 @@ jobs:
       COUCH_HOST: http://admin:password@127.0.0.1:5984
       SKIP_MIGRATION: 1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/install-deps
         with:
           node-version: ${{ matrix.node }}
@@ -97,7 +97,7 @@ jobs:
       COUCH_HOST: http://admin:password@127.0.0.1:5984
       SKIP_MIGRATION: 1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/install-deps
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -134,7 +134,7 @@ jobs:
       CLIENT: node
       ADAPTERS: ${{ matrix.adapter }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/install-deps
         with:
           node-version: ${{ matrix.node }}
@@ -177,7 +177,7 @@ jobs:
       CLIENT: ${{ matrix.client }}
       ADAPTERS: ${{ matrix.adapter }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/install-deps
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -220,7 +220,7 @@ jobs:
       CLIENT: ${{ matrix.client }}
       SERVER: pouchdb-server
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/install-deps
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -256,7 +256,7 @@ jobs:
           - npm run verify-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/install-deps
         with:
           node-version: ${{ matrix.node }}


### PR DESCRIPTION
Current versions are EOL as per https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This should resolve the warning in current Actions jobs:

![Screenshot_2023-04-12_18-51-06](https://user-images.githubusercontent.com/191496/231513025-79160ece-c99f-476d-917e-b048c59c2717.png)
