### PR TITLE
tests/browser.migration: compare version parts as numbers not strings

### DIFF
--- a/tests/integration/browser.migration.js
+++ b/tests/integration/browser.migration.js
@@ -1170,9 +1170,9 @@ describe('migration', function () {
 function versionGte(scenario, minimumRequired) {
   const match = scenario.match(/^PouchDB v([.\d]+)$/);
   if (!match) { return false; }
-  const actual = match[1].split('.');
+  const actual = match[1].split('.').map(Number);
 
-  const min = minimumRequired.split('.');
+  const min = minimumRequired.split('.').map(Number);
 
   for (let i=0; i<min.length; ++i) {
     if (actual[i] > min[i]) { return true; }


### PR DESCRIPTION
### Current `master` implementation:

```js
> versionGte('PouchDB v9.0.0', '8.0.0')
true
> versionGte('PouchDB v10.0.0', '8.0.0')
false
```

### This PR implementation:

```js
> versionGte('PouchDB v9.0.0', '8.0.0')
true
> versionGte('PouchDB v10.0.0', '8.0.0')
true
```