### PR TITLE
docs: updated Discuss links

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -174,9 +174,8 @@
           <div class="col-sm-3">
             <h3 class="nav-head">Discuss</h3>
             <ul class="nav nav-silent">
-              <li><a href="https://groups.google.com/forum/#!forum/pouchdb">Mailing List</a></li>
-              <li><a href="ircs://irc.libera.chat:6697#pouchdb">IRC</a> <a href="https://web.libera.chat/#pouchdb">(web)</a></li>
-              <li><a href="http://twitter.com/pouchdb">Twitter</a></li>
+              <li><a href="https://github.com/apache/pouchdb/discussions">GitHub Discussions</a></li>
+              <li><a href="https://join.slack.com/t/couchdb/shared_invite/zt-3aqucllea-C92fkzW5oO_VhllRCqFbcw">Slack</a></li>
               <li><a href="http://stackoverflow.com/questions/tagged/pouchdb">StackOverflow</a></li>
             </ul>
           </div>


### PR DESCRIPTION
Remove outdated community links and replace with current ones.

### Before

<img width="248" height="229" alt="Screenshot_2025-11-28_11-27-49" src="https://github.com/user-attachments/assets/7b9ec078-3e3b-4a03-a3e2-06f6444c94ab" />

### After

<img width="215" height="176" alt="Screenshot_2025-11-28_11-28-09" src="https://github.com/user-attachments/assets/1785b450-c599-4b3c-b37c-300fc5b74672" />
