### PR TITLE
.gitignore: remove lerna reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ pouchdb-webpack.js
 lib
 lib_unit
 src_browser/
-lerna-debug.log
 tests/integration/utils-bundle.js
 *.heapsnapshot
 /pouchdb-server-install


### PR DESCRIPTION
lerna was removed in 2016 (9b51141a4a54ec79ac774c6117b5aa4c986d785b).