### PR TITLE
fix: remove dead `Debug mode` link

### DIFF
--- a/docs/_includes/api.html
+++ b/docs/_includes/api.html
@@ -29,4 +29,3 @@
 <li><a href="#active_tasks">Active tasks</a></li>
 <li><a href="#defaults">Default settings</a></li>
 <li><a href="#plugins">Plugins</a></li>
-<li><a href="#debug_mode">Debug mode</a></li>


### PR DESCRIPTION
Remove navigation link to non-existing `Debug mode` in API Reference