### PR TITLE
browser.worker test: simplify env checks

### DIFF
--- a/tests/integration/browser.worker.js
+++ b/tests/integration/browser.worker.js
@@ -5,13 +5,14 @@
 // Safari: doesn't have IndexedDB or WebSQL in a WW
 // NodeWebkit: not sure what the issue is
 
-var isNodeWebkit = typeof window !== 'undefined' &&
-  typeof process !== 'undefined';
 
-if ((window && typeof window.Worker === 'function') &&
-    !isNodeWebkit && !testUtils.isIE() &&
-    ((window && window.chrome) || (navigator && /Firefox/.test(navigator.userAgent)))) {
-  runTests();
+if (window && typeof window.Worker === 'function') {
+  const isNodeWebkit = typeof process !== 'undefined';
+
+  if (!isNodeWebkit && !testUtils.isIE() &&
+      (window.chrome || (navigator && /Firefox/.test(navigator.userAgent)))) {
+    runTests();
+  }
 }
 
 function runTests() {
@@ -21,7 +22,7 @@ function runTests() {
   before(function () {
     worker = new Worker('worker.js');
 
-    var sourceFile = window && window.location.search.match(/[?&]sourceFile=([^&]+)/);
+    let sourceFile = window.location.search.match(/[?&]sourceFile=([^&]+)/);
 
     if (!sourceFile) {
       sourceFile = '../../packages/node_modules/pouchdb/dist/pouchdb.js';


### PR DESCRIPTION
@garethbowen follow-up to https://github.com/pouchdb/pouchdb/pull/8676, hopefully simplifying the checks a little.