### PR TITLE
db.post(), db.bulkDocs(): throw INVALID_REV consistently

### DIFF
--- a/packages/node_modules/pouchdb-core/src/adapter.js
+++ b/packages/node_modules/pouchdb-core/src/adapter.js
@@ -785,8 +785,12 @@ class AbstractPouchDB extends EventEmitter {
       }
 
       for (var i = 0; i < req.docs.length; ++i) {
-        if (typeof req.docs[i] !== 'object' || Array.isArray(req.docs[i])) {
+        const doc = req.docs[i];
+        if (typeof doc !== 'object' || Array.isArray(doc)) {
           return callback(createError(NOT_AN_OBJECT));
+        }
+        if ('_rev' in doc && !isValidRev(doc._rev)) {
+          return callback(createError(INVALID_REV));
         }
       }
 


### PR DESCRIPTION
Bring `db.post()` and `db.bulkDocs()` rev checks in line with `db.put()`.

Follow-up to https://github.com/pouchdb/pouchdb/pull/8931.