### PR TITLE
(#8927) - Set default limit on find queries to 25

### DIFF
--- a/docs/_includes/api/query_index.html
+++ b/docs/_includes/api/query_index.html
@@ -98,7 +98,7 @@ The above is a simple example. For an in-depth tutorial, please refer to
   * `$elemMatch` Matches all documents that contain an array field with at least one element that matches all the specified query criteria.
 * `fields` (Optional) Defines a list of fields that you want to receive. If omitted, you get the full documents.
 * `sort` (Optional) Defines a list of fields defining how you want to sort. Note that sorted fields also have to be selected in the `selector`.
-* `limit` (Optional) Maximum number of documents to return. Default is `25`.
+* `limit` (Optional) Maximum number of documents to return. Default is `25` when connected to a local database.
 * `skip` (Optional) Number of docs to skip before returning.
 * `use_index` (Optional) Set which index to use for the query. It can be "design-doc-name" or "['design-doc-name', 'name']".
 

--- a/docs/_includes/api/query_index.html
+++ b/docs/_includes/api/query_index.html
@@ -98,7 +98,7 @@ The above is a simple example. For an in-depth tutorial, please refer to
   * `$elemMatch` Matches all documents that contain an array field with at least one element that matches all the specified query criteria.
 * `fields` (Optional) Defines a list of fields that you want to receive. If omitted, you get the full documents.
 * `sort` (Optional) Defines a list of fields defining how you want to sort. Note that sorted fields also have to be selected in the `selector`.
-* `limit` (Optional) Maximum number of documents to return.
+* `limit` (Optional) Maximum number of documents to return. Default is `25`.
 * `skip` (Optional) Number of docs to skip before returning.
 * `use_index` (Optional) Set which index to use for the query. It can be "design-doc-name" or "['design-doc-name', 'name']".
 

--- a/packages/node_modules/pouchdb-find/src/adapters/local/find/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/find/index.js
@@ -92,7 +92,7 @@ async function find(db, requestDef, explain) {
     requestDef.use_index = massageUseIndex(requestDef.use_index);
   }
 
-  if(!requestDef.limit) {
+  if(!('limit' in requestDef)) {
     // Match the default limit of CouchDB
     requestDef.limit = 25;
   }
@@ -136,9 +136,7 @@ async function find(db, requestDef, explain) {
   if (!queryPlan.inMemoryFields.length) {
     // no in-memory filtering necessary, so we can let the
     // database do the limit/skip for us
-    if ('limit' in requestDef) {
-      opts.limit = requestDef.limit;
-    }
+    opts.limit = requestDef.limit;
     if ('skip' in requestDef) {
       opts.skip = requestDef.skip;
     }

--- a/packages/node_modules/pouchdb-find/src/adapters/local/find/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/find/index.js
@@ -92,7 +92,7 @@ async function find(db, requestDef, explain) {
     requestDef.use_index = massageUseIndex(requestDef.use_index);
   }
 
-  if(!('limit' in requestDef)) {
+  if (!('limit' in requestDef)) {
     // Match the default limit of CouchDB
     requestDef.limit = 25;
   }

--- a/packages/node_modules/pouchdb-find/src/adapters/local/find/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/find/index.js
@@ -92,6 +92,11 @@ async function find(db, requestDef, explain) {
     requestDef.use_index = massageUseIndex(requestDef.use_index);
   }
 
+  if(!requestDef.limit) {
+    // Match the default limit of CouchDB
+    requestDef.limit = 25;
+  }
+
   validateFindRequest(requestDef);
 
   const getIndexesRes = await getIndexes(db);

--- a/tests/find/test-suite-1/test.limit.js
+++ b/tests/find/test-suite-1/test.limit.js
@@ -284,4 +284,16 @@ describe('test.limit.js', function () {
       });
     });
   });
+
+  it.only('should have default limit of 25', async () => {
+    const  extraDocs = Array
+      .from({ length: 30 }, (_, i) => ({ name: `Test${i}`, series: 'Test' }));
+    await context.db.bulkDocs(extraDocs);
+
+    const { docs } = await context.db.find({
+      selector: { series: 'Test' }
+    });
+
+    docs.length.should.equal(25);
+  });
 });

--- a/tests/find/test-suite-1/test.limit.js
+++ b/tests/find/test-suite-1/test.limit.js
@@ -285,7 +285,7 @@ describe('test.limit.js', function () {
     });
   });
 
-  it.only('should have default limit of 25', async () => {
+  it('should have default limit of 25', async () => {
     const  extraDocs = Array
       .from({ length: 30 }, (_, i) => ({ name: `Test${i}`, series: 'Test' }));
     await context.db.bulkDocs(extraDocs);


### PR DESCRIPTION
Closes #8927

As @garethbowen [noted](https://github.com/pouchdb/pouchdb/issues/8927#issuecomment-2060641535) this PR should be blocked waiting for the next major release since this is a breaking change.

The only question I had with the implementation is if we should worry about the http adapter being used with _other_ server implementations that might not implement the default limit of `25`?  Currently, this change only affects the behavior of the _local adapter_ and will not set a default limit when the http adapter is used.