### PR TITLE
ci: add node v22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         couchdb: ['2.3', '3.1']
-        node: [20]
+        node: [20, 22]
         cmd:
           - npm test
           - TYPE=find PLUGINS=pouchdb-find ADAPTERS=http npm test
@@ -158,7 +158,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20]
+        node: [20, 22]
         adapter: ['leveldb', 'memory']
         cmd:
           - npm test
@@ -237,7 +237,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20]
+        node: [20, 22]
         cmd:
           - CLIENT=firefox npm run test-webpack
           - AUTO_COMPACTION=true npm test


### PR DESCRIPTION
Follow-up: require node 22 jobs to pass for `master` branch protection rules at https://github.com/pouchdb/pouchdb/settings/branch_protection_rules/240897

