### PR TITLE
chore: add DevITJobs to users.md

### DIFF
--- a/docs/users.md
+++ b/docs/users.md
@@ -30,6 +30,9 @@ A list of known products and services that are using PouchDB.
 ## Delta
 [Delta](http://delta.octavore.com/) is a command-line utility for text diffs. View split diffs in the browser with syntax highlighting, or in the command-line using the --cli flag.
 
+## DevITJobs
+[DevITJobs](http://devitjobs.com) is a job board for the tech industry with mandatory salary ranges & tech stacks
+
 ## eHealth Africa
 
 {% include img.html width=200 src="ehealth_africa.png" alt="eHealth Africa" %}

--- a/docs/users.md
+++ b/docs/users.md
@@ -31,7 +31,7 @@ A list of known products and services that are using PouchDB.
 [Delta](http://delta.octavore.com/) is a command-line utility for text diffs. View split diffs in the browser with syntax highlighting, or in the command-line using the --cli flag.
 
 ## DevITJobs
-[DevITJobs](http://devitjobs.com) is a job board for the tech industry with mandatory salary ranges & tech stacks
+[DevITJobs](http://devitjobs.com) is a job board for the tech industry with mandatory salary ranges & tech stacks.
 
 ## eHealth Africa
 


### PR DESCRIPTION
DevITJobs.com is a job board with a transparent and inclusive approach to job offers (each employer is required to provide the tech stack and salary range). We are using PouchDB for the employer app to enable offline local edits of the job ads which can be synced afterwards.