### PR TITLE
Broken link: Pat Helland's blog is no longer available

### DIFF
--- a/docs/_guides/conflicts.md
+++ b/docs/_guides/conflicts.md
@@ -151,7 +151,7 @@ This strategy has been called the "every doc is a delta" strategy. A classic use
 
 In this system, it is impossible for two documents to conflict, because the document `_id`s are just timestamps. Ledger transactions are recorded in the order they were made, and at the end of the day, you only need to do an `allDocs()` or `query()` operation to sum the result.
 
-The wisdom of this strategy can be expressed by the maxim: ["Accountants don't use erasers"](https://blogs.msdn.microsoft.com/pathelland/2007/06/14/accountants-dont-use-erasers/). Like a diligent accountant, your app can just add new documents when you want to make a change, rather than going back and scrubbing out previous changes.
+The wisdom of this strategy can be expressed by the maxim: ["Accountants don't use erasers"](https://queue.acm.org/detail.cfm?id=2884038). Like a diligent accountant, your app can just add new documents when you want to make a change, rather than going back and scrubbing out previous changes.
 
 There is also a PouchDB plugin that implements this strategy: [delta-pouch](https://github.com/redgeoff/delta-pouch).
 


### PR DESCRIPTION
This link is broken, and I can't seem to find the article in the MSDN archives, but Pat Helland's article was published in ACM Queue on January 20, 2016 [Volume 13, issue 9](https://queue.acm.org/issuedetail.cfm?issue=2857274) at https://queue.acm.org/detail.cfm?id=2884038. 

I updated the link to reference the article in the ACM Queue archives.