### PR TITLE
tests/integration: move isSafari checks to testUtils.isSafari()

### DIFF
--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -3101,10 +3101,7 @@ adapters.forEach(function (adapter) {
     });
 
 
-    var isSafari = (typeof process === 'undefined' || process.browser) &&
-      /Safari/.test(window.navigator.userAgent) &&
-      !/Chrome/.test(window.navigator.userAgent);
-    if (!isSafari && !testUtils.isIE()) {
+    if (!testUtils.isSafari() && !testUtils.isIE()) {
       // skip in safari/ios because of size limit popup
       it('putAttachment and getAttachment with big png data', function (done) {
 

--- a/tests/integration/test.bulk_docs.js
+++ b/tests/integration/test.bulk_docs.js
@@ -1012,9 +1012,7 @@ adapters.forEach(function (adapter) {
 
       // simulate 5000 normal commits with two conflicts at the very end
 
-      var isSafari = (typeof process === 'undefined' || process.browser) &&
-        /Safari/.test(window.navigator.userAgent) &&
-        !/Chrome/.test(window.navigator.userAgent);
+      const isSafari = testUtils.isSafari();
 
       var numRevs = isSafari ? 10 : 5000;
       var expected = isSafari ? 10 : 1000;

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -171,10 +171,7 @@ adapters.forEach(function (adapters) {
       }
 
       var numRevs = 5000;
-      var isSafari = (typeof process === 'undefined' || process.browser) &&
-        /Safari/.test(window.navigator.userAgent) &&
-        !/Chrome/.test(window.navigator.userAgent);
-      if (isSafari) {
+      if (testUtils.isSafari()) {
         numRevs = 10; // fuck safari, we've hit the storage limit again
       }
 

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -24,6 +24,12 @@ testUtils.isIE = function () {
   return (isIE || isTrident || isEdge);
 };
 
+testUtils.isSafari = function () {
+  return (typeof process === 'undefined' || process.browser) &&
+      /Safari/.test(window.navigator.userAgent) &&
+      !/Chrome/.test(window.navigator.userAgent);
+};
+
 testUtils.adapterType = function () {
   return testUtils.adapters().indexOf('http') < 0 ? 'local' : 'http';
 };


### PR DESCRIPTION
* avoid repeating complicated test
* consistent with `testUtils.isIE()`