### PR TITLE
docs: fix CSS live rebuild

### DIFF
--- a/bin/build-site.js
+++ b/bin/build-site.js
@@ -74,7 +74,7 @@ if (!process.env.BUILD) {
   const watchGlob = require('glob-watcher');
 
   watchGlob('**', buildJekyll);
-  watchGlob('docs/static/less/*/*.less', buildCSS);
+  watchGlob('static/less/*/*.less', buildCSS);
   http_server.createServer({root: '_site', cache: '-1'}).listen(4000);
   console.log('Server address: http://localhost:4000');
 }


### PR DESCRIPTION
Due to `process.chdir('docs')` call on line 14, the less path should be relative to `./docs/` instead of the project root.