### PR TITLE
fix concurrent test-server errors

### DIFF
--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -54,6 +54,16 @@ pouchdb-link-server-modules() {
   cd ..
 }
 
+search-free-port() {
+  EXPRESS_HOST="127.0.0.1"
+  EXPRESS_PORT=3000
+
+  while (: < /dev/tcp/127.0.0.1/$EXPRESS_PORT) 2>/dev/null; do
+    ((EXPRESS_PORT++))
+  done
+  export PORT=$EXPRESS_PORT
+}
+
 pouchdb-build-node() {
   if [[ $BUILD_NODE_DONE -ne 1 ]]; then
     npm run build-node
@@ -75,9 +85,10 @@ if [[ ! -z $SERVER ]]; then
     fi
   elif [ "$SERVER" == "pouchdb-express-router" ]; then
     pouchdb-build-node
+    search-free-port
     node ./tests/misc/pouchdb-express-router.js &
     export SERVER_PID=$!
-    export COUCH_HOST='http://127.0.0.1:3000'
+    export COUCH_HOST="http://127.0.0.1:${PORT}"
   elif [ "$SERVER" == "express-pouchdb-minimum" ]; then
     pouchdb-build-node
     node ./tests/misc/express-pouchdb-minimum-for-pouchdb.js &

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -55,9 +55,7 @@ pouchdb-link-server-modules() {
 }
 
 search-free-port() {
-  EXPRESS_HOST="127.0.0.1"
   EXPRESS_PORT=3000
-
   while (: < /dev/tcp/127.0.0.1/$EXPRESS_PORT) 2>/dev/null; do
     ((EXPRESS_PORT++))
   done

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -12,6 +12,10 @@ export VIEW_ADAPTERS
 pouchdb-setup-server() {
   # in CI, link pouchdb-servers dependencies on pouchdb
   # modules to the current implementations
+  if [ -d "pouchdb-server-install" ]; then
+    # pouchdb server already running
+    exit 0
+  fi
   mkdir pouchdb-server-install
   cd pouchdb-server-install
   npm init -y

--- a/bin/test-node.sh
+++ b/bin/test-node.sh
@@ -12,7 +12,11 @@ else
 fi
 
 if [ $TYPE = "integration" ]; then
-    node bin/down-server.js 3010 & export DOWN_SERVER_PID=$!
+    if  (: < /dev/tcp/127.0.0.1/3010) 2>/dev/null; then
+        echo "down-server port already in use"
+    else
+        node bin/down-server.js 3010 & export DOWN_SERVER_PID=$!
+    fi
 
     TESTS_PATH="tests/integration/test.*.js"
 fi


### PR DESCRIPTION
## Motivation

GitHub Actions recycling test container, causing workflows "First retry" and "Second retry" to fail, because the express-server port is already in use.

### Error

```
> npm run build-test && node ./bin/test-browser.js

events.js:377
      throw er; // Unhandled 'error' event
      ^

Error: listen EADDRINUSE: address already in use :::3000
    at Server.setupListenHandle [as _listen2] (net.js:1331:16)
    at listenInCluster (net.js:1379:12)
    at Server.listen (net.js:1465:7)
    at Function.listen (/home/runner/work/pouchdb/pouchdb/node_modules/express/lib/application.js:618:24)
    at Object.<anonymous> (/home/runner/work/pouchdb/pouchdb/tests/misc/pouchdb-express-router.js:31:5)
    at Module._compile (internal/modules/cjs/loader.js:1114:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1143:10)
    at Module.load (internal/modules/cjs/loader.js:979:32)
    at Function.Module._load (internal/modules/cjs/loader.js:819:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:75:12)
Emitted 'error' event on Server instance at:
    at emitErrorNT (net.js:1358:8)
    at processTicksAndRejections (internal/process/task_queues.js:82:21) {
  code: 'EADDRINUSE',
  errno: -98,
  syscall: 'listen',
  address: '::',
  port: 3000
}
```

### Shadows another error

```
Run npm test
  npm test
  shell: /usr/bin/bash -e {0}
  env:
    NODE_VERSION: 14
    SELENIUM_HUB_HOST: hub
    TEST_HOST: localhost
    CLIENT: node
    SERVER: pouchdb-server
mkdir: cannot create directory ‘pouchdb-server-install’: File exists

npm ERR! Test failed.  See above for more details.
> pouchdb-monorepo@7.0.0-prerelease test /home/runner/work/pouchdb/pouchdb
> ./bin/run-test.sh

Error: Process completed with exit code 1.
```

## Solution

1. run-test.sh tests the port before starting pouchdb-express-router,
    if the port isn't free, it simply increments the port.
2. skip down-server instantiation, if port 3010 isn't free.
3. skip pouchdb-server-install build & run, if the directory exists

With this patch, GitHub-CI should only fail on if one of the test cases fail.