### PR TITLE
(#8706) - Handle null options in 'get' method

### DIFF
--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -493,6 +493,7 @@ class AbstractPouchDB extends EventEmitter {
         cb = opts;
         opts = {};
       }
+      opts = opts || {};
       if (typeof id !== 'string') {
         return cb(createError(INVALID_ID));
       }


### PR DESCRIPTION
When calling the `get` method without a callback and passing `null` as the options parameter, an unexpected error is thrown due to an unhandled case. This fix ensures that the options parameter is properly initialized when it is null, preventing the error from occurring.