### PR TITLE
docs: fix watch mode for JS

### DIFF
--- a/bin/build-site.js
+++ b/bin/build-site.js
@@ -25,7 +25,7 @@ async function checkJekyll() {
   }
 }
 
-function buildCSS() {
+async function buildCSS() {
   fs.mkdirSync(__dirname + '/../docs/static/css', { recursive:true });
   const cmd = [ resolvePath('node_modules/less/bin/lessc'), POUCHDB_LESS ].join(' ');
   const { stdout } = await exec(cmd);


### PR DESCRIPTION
* remove `buildJekyll()` path check, because `path` is not the argument that `watchGlob()` passes to the listener
* update watched paths for `buildJekyll()` to only listen for jekyll-relevant paths
* use async watcher functions so that promises are returned

Closes #9041