### PR TITLE
mocha v10: fix failure handling in browser tests

### DIFF
--- a/tests/integration/webrunner.js
+++ b/tests/integration/webrunner.js
@@ -21,7 +21,8 @@
                   title: obj.title,
                   duration: obj.duration,
                   slow: typeof obj.slow === 'function' ? obj.slow() : undefined,
-                  fullTitle: typeof obj.fullTitle === 'function' ? obj.fullTitle() : undefined
+                  fullTitle: typeof obj.fullTitle === 'function' ? obj.fullTitle() : undefined,
+                  titlePath: typeof obj.titlePath === 'function' ? obj.titlePath() : undefined,
                 },
                 err: err && {
                   actual: err.actual,


### PR DESCRIPTION
Fixes error:

    An error occurred while bailing: TypeError: Cannot read property 'forEach' of undefined

And subsequent error:

    An error occurred while bailing: TypeError: test.titlePath is not a function