### PR TITLE
ci: remove redundant install-playwright step

### DIFF
--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -1,9 +1,0 @@
-name: Install Playwright
-description: Installs Playwright with system dependencies
-
-runs:
-  using: composite
-
-  steps:
-    - run: sudo npx playwright install-deps
-      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,6 @@ jobs:
       - uses: ./.github/actions/install-node-package
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: ./.github/actions/install-playwright
       - uses: ./.github/actions/build-pouchdb
       - id: test
         run: ${{ matrix.cmd }}
@@ -225,7 +224,6 @@ jobs:
       - uses: ./.github/actions/install-node-package
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: ./.github/actions/install-playwright
       - uses: ./.github/actions/build-pouchdb
       - id: test
         run: ${{ matrix.cmd }}


### PR DESCRIPTION
Playwright browsers and deps are also installed in `bin/run-tests.sh`.

The approach in `bin/run-tests.sh` is more specific, and so likely installs less unnecessary dependencies.