### PR TITLE
run-test.sh: enable xtrace

### DIFF
--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 # Run tests against a local setup of pouchdb-express-router
 # by default unless COUCH_HOST is specified.


### PR DESCRIPTION
Issue https://github.com/pouchdb/pouchdb/issues/8713 demonstrates that test retries may call `./bin/run-test.sh`, produce zero output, and mark the build as a success.  E.g. https://github.com/pouchdb/pouchdb/actions/runs/5650289637/job/15306436535#logs:

    pouchdb-monorepo@7.0.0-prerelease test /home/runner/work/pouchdb/pouchdb
    ./bin/run-test.sh

This turns on bash's xtrace option to help debug the problem next time it occurs in CI.