### PR TITLE
unit tests: decrease default test timeout

### DIFF
--- a/bin/test-node.sh
+++ b/bin/test-node.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-: ${TIMEOUT:=50000}
+: ${TIMEOUT:=5000}
 : ${REPORTER:="spec"}
 : ${BAIL:=1}
 : ${TYPE:="integration"}


### PR DESCRIPTION
From 50 seconds to 5 seconds.

Some unit tests currently time out intermittently, e.g.:

* https://github.com/pouchdb/pouchdb/issues/8701

This timeout can safely be decreased by a significant amount without affecting build stability, but increasing build speeds.