### PR TITLE
fix: input isn't defined in array case

### DIFF
--- a/packages/node_modules/pouchdb-find/src/validateSelector.js
+++ b/packages/node_modules/pouchdb-find/src/validateSelector.js
@@ -99,7 +99,7 @@ var equalityOperators = [ '$eq', '$gt', '$gte', '$lt', '$lte' ];
 function validateSelector(input, isHttp) {
   if (Array.isArray(input)) {
     for (var entry of input) {
-      if (typeof entry === 'object' && value !== null) {
+      if (typeof entry === 'object' && entry !== null) {
         validateSelector(entry, isHttp);
       }
     }

--- a/tests/find/test-suite-1/test.eq.js
+++ b/tests/find/test-suite-1/test.eq.js
@@ -457,6 +457,19 @@ describe('test.eq.js', function () {
       resp.docs.should.deep.equal([]);
     });
   });
+
+  it('does queries with array containing null', async () => {
+    const db = context.db;
+
+    await db.put({ _id: '1', field: [null] });
+
+    const resp = await db.find({
+      selector: { field: [null] }
+    });
+
+    resp.docs.should.have.length(1);
+  });
+
   describe("implicit/explicit $eq", () => {
     it('implicit $eq queries against objects recurse', function () {
       var db = context.db;


### PR DESCRIPTION
Fixed comparison against an undeclared/undefined variable (`value !== null` always evaluates to `undefined !== null` when `input` is an array)

To me it looks like a copy & past mistake (102 looks similar to line 124)