### PR TITLE
appcache: add missing mastodon logo

### DIFF
--- a/docs/manifest.appcache
+++ b/docs/manifest.appcache
@@ -47,6 +47,7 @@ https://fonts.gstatic.com/s/opensans/v10/k3k702ZOKiLJc3WVjuplzBampu5_7CjHW5spxoe
 /static/img/friends/github.svg
 /static/img/friends/leveldb.svg
 /static/img/friends/bluesky.svg
+/static/img/friends/mastodon.svg
 
 /static/img/browser-logos/android_32x32.png
 /static/img/browser-logos/chrome-android_32x32.png


### PR DESCRIPTION
Introduced alongside `bluesky.svg` in #9139, but mistakenly omitted from `docs/manifest.appcache`.