### PR TITLE
test.issue3179: assert that conflicts exist

### DIFF
--- a/tests/integration/test.issue3179.js
+++ b/tests/integration/test.issue3179.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const should = require("chai").should();
+
 var adapters = [
   ['http', 'http'],
   ['http', 'local'],
@@ -44,6 +46,7 @@ adapters.forEach(function (adapters) {
         });
       }).then(function () {
         return local.get('1', {conflicts: true}).then(function (doc) {
+          should.exist(doc._conflicts, 'conflicts expected, but none were found');
           return local.remove(doc._id, doc._conflicts[0]);
         });
       }).then(function () {
@@ -82,6 +85,7 @@ adapters.forEach(function (adapters) {
         return local.sync(remote);
       }).then(function () {
         return local.get('1', {conflicts: true}).then(function (doc) {
+          should.exist(doc._conflicts, 'conflicts expected, but none were found');
           return local.remove(doc._id, doc._conflicts[0]);
         });
       }).then(function () {
@@ -180,6 +184,7 @@ adapters.forEach(function (adapters) {
         return waitForUptodate();
       }).then(function () {
         return local.get('1', {conflicts: true}).then(function (doc) {
+          should.exist(doc._conflicts, 'conflicts expected, but none were found');
           return local.remove(doc._id, doc._conflicts[0]);
         });
       }).then(function () {
@@ -300,6 +305,7 @@ adapters.forEach(function (adapters) {
         return waitForUptodate();
       }).then(function () {
         return local.get('1', {conflicts: true}).then(function (doc) {
+          should.exist(doc._conflicts, 'conflicts expected, but none were found');
           return local.remove(doc._id, doc._conflicts[0]);
         });
       }).then(function () {


### PR DESCRIPTION
Dereferencing `_conflicts` is a common cause of test failures, e.g.

https://github.com/pouchdb/pouchdb/actions/runs/5372099418/jobs/9745290104#step:4:1362

```
   1) test.issue3179.js-local-http #3179 conflicts synced, non-live sync:
     TypeError: Cannot read properties of undefined (reading '0')
      at tests/integration/test.issue3179.js:85:54
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

This change makes it clearer why these tests are failing.

Other recent failures:

* https://github.com/pouchdb/pouchdb/actions/runs/5372099418/jobs/9745289133#step:4:1360
* https://github.com/pouchdb/pouchdb/actions/runs/5328992647/jobs/9654247095#step:5:4629