### PR TITLE
adapter-indexeddb: don’t return too early in needsRewrite

### DIFF
--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/rewrite.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/rewrite.js
@@ -77,8 +77,8 @@ function needsRewrite(data) {
       return true;
     } else if (data[key] === null || typeof data[key] === 'boolean') {
       return true;
-    } else if (typeof data[key] === 'object') {
-      return needsRewrite(data[key]);
+    } else if (typeof data[key] === 'object' && needsRewrite(data[key])) {
+      return true;
     }
   }
 }


### PR DESCRIPTION
Fixes #9003 