### PR TITLE
adapter-idb/allDocs: simplify getMaxUpdateSeq()

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/allDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/allDocs.js
@@ -114,25 +114,19 @@ function idbAllDocs(opts, idb, callback) {
 
   /* istanbul ignore if */
   if (opts.update_seq) {
-    getMaxUpdateSeq(seqStore, function (e) {
-      if (e.target.result && e.target.result.length > 0) {
-        updateSeq = e.target.result[0];
-      }
+    getMaxUpdateSeq(seqStore, function (maxKey) {
+      updateSeq = maxKey;
     });
   }
 
   function getMaxUpdateSeq(objectStore, onSuccess) {
     function onCursor(e) {
       var cursor = e.target.result;
-      var maxKey = undefined;
       if (cursor && cursor.key) {
-        maxKey = cursor.key;
+        return onSuccess(cursor.key);
+      } else {
+        return onSuccess(undefined);
       }
-      return onSuccess({
-        target: {
-          result: [maxKey]
-        }
-      });
     }
     objectStore.openCursor(null, 'prev').onsuccess = onCursor;
   }

--- a/packages/node_modules/pouchdb-adapter-idb/src/allDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/allDocs.js
@@ -114,21 +114,13 @@ function idbAllDocs(opts, idb, callback) {
 
   /* istanbul ignore if */
   if (opts.update_seq) {
-    getMaxUpdateSeq(seqStore, function (maxKey) {
-      updateSeq = maxKey;
-    });
-  }
-
-  function getMaxUpdateSeq(objectStore, onSuccess) {
-    function onCursor(e) {
+    // get max updateSeq
+    seqStore.openCursor(null, 'prev').onsuccess = e => {
       var cursor = e.target.result;
       if (cursor && cursor.key) {
-        return onSuccess(cursor.key);
-      } else {
-        return onSuccess(undefined);
+        updateSeq = cursor.key;
       }
-    }
-    objectStore.openCursor(null, 'prev').onsuccess = onCursor;
+    };
   }
 
   // if the user specifies include_docs=true, then we don't


### PR DESCRIPTION
* The current code seems needlessly convoluted.
* Allows eslint rule `no-undef-init` (https://github.com/pouchdb/pouchdb/pull/8758) to pass.