### PR TITLE
run-test: echo COUCH_HOST value when waiting

### DIFF
--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -118,7 +118,7 @@ if [ "$SERVER" == "couchdb-master" ]; then
   ./node_modules/.bin/add-cors-to-couchdb $COUCH_HOST
 fi
 
-printf 'Waiting for host to start .'
+printf "Waiting for host to start on $COUCH_HOST..."
 WAITING=0
 until $(curl --output /dev/null --silent --head --fail --max-time 2 $COUCH_HOST); do
     if [ $WAITING -eq 4 ]; then


### PR DESCRIPTION
If trying to debug a failure to connect to COUCH_HOST, it's reassuring to be explicitly told the URL of the COUCH_HOST that run-test is failing to connect to.