### PR TITLE
perf-tests: add option to save benchmarks to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ package-lock.json
 yarn.lock
 /.eslintcache
 release-todo.txt
+/perf-test-results/

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -151,7 +151,7 @@ function BenchmarkJsonReporter(runner) {
       mkdirSync(resultsDir, { recursive: true });
 
       const jsonPath = `${resultsDir}/${new Date().toISOString()}.json`;
-      writeFileSync(jsonPath, JSON.stringify(results));
+      writeFileSync(jsonPath, JSON.stringify(results, null, 2));
       console.log('Wrote JSON results to:', jsonPath);
     } else {
       console.log('Runner failed; JSON will not be writted.');


### PR DESCRIPTION
Set env var `JSON_REPORTER` to save performance test results to a JSON file in `./perf-test-results/`.