### PR TITLE
tests/perf: remove firefox bug workaround

### DIFF
--- a/tests/performance/perf.reporter.js
+++ b/tests/performance/perf.reporter.js
@@ -16,12 +16,6 @@ function emitMochaEvent(details) {
   }
 }
 
-// fix for Firefox max timing entries capped to 150:
-// https://bugzilla.mozilla.org/show_bug.cgi?id=1331135
-if (typeof performance !== 'undefined' && performance.setResourceTimingBufferSize) {
-  performance.setResourceTimingBufferSize(100000);
-}
-
 var pre = !isNode && global.document.getElementById('output');
 
 function log(msg) {


### PR DESCRIPTION
Removes workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1331135 - the bug was closed 7 years ago by https://bugzilla.mozilla.org/show_bug.cgi?id=1462880, or perhaps https://bugzilla.mozilla.org/show_bug.cgi?id=1159003.