### PR TITLE
pouchdb-find: make _design/ prefix removal more specific

### DIFF
--- a/packages/node_modules/pouchdb-find/src/adapters/local/utils.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/utils.js
@@ -18,6 +18,7 @@ function massageSort(sort) {
   });
 }
 
+const ddocIdPrefix = /^_design\//;
 function massageUseIndex(useIndex) {
   let cleanedUseIndex = [];
   if (typeof useIndex === 'string') {
@@ -27,7 +28,7 @@ function massageUseIndex(useIndex) {
   }
 
   return cleanedUseIndex.map(function (name) {
-    return name.replace(/^_design\//, '');
+    return name.replace(ddocIdPrefix, '');
   });
 }
 

--- a/packages/node_modules/pouchdb-find/src/adapters/local/utils.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/utils.js
@@ -27,7 +27,7 @@ function massageUseIndex(useIndex) {
   }
 
   return cleanedUseIndex.map(function (name) {
-    return name.replace('_design/', '');
+    return name.replace(/^_design\//, '');
   });
 }
 


### PR DESCRIPTION
Current code will match `_design/` anywhere.

I suspect it should only be replacing `_design/` when it's a prefix...