### PR TITLE
chore(ci/docs) upgrade node v14 -> v22

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/install-node-package
         with:
-          node-version: 14
+          node-version: 22
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7


### PR DESCRIPTION
v14 is EoL; v22 is current.

Blocked by:

* https://github.com/pouchdb/pouchdb/pull/9024