### PR TITLE
fix: upgrade leveldown from 5.6.0 to 6.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "level": "6.0.1",
     "level-codec": "9.0.2",
     "level-write-stream": "1.0.0",
-    "leveldown": "5.6.0",
+    "leveldown": "6.1.1",
     "levelup": "4.4.0",
     "localstorage-down": "0.6.7",
     "ltgt": "2.2.1",


### PR DESCRIPTION
Same as https://github.com/pouchdb/pouchdb/pull/8529 

I had many issue using pouchDB and Next.js _(it seems I'm not the only one https://github.com/vercel/vercel/issues/3635 )_

So I upgraded le library from master, I ran tests locally and it worked. I hope the CI will pass :crossed_fingers: 