### PR TITLE
indexeddb.getAttachment: don't open unnecessary transaction

### DIFF
--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/getAttachment.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/getAttachment.js
@@ -2,11 +2,7 @@
 
 import { btoa, readAsBinaryString } from 'pouchdb-binary-utils';
 
-export default function getAttachment(txn, docId, attachId, attachment, opts, cb) {
-  if (txn.error) {
-    return cb(txn.error);
-  }
-
+export default function getAttachment(docId, attachId, attachment, opts, cb) {
   const doc = opts.metadata;
   const data = doc.attachments[attachment.digest].data;
 

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
@@ -118,7 +118,10 @@ function IndexeddbPouch(dbOpts, callback) {
     allDocs(txn, metadata, opts, cb);
   });
 
-  api._getAttachment = $t(getAttachment);
+  api._getAttachment = (...args) => {
+    console.log('indexeddb._getAttachment()', args.length, ...args);
+    //getAttachment;
+  }
 
   api._changes = $t(function (txn, opts) {
     changes(txn, idbChanges, api, dbOpts, opts);

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/index.js
@@ -118,10 +118,7 @@ function IndexeddbPouch(dbOpts, callback) {
     allDocs(txn, metadata, opts, cb);
   });
 
-  api._getAttachment = (...args) => {
-    console.log('indexeddb._getAttachment()', args.length, ...args);
-    //getAttachment;
-  }
+  api._getAttachment = getAttachment;
 
   api._changes = $t(function (txn, opts) {
     changes(txn, idbChanges, api, dbOpts, opts);


### PR DESCRIPTION
Here's another nice perf win, following up https://github.com/pouchdb/pouchdb/pull/8771.  N.B. perf test results on that PR were for Firefox.

Tested `master` as 2b05059497ff0e05b9cab7fd8765ac1432139177.

# Firefox

## `master` (2b05059497ff0e05b9cab7fd8765ac1432139177)
```json
    "many-attachments-base64": {                                                   
      "median": 57.5,                                                              
      "numIterations": 100                                                         
    },                                                                             
    "many-attachments-binary": {                                                   
      "median": 15,                                                                
      "numIterations": 100                                                         
    }   
```

## this pr

```json
    "many-attachments-base64": {                                                
      "median": 50,                                                             
      "numIterations": 100                                                      
    },                                                                          
    "many-attachments-binary": {                                                
      "median": 9,                                                              
      "numIterations": 100                                                      
    }  
```

# Chrome

## `master` (2b05059497ff0e05b9cab7fd8765ac1432139177)

```json
    "many-attachments-base64": {                                                   
      "median": 208.5,                                                             
      "numIterations": 100                                                         
    },                                                                             
    "many-attachments-binary": {                                                   
      "median": 183.64999999850988,                                                
      "numIterations": 100                                                         
    }  
```

## this pr

```json
    "many-attachments-base64": {                                                   
      "median": 51.20000000298023,                                                 
      "numIterations": 100                                                         
    },                                                                             
    "many-attachments-binary": {                                                   
      "median": 4.5,                                                               
      "numIterations": 100                                                         
    } 
```