### PR TITLE
tests/common-utils: parse query string w/ URLSearchParams

### DIFF
--- a/tests/common-utils.js
+++ b/tests/common-utils.js
@@ -14,14 +14,15 @@ commonUtils.params = function () {
   if (commonUtils.isNode()) {
     return process.env;
   }
-  const usp = new URLSearchParams(document.location.search);
-  return usp.entries().reduce((acc, [k, v]) => {
+  const usp = new URLSearchParams(window.location.search);
+  const acc = {};
+  for (const [k, v] of usp) {
     // REVIEW: This preserves previous behaviour: an empty value is re-mapped to
     // `true`.  This is surprising, and differs from the handling of env vars in
     // node (see above).
     acc[k] = v || true;
-    return acc;
-  }, {});
+  }
+  return acc;
 };
 
 commonUtils.adapters = function () {

--- a/tests/common-utils.js
+++ b/tests/common-utils.js
@@ -15,14 +15,14 @@ commonUtils.params = function () {
     return process.env;
   }
   const usp = new URLSearchParams(window.location.search);
-  const acc = {};
+  const params = {};
   for (const [k, v] of usp) {
-    // REVIEW: This preserves previous behaviour: an empty value is re-mapped to
+    // This preserves previous behaviour: an empty value is re-mapped to
     // `true`.  This is surprising, and differs from the handling of env vars in
     // node (see above).
-    acc[k] = v || true;
+    params[k] = v || true;
   }
-  return acc;
+  return params;
 };
 
 commonUtils.adapters = function () {

--- a/tests/common-utils.js
+++ b/tests/common-utils.js
@@ -14,7 +14,7 @@ commonUtils.params = function () {
   if (commonUtils.isNode()) {
     return process.env;
   }
-  const usp = new URLSearchParams(window.location.search);
+  const usp = new URLSearchParams(document.location.search);
   return usp.entries().reduce((acc, [k, v]) => {
     // REVIEW: This preserves previous behaviour: an empty value is re-mapped to
     // `true`.  This is surprising, and differs from the handling of env vars in

--- a/tests/common-utils.js
+++ b/tests/common-utils.js
@@ -15,12 +15,12 @@ commonUtils.params = function () {
     return process.env;
   }
   var paramStr = document.location.search.slice(1);
-  return paramStr.split('&').reduce(function (acc, val) {
-    if (!val) {
-      return acc;
-    }
-    var tmp = val.split('=');
-    acc[tmp[0]] = decodeURIComponent(tmp[1]) || true;
+  const usp = new URLSearchParams(paramStr);
+  return usp.entries().reduce((acc, [k, v]) => {
+    // REVIEW: This preserves previous behaviour: an empty value is re-mapped to
+    // `true`.  This is surprising, and differs from the handling of env vars in
+    // node (see above).
+    acc[k] = v || true;
     return acc;
   }, {});
 };

--- a/tests/common-utils.js
+++ b/tests/common-utils.js
@@ -14,8 +14,7 @@ commonUtils.params = function () {
   if (commonUtils.isNode()) {
     return process.env;
   }
-  var paramStr = document.location.search.slice(1);
-  const usp = new URLSearchParams(paramStr);
+  const usp = new URLSearchParams(document.location.search);
   return usp.entries().reduce((acc, [k, v]) => {
     // REVIEW: This preserves previous behaviour: an empty value is re-mapped to
     // `true`.  This is surprising, and differs from the handling of env vars in

--- a/tests/common-utils.js
+++ b/tests/common-utils.js
@@ -14,7 +14,7 @@ commonUtils.params = function () {
   if (commonUtils.isNode()) {
     return process.env;
   }
-  const usp = new URLSearchParams(document.location.search);
+  const usp = new URLSearchParams(window.location.search);
   return usp.entries().reduce((acc, [k, v]) => {
     // REVIEW: This preserves previous behaviour: an empty value is re-mapped to
     // `true`.  This is surprising, and differs from the handling of env vars in


### PR DESCRIPTION
* previous parsing was manual
* switch from using `document.location` to more-standard `window.location`
* currently this PR re-implements surprising details of old implementation

Original mapping of empty strings to `true` looks like it was introduced in 2f7b57baca50e893a61c33f7de15835796f083a6.