### PR TITLE
adapter.getAttachment(): don't pass rev

### DIFF
--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -653,10 +653,6 @@ class AbstractPouchDB extends EventEmitter {
           }
           Object.keys(attachments).forEach((key) => {
             this._getAttachment(doc._id, key, attachments[key], {
-              // Previously the revision handling was done in adapter.js
-              // getAttachment, however since idb-next doesnt we need to
-              // pass the rev through
-              rev: doc._rev,
               binary: opts.binary,
               metadata: metadata,
               ctx: ctx


### PR DESCRIPTION
Previously the indexeddb adapter required rev to be passed through to `_getAttachment()`.  The implementation has now changed, and this value is no longer required.