### PR TITLE
chore: ES6 update of sublevel-pouchdb

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "ltgt": "2.2.1",
     "memdown": "1.4.1",
     "node-fetch": "2.6.9",
-    "readable-stream": "1.1.14",
     "spark-md5": "3.0.2",
     "through2": "3.0.2",
     "uuid": "8.3.2",
@@ -106,13 +105,11 @@
   },
   "// greenkeeper": [
     "// chai-as-promised is pinned because of breaking changes in 6.0.0",
-    "// readable-stream has breaking changes in 2.0.0",
     "// stream-to-promise is pinned because there's a breaking change in 2.0.0"
   ],
   "greenkeeper": {
     "ignore": [
       "chai-as-promised",
-      "readable-stream",
       "stream-to-promise"
     ]
   }

--- a/packages/node_modules/sublevel-pouchdb/src/batch.js
+++ b/packages/node_modules/sublevel-pouchdb/src/batch.js
@@ -1,5 +1,5 @@
 function addOperation(type, key, value, options) {
-  var operation = {
+  const operation = {
     type,
     key,
     value,
@@ -16,22 +16,23 @@ function addOperation(type, key, value, options) {
   return this;
 }
 
-function Batch(sdb) {
-  this._operations = [];
-  this._sdb = sdb;
+class Batch {
+  constructor(sdb) {
+    this._operations = [];
+    this._sdb = sdb;
 
-  this.put = addOperation.bind(this, 'put');
-  this.del = addOperation.bind(this, 'del');
+    this.put = addOperation.bind(this, 'put');
+    this.del = addOperation.bind(this, 'del');
+  }
+
+  clear() {
+    this._operations = [];
+  }
+
+  write(cb) {
+    this._sdb.batch(this._operations, cb);
+  }
 }
 
-var B = Batch.prototype;
-
-B.clear = function () {
-  this._operations = [];
-};
-
-B.write = function (cb) {
-  this._sdb.batch(this._operations, cb);
-};
 
 export default Batch;

--- a/packages/node_modules/sublevel-pouchdb/src/index.js
+++ b/packages/node_modules/sublevel-pouchdb/src/index.js
@@ -4,7 +4,7 @@ import Codec from 'level-codec';
 import ReadStream from './readStream';
 import precodec from './legacyCodec';
 
-var codec = new Codec();
+const codec = new Codec();
 
 function sublevelPouch(db) {
   return shell(nut(db, precodec, codec), [], ReadStream, db.options);

--- a/packages/node_modules/sublevel-pouchdb/src/legacyCodec.js
+++ b/packages/node_modules/sublevel-pouchdb/src/legacyCodec.js
@@ -1,8 +1,8 @@
 export default {
-  encode: function (decodedKey) {
+  encode(decodedKey) {
     return '\xff' + decodedKey[0] + '\xff' + decodedKey[1];
   },
-  decode: function (encodedKeyAsBuffer) {
+  decode(encodedKeyAsBuffer) {
     const str = encodedKeyAsBuffer.toString();
     const idx = str.indexOf('\xff', 1);
     return [str.substring(1, idx), str.substring(idx + 1)];

--- a/packages/node_modules/sublevel-pouchdb/src/legacyCodec.js
+++ b/packages/node_modules/sublevel-pouchdb/src/legacyCodec.js
@@ -3,8 +3,8 @@ export default {
     return '\xff' + decodedKey[0] + '\xff' + decodedKey[1];
   },
   decode: function (encodedKeyAsBuffer) {
-    var str = encodedKeyAsBuffer.toString();
-    var idx = str.indexOf('\xff', 1);
+    const str = encodedKeyAsBuffer.toString();
+    const idx = str.indexOf('\xff', 1);
     return [str.substring(1, idx), str.substring(idx + 1)];
   },
   lowerBound: '\x00',

--- a/packages/node_modules/sublevel-pouchdb/src/nut.js
+++ b/packages/node_modules/sublevel-pouchdb/src/nut.js
@@ -12,11 +12,7 @@ function getPrefix(db) {
 }
 
 function clone(_obj) {
-  const obj = {};
-  for (let k in _obj) {
-    obj[k] = _obj[k];
-  }
-  return obj;
+  return Object.assign({}, _obj);
 }
 
 function nut(db, precodec, codec) {

--- a/packages/node_modules/sublevel-pouchdb/src/nut.js
+++ b/packages/node_modules/sublevel-pouchdb/src/nut.js
@@ -1,18 +1,10 @@
 import ltgt from 'ltgt';
 
-function isFunction(f) {
-  return 'function' === typeof f;
-}
-
 function getPrefix(db) {
-  if (isFunction(db.prefix)) {
+  if (typeof db.prefix === 'function') {
     return db.prefix();
   }
   return db;
-}
-
-function clone(_obj) {
-  return Object.assign({}, _obj);
 }
 
 function nut(db, precodec, codec) {
@@ -77,7 +69,7 @@ function nut(db, precodec, codec) {
       return db.close(cb);
     },
     iterator(_opts) {
-      const opts = clone(_opts || {});
+      const opts = Object.assign({}, _opts || {});
       const prefix = _opts.prefix || [];
 
       function encodeKey(key) {

--- a/packages/node_modules/sublevel-pouchdb/src/nut.js
+++ b/packages/node_modules/sublevel-pouchdb/src/nut.js
@@ -30,10 +30,10 @@ function nut(db, precodec, codec) {
     return op;
   }
 
-  db.open(function () { /* no-op */});
+  db.open(() => { /* no-op */ });
 
   return {
-    apply: function (ops, opts, cb) {
+    apply(ops, opts, cb) {
       opts = opts || {};
       const batch = [];
 
@@ -48,7 +48,7 @@ function nut(db, precodec, codec) {
       }
       db.db.batch(batch, opts, cb);
     },
-    get: function (key, prefix, opts, cb) {
+    get(key, prefix, opts, cb) {
       opts.asBuffer = codec.valueAsBuffer(opts);
       return db.db.get(
         encodePrefix(prefix, key, opts),
@@ -62,7 +62,7 @@ function nut(db, precodec, codec) {
         }
       );
     },
-    createDecoder: function (opts) {
+    createDecoder(opts) {
       return function (key, value) {
         return {
           key: codec.decodeKey(precodec.decode(key)[1], opts),
@@ -70,13 +70,13 @@ function nut(db, precodec, codec) {
         };
       };
     },
-    isClosed: function isClosed() {
+    isClosed() {
       return db.isClosed();
     },
-    close: function close(cb) {
+    close(cb) {
       return db.close(cb);
     },
-    iterator: function (_opts) {
+    iterator(_opts) {
       const opts = clone(_opts || {});
       const prefix = _opts.prefix || [];
 
@@ -109,10 +109,10 @@ function nut(db, precodec, codec) {
 
       function wrapIterator(iterator) {
         return {
-          next: function (cb) {
+          next(cb) {
             return iterator.next(cb);
           },
-          end: function (cb) {
+          end(cb) {
             iterator.end(cb);
           }
         };

--- a/packages/node_modules/sublevel-pouchdb/src/nut.js
+++ b/packages/node_modules/sublevel-pouchdb/src/nut.js
@@ -12,8 +12,8 @@ function getPrefix(db) {
 }
 
 function clone(_obj) {
-  var obj = {};
-  for (var k in _obj) {
+  const obj = {};
+  for (let k in _obj) {
     obj[k] = _obj[k];
   }
   return obj;
@@ -39,13 +39,9 @@ function nut(db, precodec, codec) {
   return {
     apply: function (ops, opts, cb) {
       opts = opts || {};
+      const batch = [];
 
-      var batch = [];
-      var i = -1;
-      var len = ops.length;
-
-      while (++i < len) {
-        var op = ops[i];
+      for (const op of ops) {
         addEncodings(op, op.prefix);
         op.prefix = getPrefix(op.prefix);
         batch.push({
@@ -85,8 +81,8 @@ function nut(db, precodec, codec) {
       return db.close(cb);
     },
     iterator: function (_opts) {
-      var opts = clone(_opts || {});
-      var prefix = _opts.prefix || [];
+      const opts = clone(_opts || {});
+      const prefix = _opts.prefix || [];
 
       function encodeKey(key) {
         return encodePrefix(prefix, key, opts, {});

--- a/packages/node_modules/sublevel-pouchdb/src/pull.js
+++ b/packages/node_modules/sublevel-pouchdb/src/pull.js
@@ -5,10 +5,10 @@ import pull from 'pull-stream';
 
 function pullReadStream(options, makeData) {
   var stream = pull.defer();
-  stream.setIterator = function (iterator) {
-    stream.resolve(function (end, cb) {
+  stream.setIterator = (iterator) => {
+    stream.resolve((end, cb) => {
       if (!end) {
-        iterator.next(function (err, key, value) {
+        iterator.next((err, key, value) => {
           if (err) {
             return cb(err);
           }

--- a/packages/node_modules/sublevel-pouchdb/src/pull.js
+++ b/packages/node_modules/sublevel-pouchdb/src/pull.js
@@ -4,7 +4,7 @@ import pull from 'pull-stream';
 // I should be able pretty much just drop that in.
 
 function pullReadStream(options, makeData) {
-  var stream = pull.defer();
+  const stream = pull.defer();
   stream.setIterator = (iterator) => {
     stream.resolve((end, cb) => {
       if (!end) {

--- a/packages/node_modules/sublevel-pouchdb/src/readStream.js
+++ b/packages/node_modules/sublevel-pouchdb/src/readStream.js
@@ -70,7 +70,7 @@ class ReadStreamInternal extends Readable {
     }
   }
 
-  destroy() {
+  _destroy() {
     this._cleanup();
   }
 

--- a/packages/node_modules/sublevel-pouchdb/src/readStream.js
+++ b/packages/node_modules/sublevel-pouchdb/src/readStream.js
@@ -3,11 +3,7 @@
  * MIT License <https://github.com/rvagg/node-levelup/blob/master/LICENSE.md>
  */
 
-// NOTE: we are fixed to readable-stream@1.0.x for now
-// for pure Streams2 across Node versions
-import ReadableStreamCore from 'readable-stream';
-
-var Readable = ReadableStreamCore.Readable;
+import { Readable } from 'node:stream';
 
 function createClass(parent, init) {
   let klass = function (...args) {
@@ -58,20 +54,19 @@ class ReadStreamInternal extends Readable {
 
     this._destroyed = true;
 
-    var self = this;
     /* istanbul ignore if */
     if (err && err.message !== 'iterator has ended') {
-      self.emit('error', err);
+      this.emit('error', err);
     }
 
     /* istanbul ignore else */
-    if (self._iterator) {
-      self._iterator.end(function () {
-        self._iterator = null;
-        self.emit('close');
+    if (this._iterator) {
+      this._iterator.end(() => {
+        this._iterator = null;
+        this.emit('close');
       });
     } else {
-      self.emit('close');
+      this.emit('close');
     }
   }
 
@@ -80,28 +75,27 @@ class ReadStreamInternal extends Readable {
   }
 
   _read() {
-    var self = this;
     /* istanbul ignore if */
-    if (self._destroyed) {
+    if (this._destroyed) {
       return;
     }
     /* istanbul ignore if */
-    if (!self._iterator) {
+    if (!this._iterator) {
       return this._waiting = true;
     }
 
-    self._iterator.next(function (err, key, value) {
+    this._iterator.next((err, key, value) => {
       if (err || (key === undefined && value === undefined)) {
-        if (!err && !self._destroyed) {
-          self.push(null);
+        if (!err && !this._destroyed) {
+          this.push(null);
         }
-        return self._cleanup(err);
+        return this._cleanup(err);
       }
 
 
-      value = self._makeData(key, value);
-      if (!self._destroyed) {
-        self.push(value);
+      value = this._makeData(key, value);
+      if (!this._destroyed) {
+        this.push(value);
       }
     });
   }
@@ -112,4 +106,3 @@ const ReadStream = createClass(ReadStreamInternal, function (options, makeData) 
 });
 
 export default ReadStream;
-

--- a/packages/node_modules/sublevel-pouchdb/src/readStream.js
+++ b/packages/node_modules/sublevel-pouchdb/src/readStream.js
@@ -3,7 +3,7 @@
  * MIT License <https://github.com/rvagg/node-levelup/blob/master/LICENSE.md>
  */
 
-import { Readable } from 'node:stream';
+import { Readable } from 'stream';
 
 function createClass(parent, init) {
   let klass = function (...args) {

--- a/packages/node_modules/sublevel-pouchdb/src/readStream.js
+++ b/packages/node_modules/sublevel-pouchdb/src/readStream.js
@@ -37,7 +37,7 @@ class ReadStreamInternal extends Readable {
     this._iterator = it;
     /* istanbul ignore if */
     if (this._destroyed) {
-      return it.end(function () {});
+      return it.end(() => { });
     }
     /* istanbul ignore if */
     if (this._waiting) {
@@ -91,7 +91,6 @@ class ReadStreamInternal extends Readable {
         }
         return this._cleanup(err);
       }
-
 
       value = this._makeData(key, value);
       if (!this._destroyed) {

--- a/packages/node_modules/sublevel-pouchdb/src/shell.js
+++ b/packages/node_modules/sublevel-pouchdb/src/shell.js
@@ -1,13 +1,11 @@
-import events from 'events';
+import { EventEmitter } from 'node:events';
 import NotFoundError from './NotFoundError';
 
-var EventEmitter = events.EventEmitter;
-var version = "6.5.4";
+const version = "6.5.4";
+const NOT_FOUND_ERROR = new NotFoundError();
 
-var NOT_FOUND_ERROR = new NotFoundError();
-
-var sublevel = function (nut, prefix, createStream, options) {
-  var emitter = new EventEmitter();
+const sublevel = function (nut, prefix, createStream, options) {
+  const emitter = new EventEmitter();
   emitter.sublevels = {};
   emitter.options = options;
 
@@ -17,8 +15,8 @@ var sublevel = function (nut, prefix, createStream, options) {
   prefix = prefix || [];
 
   function mergeOpts(opts) {
-    var o = {};
-    var k;
+    const o = {};
+    let k;
     if (options) {
       for (k in options) {
         if (typeof options[k] !== 'undefined') {
@@ -109,11 +107,9 @@ var sublevel = function (nut, prefix, createStream, options) {
   emitter.readStream = emitter.createReadStream = function (opts) {
     opts = mergeOpts(opts);
     opts.prefix = prefix;
-    var stream;
-    var it = nut.iterator(opts);
 
-    stream = createStream(opts, nut.createDecoder(opts));
-    stream.setIterator(it);
+    const stream = createStream(opts, nut.createDecoder(opts));
+    stream.setIterator(nut.iterator(opts));
 
     return stream;
   };

--- a/packages/node_modules/sublevel-pouchdb/src/shell.js
+++ b/packages/node_modules/sublevel-pouchdb/src/shell.js
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'node:events';
+import { EventEmitter } from 'events';
 import NotFoundError from './NotFoundError';
 
 const version = "6.5.4";

--- a/packages/node_modules/sublevel-pouchdb/src/shell.js
+++ b/packages/node_modules/sublevel-pouchdb/src/shell.js
@@ -4,124 +4,120 @@ import NotFoundError from './NotFoundError';
 const version = "6.5.4";
 const NOT_FOUND_ERROR = new NotFoundError();
 
-const sublevel = function (nut, prefix, createStream, options) {
-  const emitter = new EventEmitter();
-  emitter.sublevels = {};
-  emitter.options = options;
-
-  emitter.version = version;
-
-  emitter.methods = {};
+function sublevel(nut, prefix, createStream, options = {}) {
   prefix = prefix || [];
 
-  function mergeOpts(opts) {
-    const o = {};
-    let k;
-    if (options) {
-      for (k in options) {
-        if (typeof options[k] !== 'undefined') {
-          o[k] = options[k];
-        }
-      }
-    }
-    if (opts) {
-      for (k in opts) {
-        if (typeof opts[k] !== 'undefined') {
-          o[k] = opts[k];
-        }
-      }
-    }
-    return o;
+  function mergeOpts(opts = {}) {
+    return Object.assign({}, options, opts);
   }
 
-  emitter.put = function (key, value, opts, cb) {
-    if ('function' === typeof opts) {
-      cb = opts;
-      opts = {};
+  class SublevelEventEmitter extends EventEmitter {
+    constructor() {
+      super();
+      this.isOpen = nut.isOpen;
+      this.isClosed = nut.isClosed;
+      this.sublevels = {};
+      this.options = options;
+      this.version = version;
+      this.methods = {};
     }
 
-    nut.apply([{
-      key, value,
-      prefix: prefix.slice(), type: 'put'
-    }], mergeOpts(opts), function (err) {
-      /* istanbul ignore next */
-      if (err) {
-        return cb(err);
+    put(key, value, opts, cb) {
+      if ('function' === typeof opts) {
+        cb = opts;
+        opts = {};
       }
-      emitter.emit('put', key, value);
-      cb(null);
-    });
-  };
 
-  emitter.prefix = function () {
-    return prefix.slice();
-  };
-
-  emitter.batch = function (ops, opts, cb) {
-    if ('function' === typeof opts) {
-      cb = opts;
-      opts = {};
+      nut.apply(
+        [{
+          key,
+          value,
+          prefix: prefix.slice(), type: 'put'
+        }],
+        mergeOpts(opts),
+        (err) => {
+          /* istanbul ignore next */
+          if (err) {
+            return cb(err);
+          }
+          this.emit('put', key, value);
+          cb(null);
+        }
+      );
     }
 
-    ops = ops.map(function (op) {
-      return {
-        key: op.key,
-        value: op.value,
-        prefix: op.prefix || prefix,
-        keyEncoding: op.keyEncoding,    // *
-        valueEncoding: op.valueEncoding,  // * (TODO: encodings on sublevel)
-        type: op.type
-      };
-    });
+    prefix() { return prefix.slice(); }
 
-    nut.apply(ops, mergeOpts(opts), function (err) {
-      /* istanbul ignore next */
-      if (err) {
-        return cb(err);
+    batch(ops, opts, cb) {
+      if ('function' === typeof opts) {
+        cb = opts;
+        opts = {};
       }
-      emitter.emit('batch', ops);
-      cb(null);
-    });
-  };
 
-  emitter.get = function (key, opts, cb) {
-    /* istanbul ignore else */
-    if ('function' === typeof opts) {
-      cb = opts;
-      opts = {};
+      ops = ops.map((op) => {
+        return {
+          key: op.key,
+          value: op.value,
+          prefix: op.prefix || prefix,
+          keyEncoding: op.keyEncoding,    // *
+          valueEncoding: op.valueEncoding,  // * (TODO: encodings on sublevel)
+          type: op.type
+        };
+      });
+
+      nut.apply(ops, mergeOpts(opts), (err) => {
+        /* istanbul ignore next */
+        if (err) {
+          return cb(err);
+        }
+        this.emit('batch', ops);
+        cb(null);
+      });
     }
-    nut.get(key, prefix, mergeOpts(opts), function (err, value) {
-      if (err) {
-        cb(NOT_FOUND_ERROR);
-      } else {
-        cb(null, value);
+
+    get(key, opts, cb) {
+      /* istanbul ignore else */
+      if ('function' === typeof opts) {
+        cb = opts;
+        opts = {};
       }
-    });
-  };
+      nut.get(key, prefix, mergeOpts(opts), (err, value) => {
+        if (err) {
+          cb(NOT_FOUND_ERROR);
+        } else {
+          cb(null, value);
+        }
+      });
+    }
 
-  emitter.sublevel = function (name, opts) {
-    return emitter.sublevels[name] =
-      emitter.sublevels[name] || sublevel(nut, prefix.concat(name), createStream, mergeOpts(opts));
-  };
+    sublevel(name, opts) {
+      if (!(name in this.sublevels)) {
+        this.sublevels[name] = sublevel(nut, prefix.concat(name), createStream, mergeOpts(opts));
+      }
 
-  emitter.readStream = emitter.createReadStream = function (opts) {
-    opts = mergeOpts(opts);
-    opts.prefix = prefix;
+      return this.sublevels[name];
+    }
 
-    const stream = createStream(opts, nut.createDecoder(opts));
-    stream.setIterator(nut.iterator(opts));
+    readStream(opts) {
+      return this.createReadStream(opts);
+    }
 
-    return stream;
-  };
+    createReadStream(opts) {
+      opts = mergeOpts(opts);
+      opts.prefix = prefix;
 
-  emitter.close = function (cb) {
-    nut.close(cb);
-  };
+      const stream = createStream(opts, nut.createDecoder(opts));
+      stream.setIterator(nut.iterator(opts));
 
-  emitter.isOpen = nut.isOpen;
-  emitter.isClosed = nut.isClosed;
+      return stream;
+    }
 
-  return emitter;
-};
+    close(cb) {
+      nut.close(cb);
+    }
+  }
+
+  return new SublevelEventEmitter();
+}
 
 export default sublevel;


### PR DESCRIPTION
This patch modernizes sublevel-pouchdb:
- let/const instead of var
- using native Readable instead of readable-stream
- remove dependency of `readable-stream`
- ES6 arrow and method functions
- (in shell.js) class SublevelEventEmitter instead of manipulated EE instance