### PR TITLE
Remove legacy workaround for Blob.slice()

### DIFF
--- a/packages/node_modules/pouchdb-md5/src/binaryMd5-browser.js
+++ b/packages/node_modules/pouchdb-md5/src/binaryMd5-browser.js
@@ -7,17 +7,10 @@ function rawToBase64(raw) {
   return btoa(raw);
 }
 
-function sliceBlob(blob, start, end) {
-  if (blob.webkitSlice) {
-    return blob.webkitSlice(start, end);
-  }
-  return blob.slice(start, end);
-}
-
 function appendBlob(buffer, blob, start, end, callback) {
   if (start > 0 || end < blob.size) {
     // only slice blob if we really need to
-    blob = sliceBlob(blob, start, end);
+    blob = blob.slice(start, end);
   }
   readAsArrayBuffer(blob, function (arrayBuffer) {
     buffer.append(arrayBuffer);

--- a/packages/node_modules/pouchdb-utils/src/cloneBinaryObject-browser.js
+++ b/packages/node_modules/pouchdb-utils/src/cloneBinaryObject-browser.js
@@ -14,14 +14,8 @@ function cloneBinaryObject(object) {
   if (object instanceof ArrayBuffer) {
     return cloneArrayBuffer(object);
   }
-  var size = object.size;
-  var type = object.type;
   // Blob
-  if (typeof object.slice === 'function') {
-    return object.slice(0, size, type);
-  }
-  // PhantomJS slice() replacement
-  return object.webkitSlice(0, size, type);
+  return object.slice(0, object.size, object.type);
 }
 
 export default cloneBinaryObject;


### PR DESCRIPTION
Common since 2012.

See: https://developer.mozilla.org/en-US/docs/Web/API/Blob/slice#browser_compatibility