### PR TITLE
chore(abstract-mapreduce): reduce repetitive catch handlers

### DIFF
--- a/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-abstract-mapreduce/src/index.js
@@ -460,12 +460,9 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
       const purgeSeq = res.purgeSeq;
       return view.db.get('_local/purgeSeq').then(function (res) {
         return res._rev;
-      }).catch(function (err) {
-        if (err.status !== 404) {
-          throw err;
-        }
-        return undefined;
-      }).then(function (rev) {
+      })
+      .catch(defaultsTo(undefined))
+      .then(function (rev) {
         return view.db.put({
           _id: '_local/purgeSeq',
           _rev: rev,
@@ -577,12 +574,9 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
     function getRecentPurges() {
       return view.db.get('_local/purgeSeq').then(function (res) {
         return res.purgeSeq;
-      }).catch(function (err) {
-        if (err && err.status !== 404) {
-          throw err;
-        }
-        return -1;
-      }).then(function (purgeSeq) {
+      })
+      .catch(defaultsTo(-1))
+      .then(function (purgeSeq) {
         return view.sourceDB.get('_local/purges').then(function (res) {
           const recentPurges = res.purges.filter(function (purge, index) {
             return index > purgeSeq;
@@ -595,19 +589,11 @@ function createAbstractMapReduce(localDocName, mapper, reducer, ddocValidator) {
           return Promise.all(uniquePurges.map(function (docId) {
             return view.sourceDB.get(docId).then(function (doc) {
               return { docId, doc };
-            }).catch(function (err) {
-              if (err.status !== 404) {
-                throw err;
-              }
-              return { docId };
-            });
+            })
+            .catch(defaultsTo({ docId }));
           }));
-        }).catch(function (err) {
-          if (err && err.status !== 404) {
-            throw err;
-          }
-          return [];
-        });
+        })
+        .catch(defaultsTo([]));
       });
     }
 


### PR DESCRIPTION
A simple reduction of repetitive code with already existing `defaultsTo` function.