### PR TITLE
remove isIE() from integration tests

### DIFF
--- a/tests/integration/test.attachments.js
+++ b/tests/integration/test.attachments.js
@@ -3101,7 +3101,7 @@ adapters.forEach(function (adapter) {
     });
 
 
-    if (!testUtils.isSafari() && !testUtils.isIE()) {
+    if (!testUtils.isSafari()) {
       // skip in safari/ios because of size limit popup
       it('putAttachment and getAttachment with big png data', function (done) {
 

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -350,9 +350,6 @@ adapters.forEach(function (adapter) {
     });
 
     it('Remove doc twice with specified id', function () {
-      if (testUtils.isIE()) {
-        return Promise.resolve();
-      }
       var db = new PouchDB(dbs.name);
       return db.put({_id: 'specifiedId', test: 'somestuff'}).then(function () {
         return db.get('specifiedId');

--- a/tests/integration/test.bulk_docs.js
+++ b/tests/integration/test.bulk_docs.js
@@ -1005,9 +1005,6 @@ adapters.forEach(function (adapter) {
     });
 
     it('4204 respect revs_limit', function () {
-      if (testUtils.isIE()) {
-        return Promise.resolve();
-      }
       var db = new PouchDB(dbs.name);
 
       // simulate 5000 normal commits with two conflicts at the very end

--- a/tests/integration/test.changes.js
+++ b/tests/integration/test.changes.js
@@ -800,9 +800,6 @@ adapters.forEach(function (adapter) {
     // Note for the following test that CouchDB's implementation of /_changes
     // with `descending=true` ignores any `since` parameter.
     it.skip('Descending many changes', function (done) {
-      if (testUtils.isIE()) {
-        return done();
-      }
       var db = new PouchDB(dbs.name);
       var docs = [];
       var num = 100;
@@ -1568,9 +1565,6 @@ adapters.forEach(function (adapter) {
     });
 
     it('supports return_docs=false', function (done) {
-      if (testUtils.isIE()) {
-        return done();
-      }
       var db = new PouchDB(dbs.name);
       var docs = [];
       var num = 10;
@@ -1632,9 +1626,6 @@ adapters.forEach(function (adapter) {
     });
 
     it('handle individual changes in live replication', function (done) {
-      if (testUtils.isIE()) {
-        return done();
-      }
       var db = new PouchDB(dbs.name);
       var len = 80;
       var called = 0;

--- a/tests/integration/test.compaction.js
+++ b/tests/integration/test.compaction.js
@@ -173,9 +173,6 @@ adapters.forEach(function (adapter) {
     ];
 
     it('Compact more complicated tree', function (done) {
-      if (testUtils.isIE()) {
-        return done();
-      }
       var db = new PouchDB(dbs.name);
       testUtils.putTree(db, exampleTree, function () {
         db.compact(function () {
@@ -187,9 +184,6 @@ adapters.forEach(function (adapter) {
     });
 
     it('Compact two times more complicated tree', function (done) {
-      if (testUtils.isIE()) {
-        return done();
-      }
       var db = new PouchDB(dbs.name);
       testUtils.putTree(db, exampleTree, function () {
         db.compact(function () {
@@ -203,9 +197,6 @@ adapters.forEach(function (adapter) {
     });
 
     it('Compact database with at least two documents', function (done) {
-      if (testUtils.isIE()) {
-        return done();
-      }
       var db = new PouchDB(dbs.name);
       testUtils.putTree(db, exampleTree, function () {
         testUtils.putTree(db, exampleTree2, function () {

--- a/tests/integration/test.issue2674.js
+++ b/tests/integration/test.issue2674.js
@@ -32,9 +32,6 @@ adapterPairs.forEach(function (adapters) {
     });
 
     it('Should correctly synchronize attachments (#2674)', function () {
-      if (testUtils.isIE()) {
-        return Promise.resolve();
-      }
 // 1. So I ran client app on two browsers (let’s call them A and B).
 // 2. Then on client A I created plain document (without any attachments).
 // 3. After that I put two attachments one by one by using putAttachment method.

--- a/tests/integration/test.replication.js
+++ b/tests/integration/test.replication.js
@@ -108,9 +108,6 @@ adapters.forEach(function (adapters) {
     });
 
     it('Test pull replication with many changes', function (done) {
-      if (testUtils.isIE()) {
-        return done();
-      }
       var remote = new PouchDB(dbs.remote);
 
       var numDocs = 201;
@@ -160,9 +157,6 @@ adapters.forEach(function (adapters) {
     });
 
     it.skip('pull replication with many changes + a conflict (#2543)', function () {
-      if (testUtils.isIE()) {
-        return Promise.resolve();
-      }
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
       // simulate 5000 normal commits with two conflicts at the very end
@@ -234,9 +228,6 @@ adapters.forEach(function (adapters) {
 
 
     it('Test pull replication with many conflicts', function (done) {
-      if (testUtils.isIE()) {
-        return done();
-      }
       var remote = new PouchDB(dbs.remote);
 
       var numRevs = 200; // repro "url too long" error with open_revs
@@ -786,9 +777,6 @@ adapters.forEach(function (adapters) {
     });
 
     it('#3136 open revs returned correctly 1', function () {
-      if (testUtils.isIE()) {
-        return Promise.resolve();
-      }
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
 
@@ -840,9 +828,6 @@ adapters.forEach(function (adapters) {
     });
 
     it('#3136 open revs returned correctly 2', function () {
-      if (testUtils.isIE()) {
-        return Promise.resolve();
-      }
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
 
@@ -1669,10 +1654,7 @@ adapters.forEach(function (adapters) {
     });
 
     it('Replication with filter that leads to some empty batches (#2689)',
-       function (done) {
-      if (testUtils.isIE()) {
-        return done();
-      }
+      function (done) {
 
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
@@ -2140,9 +2122,6 @@ adapters.forEach(function (adapters) {
     });
 
     it('Replicate large number of docs', function (done) {
-      if (testUtils.isIE()) {
-        return done();
-      }
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
       var docs = [];
@@ -2208,9 +2187,6 @@ adapters.forEach(function (adapters) {
     });
 
     it('#909 Filtered replication bails at paging limit', function (done) {
-      if (testUtils.isIE()) {
-        return done();
-      }
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
       var docs = [];
@@ -2811,9 +2787,6 @@ adapters.forEach(function (adapters) {
     });
 
     it("Report write failures if whole saving fails (#942)", function (done) {
-      if (testUtils.isIE()) {
-        return done();
-      }
       var docs = [{_id: 'a', _rev: '1-a'}, {_id: 'b', _rev: '1-b'}];
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
@@ -3339,9 +3312,6 @@ adapters.forEach(function (adapters) {
     });
 
     it('#2268 dont stop replication if single unauth', function (done) {
-      if (testUtils.isIE()) {
-        return done();
-      }
       testUtils.isCouchDB(function (isCouchDB) {
         if (adapters[1] !== 'http' || !isCouchDB) {
           return done();
@@ -3382,9 +3352,6 @@ adapters.forEach(function (adapters) {
     });
 
     it('#2268 dont stop replication if many unauth', function (done) {
-      if (testUtils.isIE()) {
-        return done();
-      }
       testUtils.isCouchDB(function (isCouchDB) {
         if (adapters[1] !== 'http' || !isCouchDB) {
           return done();
@@ -4116,9 +4083,6 @@ adapters.forEach(function (adapters) {
     });
 
     it('#2426 doc_ids dont prevent replication', function () {
-      if (testUtils.isIE()) {
-        return Promise.resolve();
-      }
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
 
@@ -4137,9 +4101,6 @@ adapters.forEach(function (adapters) {
     });
 
     it('#6809 doc_ids dont prevent one-shot replication', function () {
-      if (testUtils.isIE()) {
-        return Promise.resolve();
-      }
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
 
@@ -4159,9 +4120,6 @@ adapters.forEach(function (adapters) {
 
 
     it('#6809 doc_ids dont prevent one-shot replication', function () {
-      if (testUtils.isIE()) {
-        return Promise.resolve();
-      }
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
 

--- a/tests/integration/test.replication_events.js
+++ b/tests/integration/test.replication_events.js
@@ -211,9 +211,6 @@ adapters.forEach(function (adapters) {
     // as expected, each remote document should be passed to a
     // change event exactly once (though a change might contain multiple docs)
     it('#4627 Test no duplicate changes in live replication', function (done) {
-      if (testUtils.isIE()) {
-        return done();
-      }
       var db = new PouchDB(dbs.name);
       var remote = new PouchDB(dbs.remote);
       var docId = -1;

--- a/tests/integration/test.retry.js
+++ b/tests/integration/test.retry.js
@@ -570,9 +570,6 @@ adapters.forEach(function (adapters) {
     });
 
     it('#5157 replicate many docs with live+retry', function () {
-      if (testUtils.isIE()) {
-        return Promise.resolve();
-      }
       var numDocs = 512; // uneven number
       var docs = [];
       for (var i = 0; i < numDocs; i++) {

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -20,15 +20,6 @@ testUtils.isChrome = function () {
       /Google Inc/.test(window.navigator.vendor);
 };
 
-testUtils.isIE = function () {
-  var ua = (typeof navigator !== 'undefined' && navigator.userAgent) ?
-      navigator.userAgent.toLowerCase() : '';
-  var isIE = ua.indexOf('msie') !== -1;
-  var isTrident = ua.indexOf('trident') !== -1;
-  var isEdge = ua.indexOf('edge') !== -1;
-  return (isIE || isTrident || isEdge);
-};
-
 testUtils.isSafari = function () {
   return (typeof process === 'undefined' || process.browser) &&
       /Safari/.test(window.navigator.userAgent) &&


### PR DESCRIPTION
Internet Explorer is EOL and today's MS edge is just another Chromium theme.
We haven't even set up a CI workflow to test Microsoft browsers, so: isIE() is a noop.