### PR TITLE
adapter-idb: count docs with attachments in total_rows

### DIFF
--- a/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
+++ b/packages/node_modules/pouchdb-adapter-idb/src/bulkDocs.js
@@ -236,19 +236,19 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
     var hasAttachments = doc._attachments &&
       Object.keys(doc._attachments).length;
     if (hasAttachments) {
-      return writeAttachments(docInfo, winningRev, winningRevIsDeleted,
+      return writeAttachments(docInfo, delta, winningRev, winningRevIsDeleted,
         isUpdate, resultsIdx, callback);
     }
 
-    docCountDelta += delta;
-    updateDocCountIfReady();
-
-    finishDoc(docInfo, winningRev, winningRevIsDeleted,
+    finishDoc(docInfo, delta, winningRev, winningRevIsDeleted,
       isUpdate, resultsIdx, callback);
   }
 
-  function finishDoc(docInfo, winningRev, winningRevIsDeleted,
+  function finishDoc(docInfo, delta, winningRev, winningRevIsDeleted,
                      isUpdate, resultsIdx, callback) {
+
+    docCountDelta += delta;
+    updateDocCountIfReady();
 
     var doc = docInfo.data;
     var metadata = docInfo.metadata;
@@ -305,7 +305,7 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
     putReq.onerror = afterPutDocError;
   }
 
-  function writeAttachments(docInfo, winningRev, winningRevIsDeleted,
+  function writeAttachments(docInfo, delta, winningRev, winningRevIsDeleted,
                             isUpdate, resultsIdx, callback) {
 
 
@@ -316,7 +316,7 @@ function idbBulkDocs(dbOpts, req, opts, api, idb, callback) {
 
     function collectResults() {
       if (numDone === attachments.length) {
-        finishDoc(docInfo, winningRev, winningRevIsDeleted,
+        finishDoc(docInfo, delta, winningRev, winningRevIsDeleted,
           isUpdate, resultsIdx, callback);
       }
     }

--- a/tests/integration/test.basics.js
+++ b/tests/integration/test.basics.js
@@ -1339,5 +1339,23 @@ adapters.forEach(function (adapter) {
         }).should.throw(Error, 'Invalid plugin: got "pouchdb-adapter-memory", expected an object or a function');
       });
     }
+
+    it('#9094 should update total_rows when doc is put with an attachment', async () => {
+      // given
+      const db = new PouchDB(dbs.name);
+      await db.put({ _id:'foo', _attachments:{ 'simple.txt':{ content_type:'text/plain', data:'helo' } } });
+      const { rows, total_rows } = await db.allDocs();
+      rows.length.should.equal(1);
+      total_rows.should.equal(1);
+    });
+
+    it('#9094 should update total_rows when doc is posted with an attachment', async () => {
+      // given
+      const db = new PouchDB(dbs.name);
+      await db.post({ _attachments:{ 'simple.txt':{ content_type:'text/plain', data:'helo' } } });
+      const { rows, total_rows } = await db.allDocs();
+      rows.length.should.equal(1);
+      total_rows.should.equal(1);
+    });
   });
 });


### PR DESCRIPTION
Docs initially inserted with attachments were not added to the metaDocs docCount.

Closes #9094