### PR TITLE
Fixing some non-function links in documentation + some http -> https

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -223,11 +223,11 @@
       </div>
 
     </footer>
-    <script type="text/javascript" src="//code.jquery.com/jquery.min.js"></script>
-    <script type="text/javascript" src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery.min.js"></script>
+    <script type="text/javascript" src="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="{{ site.baseurl }}/static/js/code.min.js"></script>
     <script type="text/javascript" src="{{ site.baseurl }}/static/js/stickyfill.min.js"></script>
-    <script type="text/javascript" src="//cdn.jsdelivr.net/npm/pouchdb/dist/pouchdb.min.js"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/pouchdb/dist/pouchdb.min.js"></script>
     <script type="text/javascript">
       var $navSidebarWrapper = $('.nav-sidebar-wrapper');
       if ($navSidebarWrapper.length) {

--- a/docs/download.md
+++ b/docs/download.md
@@ -7,7 +7,7 @@ sidebar: nav.html
 {% include anchor.html class="h3" title="Quick Start" hash="file" %}
 
 {% highlight html %}
-<script src="//cdn.jsdelivr.net/npm/pouchdb@{{site.version}}/dist/pouchdb.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/pouchdb@{{site.version}}/dist/pouchdb.min.js"></script>
 <script>
   var db = new PouchDB('my_database');
 </script>
@@ -22,7 +22,7 @@ If you are using PouchDB in Internet Explorer a [Promise](https://www.npmjs.com/
 
 {% include anchor.html class="h3" title="npm" hash="npm" %}
 
-PouchDB can be installed through [npm](http://npmjs.com):
+PouchDB can be installed through [npm](https://npmjs.com):
 
 {% highlight bash %}npm install --save pouchdb{% endhighlight %}
 
@@ -33,7 +33,7 @@ var PouchDB = require('pouchdb');
 var db = new PouchDB('my_database');
 {% endhighlight %}
 
-PouchDB can be used either in Node or in the browser. A bundler such as [Browserify](http://browserify.org/), [Webpack](https://webpack.github.io/), or [Rollup](http://rollupjs.org/) is needed for browser usage.
+PouchDB can be used either in Node or in the browser. A bundler such as [Browserify](https://browserify.org/), [Webpack](https://webpack.github.io/), or [Rollup](https://rollupjs.org/) is needed for browser usage.
 
 #### Browser only
 
@@ -54,7 +54,7 @@ See [custom builds]({{ site.baseurl }}/custom.html) for more options.
 PouchDB is hosted at these CDNs:
 
 * [cdnjs](https://cdnjs.com/libraries/pouchdb)
-* [jsdelivr](http://www.jsdelivr.com/#!pouchdb)
+* [jsdelivr](https://www.jsdelivr.com/#!pouchdb)
 * [unpkg](https://unpkg.com/pouchdb@{{ site.version }}/dist/)
 
 {% highlight bash %}bower install --save pouchdb{% endhighlight %}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@ In this tutorial we will write a basic Todo web application based on [TodoMVC](h
 
 Prefer video tutorials? This guide is available in video format:
 
-{% include iframe.html src="//www.youtube.com/embed/-Z7UF2TuSp0" %}
+{% include iframe.html src="https://www.youtube.com/embed/-Z7UF2TuSp0" %}
 
 {% include anchor.html class="h3" title="Download Assets" hash="download" %}
 
@@ -41,7 +41,7 @@ It's also a good idea to open your browser's console so you can see any errors o
 Open `index.html` and include PouchDB in the app by adding a script tag:
 
 {% highlight html %}
-<script src="//cdn.jsdelivr.net/npm/pouchdb@{{site.version}}/dist/pouchdb.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/pouchdb@{{site.version}}/dist/pouchdb.min.js"></script>
 <script src="js/base.js"></script>
 <script src="js/app.js"></script>
 {% endhighlight %}

--- a/docs/manifest.appcache
+++ b/docs/manifest.appcache
@@ -17,19 +17,19 @@ CACHE:
 /static/js/code.min.js
 /static/js/stickyfill.min.js
 
-http://code.jquery.com/jquery.min.js
-http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js
-http://cdn.jsdelivr.net/npm/pouchdb/dist/pouchdb.min.js
+https://code.jquery.com/jquery.min.js
+https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js
+https://cdn.jsdelivr.net/npm/pouchdb/dist/pouchdb.min.js
 
-http://fonts.googleapis.com/css?family=Lato:400,700|Open+Sans:400,700
-http://fonts.gstatic.com/s/lato/v11/8qcEw_nrk_5HEcCpYdJu8BTbgVql8nDJpwnrE27mub0.woff2
-http://fonts.gstatic.com/s/lato/v11/MDadn8DQ_3oT6kvnUq_2rxTbgVql8nDJpwnrE27mub0.woff2
-http://fonts.gstatic.com/s/lato/v11/rZPI2gHXi8zxUjnybc2ZQFKPGs1ZzpMvnHX-7fPOuAc.woff2
-http://fonts.gstatic.com/s/lato/v11/MgNNr5y1C_tIEuLEmicLm1KPGs1ZzpMvnHX-7fPOuAc.woff2
-http://fonts.gstatic.com/s/opensans/v10/u-WUoqrET9fUeobQW7jkRZBw1xU1rKptJj_0jans920.woff2
-http://fonts.gstatic.com/s/opensans/v10/cJZKeOuBrn4kERxqtaUH3ZBw1xU1rKptJj_0jans920.woff2
-http://fonts.gstatic.com/s/opensans/v10/k3k702ZOKiLJc3WVjuplzCYtBUPDK3WL7KRKS_3q7OE.woff2
-http://fonts.gstatic.com/s/opensans/v10/k3k702ZOKiLJc3WVjuplzBampu5_7CjHW5spxoeN3Vs.woff2
+https://fonts.googleapis.com/css?family=Lato:400,700|Open+Sans:400,700
+https://fonts.gstatic.com/s/lato/v11/8qcEw_nrk_5HEcCpYdJu8BTbgVql8nDJpwnrE27mub0.woff2
+https://fonts.gstatic.com/s/lato/v11/MDadn8DQ_3oT6kvnUq_2rxTbgVql8nDJpwnrE27mub0.woff2
+https://fonts.gstatic.com/s/lato/v11/rZPI2gHXi8zxUjnybc2ZQFKPGs1ZzpMvnHX-7fPOuAc.woff2
+https://fonts.gstatic.com/s/lato/v11/MgNNr5y1C_tIEuLEmicLm1KPGs1ZzpMvnHX-7fPOuAc.woff2
+https://fonts.gstatic.com/s/opensans/v10/u-WUoqrET9fUeobQW7jkRZBw1xU1rKptJj_0jans920.woff2
+https://fonts.gstatic.com/s/opensans/v10/cJZKeOuBrn4kERxqtaUH3ZBw1xU1rKptJj_0jans920.woff2
+https://fonts.gstatic.com/s/opensans/v10/k3k702ZOKiLJc3WVjuplzCYtBUPDK3WL7KRKS_3q7OE.woff2
+https://fonts.gstatic.com/s/opensans/v10/k3k702ZOKiLJc3WVjuplzBampu5_7CjHW5spxoeN3Vs.woff2
 
 /static/img/apple-indexeddb.png
 /static/img/cors_in_couchdb.png
@@ -63,5 +63,5 @@ http://fonts.gstatic.com/s/opensans/v10/k3k702ZOKiLJc3WVjuplzBampu5_7CjHW5spxoeN
 
 NETWORK:
 *
-http://*
+https://*
 https://*

--- a/docs/manifest.appcache
+++ b/docs/manifest.appcache
@@ -63,5 +63,5 @@ https://fonts.gstatic.com/s/opensans/v10/k3k702ZOKiLJc3WVjuplzBampu5_7CjHW5spxoe
 
 NETWORK:
 *
-https://*
+http://*
 https://*


### PR DESCRIPTION
Found out that the script-tag example for using pouchdb through jsdelivr wasn't fully correct, so fixed what I found and also changed some http:// to https://

There are a lot of http but saw that some Python-pages wasn't set up with https, so didn't go through the whole library, and didn't want to break localhost-stuff.

I don't get the `npm run build-site` to work, so only find-and-replace. Let me know if you want these changes in another form.