### PR TITLE
Remove legacy script: bundle-browserify-test.sh

### DIFF
--- a/scripts/bundle-browserify-test.sh
+++ b/scripts/bundle-browserify-test.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-echo '<!DOCTYPE html><html>' > test.html
-echo "<head><meta charset='utf-8'></head>" >> test.html
-echo "<script type=\"text/javascript\">" >> test.html
-browserify $1 >> test.html
-echo "</script></html>" >> test.html


### PR DESCRIPTION
This script looks like it's no longer used:

* it was introduced in 2013 in cdc9af212a007ab5cc59c4b39b58fcc4cd4e9b04
* it looks like it's been superseded by doBrowserify() in bin/build-utils.sh
* it is never called in existing scripts
* there are no references to it being called previously, either in docs or other scripts