### PR TITLE
fix build and test warnings

### DIFF
--- a/bin/build-module.js
+++ b/bin/build-module.js
@@ -74,7 +74,7 @@ function buildModule(filepath) {
         input: path.resolve(filepath, './src/index.js'),
         external: depsToSkip,
         plugins: rollupPlugins({
-          jsnext: true,
+          mainFields: ['module', 'main'],
           browser: isBrowser || forceBrowser
         })
       }).then(function (bundle) {

--- a/bin/build-pouchdb.js
+++ b/bin/build-pouchdb.js
@@ -76,9 +76,8 @@ function doRollup(input, browser, formatsToFiles) {
     input: addPath('pouchdb', input),
     external: external,
     plugins: rollupPlugins({
-      jsnext: true,
-      browser: browser,
-      main: false  // don't use "main"s that are CJS
+      mainFields: ["module"],
+      browser: browser
     })
   }).then(function (bundle) {
     return Promise.all(Object.keys(formatsToFiles).map(function (format) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "abort-controller": "3.0.0",
-    "buffer-from": "1.1.2",
     "clone-buffer": "1.0.0",
     "double-ended-queue": "2.1.0-0",
     "fetch-cookie": "0.11.0",

--- a/packages/node_modules/pouchdb-abstract-mapreduce/package.json
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/package.json
@@ -11,5 +11,5 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-abstract-mapreduce"
   },
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-adapter-http/package.json
+++ b/packages/node_modules/pouchdb-adapter-http/package.json
@@ -11,5 +11,5 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-adapter-http"
   },
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-adapter-idb/package.json
+++ b/packages/node_modules/pouchdb-adapter-idb/package.json
@@ -11,5 +11,5 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-adapter-idb"
   },
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-adapter-indexeddb/package.json
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/package.json
@@ -11,5 +11,5 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-adapter-indexeddb"
   },
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/package.json
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-adapter-leveldb-core"
   },
-  "jsnext:main": "./src/index.js",
+  "module": "./src/index.js",
   "browser": {
     "./lib/index.js": "./lib/index-browser.js",
     "./src/createEmptyBlobOrBuffer.js": "./src/createEmptyBlobOrBuffer-browser.js",

--- a/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-leveldb-core/src/index.js
@@ -2,7 +2,6 @@ import levelup from 'levelup';
 import sublevel from 'sublevel-pouchdb';
 import { obj as through } from 'through2';
 import Deque from 'double-ended-queue';
-import bufferFrom from 'buffer-from'; // ponyfill for Node <6
 import PouchDB from 'pouchdb-core';
 import {
   clone,
@@ -785,7 +784,7 @@ function LevelPouch(opts, callback) {
           type: 'put',
           prefix: stores.binaryStore,
           key: digest,
-          value: bufferFrom(data, 'binary')
+          value: Buffer.from(data, 'binary')
         }]);
         callback();
       });

--- a/packages/node_modules/pouchdb-adapter-leveldb/package.json
+++ b/packages/node_modules/pouchdb-adapter-leveldb/package.json
@@ -14,5 +14,5 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-adapter-leveldb"
   },
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-adapter-localstorage/package.json
+++ b/packages/node_modules/pouchdb-adapter-localstorage/package.json
@@ -11,5 +11,5 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-adapter-localstorage"
   },
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-adapter-memory/package.json
+++ b/packages/node_modules/pouchdb-adapter-memory/package.json
@@ -11,5 +11,5 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-adapter-memory"
   },
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-adapter-utils/package.json
+++ b/packages/node_modules/pouchdb-adapter-utils/package.json
@@ -11,5 +11,5 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-adapter-utils"
   },
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-binary-utils/package.json
+++ b/packages/node_modules/pouchdb-binary-utils/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-binary-utils"
   },
