### PR TITLE
adapter.computeHeight(): remove unused return value

### DIFF
--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -95,7 +95,6 @@ function computeHeight(revs) {
     if (prnt !== undefined) {
       edges.push({from: prnt, to: rev});
     }
-    return rev;
   });
 
   edges.reverse();


### PR DESCRIPTION
The return value from the callback passed to `traverseRevTree()` is not used for anything.