### PR TITLE
chore: PouchDB-find abstract-mapper update

### DIFF
--- a/packages/node_modules/pouchdb-find/src/adapters/local/abstract-mapper.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/abstract-mapper.js
@@ -12,24 +12,25 @@ import { matchesSelector, parseField } from 'pouchdb-selector-core';
 // the function, but it would also be a lot less performant.
 //
 
+function getDeepValue(value, path) {
+  for (const key of path) {
+    value = value[key];
+    if (value === undefined) {
+      throw new Error("value is undefined");
+    }
+  }
+  return value;
+}
 
 function createDeepMultiMapper(fields, emit, selector) {
   return function (doc) {
     if (selector && !matchesSelector(doc, selector)) { return; }
-    const toEmit = [];
-    for (let i = 0, iLen = fields.length; i < iLen; i++) {
-      const parsedField = parseField(fields[i]);
-      let value = doc;
-      for (let j = 0, jLen = parsedField.length; j < jLen; j++) {
-        const key = parsedField[j];
-        value = value[key];
-        if (typeof value === 'undefined') {
-          return; // don't emit
-        }
-      }
-      toEmit.push(value);
+
+    try {
+      const toEmit = fields.map(field => getDeepValue(doc, parseField(field)));
+      emit(toEmit);
     }
-    emit(toEmit);
+    catch (_valueIsUndefined) { /* don't emit */ }
   };
 }
 
@@ -37,15 +38,12 @@ function createDeepSingleMapper(field, emit, selector) {
   const parsedField = parseField(field);
   return function (doc) {
     if (selector && !matchesSelector(doc, selector)) { return; }
-    let value = doc;
-    for (let i = 0, len = parsedField.length; i < len; i++) {
-      const key = parsedField[i];
-      value = value[key];
-      if (typeof value === 'undefined') {
-        return; // do nothing
-      }
+
+    try {
+      const value = getDeepValue(doc, parsedField);
+      emit(value);
     }
-    emit(value);
+    catch (_valueIsUndefined) { /* don't emit */ }
   };
 }
 
@@ -59,22 +57,13 @@ function createShallowSingleMapper(field, emit, selector) {
 function createShallowMultiMapper(fields, emit, selector) {
   return function (doc) {
     if (selector && !matchesSelector(doc, selector)) { return; }
-    const toEmit = [];
-    for (let i = 0, len = fields.length; i < len; i++) {
-      toEmit.push(doc[fields[i]]);
-    }
+    const toEmit = fields.map(field => doc[field]);
     emit(toEmit);
   };
 }
 
 function checkShallow(fields) {
-  for (let i = 0, len = fields.length; i < len; i++) {
-    const field = fields[i];
-    if (field.indexOf('.') !== -1) {
-      return false;
-    }
-  }
-  return true;
+  return fields.every((field) => field.indexOf('.') === -1);
 }
 
 function createMapper(fields, emit, selector) {

--- a/packages/node_modules/pouchdb-find/src/adapters/local/abstract-mapper.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/abstract-mapper.js
@@ -16,7 +16,7 @@ function getDeepValue(value, path) {
   for (const key of path) {
     value = value[key];
     if (value === undefined) {
-      throw new Error("value is undefined");
+      return undefined;
     }
   }
   return value;
@@ -26,11 +26,15 @@ function createDeepMultiMapper(fields, emit, selector) {
   return function (doc) {
     if (selector && !matchesSelector(doc, selector)) { return; }
 
-    try {
-      const toEmit = fields.map(field => getDeepValue(doc, parseField(field)));
-      emit(toEmit);
+    const toEmit = [];
+    for (const field of fields) {
+      const value = getDeepValue(doc, parseField(field));
+      if (value === undefined) {
+        return;
+      }
+      toEmit.push(value);
     }
-    catch (_valueIsUndefined) { /* don't emit */ }
+    emit(toEmit);
   };
 }
 
@@ -39,11 +43,10 @@ function createDeepSingleMapper(field, emit, selector) {
   return function (doc) {
     if (selector && !matchesSelector(doc, selector)) { return; }
 
-    try {
-      const value = getDeepValue(doc, parsedField);
+    const value = getDeepValue(doc, parsedField);
+    if (value !== undefined) {
       emit(value);
     }
-    catch (_valueIsUndefined) { /* don't emit */ }
   };
 }
 

--- a/packages/node_modules/pouchdb-find/src/adapters/local/abstract-mapper.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/abstract-mapper.js
@@ -16,12 +16,12 @@ import { matchesSelector, parseField } from 'pouchdb-selector-core';
 function createDeepMultiMapper(fields, emit, selector) {
   return function (doc) {
     if (selector && !matchesSelector(doc, selector)) { return; }
-    var toEmit = [];
-    for (var i = 0, iLen = fields.length; i < iLen; i++) {
-      var parsedField = parseField(fields[i]);
-      var value = doc;
-      for (var j = 0, jLen = parsedField.length; j < jLen; j++) {
-        var key = parsedField[j];
+    const toEmit = [];
+    for (let i = 0, iLen = fields.length; i < iLen; i++) {
+      const parsedField = parseField(fields[i]);
+      let value = doc;
+      for (let j = 0, jLen = parsedField.length; j < jLen; j++) {
+        const key = parsedField[j];
         value = value[key];
         if (typeof value === 'undefined') {
           return; // don't emit
@@ -34,12 +34,12 @@ function createDeepMultiMapper(fields, emit, selector) {
 }
 
 function createDeepSingleMapper(field, emit, selector) {
-  var parsedField = parseField(field);
+  const parsedField = parseField(field);
   return function (doc) {
     if (selector && !matchesSelector(doc, selector)) { return; }
-    var value = doc;
-    for (var i = 0, len = parsedField.length; i < len; i++) {
-      var key = parsedField[i];
+    let value = doc;
+    for (let i = 0, len = parsedField.length; i < len; i++) {
+      const key = parsedField[i];
       value = value[key];
       if (typeof value === 'undefined') {
         return; // do nothing
@@ -59,8 +59,8 @@ function createShallowSingleMapper(field, emit, selector) {
 function createShallowMultiMapper(fields, emit, selector) {
   return function (doc) {
     if (selector && !matchesSelector(doc, selector)) { return; }
-    var toEmit = [];
-    for (var i = 0, len = fields.length; i < len; i++) {
+    const toEmit = [];
+    for (let i = 0, len = fields.length; i < len; i++) {
       toEmit.push(doc[fields[i]]);
     }
     emit(toEmit);
@@ -68,8 +68,8 @@ function createShallowMultiMapper(fields, emit, selector) {
 }
 
 function checkShallow(fields) {
-  for (var i = 0, len = fields.length; i < len; i++) {
-    var field = fields[i];
+  for (let i = 0, len = fields.length; i < len; i++) {
+    const field = fields[i];
     if (field.indexOf('.') !== -1) {
       return false;
     }
@@ -78,8 +78,8 @@ function checkShallow(fields) {
 }
 
 function createMapper(fields, emit, selector) {
-  var isShallow = checkShallow(fields);
-  var isSingle = fields.length === 1;
+  const isShallow = checkShallow(fields);
+  const isSingle = fields.length === 1;
 
   // notice we try to optimize for the most common case,
   // i.e. single shallow indexes
@@ -113,18 +113,18 @@ function reducer(/*reduceFunDef*/) {
 }
 
 function ddocValidator(ddoc, viewName) {
-  var view = ddoc.views[viewName];
+  const view = ddoc.views[viewName];
   // This doesn't actually need to be here apparently, but
   // I feel safer keeping it.
   /* istanbul ignore if */
   if (!view.map || !view.map.fields) {
-    throw new Error('ddoc ' + ddoc._id +' with view ' + viewName +
+    throw new Error('ddoc ' + ddoc._id + ' with view ' + viewName +
       ' doesn\'t have map.fields defined. ' +
       'maybe it wasn\'t created by this plugin?');
   }
 }
 
-var abstractMapper = abstractMapReduce(
+const abstractMapper = abstractMapReduce(
   /* localDocName */ 'indexes',
   mapper,
   reducer,
@@ -138,11 +138,11 @@ export default function (db) {
       // the standard findAbstractMapper query/viewCleanup.
       // This allows the indexeddb adapter to support partial_filter_selector.
       query: function addQueryFallback(signature, opts) {
-        var fallback = abstractMapper.query.bind(this);
+        const fallback = abstractMapper.query.bind(this);
         return db._customFindAbstractMapper.query.call(this, signature, opts, fallback);
       },
       viewCleanup: function addViewCleanupFallback() {
-        var fallback = abstractMapper.viewCleanup.bind(this);
+        const fallback = abstractMapper.viewCleanup.bind(this);
         return db._customFindAbstractMapper.viewCleanup.call(this, fallback);
       }
     };


### PR DESCRIPTION
Clean up the control flow of PouchDB-find/local/abstract-mapper:
- extract value traversal loops as `getDeepValue` function.
- replace loops with build-in array functions.
- replace `var` with `const`

Isolated as standalone PR from #8860