### PR TITLE
chore(mapreduce-errors) remove no-op stack regeneration

### DIFF
--- a/packages/node_modules/pouchdb-mapreduce-utils/src/errors.js
+++ b/packages/node_modules/pouchdb-mapreduce-utils/src/errors.js
@@ -6,9 +6,6 @@ class QueryParseError extends Error {
     this.name = 'query_parse_error';
     this.message = message;
     this.error = true;
-    try {
-      Error.captureStackTrace(this, QueryParseError);
-    } catch (e) {}
   }
 }
 
@@ -19,9 +16,6 @@ class NotFoundError extends Error {
     this.name = 'not_found';
     this.message = message;
     this.error = true;
-    try {
-      Error.captureStackTrace(this, NotFoundError);
-    } catch (e) {}
   }
 }
 
@@ -32,9 +26,6 @@ class BuiltInError extends Error {
     this.name = 'invalid_value';
     this.message = message;
     this.error = true;
-    try {
-      Error.captureStackTrace(this, BuiltInError);
-    } catch (e) {}
   }
 }
 


### PR DESCRIPTION
Calling `Error.captureStackTrace()` seems to be an archaic way to add stacktraces to custom Error types from before Javascript supported classes.

Now that these error classes extend `Error`, calling `Error.captureStackTrace(this, thisClass)` is effectively a no-op.

See e.g. https://github.com/pouchdb/pouchdb/blob/f5ae8e02a72a03865b9719bd77429b83c09b069d/node_modules/nano/node_modules/errs/README.md#user-content-reusing-types