### PR TITLE
Fix test.issue915.js on a clean environment

### DIFF
--- a/tests/integration/test.issue915.js
+++ b/tests/integration/test.issue915.js
@@ -15,22 +15,24 @@ if (!process.env.LEVEL_ADAPTER &&
     });
     it('Put a file in the db, then destroy it', function (done) {
       var db = new PouchDB('veryimportantfiles');
-      fs.writeFile('./tmp/_pouch_veryimportantfiles/something',
-        Buffer.from('lalala', 'utf8'), function () {
-        db.destroy(function (err) {
-          if (err) {
-            return done(err);
-          }
-          fs.readFile('./tmp/_pouch_veryimportantfiles/something',
-                      {encoding: 'utf8'}, function (err, resp) {
-            if (err) {
-              return done(err);
-            }
-            resp.should.equal('lalala',
-              './tmp/veryimportantfiles/something was not removed');
-            done();
-          });
-        });
+      fs.mkdir('./tmp/_pouch_veryimportantfiles', {recursive: true}, function () {
+        fs.writeFile('./tmp/_pouch_veryimportantfiles/something',
+            Buffer.from('lalala', 'utf8'), function () {
+              db.destroy(function (err) {
+                if (err) {
+                  return done(err);
+                }
+                fs.readFile('./tmp/_pouch_veryimportantfiles/something',
+                    {encoding: 'utf8'}, function (err, resp) {
+                      if (err) {
+                        return done(err);
+                      }
+                      resp.should.equal('lalala',
+                          './tmp/veryimportantfiles/something was not removed');
+                      done();
+                    });
+              });
+            });
       });
     });
   });


### PR DESCRIPTION
The test attempts to create the file `./tmp/_pouch_veryimportantfiles/something`, and by doing so implicitly assumes that the directory `./tmp/_pouch_veryimportantfiles` already exists, which may not be true in a clean environment.

This patch creates the directory with `{recursive: true}`, meaning that if the directory already exists, it will just succeed silently without doing anything, and if it doesn't, the directory will be created.

Fixes #9120