### PR TITLE
chore: upgrade fetch-cookie from 0.11.0 to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "abort-controller": "3.0.0",
     "clone-buffer": "1.0.0",
     "double-ended-queue": "2.1.0-0",
-    "fetch-cookie": "0.11.0",
+    "fetch-cookie": "2.1.0",
     "fruitdown": "1.0.2",
     "immediate": "3.3.0",
     "level": "6.0.1",


### PR DESCRIPTION
Mitigates CVE-2023-26136: https://github.com/advisories/GHSA-72xf-g2v4-qvf3

Only one breaking change according to changelog:
- the redirect logic is now included in the main export and the node-fetch wrapper (require('fetch-cookie/node-fetch')) was removed. Just require('node-fetch') and you're good to go with redirects!

cf. https://github.com/valeriangalliat/fetch-cookie/blob/master/CHANGELOG.md