### PR TITLE
docs: remove sentence

### DIFF
--- a/packages/node_modules/pouchdb-adapter-indexeddb/README.md
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/README.md
@@ -53,7 +53,7 @@ This is highly unlikely to be fixed in the future by PouchDB, as it would requir
 
 ### Mango Queries with `partial_filter_selector`
 
-Mango indexes with a `partial_filter_selector` are using map-reduce views. Simually to the `idb`-adabter. All performance gains of native IndexedDB indexes will be lost.
+Mango indexes with a `partial_filter_selector` are using map-reduce views. All performance gains of native IndexedDB indexes will be lost.
 
 Also ordering is CouchDB combatible.
 


### PR DESCRIPTION
This sentence does not seem to add information to the documentation.

Can it be improved, or removed?