### PR TITLE
docs: standardise docs.couchdb.org links

### DIFF
--- a/docs/_guides/mango-queries.md
+++ b/docs/_guides/mango-queries.md
@@ -89,7 +89,7 @@ db.find({
 });
 ```
 
-Note that we are specifying that the `name` must be greater than or equal to `null`, which is a workaround for the fact that the Mango query language requires us to have a selector. In [CouchDB collation order](http://docs.couchdb.org/en/2.1.1/ddocs/views/collation.html), `null` is the "lowest" value, and so this will return all documents regardless of their `name` value.
+Note that we are specifying that the `name` must be greater than or equal to `null`, which is a workaround for the fact that the Mango query language requires us to have a selector. In [CouchDB collation order](https://docs.couchdb.org/en/stable/ddocs/views/collation.html), `null` is the "lowest" value, and so this will return all documents regardless of their `name` value.
 
 {% include anchor.html title="Pagination" hash="pagination" %}
 
@@ -345,7 +345,7 @@ The Mango query language is quite large and supports many options. Some of the m
 
 There are many more options besides these, although note that not all of them can take advantage of indexes. For instance, `$regex`, `$ne`, and `$not` cannot use on-disk indexes, and must use in-memory filtering instead.
 
-The most complete documentation for selector options can be found in the [CouchDB `_find` documentation](http://docs.couchdb.org/en/2.0.0/api/database/find.html). You might also look at the [Cloudant Query Language](https://docs.cloudant.com/cloudant_query.html) documentation (which is nearly identical to Mango, other than `text` and other Cloudant-specific features). PouchDB uses CouchDB as the reference implementation; they ought to be functionally identical.
+The most complete documentation for selector options can be found in the [CouchDB `_find` documentation](https://docs.couchdb.org/en/stable/api/database/find.html). You might also look at the [Cloudant Query Language](https://docs.cloudant.com/cloudant_query.html) documentation (which is nearly identical to Mango, other than `text` and other Cloudant-specific features). PouchDB uses CouchDB as the reference implementation; they ought to be functionally identical.
 
 It should be noted that, over HTTP, this API currently works with CouchDB 2.0+, Cloudant, and PouchDB Server.
 CouchDB 2.0 is the reference implementation, so the API should be the same. CouchDB 1.6.1 and below is not supported.

--- a/docs/_includes/api/batch_fetch.html
+++ b/docs/_includes/api/batch_fetch.html
@@ -28,7 +28,7 @@ All options default to `false` unless otherwise specified.
     - For details, see the [CouchDB query options documentation](https://docs.couchdb.org/en/stable/api/ddoc/views.html#db-design-design-doc-view-view-name).
 * `options.update_seq`: Include an `update_seq` value indicating which sequence id of the underlying database the view reflects.
 
-**Notes:** For pagination, `options.limit` and `options.skip` are also available, but the same performance concerns as in CouchDB apply. Use the [startkey/endkey pattern](http://docs.couchdb.org/en/latest/couchapp/views/pagination.html) instead.
+**Notes:** For pagination, `options.limit` and `options.skip` are also available, but the same performance concerns as in CouchDB apply. Use the [startkey/endkey pattern](https://docs.couchdb.org/en/stable/couchapp/views/pagination.html) instead.
 
 #### Example Usage:
 
@@ -202,4 +202,4 @@ db.allDocs({
 {% endhighlight %}
 {% include code/end.html %}
 
-This works because CouchDB/PouchDB `_id`s are sorted [lexicographically](http://docs.couchdb.org/en/latest/couchapp/views/collation.html).
+This works because CouchDB/PouchDB `_id`s are sorted [lexicographically](https://docs.couchdb.org/en/stable/couchapp/views/collation.html).

--- a/docs/_includes/api/query_database.html
+++ b/docs/_includes/api/query_database.html
@@ -4,7 +4,7 @@
 db.query(fun, [options], [callback])
 {% endhighlight %}
 
-Invoke a map/reduce function, which allows you to perform more complex queries on PouchDB than what you get with [allDocs()](#batch_fetch), [changes()](#changes), or [find()](#query_index). The [CouchDB documentation for map/reduce](http://docs.couchdb.org/en/latest/couchapp/views/intro.html) applies to PouchDB.
+Invoke a map/reduce function, which allows you to perform more complex queries on PouchDB than what you get with [allDocs()](#batch_fetch), [changes()](#changes), or [find()](#query_index). The [CouchDB documentation for map/reduce](https://docs.couchdb.org/en/stable/couchapp/views/intro.html) applies to PouchDB.
 
 Since views perform a full scan of all documents, this method may be slow, unless you first save your view in a design document. Read the [query guide](/guides/queries.html) for a good tutorial.
 
@@ -33,7 +33,7 @@ All options default to `false` unless otherwise specified.
   * A reduce function.
   * The string name of a built-in function: `'_sum'`, `'_count'`, or `'_stats'`.
     * Tip: if you're not using a built-in, [you're probably doing it wrong](http://youtu.be/BKQ9kXKoHS8?t=865s).
-    * PouchDB will always call your reduce function with rereduce == false. As for CouchDB, refer to the [CouchDB documentation](http://docs.couchdb.org/en/1.6.1/couchapp/views/intro.html).
+    * PouchDB will always call your reduce function with rereduce == false. As for CouchDB, refer to the [CouchDB documentation](https://docs.couchdb.org/en/stable/couchapp/views/intro.html).
 * `options.include_docs`: Include the document in each row in the `doc` field.
     - `options.conflicts`: Include conflicts in the `_conflicts` field of a doc.
   - `options.attachments`: Include attachment data.
@@ -57,7 +57,7 @@ All options default to `false` unless otherwise specified.
     * `'update_after'`: Returns results immediately, but kicks off a build afterwards.
 * `options.update_seq`: Include an `update_seq` value indicating which sequence id of the underlying database the view reflects.
 
-For details, see the [CouchDB query options documentation](http://docs.couchdb.org/en/stable/api/ddoc/views.html#get--db-_design-ddoc-_view-view).
+For details, see the [CouchDB query options documentation](https://docs.couchdb.org/en/stable/api/ddoc/views.html#get--db-_design-ddoc-_view-view).
 
 #### Example Usage:
 

--- a/docs/_includes/api/query_index.html
+++ b/docs/_includes/api/query_index.html
@@ -113,7 +113,7 @@ If there's no index that matches your `selector`/`sort`, then this method will i
 
 The best index will be chosen automatically.
 
-See the [CouchDB `_find` documentation](http://docs.couchdb.org/en/2.0.0/api/database/find.html) for more details on
+See the [CouchDB `_find` documentation](https://docs.couchdb.org/en/stable/api/database/find.html) for more details on
 selectors and the Mango query language.
 
 ### More examples

--- a/packages/node_modules/pouchdb-find/README.md
+++ b/packages/node_modules/pouchdb-find/README.md
@@ -12,7 +12,7 @@ Eventually this will replace PouchDB's map/reduce API entirely. You'll still be 
 Status
 ---
 
-Implemented: `$lt`, `$gt`, `$lte`, `$gte`, `$eq`, `$exists`, `$type`, `$in`, `$nin`, `$all`, `$size`, `$or`, `$nor`, `$not`, `$mod`, `$regex`, `$elemMatch`, multi-field queries, multi-field indexes, multi-field sort, `'deep.fields.like.this'`, ascending and descending sort, [partial indexes](http://docs.couchdb.org/en/stable/api/database/find.html#find-partial-indexes).
+Implemented: `$lt`, `$gt`, `$lte`, `$gte`, `$eq`, `$exists`, `$type`, `$in`, `$nin`, `$all`, `$size`, `$or`, `$nor`, `$not`, `$mod`, `$regex`, `$elemMatch`, multi-field queries, multi-field indexes, multi-field sort, `'deep.fields.like.this'`, ascending and descending sort, [partial indexes](https://docs.couchdb.org/en/stable/api/database/find.html#find-partial-indexes).
 
 **0.2.0**: `$and`, `$ne`
 


### PR DESCRIPTION
* always use /stable/ in preference to /latest/ or /$version/
* always use https://

N.B. this commit does not change links in blog posts.