### PR TITLE
pouchdb-utils: fix nextTick "Illegal invocation" error

### DIFF
--- a/packages/node_modules/pouchdb-utils/src/nextTick.js
+++ b/packages/node_modules/pouchdb-utils/src/nextTick.js
@@ -1,5 +1,5 @@
 const nextTick = typeof queueMicrotask === "function"
-  ? queueMicrotask.bind(globalThis)
+  ? queueMicrotask.bind(undefined)
   : function nextTick(fn) {
     Promise.resolve().then(fn);
   };

--- a/packages/node_modules/pouchdb-utils/src/nextTick.js
+++ b/packages/node_modules/pouchdb-utils/src/nextTick.js
@@ -1,5 +1,5 @@
 const nextTick = typeof queueMicrotask === "function"
-  ? queueMicrotask
+  ? queueMicrotask.bind(globalThis)
   : function nextTick(fn) {
     Promise.resolve().then(fn);
   };


### PR DESCRIPTION
When instantiating a new PouchDB instance using the leveldb adapter in an Electron renderer process, `nextTick()` is called with a different context than is expected, resulting in `TypeError: Illegal invocation`. Fix this by binding `queueMicrotask` to the `globalThis` context before returning it.

Fixes #9091 