### PR TITLE
repo settings: enable updating PRs from master

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,9 @@
+# GitHub repo settings
+#
+# Mandatory ASF alternative to https://github.com/apache/pouchdb/settings.
+#
+# See: https://github.com/apache/infrastructure-asfyaml/blob/main/README.md
+
+github:
+  pull_requests:
+    allow_update_branch: true


### PR DESCRIPTION
Re-instate button to "Update Branch" in a PR which is behind `master`.

Since joining Apache Foundation, GitHub repo settings are now controlled via `.asf.yaml` instead of https://github.com/apache/pouchdb/settings.

For full documentation, see https://github.com/apache/infrastructure-asfyaml/blob/main/README.md