### PR TITLE
indexeddb.getAttachments(): reduce selects from N+1

### DIFF
--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/getAttachment.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/getAttachment.js
@@ -2,25 +2,19 @@
 
 import { btoa, readAsBinaryString } from 'pouchdb-binary-utils';
 
-function getAttachment(txn, docId, attachId, _, opts, cb) {
+export default function getAttachment(txn, docId, attachId, attachment, opts, cb) {
   if (txn.error) {
     return cb(txn.error);
   }
 
   const doc = opts.metadata;
-  const rev = doc.revs[opts.rev || doc.rev].data;
-  const digest = rev._attachments[attachId].digest;
-  const attachment = doc.attachments[digest].data;
+  const data = doc.attachments[attachment.digest].data;
 
   if (opts.binary) {
-    return cb(null, attachment);
+    return cb(null, data);
   } else {
-    readAsBinaryString(attachment, function (binString) {
+    readAsBinaryString(data, function (binString) {
       cb(null, btoa(binString));
     });
   }
 }
-
-export {
-  getAttachment,
-};

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/getAttachment.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/getAttachment.js
@@ -2,9 +2,16 @@
 
 import { btoa, readAsBinaryString } from 'pouchdb-binary-utils';
 
-import { DOC_STORE } from './util';
+function getAttachment(txn, docId, attachId, _, opts, cb) {
+  if (txn.error) {
+    return cb(txn.error);
+  }
 
-function parseAttachment(attachment, opts, cb) {
+  const doc = opts.metadata;
+  const rev = doc.revs[opts.rev || doc.rev].data;
+  const digest = rev._attachments[attachId].digest;
+  const attachment = doc.attachments[digest].data;
+
   if (opts.binary) {
     return cb(null, attachment);
   } else {
@@ -14,28 +21,6 @@ function parseAttachment(attachment, opts, cb) {
   }
 }
 
-function getAttachment(txn, docId, attachId, _, opts, cb) {
-  if (txn.error) {
-    return cb(txn.error);
-  }
-
-  var attachment;
-
-  txn.txn.objectStore(DOC_STORE).get(docId).onsuccess = function (e) {
-    var doc = e.target.result;
-    var rev = doc.revs[opts.rev || doc.rev].data;
-    var digest = rev._attachments[attachId].digest;
-    attachment = doc.attachments[digest].data;
-  };
-
-  txn.txn.oncomplete = function () {
-    parseAttachment(attachment, opts, cb);
-  };
-
-  txn.txn.onabort = cb;
-}
-
 export {
   getAttachment,
-  parseAttachment
 };

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
@@ -6,7 +6,7 @@ import setup from './setup';
 // API implementations
 import info from './info';
 import get from './get';
-import { getAttachment } from './getAttachment';
+import getAttachment from './getAttachment';
 import bulkDocs from './bulkDocs';
 import allDocs from './allDocs';
 import changes from './changes';

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -658,6 +658,7 @@ class AbstractPouchDB extends EventEmitter {
               // pass the rev through
               rev: doc._rev,
               binary: opts.binary,
+              metadata: metadata,
               ctx: ctx
             }, function (err, data) {
               var att = doc._attachments[key];
@@ -698,6 +699,7 @@ class AbstractPouchDB extends EventEmitter {
         if (res.doc._attachments && res.doc._attachments[attachmentId]) {
           opts.ctx = res.ctx;
           opts.binary = true;
+          opts.metadata = res.metadata;
           this._getAttachment(docId, attachmentId,
                               res.doc._attachments[attachmentId], opts, callback);
         } else {

--- a/tests/performance/perf.attachments.js
+++ b/tests/performance/perf.attachments.js
@@ -1,12 +1,14 @@
 'use strict';
 
+const MIME_OCTET = 'application/octet-stream';
+
 function randomBrowserBlob(size) {
   var buff = new ArrayBuffer(size);
   var arr = new Uint8Array(buff);
   for (var i = 0; i < size; i++) {
     arr[i] = Math.floor(65535 * Math.random());
   }
-  return new Blob([buff], {type: 'application/octet-stream'});
+  return new Blob([buff], {type: MIME_OCTET});
 }
 
 function randomBuffer(size) {
@@ -45,11 +47,53 @@ module.exports = function (PouchDB, callback) {
       },
       test: function (db, itr, doc, done) {
         db.putAttachment(Math.random().toString(), 'foo.txt', db._blob,
-          'application/octet-stream').then(function () {
+          MIME_OCTET).then(function () {
           done();
         }, done);
       }
-    }
+    },
+    {
+      name: 'many-attachments-base64',
+      assertions: 1,
+      iterations: 100,
+      setup: function (db, callback) {
+        const doc = {
+          _id: 'doc1',
+          _attachments: {},
+        };
+        for (let i=0; i<100; ++i) {
+          doc._attachments['att-' + i] = {
+            content_type: MIME_OCTET,
+            data: randomBlob(50000),
+          };
+        }
+        db.put(doc).then(() => callback()).catch(callback);
+      },
+      test: function (db, itr, doc, done) {
+        db.get('doc1', {attachments: true}).then(() => done()).catch(done);
+      }
+    },
+    {
+      name: 'many-attachments-binary',
+      assertions: 1,
+      iterations: 100,
+      setup: function (db, callback) {
+        const doc = {
+          _id: 'doc1',
+          _attachments: {},
+        };
+        for (let i=0; i<100; ++i) {
+          doc._attachments['att-' + i] = {
+            content_type: MIME_OCTET,
+            data: randomBlob(50000),
+          };
+        }
+        db.put(doc).then(() => callback()).catch(callback);
+      },
+      test: function (db, itr, doc, done) {
+        db.get('doc1', {attachments: true, binary: true}).then(() => done()).catch(done);
+      }
+    },
   ];
 
   utils.runTests(PouchDB, 'attachments', testCases, callback);


### PR DESCRIPTION
This one weird trick (probably) improves perf by quite a bit.