### PR TITLE
Standardise shell shebangs

### DIFF
--- a/bin/build-node.sh
+++ b/bin/build-node.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash -e
 
 # don't bother doing this in GHA because it's already been built
 if [ -z $GITHUB_REPOSITORY ]; then

--- a/bin/install-jekyll.sh
+++ b/bin/install-jekyll.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 if ! command -v bundler >/dev/null 2>&1; then
     echo "bundler is not installed.  You need to do: gem install bundler"

--- a/bin/publish-packages.sh
+++ b/bin/publish-packages.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-set -e
+#!/bin/bash -e
 
 publish_packages () {
   local root_dir="$PWD"

--- a/bin/publish-site.sh
+++ b/bin/publish-site.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Build the website
 BUILD=1 npm run build-site

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-set -e
+#!/bin/bash -e
 
 if [ ! -z $DRY_RUN ]; then
   echo "Doing a dry run release..."

--- a/bin/run-dev.sh
+++ b/bin/run-dev.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/bash -e
 
 CLIENT=dev ./bin/run-test.sh

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Run tests against a local setup of pouchdb-express-router
 # by default unless COUCH_HOST is specified.

--- a/bin/test-coverage.sh
+++ b/bin/test-coverage.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/bash -e
 
 COVERAGE=1 npm test

--- a/bin/test-node.sh
+++ b/bin/test-node.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 : ${TIMEOUT:=50000}
 : ${REPORTER:="spec"}

--- a/bin/test-webpack.sh
+++ b/bin/test-webpack.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash -e
 
 #
 # Build PouchDB with Webpack instead of Browserify, and test that.

--- a/bin/verify-build.sh
+++ b/bin/verify-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash -e
 
 # Verify various aspects of the build to make sure everything was
 # built correctly.

--- a/bin/verify-bundle-size.sh
+++ b/bin/verify-bundle-size.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash -e
 
 # Max size in bytes that we find acceptable.
 # We might have to change this later.


### PR DESCRIPTION
* always use `/bin/bash` instead of `/usr/bin/env bash` or `/bin/sh`
* always `set -e`