### PR TITLE
test.viewadapter: restructure async handling

### DIFF
--- a/tests/integration/test.viewadapter.js
+++ b/tests/integration/test.viewadapter.js
@@ -48,85 +48,110 @@ viewAdapters.forEach(viewAdapter => {
       dbs.name = testUtils.adapterUrl('local', 'testdb');
     });
 
-    it('Create pouch with separate view adapters', async function () {
+    it('Create pouch with separate view adapters', function (done) {
       const db = new PouchDB(dbs.name, {view_adapter: viewAdapter});
 
       if (db.adapter === viewAdapter) {
-        return;
+        return done();
       }
 
       if (db.adapter !== 'leveldb' && db.adapter !== 'idb') {
-        return;
+        return done();
       }
 
-      await db.bulkDocs(docs);
-      await db.query('index', { key: 'abc', include_docs: true });
+      db.bulkDocs(docs).then(function () {
+        db.query('index', {
+          key: 'abc',
+          include_docs: true
+        }).then(function () {
 
-      if (testUtils.isNode()) {
-        const dbs = getDbNamesFromLevelDBFolder(db.name);
-        dbs.length.should.equal(1); // only one db created on disk, no dependent db created
-      } else {
-        const { viewDbName, docDbName } = getDBNames(localStorage);
-        // check indexedDB for saved views
-        // need to add '_pouch_' because views are saved in memory
-        const viewRequest = indexedDB.open('_pouch_' + viewDbName, 1);
-        viewRequest.onupgradeneeded = function (event) {
-          // The version of the view database created is 1 which shows that this
-          // database was newly created in IndexedDB and did not exist there
-          // before. So the view database was created in the database specified in
-          // the view_adapter and not in the default `idb`adapter.
-          event.oldVersion.should.equal(0);
-          event.newVersion.should.equal(1);
-        };
+          if (testUtils.isNode()) {
+            const dbs = getDbNamesFromLevelDBFolder(db.name);
+            dbs.length.should.equal(1); // only one db created on disk, no dependent db created
+            done();
+          } else {
+            const { viewDbName, docDbName } = getDBNames(localStorage);
+            // check indexedDB for saved views
+            // need to add '_pouch_' because views are saved in memory
+            const viewRequest = indexedDB.open('_pouch_' + viewDbName, 1);
+            viewRequest.onupgradeneeded = function (event) {
+              // The version of the view database created is 1 which shows that this
+              // database was newly created in IndexedDB and did not exist there
+              // before. So the view database was created in the database specified in
+              // the view_adapter and not in the default `idb`adapter.
+              event.oldVersion.should.equal(0);
+              event.newVersion.should.equal(1);
+            };
+            viewRequest.onerror = function () {
+              done(new Error('viewRequest.open() failed'));
+            };
+            viewRequest.onsuccess = function () {
+              // Nothing is saved here
+              viewRequest.result.objectStoreNames.length.should.equal(0);
+              viewRequest.result.version.should.equal(1);
 
-        viewRequest.onsuccess = function () {
-          // Nothing is saved here
-          viewRequest.result.objectStoreNames.length.should.equal(0);
-          viewRequest.result.version.should.equal(1);
-        };
-
-        // check indexedDB for saved docs
-        const docRequest = indexedDB.open(docDbName, 5);
-        docRequest.onsuccess = function () {
-          // something is saved here
-          docRequest.result.objectStoreNames.length.should.equal(7);
-        };
-      }
+              // check indexedDB for saved docs
+              const docRequest = indexedDB.open(docDbName, 5);
+              docRequest.onerror = function () {
+                done(new Error('docRequest.open() failed'));
+              };
+              docRequest.onsuccess = function () {
+                // something is saved here
+                docRequest.result.objectStoreNames.length.should.equal(7);
+                done();
+              };
+            };
+          }
+        }).catch(done);
+      }).catch(done);
     });
 
-    it('Create pouch with no view adapters', async function () {
+    it('Create pouch with no view adapters', function (done) {
       const db = new PouchDB(dbs.name);
 
       if (db.adapter !== 'leveldb' && db.adapter !== 'idb') {
-        return;
+        return done();
       }
 
-      await db.bulkDocs(docs);
-      await db.query('index', { key: 'abc', include_docs: true });
+      db.bulkDocs(docs).then(function () {
+        db.query('index', {
+          key: 'abc',
+          include_docs: true
+        }).then(function () {
 
-      if (testUtils.isNode()) {
-        const dbs = getDbNamesFromLevelDBFolder(db.name);
-        const expectedLength = db.adapter === 'memory' ? 0 : 2;
-        dbs.length.should.equal(expectedLength);
-      } else {
-        const { viewDbName, docDbName } = getDBNames(localStorage);
+          if (testUtils.isNode()) {
+            const dbs = getDbNamesFromLevelDBFolder(db.name);
+            const expectedLength = db.adapter === 'memory' ? 0 : 2;
+            dbs.length.should.equal(expectedLength);
+            done();
+          } else {
+            const { viewDbName, docDbName } = getDBNames(localStorage);
 
-        // check indexedDB for saved views
-        const viewRequest = indexedDB.open(viewDbName, 5);
-        viewRequest.onsuccess = function () {
-          // Something is saved here
-          // This shows that without a view_adapter specified
-          // the view query data is stored in the default adapter database.
-          viewRequest.result.objectStoreNames.length.should.equal(7);
-        };
+            // check indexedDB for saved views
+            const viewRequest = indexedDB.open(viewDbName, 5);
+            viewRequest.onerror = function () {
+              done(new Error('viewRequest.open() failed'));
+            };
+            viewRequest.onsuccess = function () {
+              // Something is saved here
+              // This shows that without a view_adapter specified
+              // the view query data is stored in the default adapter database.
+              viewRequest.result.objectStoreNames.length.should.equal(7);
 
-        // check indexedDB for saved docs
-        const docRequest = indexedDB.open(docDbName, 5);
-        docRequest.onsuccess = function () {
-          // something is saved here
-          docRequest.result.objectStoreNames.length.should.equal(7);
-        };
-      }
+              // check indexedDB for saved docs
+              const docRequest = indexedDB.open(docDbName, 5);
+              docRequest.onerror = function () {
+                done(new Error('docRequest.open() failed'));
+              };
+              docRequest.onsuccess = function () {
+                // something is saved here
+                docRequest.result.objectStoreNames.length.should.equal(7);
+                done();
+              };
+            };
+          }
+        }).catch(done);
+      }).catch(done);
     });
   });
 });


