### PR TITLE
indexeddb: rename main adapter function

### DIFF
--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
@@ -26,7 +26,7 @@ var idbChanges = new changesHandler();
 // A shared list of database handles
 var openDatabases = {};
 
-function IdbPouch(dbOpts, callback) {
+function IndexeddbPouch(dbOpts, callback) {
 
   if (dbOpts.view_adapter) {
     console.log('Please note that the indexeddb adapter manages _find indexes itself, therefore it is not using your specified view_adapter');
@@ -161,10 +161,10 @@ function IdbPouch(dbOpts, callback) {
 }
 
 // TODO: this isnt really valid permanently, just being lazy to start
-IdbPouch.valid = function () {
+IndexeddbPouch.valid = function () {
   return true;
 };
 
 export default function (PouchDB) {
-  PouchDB.adapter(ADAPTER_NAME, IdbPouch, true);
+  PouchDB.adapter(ADAPTER_NAME, IndexeddbPouch, true);
 }


### PR DESCRIPTION
This helps differentiate from `pouchdb-adapter-idb` in stack traces.

For comparison:

https://github.com/pouchdb/pouchdb/blob/d2f6bcf478f61e3c98bdfc974ff003958f2fd43a/packages/node_modules/pouchdb-adapter-idb/src/index.js#L57

https://github.com/pouchdb/pouchdb/blob/d2f6bcf478f61e3c98bdfc974ff003958f2fd43a/packages/node_modules/pouchdb-adapter-http/src/index.js#L156

https://github.com/pouchdb/pouchdb/blob/d2f6bcf478f61e3c98bdfc974ff003958f2fd43a/packages/node_modules/pouchdb-adapter-localstorage/src/index.js#L6

https://github.com/pouchdb/pouchdb/blob/d2f6bcf478f61e3c98bdfc974ff003958f2fd43a/packages/node_modules/pouchdb-adapter-leveldb/src/index.js#L6