-  "jsnext:main": "./src/index.js",
+  "module": "./src/index.js",
   "browser": {
     "./lib/index.js": "./lib/index-browser.js",
     "./src/base64.js": "./src/base64-browser.js",

--- a/packages/node_modules/pouchdb-binary-utils/src/base64.js
+++ b/packages/node_modules/pouchdb-binary-utils/src/base64.js
@@ -1,7 +1,5 @@
-import bufferFrom from 'buffer-from'; // ponyfill for Node <6
-
 function thisAtob(str) {
-  var base64 = new Buffer(str, 'base64');
+  var base64 = Buffer.from(str, 'base64');
   // Node.js will just skip the characters it can't decode instead of
   // throwing an exception
   if (base64.toString('base64') !== str) {
@@ -11,7 +9,7 @@ function thisAtob(str) {
 }
 
 function thisBtoa(str) {
-  return bufferFrom(str, 'binary').toString('base64');
+  return Buffer.from(str, 'binary').toString('base64');
 }
 
 export {

--- a/packages/node_modules/pouchdb-binary-utils/src/typedBuffer.js
+++ b/packages/node_modules/pouchdb-binary-utils/src/typedBuffer.js
@@ -1,8 +1,6 @@
-import bufferFrom from 'buffer-from'; // ponyfill for Node <6
-
 function typedBuffer(binString, buffType, type) {
   // buffType is either 'binary' or 'base64'
-  var buff = bufferFrom(binString, buffType);
+  const buff = Buffer.from(binString, buffType);
   buff.type = type; // non-standard, but used for consistency with the browser
   return buff;
 }

--- a/packages/node_modules/pouchdb-browser/package.json
+++ b/packages/node_modules/pouchdb-browser/package.json
@@ -3,7 +3,7 @@
   "version": "7.0.0-prerelease",
   "description": "PouchDB, the browser-only edition.",
   "main": "./lib/index.js",
-  "jsnext:main": "./lib/index.es.js",
+  "module": "./lib/index.es.js",
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/node_modules/pouchdb-changes-filter/package.json
+++ b/packages/node_modules/pouchdb-changes-filter/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-changes-filter"
   },
-  "jsnext:main": "./src/index.js",
+  "module": "./src/index.js",
   "browser": {
     "./lib/index.js": "./lib/index-browser.js",
     "./src/evalFilter.js": "./src/evalFilter-browser.js",

--- a/packages/node_modules/pouchdb-checkpointer/package.json
+++ b/packages/node_modules/pouchdb-checkpointer/package.json
@@ -11,5 +11,5 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-checkpointer"
   },
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-collate/package.json
+++ b/packages/node_modules/pouchdb-collate/package.json
@@ -15,5 +15,5 @@
     "directory": "packages/node_modules/pouchdb-collate"
   },
   "license": "Apache-2.0",
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-collections/package.json
+++ b/packages/node_modules/pouchdb-collections/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-collections"
   },
-  "jsnext:main": "./src/index.js",
+  "module": "./src/index.js",
   "contributors": [
     {
       "name": "Calvin Metcalf",

--- a/packages/node_modules/pouchdb-core/package.json
+++ b/packages/node_modules/pouchdb-core/package.json
@@ -11,5 +11,5 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-core"
   },
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-errors/package.json
+++ b/packages/node_modules/pouchdb-errors/package.json
@@ -11,5 +11,5 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-errors"
   },
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-fetch/package.json
+++ b/packages/node_modules/pouchdb-fetch/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-fetch"
   },
-  "jsnext:main": "./src/index.js",
+  "module": "./src/index.js",
   "browser": {
     "./lib/index.js": "./lib/index-browser.js",
     "./src/fetch.js": "./src/fetch-browser.js"

--- a/packages/node_modules/pouchdb-find/package.json
+++ b/packages/node_modules/pouchdb-find/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-find"
   },
-  "jsnext:main": "./src/index.js",
+  "module": "./src/index.js",
   "browser": {
     "./lib/index.js": "./lib/index-browser.js"
   }

--- a/packages/node_modules/pouchdb-generate-replication-id/package.json
+++ b/packages/node_modules/pouchdb-generate-replication-id/package.json
@@ -11,5 +11,5 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-generate-replication-id"
   },
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-json/package.json
+++ b/packages/node_modules/pouchdb-json/package.json
@@ -11,5 +11,5 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-json"
   },
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-mapreduce-utils/package.json
+++ b/packages/node_modules/pouchdb-mapreduce-utils/package.json
@@ -11,5 +11,5 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-mapreduce-utils"
   },
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-mapreduce/package.json
+++ b/packages/node_modules/pouchdb-mapreduce/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-mapreduce"
   },
-  "jsnext:main": "./src/index.js",
+  "module": "./src/index.js",
   "browser": {
     "./lib/index.js": "./lib/index-browser.js",
     "./src/evalFunction.js": "./src/evalFunction-browser.js"

--- a/packages/node_modules/pouchdb-md5/package.json
+++ b/packages/node_modules/pouchdb-md5/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-md5"
   },
-  "jsnext:main": "./src/index.js",
+  "module": "./src/index.js",
   "browser": {
     "./lib/index.js": "./lib/index-browser.js",
     "./src/binaryMd5.js": "./src/binaryMd5-browser.js",

--- a/packages/node_modules/pouchdb-merge/package.json
+++ b/packages/node_modules/pouchdb-merge/package.json
@@ -11,5 +11,5 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-merge"
   },
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-node/package.json
+++ b/packages/node_modules/pouchdb-node/package.json
@@ -3,7 +3,7 @@
   "version": "7.0.0-prerelease",
   "description": "PouchDB, the Node-only edition.",
   "main": "./lib/index.js",
