### PR TITLE
(#8526): Upgrade leveldown from 5.6.0 to 6.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "level": "6.0.1",
     "level-codec": "9.0.2",
     "level-write-stream": "1.0.0",
-    "leveldown": "5.6.0",
+    "leveldown": "6.1.1",
     "levelup": "4.4.0",
     "localstorage-down": "0.6.7",
     "ltgt": "2.2.1",


### PR DESCRIPTION
Leveldown needs to be upgraded to support Apple M1. https://github.com/pouchdb/pouchdb/issues/8526