### PR TITLE
ci: use minified plugins if using minified core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           - TYPE=mapreduce ADAPTERS=http npm test
     runs-on: ubuntu-latest
     env:
-      POUCHDB_SRC: ../../packages/node_modules/pouchdb/dist/pouchdb.min.js
+      USE_MINIFIED: 1
       CLIENT: ${{ matrix.client }}
       SERVER: couchdb-master
       COUCH_HOST: http://admin:password@127.0.0.1:5984
@@ -167,7 +167,7 @@ jobs:
           - TYPE=mapreduce npm test
     runs-on: ubuntu-latest
     env:
-      POUCHDB_SRC: ../../packages/node_modules/pouchdb/dist/pouchdb.min.js
+      USE_MINIFIED: 1
       CLIENT: ${{ matrix.client }}
       ADAPTERS: ${{ matrix.adapter }}
     steps:

--- a/TESTING.md
+++ b/TESTING.md
@@ -122,6 +122,12 @@ This overrides the path used to load PouchDB in the browser. We use this in CI
 to select different builds of the PouchDB library, for example to test the
 minified version, the Webpack version, etc.
 
+#### `USE_MINIFIED`
+
+This changes the file extension used for loading PouchDB files in the browser.
+This can be used in CI and performance testing to select the minified version of
+PouchDB and its adapters, plugins, etc.
+
 #### `SERVER` (default: `pouchdb-express-router`)
 
 To support remote replication tests, we start a server in the background that
@@ -246,6 +252,7 @@ command-line options and their query string equivalents are:
 | `ITERATIONS`         | `iterations`       |
 | `PLUGINS`            | `plugins`          |
 | `POUCHDB_SRC`        | `src`              |
+| `USE_MINIFIED`       | `useMinified`      |
 | `VIEW_ADAPTERS`      | `viewAdapters`     |
 
 

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -32,6 +32,9 @@ if (process.env.COUCH_HOST) {
 if (process.env.ITERATIONS) {
   queryParams.iterations = process.env.ITERATIONS;
 }
+if (process.env.USE_MINIFIED) {
+  queryParams.useMinified = process.env.USE_MINIFIED;
+}
 
 var rebuildPromise = Promise.resolve();
 

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -52,6 +52,7 @@ const qs = {
   SERVER: process.env.SERVER,
   SKIP_MIGRATION: process.env.SKIP_MIGRATION,
   src: process.env.POUCHDB_SRC,
+  useMinified: process.env.USE_MINIFIED,
   plugins: process.env.PLUGINS,
   couchHost: process.env.COUCH_HOST,
   iterations: process.env.ITERATIONS,

--- a/tests/common-utils.js
+++ b/tests/common-utils.js
@@ -83,6 +83,10 @@ commonUtils.loadPouchDB = function (opts) {
 
 commonUtils.loadPouchDBForNode = function (plugins) {
   var params = commonUtils.params();
+  if (params.src || params.useMinified) {
+    throw new Error('POUCHDB_SRC & USE_MINIFIED options cannot be used for node tests.');
+  }
+
   var scriptPath = '../packages/node_modules';
 
   var pouchdbSrc = params.COVERAGE
@@ -99,10 +103,18 @@ commonUtils.loadPouchDBForNode = function (plugins) {
   return PouchDB;
 };
 
+const srcExtension = () => {
+  const params = commonUtils.params();
+  return params.useMinified ? 'min.js' : 'js';
+};
+
 commonUtils.pouchdbSrc = function () {
   const scriptPath = '../../packages/node_modules/pouchdb/dist';
   const params = commonUtils.params();
-  return params.src || `${scriptPath}/pouchdb.js`;
+  if (params.src && params.useMinified) {
+    throw new Error('Cannot use POUCHDB_SRC and USE_MINIFIED options together.');
+  }
+  return params.src || `${scriptPath}/pouchdb.${srcExtension()}`;
 };
 
 commonUtils.loadPouchDBForBrowser = function (plugins) {
@@ -110,7 +122,7 @@ commonUtils.loadPouchDBForBrowser = function (plugins) {
 
   plugins = plugins.map((plugin) => {
     plugin = plugin.replace(/^pouchdb-(adapter-)?/, '');
-    return `${scriptPath}/pouchdb.${plugin}.js`;
+    return `${scriptPath}/pouchdb.${plugin}.${srcExtension()}`;
   });
 
   var scripts = [commonUtils.pouchdbSrc()].concat(plugins);


### PR DESCRIPTION
Extracted from https://github.com/pouchdb/pouchdb/pull/8760.

That PR is already approved, but I have some concerns about exactly which source files each test is using.  Using minified plugins & adapters seems separate enough from the main aims of #8760 to deserve its own PR.