### PR TITLE
(#8627): Bump node-fetch to 2.6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "localstorage-down": "0.6.7",
     "ltgt": "2.2.1",
     "memdown": "1.4.1",
-    "node-fetch": "^2.6.9",
+    "node-fetch": "2.6.9",
     "promise-polyfill": "8.2.3",
     "readable-stream": "1.1.14",
     "spark-md5": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "localstorage-down": "0.6.7",
     "ltgt": "2.2.1",
     "memdown": "1.4.1",
-    "node-fetch": "2.6.7",
+    "node-fetch": "^2.6.9",
     "promise-polyfill": "8.2.3",
     "readable-stream": "1.1.14",
     "spark-md5": "3.0.2",


### PR DESCRIPTION
Resolves live changes feed interruptions not throwing errors and a couple more node-fetch bugs: 

https://github.com/node-fetch/node-fetch/releases/tag/v2.6.8
https://github.com/node-fetch/node-fetch/releases/tag/v2.6.9

#8627