### PR TITLE
 docs: build & deploy pouchdb.com on GitHub Pages

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,45 @@
+name: GitHub Pages Deploy
+
+# Only run workflow when triggered manually from Actions tab
+on: workflow_dispatch
+
+# Set permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/install-deps
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - run: sudo gem install bundler -v 2.1.4
+      - run: npm run install-jekyll
+      - run: BUILD=1 npm run build-site
+      - name: upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: docs/_site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+pouchdb.com

--- a/bin/build-site.js
+++ b/bin/build-site.js
@@ -2,7 +2,9 @@
 
 'use strict';
 
+var http_server = require('http-server');
 var fs = require('fs');
+var watchGlob = require('watch-glob');
 var replace = require('replace');
 var exec = require('child-process-promise').exec;
 var mkdirp = require('mkdirp');
@@ -70,9 +72,6 @@ function buildEverything() {
 }
 
 if (!process.env.BUILD) {
-  const http_server = require('http-server');
-  const watchGlob = require('watch-glob');
-
   watchGlob('**', buildJekyll);
   watchGlob('docs/static/less/*/*.less', buildCSS);
   http_server.createServer({root: '_site', cache: '-1'}).listen(4000);

--- a/bin/publish-site.sh
+++ b/bin/publish-site.sh
@@ -1,8 +1,0 @@
-#!/bin/bash -e
-
-# Build the website
-BUILD=1 npm run build-site
-
-# Push the site live, requires credentials, open a bug
-# if you need to be able to push the site
-rsync --recursive --progress docs/_site/* pouchdb@pouchdb.com:/home/pouchdb/www/pouchdb.com/

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "prepublish": "npm run build",
     "release": "./bin/release.sh",
     "install-jekyll": "./bin/install-jekyll.sh",
-    "publish-site": "./bin/publish-site.sh",
     "build-site": "node ./bin/build-site.js",
     "test-coverage": "./bin/test-coverage.sh",
     "coverage": "COVERAGE=1 SERVER=pouchdb-server POUCHDB_SERVER_FLAGS=--in-memory PLUGINS=pouchdb-find ./bin/test-coverage.sh",


### PR DESCRIPTION
Add github action allowing manual building of the docs website from `master`, or any branch which includes `.github/workflows/github-pages.yml` with `on: workflow_dispatch`.

-----

This branch currently deploys to: https://alxndrsn.github.io/pouchdb/

DNS changes will be required.