### PR TITLE
tests/integration: decrease default test timeout

### DIFF
--- a/bin/test-node.sh
+++ b/bin/test-node.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-: ${TIMEOUT:=50000}
+: ${TIMEOUT:=5000}
 : ${REPORTER:="spec"}
 : ${BAIL:=1}
 : ${TYPE:="integration"}

--- a/tests/integration/index.html
+++ b/tests/integration/index.html
@@ -14,7 +14,7 @@
     <script src="../../node_modules/chai-as-promised/lib/chai-as-promised.js"></script>
     <script>
       mocha.setup({
-        timeout:1200000,
+        timeout: 20_000,
         ui: 'bdd'
       });
       var should = chai.should();

--- a/tests/integration/test.compaction.js
+++ b/tests/integration/test.compaction.js
@@ -5,6 +5,7 @@ var autoCompactionAdapters = ['local'];
 
 adapters.forEach(function (adapter) {
   describe('suite2 test.compaction.js-' + adapter, function () {
+    this.timeout(120000); // 2 mins - these tests can take a while!
 
     var dbs = {};
 


### PR DESCRIPTION
browser: from 20 minutes to 20 seconds
node: from 50 seconds to 5 seconds

Various integration tests currently time out intermittently, e.g.:

* https://github.com/pouchdb/pouchdb/issues/8702
* https://github.com/pouchdb/pouchdb/issues/8695
* https://github.com/pouchdb/pouchdb/issues/8691

This timeout can safely be decreased by a significant amount without affecting build stability, but increasing build speeds.