### PR TITLE
chore: remove IE polyfill for ArrayBuffer.slice

### DIFF
--- a/packages/node_modules/pouchdb-utils/src/cloneBinaryObject-browser.js
+++ b/packages/node_modules/pouchdb-utils/src/cloneBinaryObject-browser.js
@@ -1,21 +1,12 @@
-function cloneArrayBuffer(buff) {
-  if (typeof buff.slice === 'function') {
-    return buff.slice(0);
-  }
-  // IE10-11 slice() polyfill
-  var target = new ArrayBuffer(buff.byteLength);
-  var targetArray = new Uint8Array(target);
-  var sourceArray = new Uint8Array(buff);
-  targetArray.set(sourceArray);
-  return target;
-}
-
+/**
+ * @template {ArrayBuffer | Blob} T
+ * @param {T} object
+ * @returns {T}
+ */
 function cloneBinaryObject(object) {
-  if (object instanceof ArrayBuffer) {
-    return cloneArrayBuffer(object);
-  }
-  // Blob
-  return object.slice(0, object.size, object.type);
+  return object instanceof ArrayBuffer
+    ? object.slice(0)
+    : object.slice(0, object.size, object.type);
 }
 
 export default cloneBinaryObject;


### PR DESCRIPTION
This patch cleans up an obsolete polyfill of copying ArrayBuffers in cloneBinaryObject-browser.js

I also compacted the function a bit and added a jsDoc type-hint.