### PR TITLE
ci/docs: update ubuntu version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ on:
 jobs:
 
   test-docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Per github advisory:

> The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025.