### PR TITLE
tests: safely de-reference PromiseRejectionEvent

### DIFF
--- a/tests/integration/test.setup_global_hooks.js
+++ b/tests/integration/test.setup_global_hooks.js
@@ -15,7 +15,8 @@ beforeEach(function (done) {
 afterEach(function (done) {
   testUtils.removeUnhandledRejectionListener(currentListener);
   if (currentError) {
-    if (currentError instanceof PromiseRejectionEvent) {
+    if (typeof PromiseRejectionEvent !== 'undefined' &&
+        currentError instanceof PromiseRejectionEvent) {
       currentError = currentError.reason;
     }
 


### PR DESCRIPTION
Sometimes tests fail with `ReferenceError: PromiseRejectionEvent is not defined`.  This masks the actual unhandled promise rejection.

e.g. https://github.com/alxndrsn/pouchdb/actions/runs/5355606144/jobs/9714115593:

```
   1)  "after each" hook for "Changes with invalid ddoc view name 2":
     ReferenceError: PromiseRejectionEvent is not defined
      at Context.<anonymous> (tests/integration/test.setup_global_hooks.js:18:33)
      at processImmediate (internal/timers.js:464:
```