### PR TITLE
chore: PouchDB-find adapters/http update

### DIFF
--- a/packages/node_modules/pouchdb-find/src/adapters/http/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/http/index.js
@@ -3,33 +3,24 @@ import { Headers } from 'pouchdb-fetch';
 import massageCreateIndexRequest from '../../massageCreateIndexRequest';
 import validateSelector from '../../validateSelector';
 
-async function dbFetch(db, path, opts = { method: 'GET' }) {
+async function dbFetch(db, path, opts) {
   if (opts.body) {
-    opts = {
-      method: 'POST',
-      body: JSON.stringify(opts.body),
-      headers: new Headers({ 'Content-type': 'application/json' }),
-    };
+    opts.body = JSON.stringify(opts.body);
+    opts.headers = new Headers({ 'Content-type': 'application/json' });
   }
+
   const response = await db.fetch(path, opts);
-  let ok = response.ok;
-  const json = await response.json()
-    .catch((error) => {
-      ok = false;
-      return { error };
-    });
-
-  if (!ok) {
+  const json = await response.json();
+  if (!response.ok) {
     json.status = response.status;
-    const pouchError = createError(json);
-    throw generateErrorFromResponse(pouchError);
+    throw generateErrorFromResponse(createError(json));
   }
-
   return json;
 }
 
 function createIndex(db, requestDef, callback) {
   dbFetch(db, '_index', {
+    method: 'POST',
     body: massageCreateIndexRequest(requestDef)
   })
     .then((result) => {
@@ -41,6 +32,7 @@ function createIndex(db, requestDef, callback) {
 function find(db, requestDef, callback) {
   validateSelector(requestDef.selector, true);
   dbFetch(db, '_find', {
+    method: 'POST',
     body: requestDef
   })
     .then((result) => {
@@ -51,6 +43,7 @@ function find(db, requestDef, callback) {
 
 function explain(db, requestDef, callback) {
   dbFetch(db, '_explain', {
+    method: 'POST',
     body: requestDef
   })
     .then((result) => {
@@ -60,7 +53,9 @@ function explain(db, requestDef, callback) {
 }
 
 function getIndexes(db, callback) {
-  return dbFetch(db, '_index')
+  return dbFetch(db, '_index', {
+    method: 'GET',
+  })
     .then((result) => {
       callback(null, result);
     })

--- a/packages/node_modules/pouchdb-find/src/adapters/http/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/http/index.js
@@ -3,22 +3,22 @@ import { Headers } from 'pouchdb-fetch';
 import massageCreateIndexRequest from '../../massageCreateIndexRequest';
 import validateSelector from '../../validateSelector';
 
-function dbFetch(db, path, opts, callback) {
-  var status, ok;
-  opts.headers = new Headers({'Content-type': 'application/json'});
-  db.fetch(path, opts).then(function (response) {
-    status = response.status;
-    ok = response.ok;
-    return response.json();
-  }).then(function (json) {
-    if (!ok) {
-      json.status = status;
-      var err = generateErrorFromResponse(json);
-      callback(err);
-    } else {
-      callback(null, json);
-    }
-  }).catch(callback);
+async function dbFetch(db, path, opts) {
+  opts.headers = new Headers({ 'Content-type': 'application/json' });
+  const response = await db.fetch(path, opts);
+  let ok = response.ok;
+  const json = await response.json()
+    .catch((error) => {
+      ok = false;
+      return { error };
+    });
+
+  if (!ok) {
+    json.status = response.status;
+    throw generateErrorFromResponse(json);
+  }
+
+  return json;
 }
 
 function createIndex(db, requestDef, callback) {
@@ -26,7 +26,11 @@ function createIndex(db, requestDef, callback) {
   dbFetch(db, '_index', {
     method: 'POST',
     body: JSON.stringify(requestDef)
-  }, callback);
+  })
+    .then((result) => {
+      callback(null, result);
+    })
+    .catch(callback);
 }
 
 function find(db, requestDef, callback) {
@@ -34,28 +38,38 @@ function find(db, requestDef, callback) {
   dbFetch(db, '_find', {
     method: 'POST',
     body: JSON.stringify(requestDef)
-  }, callback);
+  })
+    .then((result) => {
+      callback(null, result);
+    })
+    .catch(callback);
 }
 
 function explain(db, requestDef, callback) {
   dbFetch(db, '_explain', {
     method: 'POST',
     body: JSON.stringify(requestDef)
-  }, callback);
+  })
+    .then((result) => {
+      callback(null, result);
+    })
+    .catch(callback);
 }
 
 function getIndexes(db, callback) {
-  dbFetch(db, '_index', {
+  return dbFetch(db, '_index', {
     method: 'GET'
-  }, callback);
+  })
+    .then((result) => {
+      callback(null, result);
+    })
+    .catch(callback);
 }
 
 function deleteIndex(db, indexDef, callback) {
-
-
-  var ddoc = indexDef.ddoc;
-  var type = indexDef.type || 'json';
-  var name = indexDef.name;
+  const ddoc = indexDef.ddoc;
+  const type = indexDef.type || 'json';
+  const name = indexDef.name;
 
   if (!ddoc) {
     return callback(new Error('you must provide an index\'s ddoc'));
@@ -65,9 +79,13 @@ function deleteIndex(db, indexDef, callback) {
     return callback(new Error('you must provide an index\'s name'));
   }
 
-  var url = '_index/' + [ddoc, type, name].map(encodeURIComponent).join('/');
+  const url = '_index/' + [ddoc, type, name].map(encodeURIComponent).join('/');
 
-  dbFetch(db, url, {method: 'DELETE'}, callback);
+  dbFetch(db, url, { method: 'DELETE' })
+    .then((result) => {
+      callback(null, result);
+    })
+    .catch(callback);
 }
 
 export {

--- a/packages/node_modules/pouchdb-find/src/adapters/http/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/http/index.js
@@ -1,5 +1,4 @@
 import { createError, generateErrorFromResponse } from 'pouchdb-errors';
-import { Headers } from 'pouchdb-fetch';
 import massageCreateIndexRequest from '../../massageCreateIndexRequest';
 import validateSelector from '../../validateSelector';
 

--- a/packages/node_modules/pouchdb-find/src/adapters/http/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/http/index.js
@@ -1,4 +1,5 @@
 import { createError, generateErrorFromResponse } from 'pouchdb-errors';
+import { Headers } from 'pouchdb-fetch';
 import massageCreateIndexRequest from '../../massageCreateIndexRequest';
 import validateSelector from '../../validateSelector';
 

--- a/packages/node_modules/pouchdb-find/src/adapters/http/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/http/index.js
@@ -2,8 +2,14 @@ import { createError, generateErrorFromResponse } from 'pouchdb-errors';
 import massageCreateIndexRequest from '../../massageCreateIndexRequest';
 import validateSelector from '../../validateSelector';
 
-async function dbFetch(db, path, opts) {
-  opts.headers = new Headers({ 'Content-type': 'application/json' });
+async function dbFetch(db, path, opts = { method: 'GET' }) {
+  if (opts.body) {
+    opts = {
+      method: 'POST',
+      body: JSON.stringify(opts.body),
+      headers: new Headers({ 'Content-type': 'application/json' }),
+    };
+  }
   const response = await db.fetch(path, opts);
   let ok = response.ok;
   const json = await response.json()
@@ -22,10 +28,8 @@ async function dbFetch(db, path, opts) {
 }
 
 function createIndex(db, requestDef, callback) {
-  requestDef = massageCreateIndexRequest(requestDef);
   dbFetch(db, '_index', {
-    method: 'POST',
-    body: JSON.stringify(requestDef)
+    body: massageCreateIndexRequest(requestDef)
   })
     .then((result) => {
       callback(null, result);
@@ -36,8 +40,7 @@ function createIndex(db, requestDef, callback) {
 function find(db, requestDef, callback) {
   validateSelector(requestDef.selector, true);
   dbFetch(db, '_find', {
-    method: 'POST',
-    body: JSON.stringify(requestDef)
+    body: requestDef
   })
     .then((result) => {
       callback(null, result);
@@ -47,8 +50,7 @@ function find(db, requestDef, callback) {
 
 function explain(db, requestDef, callback) {
   dbFetch(db, '_explain', {
-    method: 'POST',
-    body: JSON.stringify(requestDef)
+    body: requestDef
   })
     .then((result) => {
       callback(null, result);
@@ -57,9 +59,7 @@ function explain(db, requestDef, callback) {
 }
 
 function getIndexes(db, callback) {
-  return dbFetch(db, '_index', {
-    method: 'GET'
-  })
+  return dbFetch(db, '_index')
     .then((result) => {
       callback(null, result);
     })

--- a/packages/node_modules/pouchdb-find/src/adapters/http/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/http/index.js
@@ -1,4 +1,4 @@
-import { generateErrorFromResponse } from 'pouchdb-errors';
+import { createError, generateErrorFromResponse } from 'pouchdb-errors';
 import { Headers } from 'pouchdb-fetch';
 import massageCreateIndexRequest from '../../massageCreateIndexRequest';
 import validateSelector from '../../validateSelector';
@@ -15,7 +15,8 @@ async function dbFetch(db, path, opts) {
 
   if (!ok) {
     json.status = response.status;
-    throw generateErrorFromResponse(json);
+    const pouchError = createError(json);
+    throw generateErrorFromResponse(pouchError);
   }
 
   return json;

--- a/packages/node_modules/pouchdb-find/src/adapters/http/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/http/index.js
@@ -13,7 +13,8 @@ async function dbFetch(db, path, opts) {
   const json = await response.json();
   if (!response.ok) {
     json.status = response.status;
-    throw generateErrorFromResponse(createError(json));
+    const pouchError = createError(json);
+    throw generateErrorFromResponse(pouchError);
   }
   return json;
 }

--- a/tests/find/test-suite-1/test.errors.js
+++ b/tests/find/test-suite-1/test.errors.js
@@ -163,4 +163,52 @@ describe('test.errors.js', function () {
       });
     });
   });
+
+  it('should throw an instance of error if createIndex throws', async () => {
+    const db = context.db;
+
+    try {
+      await db.createIndex({});
+    } catch (exception) {
+      //! FIXME check for instance of PouchError if available
+      exception.should.be.instanceOf(Error);
+    }
+  });
+
+  it('should throw an instance of error if find throws', async () => {
+    const db = context.db;
+
+    try {
+      await db.find({ selector: [] });
+    } catch (exception) {
+      //! FIXME check for instance of PouchError if available
+      exception.should.be.instanceOf(Error);
+    }
+  });
+
+  it('should throw an instance of error if explain throws', async () => {
+    const db = context.db;
+
+    try {
+      await db.explain({});
+    } catch (exception) {
+      //! FIXME check for instance of PouchError if available
+      exception.should.be.instanceOf(Error);
+    }
+  });
+
+  it('should throw an instance of error if deleteIndex throws', async () => {
+    const db = context.db;
+
+    try {
+      await db.deleteIndex({
+        ddoc: "foo",
+        name: "bar"
+      });
+    }
+    catch (exception) {
+      //! FIXME check for instance of PouchError if available
+      exception.should.be.instanceOf(Error);
+    }
+  });
 });


### PR DESCRIPTION
This refactors `dbFetch` into an async function.
Instead of anonymous objects, instances of `PouchError` are now thrown.

Additional changes:
- update `var` to `const`.
- avoid setting "Content-Type" request header for `getIndexes` and `deleteIndex`.

I isolated this PR from #8860, because it includes type change of exceptions.

NOTE: Can't check for `instanceof PouchError`.
Class `PouchError` isn't exported, left a hints as `FIXME` in tests.