### PR TITLE
test-webpack: don't save new dependencies

### DIFF
--- a/bin/test-webpack.sh
+++ b/bin/test-webpack.sh
@@ -7,7 +7,7 @@
 #
 
 npm run build
-npm i webpack@5.66.0 -D webpack-cli@4.9.2 # do this on-demand to avoid slow installs
+npm i webpack@5.66.0 webpack-cli@4.9.2 # do this on-demand to avoid slow installs
 node bin/update-package-json-for-publish.js
 ./node_modules/.bin/webpack
 BUILD_NODE_DONE=0 POUCHDB_SRC='../../pouchdb-webpack.js' npm test


### PR DESCRIPTION
This removes the `-D` flag from `npm install`, which was introduced in 404346bba500c357c0276ad15762e985fb143eea