### PR TITLE
playwright: handle externally-triggered browser-close event

### DIFF
--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -159,7 +159,7 @@ async function startTest() {
   // choice here, but it does not seem to be triggered if the browser is closed
   // by an external event (e.g. process is killed, user closes non-headless
   // browser window).
-  page.on('close', data => {
+  page.on('close', () => {
     if (!closeRequested) {
       console.log('!!! Browser closed by external event.');
       process.exit(1);

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -12,6 +12,9 @@ var devserver = require('./dev-server.js');
 // BAIL=0 to disable bailing
 var bail = process.env.BAIL !== '0';
 
+// Track if the browser has closed at the request of this script, or due to an external event.
+let closeRequested;
+
 // Playwright BrowserType whitelist.
 // See: https://playwright.dev/docs/api/class-playwright
 const SUPPORTED_BROWSERS = [ 'chromium', 'firefox', 'webkit' ];
@@ -91,12 +94,14 @@ class RemoteRunner {
     } catch (e) {
       console.error('Tests failed:', e);
 
+      closeRequested = true;
       await this.browser.close();
       process.exit(3);
     }
   }
 
   async handleEnd(failed) {
+    closeRequested = true;
     await this.browser.close();
     process.exit(!process.env.PERF && failed ? 1 : 0);
   }
@@ -147,7 +152,19 @@ async function startTest() {
     headless: true,
   };
   const browser = await playwright[browserName].launch(options);
+
   const page = await browser.newPage();
+
+  // Playwright's Browser.on('close') event handler would be the more obvious
+  // choice here, but it does not seem to be triggered if the browser is closed
+  // by an external event (e.g. process is killed, user closes non-headless
+  // browser window).
+  page.on('close', data => {
+    if (!closeRequested) {
+      console.log('!!! Browser closed by external event.');
+      process.exit(1);
+    }
+  });
 
   const runner = new RemoteRunner(browser);
   new MochaSpecReporter(runner);


### PR DESCRIPTION
Previously if the browser is closed during a playwright test run by an external event, the tests would hang indefinitely.  This commit makes the test run fail immediately.