### PR TITLE
pouchdb-errors: remove no-op call to Error constructor

### DIFF
--- a/packages/node_modules/pouchdb-errors/src/index.js
+++ b/packages/node_modules/pouchdb-errors/src/index.js
@@ -1,7 +1,6 @@
 class PouchError extends Error {
   constructor(status, error, reason) {
     super();
-    Error(reason);
     this.status = status;
     this.name = error;
     this.message = reason;


### PR DESCRIPTION
Introduced in cef1ded5712dea0256e8fe4d2c9ffaf48c891651.

The original intention is unclear.