### PR TITLE
browser.worker test: dereference globals safely

### DIFF
--- a/tests/integration/browser.worker.js
+++ b/tests/integration/browser.worker.js
@@ -1,13 +1,5 @@
 'use strict';
 
-var sourceFile = window.location.search.match(/[?&]sourceFile=([^&]+)/);
-
-if (!sourceFile) {
-  sourceFile = '../../packages/node_modules/pouchdb/dist/pouchdb.js';
-} else {
-  sourceFile = '../../packages/node_modules/pouchdb/dist/' + sourceFile[1];
-}
-
 // only running in Chrome and Firefox due to various bugs.
 // IE: https://connect.microsoft.com/IE/feedback/details/866495
 // Safari: doesn't have IndexedDB or WebSQL in a WW
@@ -16,9 +8,9 @@ if (!sourceFile) {
 var isNodeWebkit = typeof window !== 'undefined' &&
   typeof process !== 'undefined';
 
-if (typeof window.Worker === 'function' &&
+if ((window && typeof window.Worker === 'function') &&
     !isNodeWebkit && !testUtils.isIE() &&
-    (window.chrome || /Firefox/.test(navigator.userAgent))) {
+    ((window && window.chrome) || (navigator && /Firefox/.test(navigator.userAgent)))) {
   runTests();
 }
 
@@ -28,6 +20,15 @@ function runTests() {
 
   before(function () {
     worker = new Worker('worker.js');
+
+    var sourceFile = window && window.location.search.match(/[?&]sourceFile=([^&]+)/);
+
+    if (!sourceFile) {
+      sourceFile = '../../packages/node_modules/pouchdb/dist/pouchdb.js';
+    } else {
+      sourceFile = '../../packages/node_modules/pouchdb/dist/' + sourceFile[1];
+    }
+
     worker.postMessage(['source', sourceFile]);
   });
 


### PR DESCRIPTION
The following line implies `window` may be `undefined`:
```js
var isNodeWebkit = typeof window !== 'undefined' && ...
```
If that's the case, then it doesn't make sense to be referring to `window.location`, `window.Worker`, `window.chrome`, or `navigator` without guards.