### PR TITLE
chore(PouchDB-find): loop updates

### DIFF
--- a/packages/node_modules/pouchdb-find/src/adapters/local/find/query-planner.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/find/query-planner.js
@@ -31,13 +31,8 @@ const SHORT_CIRCUIT_QUERY = {
 // couchdb second-lowest collation value
 
 function checkFieldInIndex(index, field) {
-  const indexFields = index.def.fields.map(getKey);
-  for (const indexField of indexFields) {
-    if (field === indexField) {
-      return true;
-    }
-  }
-  return false;
+  return index.def.fields
+    .some((key) => getKey(key) === field);
 }
 
 // so when you do e.g. $eq/$eq, we can do it entirely in the database.

--- a/packages/node_modules/pouchdb-find/src/adapters/local/find/query-planner.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/find/query-planner.js
@@ -32,8 +32,7 @@ const SHORT_CIRCUIT_QUERY = {
 
 function checkFieldInIndex(index, field) {
   const indexFields = index.def.fields.map(getKey);
-  for (let i = 0, len = indexFields.length; i < len; i++) {
-    const indexField = indexFields[i];
+  for (const indexField of indexFields) {
     if (field === indexField) {
       return true;
     }
@@ -92,14 +91,13 @@ function getBasicInMemoryFields(index, selector, userFields) {
 
 function getInMemoryFieldsFromNe(selector) {
   const fields = [];
-  Object.keys(selector).forEach(function (field) {
-    const matcher = selector[field];
-    Object.keys(matcher).forEach(function (operator) {
+  for (const [field, matcher] of Object.entries(selector)) {
+    for (const operator of Object.keys(matcher)) {
       if (operator === '$ne') {
         fields.push(field);
       }
-    });
-  });
+    }
+  }
   return fields;
 }
 
@@ -212,8 +210,7 @@ function findBestMatchingIndex(selector, userFields, sortOrder, indexes, useInde
   function scoreIndex(index) {
     const indexFields = index.def.fields.map(getKey);
     let score = 0;
-    for (let i = 0, len = indexFields.length; i < len; i++) {
-      const indexField = indexFields[i];
+    for (const indexField of indexFields) {
       if (userFieldsMap[indexField]) {
         score++;
       }
@@ -285,8 +282,7 @@ function getSingleFieldCoreQueryPlan(selector, index) {
 
   let combinedOpts;
 
-  userOperators.forEach(function (userOperator) {
-
+  for (const userOperator of userOperators) {
     if (isNonLogicalMatcher(userOperator)) {
       inMemoryFields.push(field);
     }
@@ -300,7 +296,7 @@ function getSingleFieldCoreQueryPlan(selector, index) {
     } else {
       combinedOpts = newQueryOpts;
     }
-  });
+  }
 
   return {
     queryOpts: combinedOpts,
@@ -389,8 +385,7 @@ function getMultiFieldQueryOpts(selector, index) {
 
     let combinedOpts = null;
 
-    for (let j = 0; j < userOperators.length; j++) {
-      const userOperator = userOperators[j];
+    for (const userOperator of userOperators) {
       const userValue = matcher[userOperator];
 
       const newOpts = getMultiFieldCoreQueryPlan(userOperator, userValue);

--- a/packages/node_modules/pouchdb-find/src/adapters/local/utils.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/utils.js
@@ -49,22 +49,18 @@ function massageIndexDef(indexDef) {
 }
 
 function getKeyFromDoc(doc, index) {
-  const res = [];
-  for (let i = 0; i < index.def.fields.length; i++) {
-    const field = getKey(index.def.fields[i]);
-    res.push(getFieldFromDoc(doc, parseField(field)));
-  }
-  return res;
+  return index.def.fields.map((obj) => {
+    const field = getKey(obj);
+    return getFieldFromDoc(doc, parseField(field));
+  });
 }
 
 // have to do this manually because REASONS. I don't know why
 // CouchDB didn't implement inclusive_start
 function filterInclusiveStart(rows, targetValue, index) {
   const indexFields = index.def.fields;
-  let i = 0;
-  for (let len = rows.length; i < len; i++) {
-    const row = rows[i];
-
+  let startAt = 0;
+  for (const row of rows) {
     // shave off any docs at the beginning that are <= the
     // target value
 
@@ -83,8 +79,9 @@ function filterInclusiveStart(rows, targetValue, index) {
       // no need to filter any further; we're past the key
       break;
     }
+    ++startAt;
   }
-  return i > 0 ? rows.slice(i) : rows;
+  return startAt > 0 ? rows.slice(startAt) : rows;
 }
 
 function reverseOptions(opts) {

--- a/packages/node_modules/pouchdb-find/src/massageCreateIndexRequest.js
+++ b/packages/node_modules/pouchdb-find/src/massageCreateIndexRequest.js
@@ -11,12 +11,12 @@ function massageCreateIndexRequest(requestDef) {
     requestDef.index = {};
   }
 
-  ['type', 'name', 'ddoc'].forEach(function (key) {
+  for (const key of ['type', 'name', 'ddoc']) {
     if (requestDef.index[key]) {
       requestDef[key] = requestDef.index[key];
       delete requestDef.index[key];
     }
-  });
+  }
 
   if (requestDef.fields) {
     requestDef.index.fields = requestDef.fields;

--- a/packages/node_modules/pouchdb-find/src/utils.js
+++ b/packages/node_modules/pouchdb-find/src/utils.js
@@ -86,17 +86,23 @@ function promisedCallback(promise, callback) {
   return promise;
 }
 
-const flatten = (...args) => {
+const nativeFlat = (...args) => args.flat(Infinity);
+
+const polyFlat = (...args) => {
   let res = [];
   for (const subArr of args) {
     if (Array.isArray(subArr)) {
-      res = res.concat(flatten(...subArr));
+      res = res.concat(polyFlat(...subArr));
     } else {
       res.push(subArr);
     }
   }
   return res;
 };
+
+const flatten = typeof Array.prototype.flat === 'function'
+  ? nativeFlat
+  : polyFlat;
 
 function mergeObjects(arr) {
   const res = {};

--- a/packages/node_modules/pouchdb-find/src/utils.js
+++ b/packages/node_modules/pouchdb-find/src/utils.js
@@ -86,12 +86,11 @@ function promisedCallback(promise, callback) {
   return promise;
 }
 
-const flatten = function (...args) {
+const flatten = (...args) => {
   let res = [];
-  for (let i = 0, len = args.length; i < len; i++) {
-    const subArr = args[i];
+  for (const subArr of args) {
     if (Array.isArray(subArr)) {
-      res = res.concat(flatten.apply(null, subArr));
+      res = res.concat(flatten(...subArr));
     } else {
       res.push(subArr);
     }
@@ -100,9 +99,9 @@ const flatten = function (...args) {
 };
 
 function mergeObjects(arr) {
-  let res = {};
-  for (let i = 0, len = arr.length; i < len; i++) {
-    res = Object.assign(res, arr[i]);
+  const res = {};
+  for (const element of arr) {
+    Object.assign(res, element);
   }
   return res;
 }
@@ -111,8 +110,8 @@ function mergeObjects(arr) {
 // and copies them to a new doc. Like underscore _.pick but supports nesting.
 function pick(obj, arr) {
   const res = {};
-  for (let i = 0, len = arr.length; i < len; i++) {
-    const parsedField = parseField(arr[i]);
+  for (const field of arr) {
+    const parsedField = parseField(field);
     const value = getFieldFromDoc(obj, parsedField);
     if (typeof value !== 'undefined') {
       setFieldInDoc(res, parsedField, value);
@@ -163,8 +162,8 @@ function oneSetIsSubArrayOfOther(left, right) {
 
 function arrayToObject(arr) {
   const res = {};
-  for (let i = 0, len = arr.length; i < len; i++) {
-    res[arr[i]] = true;
+  for (const field of arr) {
+    res[field] = true;
   }
   return res;
 }
@@ -172,8 +171,7 @@ function arrayToObject(arr) {
 function max(arr, fun) {
   let max = null;
   let maxScore = -1;
-  for (let i = 0, len = arr.length; i < len; i++) {
-    const element = arr[i];
+  for (const element of arr) {
     const score = fun(element);
     if (score > maxScore) {
       maxScore = score;
@@ -196,13 +194,7 @@ function arrayEquals(arr1, arr2) {
 }
 
 function uniq(arr) {
-  const obj = {};
-  for (let i = 0; i < arr.length; i++) {
-    obj['$' + arr[i]] = true;
-  }
-  return Object.keys(obj).map(function (key) {
-    return key.substring(1);
-  });
+  return Array.from(new Set(arr));
 }
 
 export {


### PR DESCRIPTION
Improve readability and performance (slightly) of loops in pouchdb-find.

- refactor iterator loops to for ... of: when `i` was only for element lookup.
- flatten: use native `Array.prototype.flat` is 2x faster than polyfill.
- `uniq` utility -> Array.from(Set): slight perf boost (`Set` is guaranteed to be unique).

Isolated from #8860