### PR TITLE
chore: remove AbortController dependency and polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "url": "https://github.com/pouchdb/pouchdb.git"
   },
   "dependencies": {
-    "abort-controller": "3.0.0",
     "clone-buffer": "1.0.0",
     "double-ended-queue": "2.1.0-0",
     "fetch-cookie": "2.2.0",

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -2,7 +2,7 @@
 
 import pool from './promise-pool';
 
-import { fetch, Headers, AbortController } from 'pouchdb-fetch';
+import { fetch, Headers } from 'pouchdb-fetch';
 
 import {
   createError,

--- a/packages/node_modules/pouchdb-fetch/src/fetch-browser.js
+++ b/packages/node_modules/pouchdb-fetch/src/fetch-browser.js
@@ -1,12 +1,6 @@
 'use strict';
 
-// AbortController was introduced quite a while after fetch and
-// isnt required for PouchDB to function so polyfill if needed
-var a = (typeof AbortController !== 'undefined')
-    ? AbortController
-    : function () { return {abort: function () {}}; };
-
 var f = fetch;
 var h = Headers;
 
-export {f as fetch, h as Headers, a as AbortController};
+export { f as fetch, h as Headers };

--- a/packages/node_modules/pouchdb-fetch/src/fetch.js
+++ b/packages/node_modules/pouchdb-fetch/src/fetch.js
@@ -2,8 +2,7 @@
 
 import nodeFetch, {Headers} from 'node-fetch';
 import fetchCookie from 'fetch-cookie';
-import AbortController from 'abort-controller';
 
 var fetch = fetchCookie(nodeFetch);
 
-export {fetch, Headers, AbortController};
+export { fetch, Headers };

--- a/packages/node_modules/pouchdb-fetch/src/index.js
+++ b/packages/node_modules/pouchdb-fetch/src/index.js
@@ -1,1 +1,1 @@
-export {fetch, Headers, AbortController} from './fetch';
+export { fetch, Headers } from './fetch';


### PR DESCRIPTION
This patch removes the "abort-controller" dependency and a polyfill in pouchdb-fetch/fetch-browser.

Required versions for this cleanup:
node: AbortController is stable since 15.4.0
Chrome: 66
Firefox: 57
Safari: 12.1 (introduced in 12.0, but as a noop)

The min. requirements were fulfilled by #8928 and #8664