### PR TITLE
pouchdb-find/README: remove outdated links to old repo

### DIFF
--- a/packages/node_modules/pouchdb-find/README.md
+++ b/packages/node_modules/pouchdb-find/README.md
@@ -1,4 +1,4 @@
-PouchDB Find [![Build Status](https://travis-ci.org/nolanlawson/pouchdb-find.svg)](https://travis-ci.org/nolanlawson/pouchdb-find) [![Coverage Status](https://coveralls.io/repos/nolanlawson/pouchdb-find/badge.svg?branch=master&service=github)](https://coveralls.io/github/nolanlawson/pouchdb-find?branch=master)
+PouchDB Find
 =====
 
 ([Live demo](http://nolanlawson.github.io/pouchdb-find/))


### PR DESCRIPTION
Removes outdated references to nolanlawson/pouchdb-find repo for:

* Travis CI
* Coveralls

pouchdb-find is now included in the pouchdb monorepo, so these links are out-of-date.