-  "jsnext:main": "./lib/index.es.js",
+  "module": "./lib/index.es.js",
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/node_modules/pouchdb-replication/package.json
+++ b/packages/node_modules/pouchdb-replication/package.json
@@ -11,5 +11,5 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-replication"
   },
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-selector-core/package.json
+++ b/packages/node_modules/pouchdb-selector-core/package.json
@@ -11,5 +11,5 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-selector-core"
   },
-  "jsnext:main": "./src/index.js"
+  "module": "./src/index.js"
 }

--- a/packages/node_modules/pouchdb-utils/package.json
+++ b/packages/node_modules/pouchdb-utils/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/pouchdb-utils"
   },
-  "jsnext:main": "./src/index.js",
+  "module": "./src/index.js",
   "browser": {
     "./lib/index.js": "./lib/index-browser.js",
     "./src/cloneBinaryObject.js": "./src/cloneBinaryObject-browser.js",

--- a/packages/node_modules/pouchdb/package.json
+++ b/packages/node_modules/pouchdb/package.json
@@ -3,7 +3,7 @@
   "version": "7.0.0-prerelease",
   "description": "PouchDB is a pocket-sized database",
   "main": "./lib/index.js",
-  "jsnext:main": "./lib/index.es.js",
+  "module": "./lib/index.es.js",
   "author": "Dale Harvey <dale@arandomurl.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/pouchdb/pouchdb",

--- a/packages/node_modules/sublevel-pouchdb/package.json
+++ b/packages/node_modules/sublevel-pouchdb/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/pouchdb/pouchdb.git",
     "directory": "packages/node_modules/sublevel-pouchdb"
   },
-  "jsnext:main": "./src/index.js",
+  "module": "./src/index.js",
   "contributors": [
     {
       "name": "Dominic Tarr",

--- a/tests/component/test.headers.js
+++ b/tests/component/test.headers.js
@@ -42,12 +42,13 @@ describe('test.headers.js', function () {
   it('4450 Test headers are sent correctly on put', function () {
     var opts = {auth: {username: 'foo', password: 'bar'}};
     var db = new PouchDB('http://127.0.0.1:' + PORT, opts);
+
     return db.put({
       _id: 'doc',
       _attachments: {
         'att.txt': {
           content_type: 'text/plain',
-          data: new Buffer(['Is there life on Mars?'], {type: 'text/plain'})
+          data: Buffer.from('Is there life on Mars?', "utf8")
         }
       }
     }).then(function () {

--- a/tests/integration/test.issue915.js
+++ b/tests/integration/test.issue915.js
@@ -5,7 +5,6 @@ if (!process.env.LEVEL_ADAPTER &&
     !process.env.ADAPTERS) {
   // these tests don't make sense for anything other than default leveldown
   var fs = require('fs');
-  var bufferFrom = require('buffer-from');
   describe('test.issue915.js', function () {
     afterEach(function (done) {
       fs.unlink('./tmp/_pouch_veryimportantfiles/something', function () {
@@ -17,7 +16,7 @@ if (!process.env.LEVEL_ADAPTER &&
     it('Put a file in the db, then destroy it', function (done) {
       var db = new PouchDB('veryimportantfiles');
       fs.writeFile('./tmp/_pouch_veryimportantfiles/something',
-                   bufferFrom('lalala'), function () {
+        Buffer.from('lalala', 'utf8'), function () {
         db.destroy(function (err) {
           if (err) {
             return done(err);

--- a/tests/performance/perf.attachments.js
+++ b/tests/performance/perf.attachments.js
@@ -10,7 +10,7 @@ function randomBrowserBlob(size) {
 }
 
 function randomBuffer(size) {
-  var buff = new Buffer(size);
+  var buff = Buffer.alloc(size);
   for (var i = 0; i < size; i++) {
     buff.write(
       String.fromCharCode(Math.floor(65535 * Math.random())),

--- a/tests/unit/test.ajax.js
+++ b/tests/unit/test.ajax.js
@@ -74,7 +74,7 @@ describe.skip('test.ajax.js', function () {
         headers: {
           'Content-Type': 'image/jpeg'
         }
-      }, new Buffer('sure this is binary data'));
+      }, Buffer.from('sure this is binary data', "utf8"));
     }, 4);
   });
 


### PR DESCRIPTION
## Intention:
I got annoyed by these warnings, so I patched 'em.

## Changes:
1. updates the rollup-plugin-node-resolve config fields "jsnext" and "main" to "mainFields".
2. replace package.json's field "jsnext:main" to modern standard "module".
3. replace deprecated Buffer() constructor call with equivalent Buffer.from()/Buffer.alloc().
4. replace module "buffer-from" with Buffer.from (obsolete, since node versions below 14 aren't supported by PouchDB).