### PR TITLE
Revert "perf-tests: allow running specific suite(s) (#8592)"

### DIFF
--- a/tests/performance/index.js
+++ b/tests/performance/index.js
@@ -1,12 +1,5 @@
 'use strict';
 
-const ALL_SUITES = [
-  'basics',
-  'views',
-  'find',
-  'attachments',
-];
-
 var commonUtils = require('../common-utils');
 
 function runTestSuites(PouchDB) {
@@ -18,24 +11,19 @@ function runTestSuites(PouchDB) {
     (adapters.length > 0 ? (', using adapter(s): ' + adapters.join(', ')) : '') +
     '\n\n');
 
-  const suites = (commonUtils.params().suites && commonUtils.params().suites.split(',')) || ALL_SUITES;
-  if (suites.some(s => !ALL_SUITES.includes(s))) {
-    throw new Error(`Unrecongnised suite(s): '${suites}'`);
-  }
-
   var theAdapterUsed;
   var count = 0;
   function checkDone(adapterUsed) {
     theAdapterUsed = theAdapterUsed || adapterUsed;
-    if (++count === suites.length) {
+    if (++count === 4) { // number of perf.xxxx.js tests
       reporter.complete(theAdapterUsed);
     }
   }
 
-  if (suites.includes('basics')) { require('./perf.basics')(PouchDB, checkDone); }
-  if (suites.includes('views')) { require('./perf.views')(PouchDB, checkDone); }
-  if (suites.includes('find')) { require('./perf.find')(PouchDB, checkDone); }
-  if (suites.includes('attachments')) { require('./perf.attachments')(PouchDB, checkDone); }
+  require('./perf.basics')(PouchDB, checkDone);
+  require('./perf.views')(PouchDB, checkDone);
+  require('./perf.find')(PouchDB, checkDone);
+  require('./perf.attachments')(PouchDB, checkDone);
 }
 
 var PouchDB = commonUtils.loadPouchDB({ plugins: ['pouchdb-find'] });


### PR DESCRIPTION
This reverts commit 71501f893b6352d31d297f3a9fbca1832ca5c054.

This functionality was already available with the `GREP` env var :facepalm: 