### PR TITLE
tests/integration: use asyncLoadScript()

### DIFF
--- a/tests/common-utils.js
+++ b/tests/common-utils.js
@@ -120,7 +120,7 @@ commonUtils.loadPouchDBForBrowser = function (plugins) {
 
 // Thanks to http://engineeredweb.com/blog/simple-async-javascript-loader/
 commonUtils.asyncLoadScript = function (url) {
-  return new commonUtils.Promise(function (resolve) {
+  return new commonUtils.Promise(function (resolve, reject) {
     // Create a new script and setup the basics.
     var script = document.createElement("script");
     var firstScript = document.getElementsByTagName('script')[0];
@@ -128,6 +128,7 @@ commonUtils.asyncLoadScript = function (url) {
     script.async = true;
     script.src = url;
 
+    script.onerror = reject;
     script.onload = function () {
       resolve();
 

--- a/tests/common-utils.js
+++ b/tests/common-utils.js
@@ -123,7 +123,6 @@ commonUtils.asyncLoadScript = function (url) {
   return new commonUtils.Promise(function (resolve, reject) {
     // Create a new script and setup the basics.
     var script = document.createElement("script");
-    var firstScript = document.getElementsByTagName('script')[0];
 
     script.async = true;
     script.src = url;
@@ -142,9 +141,7 @@ commonUtils.asyncLoadScript = function (url) {
       }
     };
 
-    // Attach the script tag to the page (before the first script) so the
-    //magic can happen.
-    firstScript.parentNode.insertBefore(script, firstScript);
+    document.body.append(script);
   });
 };
 

--- a/tests/integration/browser.migration.js
+++ b/tests/integration/browser.migration.js
@@ -46,13 +46,7 @@ describe('migration', function () {
       if (!match) {
         return testUtils.Promise.resolve();
       }
-      return new testUtils.Promise(function (resolve, reject) {
-        var script = document.createElement('script');
-        script.onload = resolve;
-        script.onerror = reject;
-        script.src = 'deps/pouchdb-' + match[1] + '-postfixed.js';
-        document.body.appendChild(script);
-      });
+      return testUtils.asyncLoadScript('deps/pouchdb-' + match[1] + '-postfixed.js');
     }));
   });
 

--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -3113,15 +3113,9 @@ adapters.forEach(function (adapter) {
             var bigimage = require('./deps/bigimage.js');
             cb(null, bigimage);
           } else { // browser
-            var script = document.createElement('script');
-            script.src = 'deps/bigimage.js';
-            document.body.appendChild(script);
-            var timeout = setInterval(function () {
-              if (window.bigimage) {
-                clearInterval(timeout);
-                cb(null, window.bigimage);
-              }
-            }, 500);
+            testUtils.asyncLoadScript('deps/bigimage.js')
+                .then(() => cb(null, window.bigimage))
+                .catch(err => cb(err));
           }
         }
 


### PR DESCRIPTION
Replace duplicated script-loading code with existing `commonUtils.asyncLoadScript()` function.

Also removes a timeout-based implementation in `tests/integration/test.attachments.js`.