### PR TITLE
test current couchdb versions

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -2,7 +2,7 @@ name: Install dependencies
 
 inputs:
   node-version: { required: true }
-  couchdb-version: { required: false, default: '3.1' }
+  couchdb-version: { required: false, default: '3.3' }
 
 runs:
   using: composite
@@ -22,6 +22,6 @@ runs:
     - run: npm install
       shell: bash
 
-    - uses: iamssen/couchdb-github-action@master
+    - uses: SourceR85/couchdb-github-action@2023-06-17
       with:
         couchdb-version: ${{ inputs.couchdb-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        couchdb: ['2.3', '3.1']
+        couchdb: ['2.3', '3.1', '3.2', '3.3']
         node: [14, 16]
         cmd:
           - npm test
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        couchdb: ['2.3','3.1']
+        couchdb: ['2.3', '3.1', '3.2', '3.3']
         client: ['selenium:firefox', 'selenium:chrome']
         cmd:
           - npm test


### PR DESCRIPTION
I've published a fork of couchdb-github-action with currently supported CouchDB version.

The original by iamssen wasn't updated since mid 2020 (3.0 droped and CouchDB 3.2 and 3.3 were added since then).

If somebody else want to maintain the gh action, feel free to replace my fork :wink: