### PR TITLE
chore(ci): switch from node v{18,20} to v{20,22}

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         couchdb: ['2.3', '3.1']
-        node: [18, 20]
+        node: [20, 22]
         cmd:
           - npm test
           - TYPE=find PLUGINS=pouchdb-find ADAPTERS=http npm test
@@ -158,7 +158,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20]
+        node: [20, 22]
         adapter: ['leveldb', 'memory']
         cmd:
           - npm test
@@ -237,7 +237,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20]
+        node: [20, 22]
         cmd:
           - CLIENT=firefox npm run test-webpack
           - AUTO_COMPACTION=true npm test

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -95,7 +95,7 @@ if [[ -n $SERVER ]]; then
       echo -e "pouchdb-server should be running on $COUCH_HOST\n"
     fi
   elif [ "$SERVER" == "couchdb-master" ]; then
-    if [ -z $COUCH_HOST ]; then
+    if [ -z "$COUCH_HOST" ]; then
       export COUCH_HOST="http://127.0.0.1:5984"
     fi
   elif [ "$SERVER" == "pouchdb-express-router" ]; then
@@ -120,7 +120,7 @@ fi
 
 if [ "$SERVER" == "couchdb-master" ]; then
   printf '\nEnabling CORS...'
-  ./node_modules/.bin/add-cors-to-couchdb $COUCH_HOST
+  ./node_modules/.bin/add-cors-to-couchdb "$COUCH_HOST"
 fi
 
 if [ "$CLIENT" == "unit" ]; then

--- a/bin/test-node.sh
+++ b/bin/test-node.sh
@@ -5,13 +5,13 @@
 : "${BAIL:=1}"
 : "${TYPE:="integration"}"
 
-if [ $BAIL -eq 1 ]; then
+if [ "$BAIL" -eq 1 ]; then
     BAIL_OPT="--bail"
 else
     BAIL_OPT=""
 fi
 
-if [ $TYPE = "integration" ]; then
+if [ "$TYPE" = "integration" ]; then
     if  (: < /dev/tcp/127.0.0.1/3010) 2>/dev/null; then
         echo "down-server port already in use"
     else
@@ -20,13 +20,13 @@ if [ $TYPE = "integration" ]; then
 
     TESTS_PATH="tests/integration/test.*.js"
 fi
-if [ $TYPE = "fuzzy" ]; then
+if [ "$TYPE" = "fuzzy" ]; then
     TESTS_PATH="tests/fuzzy/test.*.js"
 fi
-if [ $TYPE = "mapreduce" ]; then
+if [ "$TYPE" = "mapreduce" ]; then
     TESTS_PATH="tests/mapreduce/test.*.js"
 fi
-if [ $TYPE = "find" ]; then
+if [ "$TYPE" = "find" ]; then
     TESTS_PATH="tests/find/*/test.*.js"
 fi
 if [ "$COVERAGE" ]; then
@@ -64,6 +64,6 @@ fi
 
 EXIT_STATUS=$?
 if [[ -n $DOWN_SERVER_PID ]]; then
-  kill $DOWN_SERVER_PID
+  kill "$DOWN_SERVER_PID"
 fi
 exit $EXIT_STATUS


### PR DESCRIPTION
Drop from Node.js v18.
Add Node.js v22.

Since v18 is EOL in April anyway, I guess: now it's the right time to switch.