### PR TITLE
NOT_AN_OBJECT: throw for null; add additional tests

### DIFF
--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -190,6 +190,10 @@ function attachmentNameError(name) {
   return false;
 }
 
+function isNotSingleDoc(doc) {
+  return doc === null || typeof doc !== 'object' || Array.isArray(doc);
+}
+
 function isValidRev(rev) {
   return typeof rev === 'string' && /^\d+-/.test(rev);
 }
@@ -201,7 +205,7 @@ class AbstractPouchDB extends EventEmitter {
         callback = opts;
         opts = {};
       }
-      if (doc == null || typeof doc !== 'object' || Array.isArray(doc)) {
+      if (isNotSingleDoc(doc)) {
         return callback(createError(NOT_AN_OBJECT));
       }
       this.bulkDocs({docs: [doc]}, opts, yankError(callback, doc._id));
@@ -212,7 +216,7 @@ class AbstractPouchDB extends EventEmitter {
         cb = opts;
         opts = {};
       }
-      if (doc == null || typeof doc !== 'object' || Array.isArray(doc)) {
+      if (isNotSingleDoc(doc)) {
         return cb(createError(NOT_AN_OBJECT));
       }
       invalidIdError(doc._id);
@@ -785,7 +789,7 @@ class AbstractPouchDB extends EventEmitter {
       }
 
       for (var i = 0; i < req.docs.length; ++i) {
-        if (req.docs[i] == null || typeof req.docs[i] !== 'object' || Array.isArray(req.docs[i])) {
+        if (isNotSingleDoc(req.docs[i])) {
           return callback(createError(NOT_AN_OBJECT));
         }
       }

--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -197,7 +197,7 @@ class AbstractPouchDB extends EventEmitter {
         callback = opts;
         opts = {};
       }
-      if (typeof doc !== 'object' || Array.isArray(doc)) {
+      if (doc == null || typeof doc !== 'object' || Array.isArray(doc)) {
         return callback(createError(NOT_AN_OBJECT));
       }
       this.bulkDocs({docs: [doc]}, opts, yankError(callback, doc._id));
@@ -208,7 +208,7 @@ class AbstractPouchDB extends EventEmitter {
         cb = opts;
         opts = {};
       }
-      if (typeof doc !== 'object' || Array.isArray(doc)) {
+      if (doc == null || typeof doc !== 'object' || Array.isArray(doc)) {
         return cb(createError(NOT_AN_OBJECT));
       }
       invalidIdError(doc._id);
@@ -778,7 +778,7 @@ class AbstractPouchDB extends EventEmitter {
       }
 
       for (var i = 0; i < req.docs.length; ++i) {
-        if (typeof req.docs[i] !== 'object' || Array.isArray(req.docs[i])) {
+        if (req.docs[i] == null || typeof req.docs[i] !== 'object' || Array.isArray(req.docs[i])) {
           return callback(createError(NOT_AN_OBJECT));
         }
       }

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -747,8 +747,8 @@ adapters.forEach(function (adapter) {
     });
 
     [
-      null,
       undefined,
+      null,
       [],
       [{ _id: 'foo' }, { _id: 'bar' }],
       'this is not an object',
@@ -758,48 +758,26 @@ adapters.forEach(function (adapter) {
       describe(`Should error when document is not an object #${idx}`, () => {
         let db;
 
+        const expectNotAnObject = fn => async () => {
+          let threw;
+          try {
+            await fn();
+          } catch (err) {
+            threw = true;
+            err.message.should.equal('Document must be a JSON object');
+          }
+          if (!threw) {
+            throw new Error('should have thrown');
+          }
+        };
+
         beforeEach(() => {
           db = new PouchDB(dbs.name);
         });
 
-        it('should error for .post()', async () => {
-          let threw;
-          try {
-            await db.post(badDoc);
-          } catch (err) {
-            threw = true;
-            err.message.should.equal('Document must be a JSON object');
-          }
-          if (!threw) {
-            throw new Error('should have thrown');
-          }
-        });
-
-        it('should error for .put()', async () => {
-          let threw;
-          try {
-            await db.post(badDoc);
-          } catch (err) {
-            threw = true;
-            err.message.should.equal('Document must be a JSON object');
-          }
-          if (!threw) {
-            throw new Error('should have thrown');
-          }
-        });
-
-        it('should error for .bulkDocs()', async () => {
-          let threw;
-          try {
-            await db.bulkDocs({docs: [badDoc]});
-          } catch (err) {
-            threw = true;
-            err.message.should.equal('Document must be a JSON object');
-          }
-          if (!threw) {
-            throw new Error('should have thrown');
-          }
-        });
+        it('should error for .post()', expectNotAnObject(() => db.post(badDoc)));
+        it('should error for .put()', expectNotAnObject(() => db.put(badDoc)));
+        it('should error for .bulkDocs()', expectNotAnObject(() => db.bulkDocs({docs: [badDoc]})));
       });
     });
 

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -746,23 +746,61 @@ adapters.forEach(function (adapter) {
       });
     });
 
-    it('Error when document is not an object', function (done) {
-      var db = new PouchDB(dbs.name);
-      var doc1 = [{ _id: 'foo' }, { _id: 'bar' }];
-      var doc2 = 'this is not an object';
-      var count = 5;
-      var callback = function (err) {
-        should.exist(err);
-        count--;
-        if (count === 0) {
-          done();
-        }
-      };
-      db.post(doc1, callback);
-      db.post(doc2, callback);
-      db.put(doc1, callback);
-      db.put(doc2, callback);
-      db.bulkDocs({docs: [doc1, doc2]}, callback);
+    [
+      null,
+      undefined,
+      [],
+      [{ _id: 'foo' }, { _id: 'bar' }],
+      'this is not an object',
+      String('this is not an object'),
+      //new String('this is not an object'), actually, this _is_ an object
+    ].forEach((badDoc, idx) => {
+      describe(`Should error when document is not an object #${idx}`, () => {
+        let db;
+
+        beforeEach(() => {
+          db = new PouchDB(dbs.name);
+        });
+
+        it('should error for .post()', async () => {
+          let threw;
+          try {
+            await db.post(badDoc);
+          } catch (err) {
+            threw = true;
+            err.message.should.equal('Document must be a JSON object');
+          }
+          if (!threw) {
+            throw new Error('should have thrown');
+          }
+        });
+
+        it('should error for .put()', async () => {
+          let threw;
+          try {
+            await db.post(badDoc);
+          } catch (err) {
+            threw = true;
+            err.message.should.equal('Document must be a JSON object');
+          }
+          if (!threw) {
+            throw new Error('should have thrown');
+          }
+        });
+
+        it('should error for .bulkDocs()', async () => {
+          let threw;
+          try {
+            await db.bulkDocs({docs: [badDoc]});
+          } catch (err) {
+            threw = true;
+            err.message.should.equal('Document must be a JSON object');
+          }
+          if (!threw) {
+            throw new Error('should have thrown');
+          }
+        });
+      });
     });
 
     it('Test instance update_seq updates correctly', function (done) {


### PR DESCRIPTION
Also separates test cases so specific failures can be understood.

Without the fix, tests fail:

```
  test.basics.js-http
    Should error when document is not an object #0
      ✔ should error for .post()
Testing on: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/123.0.6312.4 Safari/537.36
      ✔ should error for .put()
      ✔ should error for .bulkDocs()
    Should error when document is not an object #1
      1) should error for .post()
      2) should error for .put()
      3) should error for .bulkDocs()
    Should error when document is not an object #2
      ✔ should error for .post()
      ✔ should error for .put()
      ✔ should error for .bulkDocs()
    Should error when document is not an object #3
      ✔ should error for .post()
      ✔ should error for .put()
      ✔ should error for .bulkDocs()
    Should error when document is not an object #4
      ✔ should error for .post()
      ✔ should error for .put()
      ✔ should error for .bulkDocs()
    Should error when document is not an object #5
      ✔ should error for .post()
      ✔ should error for .put()
      ✔ should error for .bulkDocs()

  test.basics.js-local
    Should error when document is not an object #0
      ✔ should error for .post()
      ✔ should error for .put()
      ✔ should error for .bulkDocs()
    Should error when document is not an object #1
      4) should error for .post()
      5) should error for .put()
      6) should error for .bulkDocs()
    Should error when document is not an object #2
      ✔ should error for .post()
      ✔ should error for .put()
      ✔ should error for .bulkDocs()
    Should error when document is not an object #3
      ✔ should error for .post()
      ✔ should error for .put()
      ✔ should error for .bulkDocs()
    Should error when document is not an object #4
      ✔ should error for .post()
      ✔ should error for .put()
      ✔ should error for .bulkDocs()
    Should error when document is not an object #5
      ✔ should error for .post()
      ✔ should error for .put()
      ✔ should error for .bulkDocs()


  30 passing (515ms)
  6 failing

  1) test.basics.js-http
       Should error when document is not an object #1
         should error for .post():

      AssertionError: expected 'Cannot read properties of null (reading \'_id\')' to equal 'Document must be a JSON object'
      + expected - actual

      -Cannot read properties of null (reading '_id')
      +Document must be a JSON object
      
      at Context.<anonymous> (test.basics.js:767:32)

  2) test.basics.js-http
       Should error when document is not an object #1
         should error for .put():

      AssertionError: expected 'Cannot read properties of null (reading \'_id\')' to equal 'Document must be a JSON object'
      + expected - actual

      -Cannot read properties of null (reading '_id')
      +Document must be a JSON object
      
      at Context.<anonymous> (test.basics.js:767:32)

  3) test.basics.js-http
       Should error when document is not an object #1
         should error for .bulkDocs():

      AssertionError: expected 'Cannot read properties of null (reading \'_attachments\')' to equal 'Document must be a JSON object'
      + expected - actual

      -Cannot read properties of null (reading '_attachments')
      +Document must be a JSON object
      
      at Context.<anonymous> (test.basics.js:767:32)

  4) test.basics.js-local
       Should error when document is not an object #1
         should error for .post():

      AssertionError: expected 'Cannot read properties of null (reading \'_id\')' to equal 'Document must be a JSON object'
      + expected - actual

      -Cannot read properties of null (reading '_id')
      +Document must be a JSON object
      
      at Context.<anonymous> (test.basics.js:767:32)

  5) test.basics.js-local
       Should error when document is not an object #1
         should error for .put():

      AssertionError: expected 'Cannot read properties of null (reading \'_id\')' to equal 'Document must be a JSON object'
      + expected - actual

      -Cannot read properties of null (reading '_id')
      +Document must be a JSON object
      
      at Context.<anonymous> (test.basics.js:767:32)

  6) test.basics.js-local
       Should error when document is not an object #1
         should error for .bulkDocs():

      AssertionError: expected 'Cannot read properties of null (reading \'_attachments\')' to equal 'Document must be a JSON object'
      + expected - actual

      -Cannot read properties of null (reading '_attachments')
      +Document must be a JSON object
      
      at Context.<anonymous> (test.basics.js:767:32)
```