### PR TITLE
docs: include baseurl for favicon

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -21,7 +21,7 @@
       })();
     </script>
     <link href='//fonts.googleapis.com/css?family=Lato:400,700|Open+Sans:400,700' rel='stylesheet' type='text/css'>
-    <link rel="icon" href="/static/favicon.ico" type="image/x-icon"/>
+    <link rel="icon" href="{{ site.baseurl }}/static/favicon.ico" type="image/x-icon"/>
   </head>
 
   <body data-spy="scroll" data-target="#sidebar">


### PR DESCRIPTION
In line with other links in the docs, include the jekyll baseurl in the favicon reference.  This allows docs to be hosted at a different path than root, and still have a favicon.