### PR TITLE
Checkpointer shortcut

### DIFF
--- a/packages/node_modules/pouchdb-checkpointer/src/index.js
+++ b/packages/node_modules/pouchdb-checkpointer/src/index.js
@@ -121,7 +121,7 @@ class CheckpointerInternal {
       return Promise.resolve(LOWEST_SEQ);
     }
 
-    if (self.opts.writeSourceCheckpoint && !self.opts.writeTargetCheckpoint) {
+    if (self.opts && self.opts.writeSourceCheckpoint && !self.opts.writeTargetCheckpoint) {
       return self.src.get(self.id).then(function (sourceDoc) {
         return sourceDoc.last_seq || LOWEST_SEQ;
       }).catch(function (err) {
@@ -134,7 +134,7 @@ class CheckpointerInternal {
     }
 
     return self.target.get(self.id).then(function (targetDoc) {
-      if (self.opts.writeTargetCheckpoint && !self.opts.writeSourceCheckpoint) {
+      if (self.opts && self.opts.writeTargetCheckpoint && !self.opts.writeSourceCheckpoint) {
         return targetDoc.last_seq || LOWEST_SEQ;
       }
 

--- a/packages/node_modules/pouchdb-checkpointer/src/index.js
+++ b/packages/node_modules/pouchdb-checkpointer/src/index.js
@@ -117,6 +117,10 @@ class CheckpointerInternal {
   getCheckpoint() {
     var self = this;
 
+    if (!self.opts.writeSourceCheckpoint && !self.opts.writeTargetCheckpoint) {
+      return LOWEST_SEQ;
+    }
+
     if (self.opts && self.opts.writeSourceCheckpoint && !self.opts.writeTargetCheckpoint) {
       return self.src.get(self.id).then(function (sourceDoc) {
         return sourceDoc.last_seq || LOWEST_SEQ;

--- a/packages/node_modules/pouchdb-checkpointer/src/index.js
+++ b/packages/node_modules/pouchdb-checkpointer/src/index.js
@@ -117,11 +117,11 @@ class CheckpointerInternal {
   getCheckpoint() {
     var self = this;
 
-    if (self.opts && !self.opts.writeSourceCheckpoint && !self.opts.writeTargetCheckpoint) {
+    if (self.opts.writeSourceCheckpoint === false && self.opts.writeTargetCheckpoint === false) {
       return Promise.resolve(LOWEST_SEQ);
     }
 
-    if (self.opts && self.opts.writeSourceCheckpoint && !self.opts.writeTargetCheckpoint) {
+    if (self.opts.writeSourceCheckpoint && !self.opts.writeTargetCheckpoint) {
       return self.src.get(self.id).then(function (sourceDoc) {
         return sourceDoc.last_seq || LOWEST_SEQ;
       }).catch(function (err) {
@@ -134,7 +134,7 @@ class CheckpointerInternal {
     }
 
     return self.target.get(self.id).then(function (targetDoc) {
-      if (self.opts && self.opts.writeTargetCheckpoint && !self.opts.writeSourceCheckpoint) {
+      if (self.opts.writeTargetCheckpoint && !self.opts.writeSourceCheckpoint) {
         return targetDoc.last_seq || LOWEST_SEQ;
       }
 

--- a/packages/node_modules/pouchdb-checkpointer/src/index.js
+++ b/packages/node_modules/pouchdb-checkpointer/src/index.js
@@ -118,7 +118,7 @@ class CheckpointerInternal {
     var self = this;
 
     if (!self.opts.writeSourceCheckpoint && !self.opts.writeTargetCheckpoint) {
-      return LOWEST_SEQ;
+      return Promise.resolve(LOWEST_SEQ);
     }
 
     if (self.opts && self.opts.writeSourceCheckpoint && !self.opts.writeTargetCheckpoint) {

--- a/packages/node_modules/pouchdb-checkpointer/src/index.js
+++ b/packages/node_modules/pouchdb-checkpointer/src/index.js
@@ -117,7 +117,7 @@ class CheckpointerInternal {
   getCheckpoint() {
     var self = this;
 
-    if (!self.opts.writeSourceCheckpoint && !self.opts.writeTargetCheckpoint) {
+    if (self.opts && !self.opts.writeSourceCheckpoint && !self.opts.writeTargetCheckpoint) {
       return Promise.resolve(LOWEST_SEQ);
     }
 

--- a/packages/node_modules/pouchdb-checkpointer/src/index.js
+++ b/packages/node_modules/pouchdb-checkpointer/src/index.js
@@ -117,7 +117,7 @@ class CheckpointerInternal {
   getCheckpoint() {
     var self = this;
 
-    if (self.opts.writeSourceCheckpoint === false && self.opts.writeTargetCheckpoint === false) {
+    if (!self.opts.writeSourceCheckpoint && !self.opts.writeTargetCheckpoint) {
       return Promise.resolve(LOWEST_SEQ);
     }
 


### PR DESCRIPTION
Omit checkpoint lookup when `writeSourceCheckpoint` and `writeTargetCheckpoint` set to false.
E.g. replicate with `{ checkpoint: false }` option.

Before this patch, a request to a never written document was made, resulting in a network request that fail every time.
Nice side-effects of this patch: reduced latency, less error prone (due to network failures), and reduced network noise in replications when checkpoints are unnecessary.

These tests already cover my patch:
- test.replication.js `Test disable checkpoints on both source and target` and
- test.read_only_replication.js `Test checkpointer handles error codes` (implicitly tests for default/missing option)
