### PR TITLE
fix(ci): playwright 1.42.1 didn't work in Ubuntu 24.01

### DIFF
--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -95,7 +95,7 @@ if [[ -n $SERVER ]]; then
       echo -e "pouchdb-server should be running on $COUCH_HOST\n"
     fi
   elif [ "$SERVER" == "couchdb-master" ]; then
-    if [ -z $COUCH_HOST ]; then
+    if [ -z "$COUCH_HOST" ]; then
       export COUCH_HOST="http://127.0.0.1:5984"
     fi
   elif [ "$SERVER" == "pouchdb-express-router" ]; then
@@ -120,7 +120,7 @@ fi
 
 if [ "$SERVER" == "couchdb-master" ]; then
   printf '\nEnabling CORS...'
-  ./node_modules/.bin/add-cors-to-couchdb $COUCH_HOST
+  ./node_modules/.bin/add-cors-to-couchdb "$COUCH_HOST"
 fi
 
 if [ "$CLIENT" == "unit" ]; then

--- a/bin/test-node.sh
+++ b/bin/test-node.sh
@@ -5,13 +5,13 @@
 : "${BAIL:=1}"
 : "${TYPE:="integration"}"
 
-if [ $BAIL -eq 1 ]; then
+if [ "$BAIL" -eq 1 ]; then
     BAIL_OPT="--bail"
 else
     BAIL_OPT=""
 fi
 
-if [ $TYPE = "integration" ]; then
+if [ "$TYPE" = "integration" ]; then
     if  (: < /dev/tcp/127.0.0.1/3010) 2>/dev/null; then
         echo "down-server port already in use"
     else
@@ -20,13 +20,13 @@ if [ $TYPE = "integration" ]; then
 
     TESTS_PATH="tests/integration/test.*.js"
 fi
-if [ $TYPE = "fuzzy" ]; then
+if [ "$TYPE" = "fuzzy" ]; then
     TESTS_PATH="tests/fuzzy/test.*.js"
 fi
-if [ $TYPE = "mapreduce" ]; then
+if [ "$TYPE" = "mapreduce" ]; then
     TESTS_PATH="tests/mapreduce/test.*.js"
 fi
-if [ $TYPE = "find" ]; then
+if [ "$TYPE" = "find" ]; then
     TESTS_PATH="tests/find/*/test.*.js"
 fi
 if [ "$COVERAGE" ]; then
@@ -64,6 +64,6 @@ fi
 
 EXIT_STATUS=$?
 if [[ -n $DOWN_SERVER_PID ]]; then
-  kill $DOWN_SERVER_PID
+  kill "$DOWN_SERVER_PID"
 fi
 exit $EXIT_STATUS

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "mkdirp": "0.5.1",
         "mocha": "10.2.0",
         "ncp": "2.0.0",
-        "playwright": "1.42.1",
+        "playwright": "1.49.1",
         "pouchdb-express-router": "0.0.11",
         "replace": "1.2.1",
         "rimraf": "2.7.1",
@@ -7023,33 +7023,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
-      "integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.42.1"
+        "playwright-core": "1.49.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
-      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "mkdirp": "0.5.1",
     "mocha": "10.2.0",
     "ncp": "2.0.0",
-    "playwright": "1.42.1",
+    "playwright": "1.49.1",
     "pouchdb-express-router": "0.0.11",
     "replace": "1.2.1",
     "rimraf": "2.7.1",


### PR DESCRIPTION
Github CI switching `ubuntu-latest` from 22.04 to 24.04.
playwright 1.42.1 didn't work (out of the box) with 24.04, due to missing dependencies.

This patch updates playwright to 1.49.1.

CI output:
```console
Package libasound2 is a virtual package provided by:
  liboss4-salsa-asound2 4.2-build2020-1ubuntu3
  libasound2t64 1.2.11-1build2 (= 1.2.11-1build2)

Package libicu70 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'libasound2' has no installation candidate
E: Package 'libicu70' has no installation candidate
E: Unable to locate package libffi7
E: Unable to locate package libx264-163
Failed to install browser dependencies
Error: Installation process exited with code: 100
```

Also: shellcheck complains,
I've merged https://github.com/pouchdb/pouchdb/pull/9034 into this patch to make it green again.