### PR TITLE
test.issue3179: fix: allow test to run in browsers

### DIFF
--- a/tests/integration/test.issue3179.js
+++ b/tests/integration/test.issue3179.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const should = require("chai").should();
-
 var adapters = [
   ['http', 'http'],
   ['http', 'local'],


### PR DESCRIPTION
Introduced in e6b8c9371a6e5682e35b368b2ababb4a288a17a5, use of `require()` silently fails tests in browser environments.  Also `should` is already declared as a global.