### PR TITLE
fix(indexeddb) don't store _attachments in IndexedDB

### DIFF
--- a/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-indexeddb/src/bulkDocs.js
@@ -21,7 +21,8 @@ import { winningRev as calculateWinningRev, merge, compactTree } from 'pouchdb-m
 
 import { DOC_STORE, META_LOCAL_STORE, idbError } from './util';
 
-import { rewrite } from './rewrite';
+import { rewrite, sanitise } from './rewrite';
+const sanitisedAttachmentKey = sanitise('_attachments');
 
 export default function (api, req, opts, metadata, dbOpts, idbChanges, callback) {
 
@@ -200,7 +201,7 @@ export default function (api, req, opts, metadata, dbOpts, idbChanges, callback)
       const result = rewrite(theDoc);
       if (result) {
         doc.data = result;
-        delete doc.data._attachments;
+        delete doc.data[sanitisedAttachmentKey];
       } else {
         doc.data = theDoc;
       }


### PR DESCRIPTION
Attachments do not need to be stored in `doc.data._attachments`, as they are stored in `doc.attachments`, and the user-facing `._attachments` is recreated in `util/processAttachments()` when docs are read from IndexedDB.

However, the current code is deleting the wrong path - as `._attachments` is deleted _after_ `rewrite()` has been called, the property will have moved to `._c95_attachments`.  Instead of hard-coding the key for `._c95_attachments`, it is calculated once when the adapter is first loaded (as `sanitisedAttachmentKey`).