### PR DESCRIPTION
Reinstate async test handling using `done()` which was removed in 25db22fb0ff025b8d2c698da30c6c409066baa0c, and add more direct handling of errors.

-----

I think the current structure of tests mean that assertion failures in IndexedDB event handlers may not be detected.

This seems to introduce instability in the tests, see in places like https://github.com/pouchdb/pouchdb/pull/8569#issuecomment-1523449019.

## Example

```js
require('chai').should();

describe('async handling', () => {
  it('may not fail if error is thrown in async handler', async function() {
    setTimeout(() => {
      const x = 1;
      x.should.equal(2);
    }, 1000);
  }); 

  it('should fail if done() is used', function(done) {
    setTimeout(() => {
      const x = 1;
      x.should.equal(2);
    }, 1000);
  }); 
});
```

### Result

```
$ npx mocha mytest.js


  async handling
    ✓ may not fail if error is thrown in async handler
    1) should fail if done() is used


  1 passing (1s)
  1 failing

  1) async handling should fail if done() is used:

      Uncaught AssertionError: expected 1 to equal 2
      + expected - actual

      -1
      +2
      
      at Timeout._onTimeout (mytest.js:7:16)
      at listOnTimeout (internal/timers.js:557:17)
      at processTimers (internal/timers.js:500:7)
```