### PR TITLE
test-browser: catch-and-fail on unhandled error

### DIFF
--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -180,12 +180,19 @@ async function startTest() {
   };
   const browser = await playwright[browserName].launch(options);
   const page = await browser.newPage();
+
+  page.on('pageerror', err => {
+    console.log('Unhandled error in test page:', err);
+    process.exit(1);
+  });
+
   if (process.env.BROWSER_CONSOLE) {
     page.on('console', message => {
       const { url, lineNumber } = message.location();
       console.log('BROWSER', message.type().toUpperCase(), `${url}:${lineNumber}`, message.text());
     });
   }
+
   await page.goto(testUrl);
 
   const userAgent = await page.evaluate('navigator.userAgent');


### PR DESCRIPTION
This highlights a bug introduced in e6b8c9371a6e5682e35b368b2ababb4a288a17a5

Closes #8673