### PR TITLE
feat(indexeddb) simplify rewrite()

### DIFF
--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
@@ -21,8 +21,7 @@ import { winningRev as calculateWinningRev, merge, compactTree } from 'pouchdb-m
 
 import { DOC_STORE, META_LOCAL_STORE, idbError } from './util';
 
-import { rewrite, sanitise } from './rewrite';
-const sanitisedAttachmentKey = sanitise('_attachments');
+import { rewrite } from './rewrite';
 
 export default function (api, req, opts, metadata, dbOpts, idbChanges, callback) {
 
@@ -199,7 +198,7 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
       // doc.data is what we index, so we need to clone and rewrite it, and clean
       // it up for indexability
       doc.data = rewrite(theDoc);
-      delete doc.data[sanitisedAttachmentKey];
+      delete doc.data._attachments;
     } else {
       doc.data = theDoc;
     }

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
@@ -21,7 +21,8 @@ import { winningRev as calculateWinningRev, merge, compactTree } from 'pouchdb-m
 
 import { DOC_STORE, META_LOCAL_STORE, idbError } from './util';
 
-import { rewrite } from './rewrite';
+import { rewrite, sanitise } from './rewrite';
+const sanitisedAttachmentKey = sanitise('_attachments');
 
 export default function (api, req, opts, metadata, dbOpts, idbChanges, callback) {
 
@@ -197,13 +198,8 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
     if (rewriteEnabled) {
       // doc.data is what we index, so we need to clone and rewrite it, and clean
       // it up for indexability
-      const result = rewrite(theDoc);
-      if (result) {
-        doc.data = result;
-        delete doc.data._attachments;
-      } else {
-        doc.data = theDoc;
-      }
+      doc.data = rewrite(theDoc);
+      delete doc.data[sanitisedAttachmentKey];
     } else {
       doc.data = theDoc;
     }

--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/rewrite.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/rewrite.js
@@ -79,42 +79,37 @@ function needsRewrite(data) {
   }
 }
 
-function rewrite(data) {
+function rewriteValue(v) {
+  if (v === null) {
+    return IDB_NULL;
+  } else if (typeof v === 'boolean') {
+    return v ? IDB_TRUE : IDB_FALSE;
+  } else if (typeof v === 'object') {
+    return rewriteObject(v);
+  } else {
+    return v;
+  }
+}
+
+function rewriteObject(data) {
   if (!needsRewrite(data)) {
-    return false;
+    return data;
   }
 
-  const isArray = Array.isArray(data);
-  const clone = isArray
-    ? []
-    : {};
+  if (Array.isArray(data)) {
+    return data.map(rewriteValue);
+  }
 
-  Object.keys(data).forEach(function (key) {
-    const safeKey = isArray ? key : sanitise(key);
-
-    if (data[key] === null) {
-      clone[safeKey] = IDB_NULL;
-    } else if (typeof data[key] === 'boolean') {
-      clone[safeKey] = data[key] ? IDB_TRUE : IDB_FALSE;
-    } else if (typeof data[key] === 'object') {
-      const val = rewrite(data[key]);
-      if (val) {
-        clone[safeKey] = val;
-      } else {
-        clone[safeKey] = data[key];
-      }
-    } else {
-      clone[safeKey] = data[key];
-    }
-  });
-
-  return clone;
+  return Object.keys(data).reduce((clone, k) => {
+    clone[sanitise(k)] = rewriteValue(data[k]);
+    return clone;
+  }, {});
 }
 
 export {
   IDB_NULL,
   IDB_TRUE,
   IDB_FALSE,
-  rewrite,
+  rewriteObject as rewrite,
   sanitise
 };


### PR DESCRIPTION
I think this code is faster, simpler, and more explicit.

### TODO

- [x] https://github.com/pouchdb/pouchdb/issues/9002
- [x] https://github.com/pouchdb/pouchdb/pull/9000
- [x] https://github.com/pouchdb/pouchdb/pull/9011
- [x] ~https://github.com/pouchdb/pouchdb/pull/9010~ revert _attachments behaviour to match master until it's better understood
- [x] performance impact has been assessed