### PR TITLE
Fix dead link in docs

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -12,7 +12,7 @@ The PouchDB test suite expects an instance of CouchDB (version 1.6.1 and above)
 running in [Admin Party](http://guide.couchdb.org/draft/security.html#party) on
 `http://127.0.0.1:5984` with [CORS
 enabled](https://github.com/pouchdb/add-cors-to-couchdb). See the [official
-CouchDB documentation](http://docs.couchdb.org/en/1.6.1/install/index.html) for
+CouchDB documentation](https://docs.couchdb.org/en/stable/install/index.html) for
 a guide on how to install CouchDB.
 
 If you have CouchDB available at a different URL, you can assign this URL to the

--- a/docs/_includes/api/changes.html
+++ b/docs/_includes/api/changes.html
@@ -30,7 +30,7 @@ All options default to `false` unless otherwise specified.
 * `options.doc_ids`: Only show changes for docs with these ids (array of strings).
 * `options.query_params`: Object containing properties that are passed to the filter function, e.g. `{"foo:"bar"}`, where `"bar"` will be available in the filter function as `params.query.foo`. To access the `params`, define your filter function like `function (doc, params) {/* ... */}`.
 * `options.view`: Specify a view function (e.g. `'design_doc_name/view_name'` or `'view_name'` as shorthand for `'view_name/view_name'`) to act as a filter. Documents counted as "passed" for a view filter if a map function emits at least one record for them. **Note**: `options.filter` must be set to `'_view'` for this option to work.
-* `options.selector`: Filter using a query/pouchdb-find [selector](http://docs.couchdb.org/en/2.0.0/api/database/find.html#selector-syntax). **Note**: Selectors are not supported in CouchDB 1.x. Cannot be used in combination with the filter option.
+* `options.selector`: Filter using a query/pouchdb-find [selector](https://docs.couchdb.org/en/stable/api/database/find.html#find-selectors). **Note**: Cannot be used in combination with the filter option.
 
 **Advanced Options:**
 

--- a/docs/_includes/api/replication.html
+++ b/docs/_includes/api/replication.html
@@ -21,7 +21,7 @@ All options default to `false` unless otherwise specified.
 * `options.doc_ids`: Only show changes for docs with these ids (array of strings).
 * `options.query_params`: Object containing properties that are passed to the filter function, e.g. `{"foo":"bar"}`, where `"bar"` will be available in the filter function as `params.query.foo`. To access the `params`, define your filter function like `function (doc, params) {/* ... */}`.
 * `options.view`: Specify a view function (e.g. `'design_doc_name/view_name'` or `'view_name'` as shorthand for `'view_name/view_name'`) to act as a filter. Documents counted as "passed" for a view filter if a map function emits at least one record for them. **Note**: `options.filter` must be set to `'_view'` for this option to work.
-* `options.selector`: Filter using a query/pouchdb-find [selector](http://docs.couchdb.org/en/2.0.0/api/database/find.html#selector-syntax). **Note**: Selectors are not supported in CouchDB 1.x.
+* `options.selector`: Filter using a query/pouchdb-find [selector](https://docs.couchdb.org/en/stable/api/database/find.html#find-selectors).
 
 **Advanced Options:**
 


### PR DESCRIPTION
- Fix dead link to selector syntax
- Remove reference to CouchDB 1.x.x (last release was almost 10 years ago, I think people have updated by now).