### PR TITLE
test.viewadapter: only run for expected adapters

### DIFF
--- a/tests/integration/test.viewadapter.js
+++ b/tests/integration/test.viewadapter.js
@@ -55,6 +55,10 @@ viewAdapters.forEach(viewAdapter => {
         return;
       }
 
+      if (db.adapter !== 'leveldb' && db.adapter !== 'idb') {
+        return;
+      }
+
       await db.bulkDocs(docs);
       await db.query('index', { key: 'abc', include_docs: true });
 
@@ -92,6 +96,10 @@ viewAdapters.forEach(viewAdapter => {
 
     it('Create pouch with no view adapters', async function () {
       const db = new PouchDB(dbs.name);
+
+      if (db.adapter !== 'leveldb' && db.adapter !== 'idb') {
+        return;
+      }
 
       await db.bulkDocs(docs);
       await db.query('index', { key: 'abc', include_docs: true });


### PR DESCRIPTION
These tests are written explicitly for `leveldb` and `idb`, but currently also run in CI with the primary adapter as `memory`.

The tests do not fail in CI because of a race condition, which is eliminated by https://github.com/pouchdb/pouchdb/pull/8651.