### PR TITLE
fix subsequent fails of `5007 sync 2 databases`

### DIFF
--- a/tests/integration/test.sync.js
+++ b/tests/integration/test.sync.js
@@ -815,7 +815,7 @@ adapters.forEach(function (adapters) {
       });
     });
 
-    it('5007 sync 2 databases', function () {
+    it('5007 sync 2 databases', async function () {
       if (testUtils.isSafari()) {
         // FIXME this test fails consistently on webkit.  It needs to be
         // investigated, but for now it would be better to have the rest of the
@@ -826,7 +826,13 @@ adapters.forEach(function (adapters) {
       const db = new PouchDB(dbs.name);
 
       const remote1 = new PouchDB(dbs.remote);
-      const remote2 = new PouchDB(dbs.remote + '_2');
+      let remote2 = new PouchDB(dbs.remote + '_2');
+
+      const remote2docs = await remote2.allDocs();
+      if (remote2docs.total_rows > 0) {
+        await remote2.destroy();
+        remote2 = new PouchDB(dbs.remote + '_2');
+      }
 
       const sync1 = db.sync(remote1, { live: true });
       const sync2 = db.sync(remote2, { live: true });


### PR DESCRIPTION
This patch refactors `test.sync.js` case `5007 sync 2 databases` to es6 and ensure remote2 is destroyed before and after manipulation.

Without this cleanup, CI steps `First retry` and `Second retry` fail because synchronization with `remote2` emit changes for documents inserted in previous runs.

**This patch hasn't the intention to fix `Intermittent test failure`!**

(In combination with #8862, this has the potential to eliminate 90% of false-negatives I regularly encounter)