### PR TITLE
test.migration: move before() above beforeEach()

### DIFF
--- a/tests/integration/browser.migration.js
+++ b/tests/integration/browser.migration.js
@@ -80,6 +80,12 @@ describe('migration', function () {
 
       var dbs = {};
 
+      before(function () {
+        if (usingIndexeddb() && !versionGte(scenario, '7.2.1')) {
+          return this.skip();
+        }
+      });
+
       beforeEach(function (done) {
         if (skip) {
           return this.skip();
@@ -120,12 +126,6 @@ describe('migration', function () {
 
       afterEach(function (done) {
         testUtils.cleanup([dbs.first.local, dbs.second.local], done);
-      });
-
-      before(function () {
-        if (usingIndexeddb() && !versionGte(scenario, '7.2.1')) {
-          return this.skip();
-        }
       });
 
       var origDocs = [


### PR DESCRIPTION
before() runs before beforeEach().  Re-ordering the functions to reflect that makes it easier to see what is happening.