### PR TITLE
indexeddb: remove no-op delete of _attachments after rewrite

### DIFF
--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
@@ -198,12 +198,7 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
       // doc.data is what we index, so we need to clone and rewrite it, and clean
       // it up for indexability
       const result = rewrite(theDoc);
-      if (result) {
-        doc.data = result;
-        delete doc.data._attachments;
-      } else {
-        doc.data = theDoc;
-      }
+      doc.data = result || theDoc;
     } else {
       doc.data = theDoc;
     }


### PR DESCRIPTION
If `rewrite()` had an effect, `doc.data._attachments` will have been rewritten as `doc.data._c95_attachments`, so `delete doc.data._attachments` is a no-op.