### PR TITLE
eslint: comma-dangle: only allow for multiline declarations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
   },
 
   "rules": {
+    "comma-dangle": ["error", "only-multiline"],
     "eol-last": "error",
     "no-empty": "off",
     "no-console": "off",

--- a/tests/find/test-suite-1/test.default-index.js
+++ b/tests/find/test-suite-1/test.default-index.js
@@ -126,7 +126,7 @@ describe('test.default-index.js', function () {
     ]).then(function () {
       return db.find({
         selector: {foo: {$ne: "eba"}},
-        fields: ["_id",],
+        fields: ["_id"],
         sort: ["_id"]
       });
     }).then(function (resp) {


### PR DESCRIPTION
Ref: https://eslint.org/docs/latest/rules/comma-dangle#options