### PR TITLE
README: Getting Help: remove glitch.com reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Getting Help
 
 The PouchDB community is active [on Libera IRC](ircs://irc.libera.chat:6697) [(web)](https://web.libera.chat/#pouchdb), in [the Google Groups mailing list](https://groups.google.com/forum/#!forum/pouchdb), and [on StackOverflow](http://stackoverflow.com/questions/tagged/pouchdb). Or you can [tweet @pouchdb](http://twitter.com/pouchdb)!
 
-If you think you've found a bug in PouchDB, please write a reproducible test case and file [a Github issue](https://github.com/pouchdb/pouchdb/issues). You can start with a [template we have built on glitch](https://glitch.com/~pouchdb-bug-helper).
+If you think you've found a bug in PouchDB, please write a reproducible test case and file [a Github issue](https://github.com/pouchdb/pouchdb/issues).
 
 Prerelease builds
 ----


### PR DESCRIPTION
The glitch link at https://glitch.com/~pouchdb-bug-helper does not work, stating:

> Oops! This project isn't running.
>
> It looks like this project isn't running because the version of Node.js it relies on is too old.
>
> If this is your project, head on over to the Glitch Editor so you can fix the required Node version in your package.json file, or head over to the Help Center page on supported Node versions to learn more.