### PR TITLE
test.browser.worker: use same PouchDB src as other tests

### DIFF
--- a/tests/common-utils.js
+++ b/tests/common-utils.js
@@ -99,17 +99,21 @@ commonUtils.loadPouchDBForNode = function (plugins) {
   return PouchDB;
 };
 
+commonUtils.pouchdbSrc = function () {
+  const scriptPath = '../../packages/node_modules/pouchdb/dist';
+  const params = commonUtils.params();
+  return params.src || `${scriptPath}/pouchdb.js`;
+};
+
 commonUtils.loadPouchDBForBrowser = function (plugins) {
-  var params = commonUtils.params();
   var scriptPath = '../../packages/node_modules/pouchdb/dist';
-  var pouchdbSrc = params.src || `${scriptPath}/pouchdb.js`;
 
   plugins = plugins.map((plugin) => {
     plugin = plugin.replace(/^pouchdb-(adapter-)?/, '');
     return `${scriptPath}/pouchdb.${plugin}.js`;
   });
 
-  var scripts = [pouchdbSrc].concat(plugins);
+  var scripts = [commonUtils.pouchdbSrc()].concat(plugins);
 
   var loadScripts = scripts.reduce((prevScriptLoaded, script) => {
     return prevScriptLoaded.then(() => commonUtils.asyncLoadScript(script));

--- a/tests/integration/browser.worker.js
+++ b/tests/integration/browser.worker.js
@@ -17,15 +17,7 @@ describe.skip('browser.worker.js', function () {
   before(function () {
     worker = new Worker('worker.js');
 
-    var sourceFile = window && window.location.search.match(/[?&]sourceFile=([^&]+)/);
-
-    if (!sourceFile) {
-      sourceFile = '../../packages/node_modules/pouchdb/dist/pouchdb.js';
-    } else {
-      sourceFile = '../../packages/node_modules/pouchdb/dist/' + sourceFile[1];
-    }
-
-    worker.postMessage(['source', sourceFile]);
+    worker.postMessage(['source', testUtils.pouchdbSrc()]);
   });
 
   function workerPromise(message) {


### PR DESCRIPTION
It seems surprising that to change the PouchDB source file, `tests/integration/browser.worker.js` uses a different query param mapping from all the other integration tests (`sourceFile` vs `src`).

This PR changes `tests/integration/browser.worker.js` to use the standard mapping, which is documented at https://github.com/pouchdb/pouchdb/blob/2b05059497ff0e05b9cab7fd8765ac1432139177/TESTING.md?plain=1#L119-L123 and https://github.com/pouchdb/pouchdb/blob/2b05059497ff0e05b9cab7fd8765ac1432139177/TESTING.md?plain=1#L248 