### PR TITLE
tests/perf: support regex in GREP option

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -107,7 +107,7 @@ not available.
 
 Use this to request that a specific test is run; if you set `GREP='name of
 test'` then only those tests whose names include the string `name of test` will
-run.
+run.  Regular expressions are also supported.
 
 #### `PLUGINS` (default: empty)
 

--- a/tests/performance/utils.js
+++ b/tests/performance/utils.js
@@ -10,7 +10,7 @@ var grep;
 var iterations;
 if (global.window && global.window.location && global.window.location.search) {
   grep = global.window.location.search.match(/[&?]grep=([^&]+)/);
-  grep = grep && grep[1];
+  grep = grep && decodeURIComponent(grep[1]);
   iterations = global.window.location.search.match(/[&?]iterations=([^&]+)/);
   iterations = iterations && parseInt(iterations[1], 10);
 } else if (process && process.env) {
@@ -23,9 +23,11 @@ var adapterUsed;
 exports.runTests = function (PouchDB, suiteName, testCases, callback) {
 
   testCases = testCases.filter(function (testCase) {
-    if (grep && suiteName.indexOf(grep) === -1 &&
-      testCase.name.indexOf(grep) === -1) {
-      return false;
+    if (grep) {
+      const regexp = new RegExp(grep);
+      if (!regexp.test(suiteName) && !regexp.test(testCase.name)) {
+        return false;
+      }
     }
     var iter = typeof iterations === 'number' ? iterations :
       testCase.iterations;


### PR DESCRIPTION
This matches the behaviour of mocha's `--grep` option, which is used by other test suites (unit, integration etc.).

See: https://mochajs.org/#-grep-regexp-g-regexp

# Examples

## Perf tests

### String
```
GREP='attachments' PERF=1 CLIENT=firefox COUCH_HOST=http://admin:password@127.0.0.1:5984 npm run test
...
attachments
  ✓ basic-attachments
       { median: 4, numIterations: 1000 }
  ✓ many-attachments-base64
       { median: 59.5, numIterations: 100 }
  ✓ many-attachments-binary
       { median: 16, numIterations: 100 }

  3 passing (16s)
```

### Regex
```
GREP='(bulk|basic)-inserts$' PERF=1 CLIENT=firefox COUCH_HOST=http://admin:password@127.0.0.1:5984 npm run test
...
basics
  ✓ basic-inserts
       { median: 2, numIterations: 1000 }
  ✓ bulk-inserts
       { median: 34.5, numIterations: 100 }

  2 passing (8s)
```
## Other tests

### String
```
GREP='attachments' CLIENT=firefox COUCH_HOST=http://admin:password@127.0.0.1:5984 npm run test
...
  258 passing (1m)
  30 pending
```

### Regex
```
GREP='(create|put) attachment' CLIENT=firefox COUCH_HOST=http://admin:password@127.0.0.1:5984 npm run test
...
  suite2 test.attachments.js-local
    ✓ Test create attachment and doc in one go (70ms)
    ✓ Test create attachment and doc in one go without callback (68ms)
    ✓ Test create attachment without callback (80ms)
    ✓ Test put attachment on a doc without attachments (68ms)
    ✓ Test put attachment with unencoded name (74ms)

  suite2 test.attachments.js-http
    ✓ Test create attachment and doc in one go (53ms)
    ✓ Test create attachment and doc in one go without callback (69ms)
    ✓ Test create attachment without callback (87ms)
    ✓ Test put attachment on a doc without attachments (41ms)
    ✓ Test put attachment with unencoded name (58ms)


  10 passing (996ms)
```