### PR TITLE
#5798 set terser to minify with option ascii_only=true

### DIFF
--- a/bin/build-utils.js
+++ b/bin/build-utils.js
@@ -29,7 +29,7 @@ function writeFile(filename, contents) {
 }
 
 function doUglify(pkgName, code, prepend, fileOut) {
-  var miniCode = prepend + terser.minify(code).code;
+  var miniCode = prepend + terser.minify(code, { output: { ascii_only: true }}).code;
   return writeFile(addPath(pkgName, fileOut), miniCode);
 }
 


### PR DESCRIPTION
Using this setting will fix the encoding problems occurring when using the minified version in a Chrome extension and other places.