### PR TITLE
fix assert in error handler results in out of bound exception

### DIFF
--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -329,17 +329,18 @@ adapters.forEach(function (adapter) {
       });
 
       changes.on('error', (err) => {
-        assert.equal(
-          err.status,
-          testUtils.errors.MISSING_DOC.status,
-          'correct error status returned'
-        );
-        assert.equal(err.name, 'not_found');
         caughtErrors.push(err);
       });
 
       await assert.isRejected(changes, 'completes with an exception');
       assert.lengthOf(caughtErrors, 1, 'changes emitted the expected error');
+      const caughtError = caughtErrors[0];
+      assert.equal(
+        caughtError.status,
+        testUtils.errors.MISSING_DOC.status,
+        'correct error status returned'
+      );
+      assert.equal(caughtError.name, 'not_found');
     });
 
     it('Changes with `filters` key not present in ddoc', async function () {

--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -361,25 +361,26 @@ adapters.forEach(function (adapter) {
 
       await testUtils.promisify(testUtils.writeDocs)(db, docs);
 
-      const caughtErrors = [];
       const changes = db.changes({
         filter: 'foo/even',
         limit: 2,
         include_docs: true
       });
 
-      changes.on('error', (err) => {
-        assert.equal(
-          err.status,
-          testUtils.errors.MISSING_DOC.status,
-          'correct error status returned'
-        );
-        assert.equal(err.name, 'not_found');
+      const caughtErrors = [];
+      changes.on('error', function (err) {
         caughtErrors.push(err);
       });
 
       await assert.isRejected(changes, 'completes with an exception');
-      assert.lengthOf(caughtErrors, 1, 'changes emitted the expected error');
+      assert.equal(caughtErrors.length, 1);
+      const caughtError = caughtErrors[0];
+      assert.equal(
+        caughtError.status,
+        testUtils.errors.MISSING_DOC.status,
+        'correct error status returned'
+      );
+      assert.equal(caughtError.name, 'not_found');
     });
 
     it('Changes limit and filter', function (done) {


### PR DESCRIPTION
Calling assert in error handler results in out of bound exception.

Impact: when an exception is thrown (by chai assert in "fail" case) within an event handler, the test-suite isn't the handling scope and node (v20+) exits unintentionally with "unhandled exception" error.