### PR TITLE
Fix typo in attachments guide

### DIFF
--- a/docs/_guides/attachments.md
+++ b/docs/_guides/attachments.md
@@ -204,7 +204,7 @@ input.addEventListener('change', function () {
     _id: 'mydoc',
     _attachments: {
       filename: {
-        type: file.type,
+        content_type: file.type,
         data: file
       }
     }


### PR DESCRIPTION
"Allow users to store an attachment" guide uses `type` instead of `content_type`