### PR TITLE
isValidRev(): reject revs with more than one dash

### DIFF
--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -191,7 +191,7 @@ function attachmentNameError(name) {
 }
 
 function isValidRev(rev) {
-  return typeof rev === 'string' && /^\d+-/.test(rev);
+  return typeof rev === 'string' && /^\d+-[^-]*$/.test(rev);
 }
 
 class AbstractPouchDB extends EventEmitter {

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -271,6 +271,7 @@ adapters.forEach(function (adapter) {
     [
       () => '-format',
       () => 'bad-format',
+      () => '1-ok-bad',
       () => ({}),
       () => ({ toString:'2-abc' }),
       () => ({ toString:'2-abc', indexOf:777 }),


### PR DESCRIPTION
There are various places in the code where revs are assumed to include a single dash character:

```js
* pouchdb-adapter-idb/src/index.js:533: doc._rev = '0-' + (parseInt(oldRev.split('-')[1], 10) + 1);
* pouchdb-adapter-leveldb-core/src/index.js:1402: oldRev ? '0-' + (parseInt(oldRev.split('-')[1], 10) + 1) : '0-1';
* pouchdb-core/src/adapter.js:249: var parts = doc._rev.split('-');
* pouchdb-core/src/adapter.js:599: var splittedRev = doc._rev.split('-');
* pouchdb-core/src/adapter.js:623: const pathId = doc._rev.split('-')[1];
* pouchdb-merge/src/revExists.js:4: var splitRev = rev.split('-');
```

Follow-up to https://github.com/pouchdb/pouchdb/pull/8931