### PR TITLE
build: harden ci.yml permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ env:
   SELENIUM_HUB_HOST: hub
   TEST_HOST: localhost
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
 
   lint:


### PR DESCRIPTION
original PR https://github.com/pouchdb/pouchdb/pull/8567 didn’t have any checks run

closes https://github.com/pouchdb/pouchdb/pull/8567