### PR TITLE
ci: don't rebuild when running dev-server

### DIFF
--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -86,7 +86,8 @@ var filesWritten = false;
 
 Promise.resolve().then(function () {
   if (process.env.CI) {
-    return; // don't bother rebuilding in CI; we already built
+    process.exit(66);
+//    return; // don't bother rebuilding in CI; we already built
   }
   return Promise.all([
     rebuildPouch(),

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -85,8 +85,8 @@ function watchAll() {
 var filesWritten = false;
 
 Promise.resolve().then(function () {
-  if (process.env.TRAVIS) {
-    return; // don't bother rebuilding in Travis; we already built
+  if (process.env.CI) {
+    return; // don't bother rebuilding in CI; we already built
   }
   return Promise.all([
     rebuildPouch(),

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -85,9 +85,7 @@ function watchAll() {
 var filesWritten = false;
 
 Promise.resolve().then(function () {
-  if (process.env.CI) {
-    return; // don't bother rebuilding in CI; we already built
-  }
+  process.exit(69);
   return Promise.all([
     rebuildPouch(),
     rebuildTestUtils(),

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -85,7 +85,9 @@ function watchAll() {
 var filesWritten = false;
 
 Promise.resolve().then(function () {
-  process.exit(69);
+  if (process.env.CI) {
+    return; // don't bother rebuilding in CI; we already built
+  }
   return Promise.all([
     rebuildPouch(),
     rebuildTestUtils(),

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -85,6 +85,7 @@ function watchAll() {
 var filesWritten = false;
 
 Promise.resolve().then(function () {
+  process.exit(66);
   if (process.env.CI) {
     return; // don't bother rebuilding in CI; we already built
   }

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -86,8 +86,7 @@ var filesWritten = false;
 
 Promise.resolve().then(function () {
   if (process.env.CI) {
-    process.exit(66);
-//    return; // don't bother rebuilding in CI; we already built
+    return; // don't bother rebuilding in CI; we already built
   }
   return Promise.all([
     rebuildPouch(),

--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -85,7 +85,6 @@ function watchAll() {
 var filesWritten = false;
 
 Promise.resolve().then(function () {
-  process.exit(66);
   if (process.env.CI) {
     return; // don't bother rebuilding in CI; we already built
   }


### PR DESCRIPTION
This updates a historic reference to the `TRAVIS` env var with the more portable `CI` env var.

This skips rebuilding in CI for browser tests; seems to save ~15 seconds.