### PR TITLE
Set default opts for `CheckpointerInternal`

### DIFF
--- a/packages/node_modules/pouchdb-checkpointer/src/index.js
+++ b/packages/node_modules/pouchdb-checkpointer/src/index.js
@@ -73,12 +73,15 @@ function updateCheckpoint(db, id, checkpoint, session, returnValue) {
 }
 
 class CheckpointerInternal {
-  constructor(src, target, id, returnValue, opts) {
+  constructor(src, target, id, returnValue, opts = {
+    writeSourceCheckpoint: true,
+    writeTargetCheckpoint: true,
+  }) {
     this.src = src;
     this.target = target;
     this.id = id;
     this.returnValue = returnValue;
-    this.opts = opts || {};
+    this.opts = opts;
   }
 
   writeCheckpoint(checkpoint, session) {

--- a/packages/node_modules/pouchdb-checkpointer/src/index.js
+++ b/packages/node_modules/pouchdb-checkpointer/src/index.js
@@ -82,6 +82,14 @@ class CheckpointerInternal {
     this.id = id;
     this.returnValue = returnValue;
     this.opts = opts;
+
+    if (typeof opts.writeSourceCheckpoint === "undefined") {
+      opts.writeSourceCheckpoint = true;
+    }
+
+    if (typeof opts.writeTargetCheckpoint === "undefined") {
+      opts.writeTargetCheckpoint = true;
+    }
   }
 
   writeCheckpoint(checkpoint, session) {


### PR DESCRIPTION
This patch fixes the fallback/default value of `CheckpointerInternal`'s `opts` parameter.

Since `Checkpoint` is the backbone for replication, I've derived the "default" from it's `checkpoint` parameter:
If no `opts` parameter is passed, checkpoints for source and target will be written.