### PR TITLE
(#9104) - allow _stats reducer to digest arrays

### DIFF
--- a/packages/node_modules/pouchdb-mapreduce/src/index.js
+++ b/packages/node_modules/pouchdb-mapreduce/src/index.js
@@ -1,5 +1,6 @@
 import evalFunction from './evalFunction';
 import sum from './sum';
+import { min, max, sumsqr } from './stats';
 import { NotFoundError } from 'pouchdb-mapreduce-utils';
 import createAbstractMapReduce from 'pouchdb-abstract-mapreduce';
 
@@ -15,18 +16,10 @@ var builtInReduce = {
   _stats: function (keys, values) {
     // no need to implement rereduce=true, because Pouch
     // will never call it
-    function sumsqr(values) {
-      var _sumsqr = 0;
-      for (var i = 0, len = values.length; i < len; i++) {
-        var num = values[i];
-        _sumsqr += (num * num);
-      }
-      return _sumsqr;
-    }
     return {
       sum     : sum(values),
-      min     : Math.min.apply(null, values),
-      max     : Math.max.apply(null, values),
+      min     : min(values),
+      max     : max(values),
       count   : values.length,
       sumsqr : sumsqr(values)
     };

--- a/packages/node_modules/pouchdb-mapreduce/src/stats.js
+++ b/packages/node_modules/pouchdb-mapreduce/src/stats.js
@@ -1,0 +1,77 @@
+import createBuiltInError from 'pouchdb-mapreduce/src/createBuiltInError';
+
+// This helper function builds the reducers required for the builtin _stats reducer:
+// sumsqr, min and max.
+// It contains all the boilerplate logic for handling numbers vs. arrays.
+// "sum" needs to remain a standalone function because it gets
+// converted into a string somewhere else and closures aren't preserved in this case.
+
+function createReducer({ initialValue, op, preprocess = x => x, errorName }) {
+  // The returned function is the actual reducer, e.g., sum(values)
+  return function(values) {
+    let result = initialValue;
+
+    if (!values) {
+      return result;
+    }
+
+    for (const val of values) {
+      // A. The current map value is an array
+      if (Array.isArray(val)) {
+        // Ensure our result is also an array. If it was a number, wrap it.
+        if (typeof result === 'number') result = [result];
+        else if (result === null) result = [];
+
+        // Apply the operation element-wise
+        val.forEach((item, i) => {
+          if (typeof item !== 'number') throw createBuiltInError(errorName);
+          const processedItem = preprocess(item);
+          const current = result[i];
+          // If the slot is empty, assign the item. Otherwise, apply the operation.
+          result[i] = (current === undefined || current === null)
+            ? processedItem
+            : op(current, processedItem);
+        });
+      }
+      // B. The current map value is a single number
+      else if (typeof val === 'number') {
+        const processedVal = preprocess(val);
+        // If the result is already an array, operate on its first element
+        if (Array.isArray(result)) {
+          const current = result[0];
+          result[0] = (current === undefined || current === null)
+            ? processedVal
+            : op(current, processedVal);
+        } else { // Otherwise, the result is a number or null
+          result = (result === null)
+            ? processedVal
+            : op(result, processedVal);
+        }
+      }
+      // C. The value is an invalid type
+      else {
+        throw createBuiltInError(errorName);
+      }
+    }
+    return result;
+  };
+}
+
+export const min = createReducer({
+  initialValue: null,
+  op: (a, b) => Math.min(a, b),
+  errorName: '_min'
+});
+
+export const max = createReducer({
+  initialValue: null,
+  op: (a, b) => Math.max(a, b),
+  errorName: '_max'
+});
+
+export const sumsqr = createReducer({
+  initialValue: 0,
+  op: (a, b) => a + b,
+  preprocess: x => x * x, // Special step for sumsqr
+  errorName: '_sumsqr'
+});


### PR DESCRIPTION
The builtin _sum reducer already handled numbers AND arrays of numbers. In couchdb, this is also true for the _stats reducer. I abstracted the logic for the num/array distinction. I tried to apply that to "sum" as well, but "sum" is converted to a string somewhere else and this doesn't work with closures. I also added a test case.