### PR TITLE
refactor mapreduce tests with async/await

### DIFF
--- a/tests/mapreduce/test.mapreduce.js
+++ b/tests/mapreduce/test.mapreduce.js
@@ -1,11 +1,11 @@
 /* global sum */
 'use strict';
 
-var viewTypes = ['persisted', 'temp'];
+const viewTypes = ['persisted', 'temp'];
 viewTypes.forEach(function (viewType) {
-  var suiteName = 'test.mapreduce.js-' + viewType;
-  var adapter = testUtils.adapterType();
-  var dbName = testUtils.adapterUrl(adapter, 'testdb');
+  const suiteName = 'test.mapreduce.js-' + viewType;
+  const adapter = testUtils.adapterType();
+  const dbName = testUtils.adapterUrl(adapter, 'testdb');
 
   tests(suiteName, dbName, adapter, viewType);
 });
@@ -13,10 +13,10 @@ viewTypes.forEach(function (viewType) {
 function tests(suiteName, dbName, dbType, viewType) {
 
   describe(suiteName, function () {
-    var createView;
+    let createView;
     if (dbType === 'http' || viewType === 'persisted') {
       createView = function (db, viewObj) {
-        var storableViewObj = {
+        const storableViewObj = {
           map: viewObj.map.toString()
         };
         if (viewObj.reduce) {
@@ -63,7 +63,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Test basic view", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.foo, doc);
@@ -94,7 +94,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Test basic view, no emitted value", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.foo);
@@ -126,12 +126,12 @@ function tests(suiteName, dbName, dbType, viewType) {
 
     if (dbType === 'local' && viewType === 'temp') {
       it("with a closure", function () {
-        var db = new PouchDB(dbName);
+        const db = new PouchDB(dbName);
         return db.bulkDocs({docs: [
           {foo: 'bar'},
           { _id: 'volatile', foo: 'baz' }
         ]}).then(function () {
-          var queryFun = (function (test) {
+          const queryFun = (function (test) {
             return function (doc, emit) {
               if (doc._id === test) {
                 emit(doc.foo);
@@ -155,10 +155,10 @@ function tests(suiteName, dbName, dbType, viewType) {
     if (viewType === 'temp' && dbType !== 'http') {
 
       it('Test simultaneous temp views', function () {
-        var db = new PouchDB(dbName);
+        const db = new PouchDB(dbName);
         return db.put({_id: '0', foo: 1, bar: 2, baz: 3}).then(function () {
           return Promise.all(['foo', 'bar', 'baz'].map(function (key, i) {
-            var fun = 'function(doc){emit(doc.' + key + ');}';
+            const fun = 'function(doc){emit(doc.' + key + ');}';
             return db.query({map: fun}).then(function (res) {
               res.rows.should.deep.equal([{
                 id: '0',
@@ -171,7 +171,7 @@ function tests(suiteName, dbName, dbType, viewType) {
       });
 
       it("Test passing just a function", function () {
-        var db = new PouchDB(dbName);
+        const db = new PouchDB(dbName);
         return db.bulkDocs({docs: [
           {foo: 'bar'},
           { _id: 'volatile', foo: 'baz' }
@@ -198,7 +198,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     }
 
     it("Test opts.startkey/opts.endkey", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.key, doc);
@@ -236,7 +236,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("#4154 opts.start_key/opts.end_key are synonyms", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.key, doc);
@@ -275,7 +275,7 @@ function tests(suiteName, dbName, dbType, viewType) {
 
     //TODO: split this to their own tests within a describe block
     it("Test opts.inclusive_end = false", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.key, doc);
@@ -329,7 +329,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Test opts.key", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.key, doc);
@@ -353,7 +353,7 @@ function tests(suiteName, dbName, dbType, viewType) {
 
     it("Test basic view collation", function () {
 
-      var values = [];
+      const values = [];
 
       // special values sort before all other types
       values.push(null);
@@ -397,14 +397,14 @@ function tests(suiteName, dbName, dbType, viewType) {
       // (this test might fail if used with a js engine
       // that doesn't preserve order)
       values.push({b: 2, c: 2});
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.foo);
         }
       }).then(function (queryFun) {
 
-        var docs = values.map(function (x, i) {
+        const docs = values.map(function (x, i) {
           return {_id: (i).toString(), foo: x};
         });
         return db.bulkDocs({docs}).then(function () {
@@ -426,7 +426,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Test complex key collation', function () {
-      var map = function () {
+      const map = function () {
         emit(null);
         emit(false);
         emit(true);
@@ -452,7 +452,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         emit({"b":2,"a":1});
         emit({"b":2,"c":2});
       };
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
@@ -460,7 +460,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         return createView(db, { map });
       }).then(function (queryFun) {
         return db.query(queryFun).then(function (res) {
-          var rows = res.rows.map(function (x) {
+          const rows = res.rows.map(function (x) {
             return {
               id: x.id,
               key: x.key,
@@ -522,7 +522,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Test duplicate collation of objects', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
@@ -535,7 +535,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         });
       }).then(function (queryFun) {
         return db.query(queryFun).then(function (res) {
-          var rows = res.rows.map(function (x) {
+          const rows = res.rows.map(function (x) {
             return {
               id: x.id,
               key: x.key,
@@ -553,7 +553,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Test collation of undefined/null', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
@@ -566,7 +566,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         });
       }).then(function (queryFun) {
         return db.query(queryFun).then(function (res) {
-          var rows = res.rows.map(function (x) {
+          const rows = res.rows.map(function (x) {
             return {
               id: x.id,
               key: x.key,
@@ -584,7 +584,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Test collation of null/undefined', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
@@ -597,7 +597,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         });
       }).then(function (queryFun) {
         return db.query(queryFun).then(function (res) {
-          var rows = res.rows.map(function (x) {
+          const rows = res.rows.map(function (x) {
             return {
               id: x.id,
               key: x.key,
@@ -615,7 +615,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Test duplicate collation of nulls', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
@@ -628,7 +628,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         });
       }).then(function (queryFun) {
         return db.query(queryFun).then(function (res) {
-          var rows = res.rows.map(function (x) {
+          const rows = res.rows.map(function (x) {
             return {
               id: x.id,
               key: x.key,
@@ -646,7 +646,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Test duplicate collation of booleans', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
@@ -659,7 +659,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         });
       }).then(function (queryFun) {
         return db.query(queryFun).then(function (res) {
-          var rows = res.rows.map(function (x) {
+          const rows = res.rows.map(function (x) {
             return {
               id: x.id,
               key: x.key,
@@ -677,7 +677,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Test collation of different objects', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
@@ -690,7 +690,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         });
       }).then(function (queryFun) {
         return db.query(queryFun).then(function (res) {
-          var rows = res.rows.map(function (x) {
+          const rows = res.rows.map(function (x) {
             return {
               id: x.id,
               key: x.key,
@@ -708,7 +708,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Test collation of different objects 2', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
@@ -721,7 +721,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         });
       }).then(function (queryFun) {
         return db.query(queryFun).then(function (res) {
-          var rows = res.rows.map(function (x) {
+          const rows = res.rows.map(function (x) {
             return {
               id: x.id,
               key: x.key,
@@ -739,7 +739,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Test collation of different objects 3', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
@@ -752,7 +752,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         });
       }).then(function (queryFun) {
         return db.query(queryFun).then(function (res) {
-          var rows = res.rows.map(function (x) {
+          const rows = res.rows.map(function (x) {
             return {
               id: x.id,
               key: x.key,
@@ -770,7 +770,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Test collation of different objects 4', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
@@ -783,7 +783,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         });
       }).then(function (queryFun) {
         return db.query(queryFun).then(function (res) {
-          var rows = res.rows.map(function (x) {
+          const rows = res.rows.map(function (x) {
             return {
               id: x.id,
               key: x.key,
@@ -801,7 +801,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Test collation of different objects 5', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
@@ -814,7 +814,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         });
       }).then(function (queryFun) {
         return db.query(queryFun).then(function (res) {
-          var rows = res.rows.map(function (x) {
+          const rows = res.rows.map(function (x) {
             return {
               id: x.id,
               key: x.key,
@@ -832,7 +832,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Test collation of different objects 6', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
@@ -845,7 +845,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         });
       }).then(function (queryFun) {
         return db.query(queryFun).then(function (res) {
-          var rows = res.rows.map(function (x) {
+          const rows = res.rows.map(function (x) {
             return {
               id: x.id,
               key: x.key,
@@ -863,7 +863,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Test collation of different booleans', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
@@ -876,7 +876,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         });
       }).then(function (queryFun) {
         return db.query(queryFun).then(function (res) {
-          var rows = res.rows.map(function (x) {
+          const rows = res.rows.map(function (x) {
             return {
               id: x.id,
               key: x.key,
@@ -894,7 +894,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Test collation of different booleans 2', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
@@ -907,7 +907,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         });
       }).then(function (queryFun) {
         return db.query(queryFun).then(function (res) {
-          var rows = res.rows.map(function (x) {
+          const rows = res.rows.map(function (x) {
             return {
               id: x.id,
               key: x.key,
@@ -925,7 +925,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Test joins", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           if (doc.doc_id) {
@@ -946,7 +946,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("No reduce function", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function () {
           emit('key', 'val');
@@ -959,7 +959,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Query after db.close", function () {
-      var db = new PouchDB(dbName);
+      let db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.foo, 'val');
@@ -992,7 +992,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Built in _sum reduce function", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.val, 1);
@@ -1016,7 +1016,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Built in _count reduce function", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.val, doc.val);
@@ -1040,7 +1040,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Built in _stats reduce function", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: "function(doc){emit(doc.val, 1);}",
         reduce: "_stats"
@@ -1146,7 +1146,7 @@ function tests(suiteName, dbName, dbType, viewType) {
 
     it("Built in _sum reduce function should throw an error with a promise",
       function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: "function(doc){emit(null, doc.val);}",
         reduce: "_sum"
@@ -1165,7 +1165,7 @@ function tests(suiteName, dbName, dbType, viewType) {
 
     it("Built in _sum reduce function with num arrays should throw an error",
       function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: "function(doc){emit(null, doc.val);}",
         reduce: "_sum"
@@ -1183,7 +1183,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Built in _sum can be used with lists of numbers", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: "function(doc){emit(null, doc.val);}",
         reduce: "_sum"
@@ -1207,7 +1207,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("#6364 Recognize built in reduce functions with trailing garbage", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.val, 1);
@@ -1232,7 +1232,7 @@ function tests(suiteName, dbName, dbType, viewType) {
 
     it("Starts with _ but not a built in reduce function should throw",
       function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: "function(doc){emit(null, doc.val);}",
         reduce: "_product"
@@ -1251,9 +1251,9 @@ function tests(suiteName, dbName, dbType, viewType) {
 
     if (viewType === 'temp' && dbType !== 'http') {
       it("No reduce function, passing just a function", function () {
-        var db = new PouchDB(dbName);
+        const db = new PouchDB(dbName);
         return db.post({foo: 'bar'}).then(function () {
-          var queryFun = function () {
+          const queryFun = function () {
             emit('key', 'val');
           };
           return db.query(queryFun);
@@ -1262,13 +1262,13 @@ function tests(suiteName, dbName, dbType, viewType) {
     }
 
     it('Query result should include _conflicts', function () {
-      var db2name = testUtils.adapterUrl(dbType, 'test2b');
-      var cleanup = function () {
+      const db2name = testUtils.adapterUrl(dbType, 'test2b');
+      const cleanup = function () {
         return new PouchDB(db2name).destroy();
       };
-      var doc1 = {_id: '1', foo: 'bar'};
-      var doc2 = {_id: '1', foo: 'baz'};
-      var db = new PouchDB(dbName);
+      const doc1 = {_id: '1', foo: 'bar'};
+      const doc2 = {_id: '1', foo: 'baz'};
+      const db = new PouchDB(dbName);
       return testUtils.fin(db.info().then(function () {
         return db.put({
           _id: '_design/test',
@@ -1283,9 +1283,9 @@ function tests(suiteName, dbName, dbType, viewType) {
           }
         });
       }).then(function () {
-        var remote = new PouchDB(db2name);
+        const remote = new PouchDB(db2name);
         return remote.info().then(function () {
-          var replicate = testUtils.promisify(db.replicate.from, db.replicate);
+          const replicate = testUtils.promisify(db.replicate.from, db.replicate);
           return db.post(doc1).then(function () {
             return remote.post(doc2);
           }).then(function () {
@@ -1302,7 +1302,7 @@ function tests(suiteName, dbName, dbType, viewType) {
       }), cleanup);
     });
 
-    var icons = [
+    const icons = [
       "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAABIAAAASABGyWs+AAAACXZwQWcAAAAQAAAAEABcxq3DAAAC8klEQVQ4y6WTS2hcZQCFv//eO++ZpDMZZjKdZB7kNSUpeWjANikoWiMUtEigBdOFipS6Ercu3bpTKF23uGkWBUGsoBg1KRHapjU0U81rpp3ESdNMZu6dx70zc38XdSFYVz1wNmdxzuKcAy8I8RxNDfs705ne5FmX0+mXUtK0mka2kLvxRC9vAe3nGmRiCQ6reux4auDi6ZenL0wOjaa6uoKK2+kgv1O0l1dvby/8/tvVe1t/XAn6ArvZ3fyzNIBjsQS5YiH6/ul3v/z0/AcfTx8fC24+zgvV4SXccYTtYlGM9MSDMydee1W27OQPd5d+Hujure4bZRQVeLCTY2p44tJ7M2/Pjg1lOLQkXy2scP3OQ1b3Snzx3SK/PCoxOphh7q13ZqeGJy492MmhAkoyHMUlRN8b4yfnBnqSWLqJItzkXZPoWhzF4WZdjGJ6+7H0OoPxFG9OnppzCtGXCEdRZ16axu1yffjRmfPnYqEw7WIdj1OlO6wx1e0g7hckO1ReH4wSrkgUVcEfDITub6w9Gus7tqS4NAcOVfMpCFq2jdrjwxv2cG48SejPFe59/gmnyuuMHA0ien0oR1x0BgJ4XG5fwO9Hk802sm3TbFiYVhNNU1FUBYCBsRNEmiad469gYyNUgRDPipNIQKKVajo1s1F9WjqgVjZQELg9Ek3TUFNHCaXnEEiQEvkPDw4PqTfMalk3UKt1g81ioRgLRc6MxPtDbdtGKgIhBdgSKW2kLWm327SaLayGxfzCzY2vf/zms0pVLyn7lQOadbmxuHb7WrawhW220J+WKZXK6EaNsl7F0GsYep1q3eTW6grfLv90zZRyI7dfRDNtSPdE+av05PL8re+HgdlMPI2wJXrDRAACgdVusfZ4k+uLN+eXs/cvp7oitP895UQogt6oxYZiiYsnMxMXpjPjqaC/QwEoGRX71+yd7aXs3asPd/NXAm7vbv5g7//P1OHxpvsj8bMep8sPULdMY32vcKNSr/3nTC+MvwEdhUhhkKTyPgAAAEJ0RVh0Y29tbWVudABGaWxlIHNvdXJjZTogaHR0cDovL3d3dy5zc2J3aWtpLmNvbS9GaWxlOktpcmJ5SGVhZFNTQkIucG5nSbA1rwAAACV0RVh0Y3JlYXRlLWRhdGUAMjAxMC0xMi0xNFQxNjozNDoxMCswMDowMDpPBjcAAAAldEVYdG1vZGlmeS1kYXRlADIwMTAtMTAtMDdUMjA6NTA6MzYrMDA6MDCjC6s7AAAAAElFTkSuQmCC",
       "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAC3ElEQVQ4jX2SX2xTdRzFP/d3f5d7u7ZbGes6LyAFWSiNmbMuSqb4wgxGVMiYT/BkNPMNfV1MDAFfNDHxwWSJU4wsMsKLEhI3gmE0JHO6FTBzMrZlS3V3Qun+sG70tvePD4ZlI8BJvi/fc/LN9+QceAIanm1oa2xo7HuSRn0c0dUq5fbd2teerLRHxqzuhzjDEs+0VYSrT4vHHbAW1ZrWg9aeYweurdv3vCsTL7Yy+GmHfcb3/Qn5T49MCYMW85Dz2Vphdl6jWPLJjmAOfSN/QsFY+ZdfNic5tuUFzLEfZjOLi1Xt5C7J44VJ6V/9Up546M0NFz/Xhp070l8789elf65DH3wvFYoACK2KNiMMz79Nx9ojEZOWP/Lx1NCv/7v8fTDK0fe34QF/ZsS5rkxhAUC4ZZJeGfQgovFNPu4+KtsAYsWad+rjM1TqHvcsqNmUY59pow/HqI07b62msEtqwijzku4inXmorqXllWpxybgb3f/akVLi7lAJ60KA+gMOTTcSWKc1rgZyi1f+8joB1PPDbn85W/GzYxOL1XgJaRDoTW9ID8ysnKyK24dSh/3auoSGUuGQFxb2UzlERL19Nu12AkiArkwhA6HDT29yLi+j1s3Oih/royUZjXihYg5W7txH5EGrhI17wMy6yWRUT47m7NHVHmypcirnl8SO6pBnNiWdr4q6+kZksxI3oiDCsLwE9/LARlguIm/lXbmuif3TTjG4Ejj724RbDuleezimbHv1dW/rrTQE62ByRLC8AJ4C2SkIIiauTbsD65rYlSlYp9LlTy5muBkx/WYZgMQ++HtcsGunR33S5+Y4NKcgHFQAeGSV09PsnZtRuu05uD8LZsDDXgDXhubd0DfAaM9l7/t1FtbC871Sbk5MbdX5oHwbOs+ovVPj9C7N0VhyUfv61Q/7x0qDqyk8CnURZcdkzufbC0p7bVn77otModRkGqdefs79qOj7xgPdf3d0KpBuuY7dAAAAAElFTkSuQmCC",
       "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAABZ0RVh0Q3JlYXRpb24gVGltZQAwMS8wNy8wOCumXF8AAAAfdEVYdFNvZnR3YXJlAE1hY3JvbWVkaWEgRmlyZXdvcmtzIDi1aNJ4AAADHElEQVQ4EYXBe0wUBADH8R/CcSccQnfcIcbrXgRixKPSMIxklU4tJOUfyflIcmVJzamTVjJrJIRa6OZ4DmGMwSoEfKIVkcTC5qNRmqxpuki3VFiIjMc33fijka3PR/o3s7/R+Hl8QTgpxz2kHHWTuC8Cf7PxlCSr/ke0Ndrc5ioPJejONHxHjfiOGAkYNuNqDMX2WEC3pCf0H2LMScbLMcciiB0KJGbcwMy7RmYOG4kdMxA7EkBsRySB6X43JM3TJD6aoT3OvOlsPxVNX+807oyJ/rtiYFgMI271mdjdEcMjhQ8jl1eNpEDdV/PugrajpZu/ejndwafvpdB/1sHtS+EM/m4BBGNTuNCawPk2B6M3jNRXRvJSmpOG4je7Gj5Yekw7spLPXe8s42xdMfXvuzh3OIHerihADP1poeuQP0f2vMbX5fmcbnHS3eDg+6oCbp+ppWjV3Iu6Lzf10fzGotnUFVmp2pBGX3sS54+7KXsribq8V/nrl2aun66gfOOLnKx0cqLqKTalP14iyaQJ7uwsH/p7oli/OJV31q7i7bREmovfYPBSE83FG1m37BVWL17I1W8cbMn1RdIz+ofpCdHBtcvnhIxXf5zLjjLI23qQ4StNjF5rpSi/ltyd0FK9k8xk23hqQuhBSW49QGlOZjwdpZ8w2NsDV9vh8klGfvuJzuoytq6cjTTlM0l+msT0kMu6u/Bw3uBHza+zaJmFwsol7G3MoaRxHbtqMslcYWNb1Qr2dxYMRSSFV0iyaoItLjrizIUf6znRuZ/EjCie3+5iXomTZw+EMb82jNQSB8996CYxI5za5gKuXDvE00/O6pXk0T3BnoiQ75r2bSNnw3JU5sWc9iCy17j441cTQzcN5Kx3kdpqxesLsXTtCxwpzyc5ztEjyaUJBkmrJR0wxHtjrQjC+XMIK2/5kjPgg/uiHXuDBUOKN5JaJK2RFKhJkrItQTe7Z8SRNTUMc6QBebx+kMfrW98obxaZQ+mwz2KTLXhA0hI9gGuuv3/TZruNDL9grDKVS5qqe8wyFC00Wdlit7MgIOBLSYma8DfYI5E1lrjnEQAAAABJRU5ErkJggg==",
@@ -1310,7 +1310,7 @@ function tests(suiteName, dbName, dbType, viewType) {
       "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAEG0lEQVQ4EQEQBO/7AQAAAAAAAAAAAAAAAAAAAACmm0ohDxD8bwT//ksOBPAhAAAAAPL8EN8IDQLB5eQEhVpltt8AAAAAAAAAAAAAAAABAAAAAAAAAACHf0UGKSgBgygY7m/w4O8F5t71ABMaCQAPEAQAAAAAAPwEBgAMFAn74/ISnunoA3RcZ7f2AAAAAAEAAAAAh39FBjo4AZYTAOtf1sLmAvb1+gAAAAAALzsVACEn+wAAAAAA/f4G/+LcAgH9AQIA+hAZpuDfBmhaZrb1AwAAAABtaCSGHAjraf///wD47/kB9vX7AAAAAAAYHgsAERT+AAAAAAACAf0BERT/AAQHB/746/IuBRIMFfL3G8ECpppKHigY7m/68vcCHRv0AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA//0ADgvzAgP//gAWBe1hUEgMOgIKDfxr9Oz3BRsiAf8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHCP///zu8gMjIftYAgkD/1ID//4ABwb6Af//AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFBPwBAAAAAAP0710CDgTvIQD//QAAAP8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD//QD8BAYADQv//gQAAAAAAAAAAAAAAgABAf4AAAAAAAAAAAAAAAAAAAAAAAABAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAP//gAAAAAABPL7D+D57Owh0MQAAAAAAAD08/sAAAAAAAAAAADj2fQA8ewGAAAAAAAAAAAAAAAAAAAAAAAAAAAA+/r1AAwECwIEAggDugsNBGcAAAAAAwMBAO7o+AAAAAAAAAAAAAgKBAAOEAUAAAAAAAAAAAAAAAAAAAAAAAAAAADz8vwA/QwRowTr6gSLHSQQYvfr9QUhJ/sA6OEEAPPy+QAAAAAAFR0IACEn+wAAAAAAAAAAAAAAAAAAAAAA4+YP/g0OAgDT3wWoAlpltt/d7BKYBAwH/uTmDf4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPL1Df798fUC+AgSqMfL9sICAAAAAOblAHXzBRSo////APTz+wD//wAAAAAAAAAAAAAAAAAAAAEBAP3+Bv/j5g/+7uL3AukDH97g3wZomJzA9wMAAAAAs7jd/kE8J7n9BwoSJSgGMQYD/wL++/8ABAUCAPb1BQDw7AIA8e8DAQAFBf/0DBqj6OgGTlpmtvUAAAAAAQAAAAAAAAAAAAAAAFFRPg1SSAwbGxv8cQn67mMHBf7/AwL/APb5AwH/DRCn294GpMLH9sKdoMD3AAAAAAAAAABEawlCEphz4AAAAABJRU5ErkJggg=="
     ];
 
-    var iconDigests = [
+    const iconDigests = [
       "md5-Mf8m9ehZnCXC717bPkqkCA==",
       "md5-fdEZBYtnvr+nozYVDzzxpA==",
       "md5-ImDARszfC+GA3Cv9TVW4HA==",
@@ -1318,13 +1318,13 @@ function tests(suiteName, dbName, dbType, viewType) {
       "md5-jDUyV6ySnTVANn2qq3332g=="
     ];
 
-    var iconLengths = [1047, 789, 967, 527, 1108];
+    const iconLengths = [1047, 789, 967, 527, 1108];
 
     it('#190 Query works with attachments=true', function () {
 
-      var db = new PouchDB(dbName);
-      var docs = [];
-      for (var i = 0; i < 5; i++) {
+      const db = new PouchDB(dbName);
+      const docs = [];
+      for (let i = 0; i < 5; i++) {
         docs.push({
           _id: i.toString(),
           _attachments: {
@@ -1346,8 +1346,8 @@ function tests(suiteName, dbName, dbType, viewType) {
           include_docs: true,
           attachments: true
         }).then(function (res) {
-          var attachments = res.rows.map(function (row) {
-            var doc = row.doc;
+          const attachments = res.rows.map(function (row) {
+            const doc = row.doc;
             delete doc._attachments['foo.png'].revpos;
             return doc._attachments;
           });
@@ -1362,8 +1362,8 @@ function tests(suiteName, dbName, dbType, viewType) {
           }), 'works with attachments=true');
           return db.query(queryFun, {include_docs: true});
         }).then(function (res) {
-          var attachments = res.rows.map(function (row) {
-            var doc = row.doc;
+          const attachments = res.rows.map(function (row) {
+            const doc = row.doc;
             delete doc._attachments['foo.png'].revpos;
             return doc._attachments['foo.png'];
           });
@@ -1390,14 +1390,14 @@ function tests(suiteName, dbName, dbType, viewType) {
 
       // Need to avoid the cache to workaround
       // https://issues.apache.org/jira/browse/COUCHDB-2880
-      var db = new PouchDB(dbName, {
+      const db = new PouchDB(dbName, {
         fetch: function (url, opts) {
           opts.cache = 'no-store';
           return PouchDB.fetch(url, opts);
         }
       });
-      var docs = [];
-      for (var i = 0; i < 5; i++) {
+      const docs = [];
+      for (let i = 0; i < 5; i++) {
         docs.push({
           _id: i.toString(),
           _attachments: {
@@ -1421,9 +1421,9 @@ function tests(suiteName, dbName, dbType, viewType) {
           binary: true
         }).then(function (res) {
           res.rows.forEach(function (row) {
-            var doc = row.doc;
+            const doc = row.doc;
             Object.keys(doc._attachments).forEach(function (attName) {
-              var att = doc._attachments[attName];
+              const att = doc._attachments[attName];
               should.not.exist(att.stub);
               att.data.should.not.be.a('string');
             });
@@ -1436,14 +1436,14 @@ function tests(suiteName, dbName, dbType, viewType) {
 
       // Need to avoid the cache to workaround
       // https://issues.apache.org/jira/browse/COUCHDB-2880
-      var db = new PouchDB(dbName, {
+      const db = new PouchDB(dbName, {
         fetch: function (url, opts) {
           opts.cache = 'no-store';
           return PouchDB.fetch(url, opts);
         }
       });
-      var docs = [];
-      for (var i = 0; i < 5; i++) {
+      const docs = [];
+      for (let i = 0; i < 5; i++) {
         docs.push({
           _id: i.toString()
         });
@@ -1461,7 +1461,7 @@ function tests(suiteName, dbName, dbType, viewType) {
           binary: true
         }).then(function (res) {
           res.rows.forEach(function (row) {
-            var doc = row.doc;
+            const doc = row.doc;
             should.not.exist(doc._attachments);
           });
         });
@@ -1469,7 +1469,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('#242 conflicts at the root level', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
 
       return db.bulkDocs([
         {
@@ -1517,7 +1517,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('#242 conflicts at the root+1 level', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
 
       return db.bulkDocs([
         {
@@ -1572,22 +1572,22 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Views should include _conflicts', function () {
-      var db2name = testUtils.adapterUrl(dbType, 'test2');
-      var cleanup = function () {
+      const db2name = testUtils.adapterUrl(dbType, 'test2');
+      const cleanup = function () {
         return new PouchDB(db2name).destroy();
       };
-      var doc1 = {_id: '1', foo: 'bar'};
-      var doc2 = {_id: '1', foo: 'baz'};
-      var db = new PouchDB(dbName);
+      const doc1 = {_id: '1', foo: 'bar'};
+      const doc2 = {_id: '1', foo: 'baz'};
+      const db = new PouchDB(dbName);
       return testUtils.fin(db.info().then(function () {
-        var remote = new PouchDB(db2name);
+        const remote = new PouchDB(db2name);
         return remote.info().then(function () {
           return createView(db, {
             map : function (doc) {
               emit(doc._id, !!doc._conflicts);
             }
           }).then(function (queryFun) {
-            var replicate = testUtils.promisify(db.replicate.from, db.replicate);
+            const replicate = testUtils.promisify(db.replicate.from, db.replicate);
             return db.post(doc1).then(function () {
               return remote.post(doc2);
             }).then(function () {
@@ -1606,7 +1606,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Test view querying with limit option", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map : function (doc) {
           if (doc.foo === 'bar') {
@@ -1630,7 +1630,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Test view querying with custom reduce function", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.foo);
@@ -1638,12 +1638,12 @@ function tests(suiteName, dbName, dbType, viewType) {
         reduce: function (keys, values) {
           if (keys) {
             return keys.map(function (keyId) {
-              var key = keyId[0];
-              // var id = keyId[1];
+              const key = keyId[0];
+              // const id = keyId[1];
               return key.join('');
             });
           } else {
-            var result = [];
+            const result = [];
             values.map(function (value) {
               value.map(function (v) {
                 result.push(v);
@@ -1695,7 +1695,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Test view querying with group_level option and reduce", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.foo);
@@ -1737,7 +1737,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Test view querying with invalid group_level options", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.foo);
@@ -1760,7 +1760,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Test view querying with limit option and reduce", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.foo);
@@ -1790,7 +1790,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Test view querying with invalid limit option and reduce", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.foo);
@@ -1821,11 +1821,11 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Test unsafe object usage (#244)', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return db.bulkDocs([
         {_id: 'constructor'}
       ]).then(function (res) {
-        var rev = res[0].rev;
+        let rev = res[0].rev;
         return createView(db, {
           map: function (doc) {
             emit(doc._id);
@@ -1875,8 +1875,8 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Test view querying with a skip option and reduce", function () {
-      var qf;
-      var db = new PouchDB(dbName);
+      let qf;
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.foo);
@@ -1907,7 +1907,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Test view querying with invalid skip option and reduce", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.foo);
@@ -1939,7 +1939,7 @@ function tests(suiteName, dbName, dbType, viewType) {
 
     it("Special document member _doc_id_rev should never leak outside",
       function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           if (doc.foo === 'bar') {
@@ -1960,10 +1960,10 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('multiple view creations and cleanups', function () {
-      var db = new PouchDB(dbName);
-      var map = function (doc) { emit(doc.num); };
+      const db = new PouchDB(dbName);
+      const map = function (doc) { emit(doc.num); };
       function createView(name) {
-        var storableViewObj = { map: map.toString() };
+        const storableViewObj = { map: map.toString() };
         return  db.put({
           _id: '_design/' + name,
           views: {
@@ -1983,19 +1983,19 @@ function tests(suiteName, dbName, dbType, viewType) {
             });
           });
         }
-        var attempts = [];
-        var numAttempts = 10;
-        for (var i = 0; i < numAttempts; i++) {
+        const attempts = [];
+        const numAttempts = 10;
+        for (let i = 0; i < numAttempts; i++) {
           attempts.push(sequence('test' + i));
         }
         return Promise.all(attempts).then(function () {
-          var keys = [];
-          for (var i = 0; i < numAttempts; i++) {
+          const keys = [];
+          for (let i = 0; i < numAttempts; i++) {
             keys.push('_design/test' + i);
           }
           return db.allDocs({keys, include_docs : true});
         }).then(function (res) {
-          var docs = res.rows.map(function (row) {
+          const docs = res.rows.map(function (row) {
             row.doc._deleted = true;
             return row.doc;
           });
@@ -2013,7 +2013,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('If reduce function returns 0, resulting value should not be null', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.foo);
@@ -2035,7 +2035,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Testing skip with a view', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map : function (doc) {
           emit(doc.foo);
@@ -2058,13 +2058,13 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Map documents on 0/null/undefined/empty string', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map : function (doc) {
           emit(doc.num);
         }
       }).then(function (mapFunction) {
-        var docs = [
+        const docs = [
           {_id: '0', num: 0},
           {_id: '1', num: 1},
           {_id: 'undef' /* num is undefined */},
@@ -2090,7 +2090,7 @@ function tests(suiteName, dbName, dbType, viewType) {
           data.rows.should.have.length(8); // everything
 
           // keys that should all resolve to null
-          var emptyKeys = [null, NaN, Infinity, -Infinity];
+          const emptyKeys = [null, NaN, Infinity, -Infinity];
           return Promise.all(emptyKeys.map(function (emptyKey) {
             return db.query(mapFunction, {key: emptyKey}).then(function (data) {
               data.rows.map(function (row) {
@@ -2103,13 +2103,13 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Testing query with keys', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.field);
         }
       }).then(function (queryFun) {
-        var opts = {include_docs: true};
+        const opts = {include_docs: true};
         return db.bulkDocs({
           docs: [
             {_id: 'doc_0', field: 0},
@@ -2204,9 +2204,9 @@ function tests(suiteName, dbName, dbType, viewType) {
       function ids(row) {
         return row.id;
       }
-      var opts = {keys: [0, 1, 2]};
-      var spec;
-      var db = new PouchDB(dbName);
+      const opts = {keys: [0, 1, 2]};
+      let spec;
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.field1);
@@ -2240,7 +2240,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Testing multiple emissions (issue #14)', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map : function (doc) {
           emit(doc.foo);
@@ -2256,7 +2256,7 @@ function tests(suiteName, dbName, dbType, viewType) {
             {_id: 'doc2', foo : 'foo', bar : 'bar'}
           ]
         }).then(function () {
-          var opts = {keys: ['foo', 'bar']};
+          const opts = {keys: ['foo', 'bar']};
 
           return db.query(mapFunction, opts);
         });
@@ -2296,7 +2296,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Testing multiple emissions (complex keys)', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function () {
           emit(['a'], 1);
@@ -2323,12 +2323,12 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Testing empty startkeys and endkeys', function () {
-      var opts = {startkey: null, endkey: ''};
+      let opts = {startkey: null, endkey: ''};
       function ids(row) {
         return row.id;
       }
-      var spec;
-      var db = new PouchDB(dbName);
+      let spec;
+      const db = new PouchDB(dbName);
       return createView(db, {
         map : function (doc) {
           emit(doc.field);
@@ -2369,7 +2369,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('#238 later non-winning revisions', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
 
       return createView(db, {
         map: function (doc) {
@@ -2410,7 +2410,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('#238 later non-winning deleted revisions', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
 
       return createView(db, {
         map: function (doc) {
@@ -2452,7 +2452,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('#238 query with conflicts', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
 
       return createView(db, {
         map: function (doc) {
@@ -2514,12 +2514,12 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('Testing ordering with startkey/endkey/key', function () {
-      var opts = {startkey: '1', endkey: '4'};
+      let opts = {startkey: '1', endkey: '4'};
       function ids(row) {
         return row.id;
       }
-      var spec;
-      var db = new PouchDB(dbName);
+      let spec;
+      const db = new PouchDB(dbName);
       return createView(db, {
         map : function (doc) {
           emit(doc.field, null);
@@ -2564,13 +2564,13 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('opts.keys should work with complex keys', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.foo, doc.foo);
         }
       }).then(function (mapFunction) {
-        var keys = [
+        const keys = [
           {key: 'missing'},
           ['test', 1],
           {key1: 'value1'},
@@ -2586,7 +2586,7 @@ function tests(suiteName, dbName, dbType, viewType) {
             {foo: [0, false]}
           ]
         }).then(function () {
-          var opts = {keys};
+          const opts = {keys};
           return db.query(mapFunction, opts);
         }).then(function (data) {
           data.rows.should.have.length(3);
@@ -2601,7 +2601,7 @@ function tests(suiteName, dbName, dbType, viewType) {
       function ids(row) {
         return row.id;
       }
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map : function (doc) {
           emit(doc.date, null);
@@ -2627,7 +2627,7 @@ function tests(suiteName, dbName, dbType, viewType) {
       function change(row) {
         return [row.key, row.doc._id, row.doc.val];
       }
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           if (doc.join) {
@@ -2649,9 +2649,9 @@ function tests(suiteName, dbName, dbType, viewType) {
       });
     });
 
-    it('should query correctly with a variety of criteria', function () {
-      var db = new PouchDB(dbName);
-      var ddoc = {
+    it('should query correctly with a constiety of criteria', function () {
+      const db = new PouchDB(dbName);
+      const ddoc = {
         _id: '_design/test',
         views: {
           test: {
@@ -2661,9 +2661,9 @@ function tests(suiteName, dbName, dbType, viewType) {
           }
         }
       };
-      var mapFun = 'test';
+      const mapFun = 'test';
       return db.put(ddoc).then(function () {
-        var docs = [
+        const docs = [
           {_id : '0'},
           {_id : '1'},
           {_id : '2'},
@@ -2766,17 +2766,17 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should query correctly with skip/limit and multiple keys/values', function () {
-      var db = new PouchDB(dbName);
-      var docs = {
+      const db = new PouchDB(dbName);
+      const docs = {
         docs: [
           {_id: 'doc1', foo : 'foo', bar : 'bar'},
           {_id: 'doc2', foo : 'foo', bar : 'bar'}
         ]
       };
-      var getValues = function (res) {
+      const getValues = function (res) {
         return res.value;
       };
-      var getIds = function (res) {
+      const getIds = function (res) {
         return res.id;
       };
 
@@ -2861,8 +2861,8 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should query correctly with undefined key/values', function () {
-      var db = new PouchDB(dbName);
-      var docs = {
+      const db = new PouchDB(dbName);
+      const docs = {
         docs: [
           {_id: 'doc1'},
           {_id: 'doc2'}
@@ -2894,7 +2894,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should query correctly with no docs', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map : function () {
           emit();
@@ -2909,7 +2909,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should query correctly with no emits', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map : function () {
         }
@@ -2941,7 +2941,7 @@ function tests(suiteName, dbName, dbType, viewType) {
       function docIds(row) {
         return row.doc._id;
       }
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map : function (doc) {
           emit(doc.name);
@@ -3038,8 +3038,8 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should query correctly after replicating and other ddoc', function () {
-      var db = new PouchDB(dbName);
-      var db2 = new PouchDB(testUtils.adapterUrl(dbType, 'local-other'));
+      const db = new PouchDB(dbName);
+      const db2 = new PouchDB(testUtils.adapterUrl(dbType, 'local-other'));
       return createView(db, {
         map: function (doc) {
           emit(doc.name);
@@ -3090,13 +3090,13 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should query correctly after many edits', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map : function (doc) {
           emit(doc.name, doc.likes);
         }
       }).then(function (queryFun) {
-        var docs = [
+        const docs = [
           { _id: '1', name: 'leonardo' },
           { _id: '2', name: 'michelangelo' },
           { _id: '3', name: 'donatello' },
@@ -3120,18 +3120,18 @@ function tests(suiteName, dbName, dbType, viewType) {
           { _id: 'l', name: 'ace duck' }
         ];
 
-        for (var i = 0; i < 100; i++) {
+        for (let i = 0; i < 100; i++) {
           docs.push({
             _id: 'z-' + (i + 1000), // for correct string ordering
             name: 'random foot soldier #' + i
           });
         }
 
-        var byId = Object.fromEntries(docs.map((doc) => [doc._id, doc]));
+        const byId = Object.fromEntries(docs.map((doc) => [doc._id, doc]));
 
         function update(res, docFun) {
-          for (var i  = 0; i < res.length; i++) {
-            var doc = byId[res[i].id];
+          for (let i  = 0; i < res.length; i++) {
+            const doc = byId[res[i].id];
             doc._rev = res[i].rev;
             docFun(doc);
           }
@@ -3179,15 +3179,15 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should query correctly with staggered seqs', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map : function (doc) {
           emit(doc.name);
         }
       }).then(function (queryFun) {
-        var docs = [];
+        const docs = [];
 
-        for (var i = 0; i < 200; i++) {
+        for (let i = 0; i < 200; i++) {
           docs.push({
             _id: 'doc-' + (i + 1000), // for correct string ordering
             name: 'gen1'
@@ -3212,7 +3212,7 @@ function tests(suiteName, dbName, dbType, viewType) {
             doc._rev = infos.find((info) => info.id === doc._id).rev;
             doc.name = 'gen-4-odd';
           });
-          var docsToUpdate = docs.filter(function (doc, i) {
+          const docsToUpdate = docs.filter(function (doc, i) {
             return i % 2 === 1;
           });
           docsToUpdate.reverse();
@@ -3220,8 +3220,8 @@ function tests(suiteName, dbName, dbType, viewType) {
         }).then(function () {
           return db.query(queryFun);
         }).then(function (res) {
-          var expected = docs.map(function (doc, i) {
-            var key = i % 2 === 1 ? 'gen-4-odd' : 'gen-3';
+          const expected = docs.map(function (doc, i) {
+            const key = i % 2 === 1 ? 'gen-4-odd' : 'gen-3';
             return {key, id: doc._id, value: null};
           });
           expected.sort(function (a, b) {
@@ -3236,9 +3236,9 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should handle removes/undeletes/updates', function () {
-      var theDoc = {name : 'bar', _id : '1'};
+      const theDoc = {name : 'bar', _id : '1'};
 
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.name);
@@ -3284,13 +3284,13 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should return error when multi-key fetch & group=false', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) { emit(doc._id); },
         reduce: '_sum'
       }).then(function (queryFun) {
-        var keys = ['1', '2'];
-        var opts = {
+        const keys = ['1', '2'];
+        let opts = {
           keys,
           group: false
         };
@@ -3314,8 +3314,8 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should handle user errors in map functions', function () {
-      var db = new PouchDB(dbName);
-      var err;
+      const db = new PouchDB(dbName);
+      let err;
       db.on('error', function (e) { err = e; });
       return createView(db, {
         map : function (doc) {
@@ -3334,8 +3334,8 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should handle user errors in reduce functions', function () {
-      var db = new PouchDB(dbName);
-      var err;
+      const db = new PouchDB(dbName);
+      let err;
       db.on('error', function (e) { err = e; });
       return createView(db, {
         map : function (doc) {
@@ -3360,8 +3360,8 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should handle reduce returning undefined', function () {
-      var db = new PouchDB(dbName);
-      var err;
+      const db = new PouchDB(dbName);
+      let err;
       db.on('error', function (e) { err = e; });
       return createView(db, {
         map : function (doc) {
@@ -3383,7 +3383,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should properly query custom reduce functions', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map : function (doc) {
           emit(doc.name, doc.count);
@@ -3391,15 +3391,15 @@ function tests(suiteName, dbName, dbType, viewType) {
         reduce : function (keys, values, rereduce) {
           // calculate the average count per name
           if (!rereduce) {
-            var result = {
+            const result = {
               sum : sum(values),
               count : values.length
             };
             result.average = result.sum / result.count;
             return result;
           } else {
-            var thisSum = sum(values.map(function (value) {return value.sum; }));
-            var thisCount = sum(values.map(function (value) {return value.count; }));
+            const thisSum = sum(values.map(function (value) {return value.sum; }));
+            const thisCount = sum(values.map(function (value) {return value.count; }));
             return {
               sum : thisSum,
               count : thisCount,
@@ -3558,9 +3558,9 @@ function tests(suiteName, dbName, dbType, viewType) {
 
     it('should handle many doc changes', function () {
 
-      var docs = [{_id: '0'}, {_id : '1'}, {_id: '2'}];
+      let docs = [{_id: '0'}, {_id : '1'}, {_id: '2'}];
 
-      var keySets = [
+      const keySets = [
         [1],
         [2, 3],
         [4],
@@ -3574,7 +3574,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         [9, 3, 2, 1]
       ];
 
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map : function (doc) {
           doc.keys.forEach(function (key) {
@@ -3583,9 +3583,9 @@ function tests(suiteName, dbName, dbType, viewType) {
         }
       }).then(function (mapFun) {
         return db.bulkDocs({docs}).then(function () {
-          var tasks = keySets.map(function (keys, i) {
+          const tasks = keySets.map(function (keys, i) {
             return function () {
-              var expectedResponseKeys = [];
+              const expectedResponseKeys = [];
               return db.allDocs({
                 keys : ['0', '1', '2'],
                 include_docs: true
@@ -3602,16 +3602,16 @@ function tests(suiteName, dbName, dbType, viewType) {
               }).then(function () {
                 return db.query(mapFun);
               }).then(function (res) {
-                var actualKeys = res.rows.map(function (x) {
+                const actualKeys = res.rows.map(function (x) {
                   return x.key;
                 });
                 actualKeys.should.deep.equal(expectedResponseKeys);
               });
             };
           });
-          var chain = tasks.shift()();
+          const chain = tasks.shift()();
           function getNext() {
-            var task = tasks.shift();
+            const task = tasks.shift();
             return task && function () {
               return task().then(getNext());
             };
@@ -3623,9 +3623,9 @@ function tests(suiteName, dbName, dbType, viewType) {
 
     it('should handle many doc changes', function () {
 
-      var docs = [{_id: '0'}, {_id : '1'}, {_id: '2'}];
+      let docs = [{_id: '0'}, {_id : '1'}, {_id: '2'}];
 
-      var keySets = [
+      const keySets = [
         [1],
         [2, 3],
         [4],
@@ -3639,7 +3639,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         [9, 3, 2, 1]
       ];
 
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map : function (doc) {
           doc.keys.forEach(function (key) {
@@ -3648,9 +3648,9 @@ function tests(suiteName, dbName, dbType, viewType) {
         }
       }).then(function (mapFun) {
         return db.bulkDocs({docs}).then(function () {
-          var tasks = keySets.map(function (keys, i) {
+          const tasks = keySets.map(function (keys, i) {
             return function () {
-              var expectedResponseKeys = [];
+              const expectedResponseKeys = [];
               return db.allDocs({
                 keys : ['0', '1', '2'],
                 include_docs: true
@@ -3669,7 +3669,7 @@ function tests(suiteName, dbName, dbType, viewType) {
               }).then(function () {
                 return db.query(mapFun);
               }).then(function (res) {
-                var actualKeys = res.rows.map(function (x) {
+                const actualKeys = res.rows.map(function (x) {
                   return x.key;
                 });
                 actualKeys.should.deep.equal(expectedResponseKeys);
@@ -3677,7 +3677,7 @@ function tests(suiteName, dbName, dbType, viewType) {
             };
           });
           function getNext() {
-            var task = tasks.shift();
+            const task = tasks.shift();
             if (task) {
               return task().then(getNext);
             }
@@ -3688,12 +3688,12 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should work with post', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) { emit(doc._id); }
       }).then(async function (mapFun) {
         return db.bulkDocs({docs: [{_id : 'bazbazbazb'}]}).then(function () {
-          var keys = ['bazbazbazb'];
+          const keys = ['bazbazbazb'];
           return db.query(mapFun, {keys}).then(function (resp) {
             resp.total_rows.should.equal(1);
             resp.rows.should.have.length(1);
@@ -3706,7 +3706,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("should accept trailing ';' in a map definition (#178)", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: "function(doc){};\n"
       }).then(function (queryFun) {
@@ -3719,7 +3719,7 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should throw a 404 when no funcs found in ddoc (#181)', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return db.put({
         _id: '_design/test'
       }).then(function () {
@@ -3733,8 +3733,8 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should continue indexing when map eval fails (#214)', function () {
-      var db = new PouchDB(dbName);
-      var err;
+      const db = new PouchDB(dbName);
+      let err;
       db.on('error', function (e) {
         err = e;
       });
@@ -3772,7 +3772,7 @@ function tests(suiteName, dbName, dbType, viewType) {
 
     it('should continue indexing when map eval fails, ' +
         'even without a listener (#214)', function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.foo.bar, doc);
@@ -3803,9 +3803,9 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('should update the emitted value', function () {
-      var db = new PouchDB(dbName);
-      var docs = [];
-      for (var i = 0; i < 300; i++) {
+      const db = new PouchDB(dbName);
+      const docs = [];
+      for (let i = 0; i < 300; i++) {
         docs.push({
           _id: i.toString(),
           name: 'foo',
@@ -3817,12 +3817,12 @@ function tests(suiteName, dbName, dbType, viewType) {
         map: "function(doc){emit(doc.name, doc.count);};\n"
       }).then(function (queryFun) {
         return db.bulkDocs({docs}).then(function (res) {
-          for (var i = 0; i < res.length; i++) {
+          for (let i = 0; i < res.length; i++) {
             docs[i]._rev = res[i].rev;
           }
           return db.query(queryFun);
         }).then(function (res) {
-          var values = res.rows.map(function (x) { return x.value; });
+          const values = res.rows.map(function (x) { return x.value; });
           values.should.have.length(docs.length);
           values[0].should.equal(1);
           docs.forEach(function (doc) {
@@ -3832,7 +3832,7 @@ function tests(suiteName, dbName, dbType, viewType) {
         }).then(function () {
           return db.query(queryFun);
         }).then(function (res) {
-          var values = res.rows.map(function (x) { return x.value; });
+          const values = res.rows.map(function (x) { return x.value; });
           values.should.have.length(docs.length);
           values[0].should.equal(2);
         });
@@ -3840,9 +3840,9 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('#6230 Test db.query() opts update_seq: false', function () {
-      var db = new PouchDB(dbName);
-      var docs = [];
-      for (var i = 0; i < 4; i++) {
+      const db = new PouchDB(dbName);
+      const docs = [];
+      for (let i = 0; i < 4; i++) {
         docs.push({
           _id: i.toString(),
           name: 'foo',
@@ -3863,9 +3863,9 @@ function tests(suiteName, dbName, dbType, viewType) {
 
     it('#6230 Test db.query() opts update_seq: true', function () {
 
-      var db = new PouchDB(dbName);
-      var docs = [];
-      for (var i = 0; i < 4; i++) {
+      const db = new PouchDB(dbName);
+      const docs = [];
+      for (let i = 0; i < 4; i++) {
         docs.push({
           _id: i.toString(),
           name: 'foo',
@@ -3888,7 +3888,7 @@ function tests(suiteName, dbName, dbType, viewType) {
             return false;
           }
         });
-        var normSeq = normalizeSeq(result.update_seq);
+        const normSeq = normalizeSeq(result.update_seq);
         normSeq.should.be.a('number');
       });
 
@@ -3905,9 +3905,9 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it('#6230 Test db.query() opts with update_seq missing', function () {
-      var db = new PouchDB(dbName);
-      var docs = [];
-      for (var i = 0; i < 4; i++) {
+      const db = new PouchDB(dbName);
+      const docs = [];
+      for (let i = 0; i < 4; i++) {
         docs.push({
           _id: i.toString(),
           name: 'foo',
@@ -3926,13 +3926,13 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("#8370 keys queries should support skip and limit", function () {
-      var db = new PouchDB(dbName);
+      const db = new PouchDB(dbName);
       return createView(db, {
         map: function (doc) {
           emit(doc.field);
         }
       }).then(function (queryFun) {
-        var opts = {include_docs: true};
+        const opts = {include_docs: true};
         return db.bulkDocs({
           docs: [
             { _id: "doc_0", field: 0 },

--- a/tests/mapreduce/test.mapreduce.js
+++ b/tests/mapreduce/test.mapreduce.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const viewTypes = ['persisted', 'temp'];
-viewTypes.forEach(function (viewType) {
+viewTypes.forEach((viewType) => {
   const suiteName = 'test.mapreduce.js-' + viewType;
   const adapter = testUtils.adapterType();
   const dbName = testUtils.adapterUrl(adapter, 'testdb');
@@ -12,134 +12,122 @@ viewTypes.forEach(function (viewType) {
 
 function tests(suiteName, dbName, dbType, viewType) {
 
-  describe(suiteName, function () {
+  describe(suiteName, () => {
     let createView;
     if (dbType === 'http' || viewType === 'persisted') {
-      createView = function (db, viewObj) {
+      createView = async (db, viewObj) => {
         const storableViewObj = {
-          map: viewObj.map.toString()
+          map: `${viewObj.map}`
         };
         if (viewObj.reduce) {
-          storableViewObj.reduce = viewObj.reduce.toString();
+          storableViewObj.reduce = `${viewObj.reduce}`;
         }
-        return new Promise(function (resolve, reject) {
-          db.put({
-            _id: '_design/theViewDoc',
-            views: {
-              'theView' : storableViewObj
-            }
-          }, function (err) {
-            if (err) {
-              reject(err);
-            } else {
-              resolve('theViewDoc/theView');
-            }
-          });
+
+        await db.put({
+          _id: '_design/theViewDoc',
+          views: {
+            'theView' : storableViewObj
+          }
         });
+        return 'theViewDoc/theView';
       };
     } else {
-      createView = function (db, viewObj) {
-        return new Promise(function (resolve) {
-          setTimeout(function () {
-            resolve(viewObj);
-          });
-        });
+      createView = async (db, viewObj) => {
+        await Promise.resolve();
+        return viewObj;
       };
     }
 
-    beforeEach(function () {
+    beforeEach(async () => {
       if (dbType === 'http') {
         const url = new URL(dbName);
         const dbUrl = `${url.origin}${url.pathname}`;
-        return PouchDB.fetch(dbUrl + '?q=1', {
+        await PouchDB.fetch(dbUrl + '?q=1', {
           method: 'PUT',
           headers: { Authorization: 'Basic ' + testUtils.btoa(`${url.username}:${url.password}`) },
         });
       }
     });
 
-    afterEach(function () {
-      return new PouchDB(dbName).destroy();
+    afterEach(async () => {
+      await new PouchDB(dbName).destroy();
     });
 
-    it("Test basic view", function () {
+    it("Test basic view", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const view = await createView(db, {
         map: function (doc) {
           emit(doc.foo, doc);
         }
-      }).then(function (view) {
-        return db.bulkDocs({docs: [
-          {foo: 'bar'},
-          { _id: 'volatile', foo: 'baz' }
-        ]}).then(function () {
-          return db.get('volatile');
-        }).then(function (doc) {
-          return db.remove(doc);
-        }).then(function () {
-          return db.query(view, {include_docs: true, reduce: false});
-        }).then(function (res) {
-          res.rows.should.have.length(1, 'Dont include deleted documents');
-          res.total_rows.should.equal(1, 'Include total_rows property.');
-          res.rows.forEach(function (x) {
-            should.exist(x.id);
-            should.exist(x.key);
-            should.exist(x.value);
-            should.exist(x.value._rev);
-            should.exist(x.doc);
-            should.exist(x.doc._rev);
-          });
-        });
+      });
+
+      await db.bulkDocs({docs: [
+        {foo: 'bar'},
+        { _id: 'volatile', foo: 'baz' }
+      ]});
+
+      const doc = await db.get('volatile');
+      await db.remove(doc);
+      const res = await db.query(view, {include_docs: true, reduce: false});
+
+      res.rows.should.have.length(1, 'Dont include deleted documents');
+      res.total_rows.should.equal(1, 'Include total_rows property.');
+      res.rows.forEach((x) => {
+        should.exist(x.id);
+        should.exist(x.key);
+        should.exist(x.value);
+        should.exist(x.value._rev);
+        should.exist(x.doc);
+        should.exist(x.doc._rev);
       });
     });
 
-    it("Test basic view, no emitted value", function () {
+    it("Test basic view, no emitted value", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const view = await createView(db, {
         map: function (doc) {
           emit(doc.foo);
         }
-      }).then(function (view) {
-        return db.bulkDocs({docs: [
-          {foo: 'bar'},
-          { _id: 'volatile', foo: 'baz' }
-        ]}).then(function () {
-          return db.get('volatile');
-        }).then(function (doc) {
-          return db.remove(doc);
-        }).then(function () {
-          return db.query(view, {include_docs: true, reduce: false});
-        }).then(function (res) {
-          res.rows.should.have.length(1,
-                                      'Dont include deleted documents');
-          res.total_rows.should.equal(1, 'Include total_rows property.');
-          res.rows.forEach(function (x) {
-            should.exist(x.id);
-            should.exist(x.key);
-            should.equal(x.value, null);
-            should.exist(x.doc);
-            should.exist(x.doc._rev);
-          });
-        });
+      });
+
+      await db.bulkDocs({docs: [
+        {foo: 'bar'},
+        { _id: 'volatile', foo: 'baz' }
+      ]});
+
+      const doc = await db.get('volatile');
+      await db.remove(doc);
+      const res = await db.query(view, {include_docs: true, reduce: false});
+
+      res.rows.should.have.length(1, 'Dont include deleted documents');
+      res.total_rows.should.equal(1, 'Include total_rows property.');
+      res.rows.forEach((x) => {
+        should.exist(x.id);
+        should.exist(x.key);
+        should.equal(x.value, null);
+        should.exist(x.doc);
+        should.exist(x.doc._rev);
       });
     });
 
     if (dbType === 'local' && viewType === 'temp') {
-      it("with a closure", function () {
+      it("with a closure", async () => {
         const db = new PouchDB(dbName);
-        return db.bulkDocs({docs: [
+        await db.bulkDocs({docs: [
           {foo: 'bar'},
           { _id: 'volatile', foo: 'baz' }
-        ]}).then(function () {
-          const queryFun = (function (test) {
-            return function (doc, emit) {
-              if (doc._id === test) {
-                emit(doc.foo);
-              }
-            };
-          }('volatile'));
-          return db.query(queryFun, {reduce: false});
-        }).should.become({
+        ]});
+
+        const queryFun = (function (test) {
+          return function (doc, emit) {
+            if (doc._id === test) {
+              emit(doc.foo);
+            }
+          };
+        }('volatile'));
+
+        const res =  await db.query(queryFun, {reduce: false});
+        res.should.deep.equal({
           total_rows: 1,
           offset: 0,
           rows: [
@@ -152,206 +140,195 @@ function tests(suiteName, dbName, dbType, viewType) {
         });
       });
     }
-    if (viewType === 'temp' && dbType !== 'http') {
 
-      it('Test simultaneous temp views', function () {
+    if (viewType === 'temp' && dbType !== 'http') {
+      it('Test simultaneous temp views', async () => {
         const db = new PouchDB(dbName);
-        return db.put({_id: '0', foo: 1, bar: 2, baz: 3}).then(function () {
-          return Promise.all(['foo', 'bar', 'baz'].map(function (key, i) {
-            const fun = 'function(doc){emit(doc.' + key + ');}';
-            return db.query({map: fun}).then(function (res) {
-              res.rows.should.deep.equal([{
-                id: '0',
-                key: i + 1,
-                value: null
-              }]);
-            });
-          }));
-        });
+        await db.put({_id: '0', foo: 1, bar: 2, baz: 3});
+
+        await Promise.all(['foo', 'bar', 'baz'].map(async (key, i) => {
+          const fun = 'function(doc){emit(doc.' + key + ');}';
+          const res = await db.query({map: fun});
+
+          res.rows.should.deep.equal([{
+            id: '0',
+            key: i + 1,
+            value: null
+          }]);
+        }));
       });
 
-      it("Test passing just a function", function () {
+      it("Test passing just a function", async () => {
         const db = new PouchDB(dbName);
-        return db.bulkDocs({docs: [
+        await db.bulkDocs({docs: [
           {foo: 'bar'},
           { _id: 'volatile', foo: 'baz' }
-        ]}).then(function () {
-          return db.get('volatile');
-        }).then(function (doc) {
-          return db.remove(doc);
-        }).then(function () {
-          return db.query(function (doc) {
+        ]});
+        const doc = await db.get('volatile');
+        await db.remove(doc);
+
+        const res = await db.query({
+          map: function (doc) {
             emit(doc.foo, doc);
-          }, {include_docs: true, reduce: false});
-        }).then(function (res) {
-          res.rows.should.have.length(1, 'Dont include deleted documents');
-          res.rows.forEach(function (x) {
-            should.exist(x.id);
-            should.exist(x.key);
-            should.exist(x.value);
-            should.exist(x.value._rev);
-            should.exist(x.doc);
-            should.exist(x.doc._rev);
-          });
+          }},
+          {include_docs: true, reduce: false});
+
+        res.rows.should.have.length(1, 'Dont include deleted documents');
+        res.rows.forEach((x) => {
+          should.exist(x.id);
+          should.exist(x.key);
+          should.exist(x.value);
+          should.exist(x.value._rev);
+          should.exist(x.doc);
+          should.exist(x.doc._rev);
         });
       });
     }
 
-    it("Test opts.startkey/opts.endkey", function () {
+    it("Test opts.startkey/opts.endkey", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.key, doc);
         }
-      }).then(function (queryFun) {
-        return db.bulkDocs({docs: [
-          {key: 'key1'},
-          {key: 'key2'},
-          {key: 'key3'},
-          {key: 'key4'},
-          {key: 'key5'}
-        ]}).then(function () {
-          return db.query(queryFun, {reduce: false, startkey: 'key2'});
-        }).then(function (res) {
-          res.rows.should.have.length(4, 'Startkey is inclusive');
-          return db.query(queryFun, {reduce: false, endkey: 'key3'});
-        }).then(function (res) {
-          res.rows.should.have.length(3, 'Endkey is inclusive');
-          return db.query(queryFun, {
+      });
+
+      await db.bulkDocs({docs: [
+        {key: 'key1'},
+        {key: 'key2'},
+        {key: 'key3'},
+        {key: 'key4'},
+        {key: 'key5'}]});
+
+      const resStartKey = await db.query(queryFun, {reduce: false, startkey: 'key2'});
+      resStartKey.rows.should.have.length(4, 'Startkey is inclusive');
+
+      const resEndKey = await db.query(queryFun, {reduce: false, endkey: 'key3'});
+      resEndKey.rows.should.have.length(3, 'Endkey is inclusive');
+
+      const resStartAndEndkey = await db.query(queryFun, {
             reduce: false,
             startkey: 'key2',
             endkey: 'key3'
-          });
-        }).then(function (res) {
-          res.rows.should.have.length(2, 'Startkey and endkey together');
-          return db.query(queryFun, {
+      });
+      resStartAndEndkey.rows.should.have.length(2, 'Startkey and endkey together');
+
+      const resStartEqualsEndkey = await db.query(queryFun, {
             reduce: false,
             startkey: 'key4',
             endkey: 'key4'
-          });
-        }).then(function (res) {
-          res.rows.should.have.length(1, 'Startkey=endkey');
-        });
       });
+      resStartEqualsEndkey.rows.should.have.length(1, 'Startkey=endkey');
     });
 
-    it("#4154 opts.start_key/opts.end_key are synonyms", function () {
+    it("#4154 opts.start_key/opts.end_key are synonyms", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.key, doc);
         }
-      }).then(function (queryFun) {
-        return db.bulkDocs({docs: [
-          {key: 'key1'},
-          {key: 'key2'},
-          {key: 'key3'},
-          {key: 'key4'},
-          {key: 'key5'}
-        ]}).then(function () {
-          return db.query(queryFun, {reduce: false, start_key: 'key2'});
-        }).then(function (res) {
-          res.rows.should.have.length(4, 'Startkey is inclusive');
-          return db.query(queryFun, {reduce: false, end_key: 'key3'});
-        }).then(function (res) {
-          res.rows.should.have.length(3, 'Endkey is inclusive');
-          return db.query(queryFun, {
-            reduce: false,
-            start_key: 'key2',
-            end_key: 'key3'
-          });
-        }).then(function (res) {
-          res.rows.should.have.length(2, 'Startkey and endkey together');
-          return db.query(queryFun, {
-            reduce: false,
-            start_key: 'key4',
-            end_key: 'key4'
-          });
-        }).then(function (res) {
-          res.rows.should.have.length(1, 'Startkey=endkey');
-        });
       });
+
+      await db.bulkDocs({docs: [
+        {key: 'key1'},
+        {key: 'key2'},
+        {key: 'key3'},
+        {key: 'key4'},
+        {key: 'key5'}
+      ]});
+
+      const resStartkey = await db.query(queryFun, {reduce: false, start_key: 'key2'});
+      resStartkey.rows.should.have.length(4, 'Startkey is inclusive');
+
+      const resEndKey = await db.query(queryFun, {reduce: false, end_key: 'key3'});
+      resEndKey.rows.should.have.length(3, 'Endkey is inclusive');
+
+      const resStartAndEndkey = await db.query(queryFun, {
+          reduce: false,
+          start_key: 'key2',
+          end_key: 'key3'
+      });
+      resStartAndEndkey.rows.should.have.length(2, 'Startkey and endkey together');
+
+      const resStartEqualsEndkey = await db.query(queryFun, {
+          reduce: false,
+          start_key: 'key4',
+          end_key: 'key4'
+      });
+      resStartEqualsEndkey.rows.should.have.length(1, 'Startkey=endkey');
     });
 
     //TODO: split this to their own tests within a describe block
-    it("Test opts.inclusive_end = false", function () {
+    it("Test opts.inclusive_end = false", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.key, doc);
         }
-      }).then(function (queryFun) {
-        return db.bulkDocs({docs: [
-          {key: 'key1'},
-          {key: 'key2'},
-          {key: 'key3'},
-          {key: 'key4'},
-          {key: 'key4'},
-          {key: 'key5'}
-        ]}).then(function () {
-          return db.query(queryFun, {
+      });
+
+      await db.bulkDocs({docs: [
+        {key: 'key1'},
+        {key: 'key2'},
+        {key: 'key3'},
+        {key: 'key4'},
+        {key: 'key4'},
+        {key: 'key5'}
+      ]});
+
+      const res = await db.query(queryFun, {
+          reduce: false,
+          endkey: 'key4',
+          inclusive_end: false
+      });
+      res.rows.should.have.length(3, 'endkey=key4 without ' + 'inclusive end');
+      res.rows[0].key.should.equal('key1');
+      res.rows[2].key.should.equal('key3');
+
+      const resStartKey = await db.query(queryFun, {
             reduce: false,
+            startkey: 'key3',
             endkey: 'key4',
             inclusive_end: false
-          });
-        }).then(function (resp) {
-          resp.rows.should.have.length(3, 'endkey=key4 without ' +
-                                       'inclusive end');
-          resp.rows[0].key.should.equal('key1');
-          resp.rows[2].key.should.equal('key3');
-        })
-          .then(function () {
-            return db.query(queryFun, {
-              reduce: false,
-              startkey: 'key3',
-              endkey: 'key4',
-              inclusive_end: false
-            });
-          }).then(function (resp) {
-            resp.rows.should.have.length(1, 'startkey=key3, endkey=key4 ' +
-                                         'without inclusive end');
-            resp.rows[0].key.should.equal('key3');
-          }).then(function () {
-            return db.query(queryFun, {
-              reduce: false,
-              startkey: 'key4',
-              endkey: 'key1',
-              descending: true,
-              inclusive_end: false
-            });
-          }).then(function (resp) {
-            resp.rows.should
-              .have.length(4, 'startkey=key4, endkey=key1 descending without ' +
-                           'inclusive end');
-            resp.rows[0].key.should.equal('key4');
-          });
       });
+      resStartKey.rows.should.have.length(1, 'startkey=key3, endkey=key4 ' + 'without inclusive end');
+      resStartKey.rows[0].key.should.equal('key3');
+
+      const resDescending = await db.query(queryFun, {
+            reduce: false,
+            startkey: 'key4',
+            endkey: 'key1',
+            descending: true,
+            inclusive_end: false
+      });
+      resDescending.rows.should.have.length(4, 'startkey=key4, endkey=key1 descending without ' +
+        'inclusive end');
+      resDescending.rows[0].key.should.equal('key4');
     });
 
-    it("Test opts.key", function () {
+    it("Test opts.key", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.key, doc);
         }
-      }).then(function (queryFun) {
-        return db.bulkDocs({docs: [
+      });
+
+      await db.bulkDocs({docs: [
           {key: 'key1'},
           {key: 'key2'},
           {key: 'key3'},
           {key: 'key3'}
-        ]}).then(function () {
-          return db.query(queryFun, {reduce: false, key: 'key2'});
-        }).then(function (res) {
-          res.rows.should.have.length(1, 'Doc with key');
-          return db.query(queryFun, {reduce: false, key: 'key3'});
-        }).then(function (res) {
-          res.rows.should.have.length(2, 'Multiple docs with key');
-        });
-      });
+      ]});
+
+      const resOneDoc = await db.query(queryFun, {reduce: false, key: 'key2'});
+      resOneDoc.rows.should.have.length(1, 'Doc with key');
+
+      const resMultipleDocs = await db.query(queryFun, {reduce: false, key: 'key3'});
+      resMultipleDocs.rows.should.have.length(2, 'Multiple docs with key');
     });
 
-    it("Test basic view collation", function () {
+    it("Test basic view collation", async () => {
 
       const values = [];
 
@@ -398,34 +375,32 @@ function tests(suiteName, dbName, dbType, viewType) {
       // that doesn't preserve order)
       values.push({b: 2, c: 2});
       const db = new PouchDB(dbName);
-      return createView(db, {
+
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.foo);
         }
-      }).then(function (queryFun) {
+      });
 
-        const docs = values.map(function (x, i) {
-          return {_id: (i).toString(), foo: x};
-        });
-        return db.bulkDocs({docs}).then(function () {
-          return db.query(queryFun, {reduce: false});
-        }).then(function (res) {
-          res.rows.forEach(function (x, i) {
-            JSON.stringify(x.key).should.equal(JSON.stringify(values[i]),
-                                               'keys collate');
-          });
-          return db.query(queryFun, {descending: true, reduce: false});
-        }).then(function (res) {
-          res.rows.forEach(function (x, i) {
-            JSON.stringify(x.key).should.equal(JSON.stringify(
-              values[values.length - 1 - i]),
-                                               'keys collate descending');
-          });
-        });
+      const docs = values.map((x, i) => ({_id: `${i}`, foo: x}));
+
+      await db.bulkDocs({docs});
+
+      const res = await db.query(queryFun, {reduce: false});
+
+      res.rows.forEach((x, i) => {
+        JSON.stringify(x.key).should.equal(JSON.stringify(values[i]), 'keys collate');
+      });
+
+      const resDescending = await db.query(queryFun, {descending: true, reduce: false});
+
+      resDescending.rows.forEach((x, i) => {
+        JSON.stringify(x.key).should.equal(JSON.stringify(
+          values[values.length - 1 - i]), 'keys collate descending');
       });
     });
 
-    it('Test complex key collation', function () {
+    it('Test complex key collation', async () => {
       const map = function () {
         emit(null);
         emit(false);
@@ -452,611 +427,522 @@ function tests(suiteName, dbName, dbType, viewType) {
         emit({"b":2,"a":1});
         emit({"b":2,"c":2});
       };
+
       const db = new PouchDB(dbName);
-      return db.bulkDocs([
+      await db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
-      ]).then(function () {
-        return createView(db, { map });
-      }).then(function (queryFun) {
-        return db.query(queryFun).then(function (res) {
-          const rows = res.rows.map(function (x) {
-            return {
-              id: x.id,
-              key: x.key,
-              value: x.value
-            };
-          });
-          assert.deepEqual(rows, [
-            { id: '1', key: null, value: null },
-            { id: '2', key: null, value: null },
-            { id: '1', key: false, value: null },
-            { id: '2', key: false, value: null },
-            { id: '1', key: true, value: null },
-            { id: '2', key: true, value: null },
-            { id: '1', key: 1, value: null },
-            { id: '2', key: 1, value: null },
-            { id: '1', key: 2, value: null },
-            { id: '2', key: 2, value: null },
-            { id: '1', key: 3, value: null },
-            { id: '2', key: 3, value: null },
-            { id: '1', key: 4, value: null },
-            { id: '2', key: 4, value: null },
-            { id: '1', key: 'a', value: null },
-            { id: '2', key: 'a', value: null },
-            { id: '1', key: 'aa', value: null },
-            { id: '2', key: 'aa', value: null },
-            { id: '1', key: 'b', value: null },
-            { id: '2', key: 'b', value: null },
-            { id: '1', key: 'ba', value: null },
-            { id: '2', key: 'ba', value: null },
-            { id: '1', key: 'bb', value: null },
-            { id: '2', key: 'bb', value: null },
-            { id: '1', key: [ 'a' ], value: null },
-            { id: '2', key: [ 'a' ], value: null },
-            { id: '1', key: [ 'b' ], value: null },
-            { id: '2', key: [ 'b' ], value: null },
-            { id: '1', key: [ 'b', 'c' ], value: null },
-            { id: '2', key: [ 'b', 'c' ], value: null },
-            { id: '1', key: [ 'b', 'c', 'a' ], value: null },
-            { id: '2', key: [ 'b', 'c', 'a' ], value: null },
-            { id: '1', key: [ 'b', 'd' ], value: null },
-            { id: '2', key: [ 'b', 'd' ], value: null },
-            { id: '1', key: [ 'b', 'd', 'e' ], value: null },
-            { id: '2', key: [ 'b', 'd', 'e' ], value: null },
-            { id: '1', key: { a: 1 }, value: null },
-            { id: '2', key: { a: 1 }, value: null },
-            { id: '1', key: { a: 2 }, value: null },
-            { id: '2', key: { a: 2 }, value: null },
-            { id: '1', key: { b: 1 }, value: null },
-            { id: '2', key: { b: 1 }, value: null },
-            { id: '1', key: { b: 2 }, value: null },
-            { id: '2', key: { b: 2 }, value: null },
-            { id: '1', key: { b: 2, a: 1 }, value: null },
-            { id: '2', key: { b: 2, a: 1 }, value: null },
-            { id: '1', key: { b: 2, c: 2 }, value: null },
-            { id: '2', key: { b: 2, c: 2 }, value: null }
-          ]);
-        });
-      });
+      ]);
+
+      const queryFun = await createView(db, { map });
+      const res = await db.query(queryFun);
+      const rows = mapToRows(res);
+
+      assert.deepEqual(rows, [
+        { id: '1', key: null, value: null },
+        { id: '2', key: null, value: null },
+        { id: '1', key: false, value: null },
+        { id: '2', key: false, value: null },
+        { id: '1', key: true, value: null },
+        { id: '2', key: true, value: null },
+        { id: '1', key: 1, value: null },
+        { id: '2', key: 1, value: null },
+        { id: '1', key: 2, value: null },
+        { id: '2', key: 2, value: null },
+        { id: '1', key: 3, value: null },
+        { id: '2', key: 3, value: null },
+        { id: '1', key: 4, value: null },
+        { id: '2', key: 4, value: null },
+        { id: '1', key: 'a', value: null },
+        { id: '2', key: 'a', value: null },
+        { id: '1', key: 'aa', value: null },
+        { id: '2', key: 'aa', value: null },
+        { id: '1', key: 'b', value: null },
+        { id: '2', key: 'b', value: null },
+        { id: '1', key: 'ba', value: null },
+        { id: '2', key: 'ba', value: null },
+        { id: '1', key: 'bb', value: null },
+        { id: '2', key: 'bb', value: null },
+        { id: '1', key: [ 'a' ], value: null },
+        { id: '2', key: [ 'a' ], value: null },
+        { id: '1', key: [ 'b' ], value: null },
+        { id: '2', key: [ 'b' ], value: null },
+        { id: '1', key: [ 'b', 'c' ], value: null },
+        { id: '2', key: [ 'b', 'c' ], value: null },
+        { id: '1', key: [ 'b', 'c', 'a' ], value: null },
+        { id: '2', key: [ 'b', 'c', 'a' ], value: null },
+        { id: '1', key: [ 'b', 'd' ], value: null },
+        { id: '2', key: [ 'b', 'd' ], value: null },
+        { id: '1', key: [ 'b', 'd', 'e' ], value: null },
+        { id: '2', key: [ 'b', 'd', 'e' ], value: null },
+        { id: '1', key: { a: 1 }, value: null },
+        { id: '2', key: { a: 1 }, value: null },
+        { id: '1', key: { a: 2 }, value: null },
+        { id: '2', key: { a: 2 }, value: null },
+        { id: '1', key: { b: 1 }, value: null },
+        { id: '2', key: { b: 1 }, value: null },
+        { id: '1', key: { b: 2 }, value: null },
+        { id: '2', key: { b: 2 }, value: null },
+        { id: '1', key: { b: 2, a: 1 }, value: null },
+        { id: '2', key: { b: 2, a: 1 }, value: null },
+        { id: '1', key: { b: 2, c: 2 }, value: null },
+        { id: '2', key: { b: 2, c: 2 }, value: null }
+      ]);
     });
 
-    it('Test duplicate collation of objects', function () {
+    it('Test duplicate collation of objects', async () => {
       const db = new PouchDB(dbName);
-      return db.bulkDocs([
+      await db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
-      ]).then(function () {
-        return createView(db, {
-          map: function () {
-            emit({ a: 'a' }, { b: 'b' });
-            emit({ a: 'a' }, { b: 'b' });
-          }
-        });
-      }).then(function (queryFun) {
-        return db.query(queryFun).then(function (res) {
-          const rows = res.rows.map(function (x) {
-            return {
-              id: x.id,
-              key: x.key,
-              value: x.value
-            };
-          });
-          assert.deepEqual(rows, [
-            { "id": "1", "key": { "a": "a" }, "value": { b: 'b' }},
-            { "id": "1", "key": { "a": "a" }, "value": { b: 'b' }},
-            { "id": "2", "key": { "a": "a" }, "value": { b: 'b' }},
-            { "id": "2", "key": { "a": "a" }, "value": { b: 'b' }}
-          ]);
-        });
+      ]);
+
+      const queryFun = await createView(db, {
+        map: function () {
+          emit({ a: 'a' }, { b: 'b' });
+          emit({ a: 'a' }, { b: 'b' });
+        }
       });
+
+      const res = await db.query(queryFun);
+      const rows = mapToRows(res);
+
+      assert.deepEqual(rows, [
+        { "id": "1", "key": { "a": "a" }, "value": { b: 'b' }},
+        { "id": "1", "key": { "a": "a" }, "value": { b: 'b' }},
+        { "id": "2", "key": { "a": "a" }, "value": { b: 'b' }},
+        { "id": "2", "key": { "a": "a" }, "value": { b: 'b' }}
+      ]);
     });
 
-    it('Test collation of undefined/null', function () {
+    it('Test collation of undefined/null', async () => {
       const db = new PouchDB(dbName);
-      return db.bulkDocs([
+      await db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
-      ]).then(function () {
-        return createView(db, {
-          map: function () {
-            emit();
-            emit(null);
-          }
-        });
-      }).then(function (queryFun) {
-        return db.query(queryFun).then(function (res) {
-          const rows = res.rows.map(function (x) {
-            return {
-              id: x.id,
-              key: x.key,
-              value: x.value
-            };
-          });
-          assert.deepEqual(rows, [
-            { "id": "1", "key": null, "value": null},
-            { "id": "1", "key": null, "value": null},
-            { "id": "2", "key": null, "value": null},
-            { "id": "2", "key": null, "value": null}
-          ]);
-        });
+      ]);
+
+      const queryFun = await createView(db, {
+        map: function () {
+          emit();
+          emit(null);
+        }
       });
+
+      const res = await db.query(queryFun);
+      const rows = mapToRows(res);
+
+      assert.deepEqual(rows, [
+        { "id": "1", "key": null, "value": null},
+        { "id": "1", "key": null, "value": null},
+        { "id": "2", "key": null, "value": null},
+        { "id": "2", "key": null, "value": null}
+      ]);
     });
 
-    it('Test collation of null/undefined', function () {
+    it('Test collation of null/undefined', async () => {
       const db = new PouchDB(dbName);
-      return db.bulkDocs([
+      await db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
-      ]).then(function () {
-        return createView(db, {
-          map: function () {
-            emit(null);
-            emit();
-          }
-        });
-      }).then(function (queryFun) {
-        return db.query(queryFun).then(function (res) {
-          const rows = res.rows.map(function (x) {
-            return {
-              id: x.id,
-              key: x.key,
-              value: x.value
-            };
-          });
-          assert.deepEqual(rows, [
-            { "id": "1", "key": null, "value": null},
-            { "id": "1", "key": null, "value": null},
-            { "id": "2", "key": null, "value": null},
-            { "id": "2", "key": null, "value": null}
-          ]);
-        });
+      ]);
+      const queryFun = await createView(db, {
+        map: function () {
+          emit(null);
+          emit();
+        }
       });
+
+      const res = await db.query(queryFun);
+      const rows = mapToRows(res);
+
+      assert.deepEqual(rows, [
+        { "id": "1", "key": null, "value": null},
+        { "id": "1", "key": null, "value": null},
+        { "id": "2", "key": null, "value": null},
+        { "id": "2", "key": null, "value": null}
+      ]);
     });
 
-    it('Test duplicate collation of nulls', function () {
+    it('Test duplicate collation of nulls', async () => {
       const db = new PouchDB(dbName);
-      return db.bulkDocs([
+      await db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
-      ]).then(function () {
-        return createView(db, {
-          map: function () {
-            emit(null);
-            emit(null);
-          }
-        });
-      }).then(function (queryFun) {
-        return db.query(queryFun).then(function (res) {
-          const rows = res.rows.map(function (x) {
-            return {
-              id: x.id,
-              key: x.key,
-              value: x.value
-            };
-          });
-          assert.deepEqual(rows, [
-            { "id": "1", "key": null, "value": null},
-            { "id": "1", "key": null, "value": null},
-            { "id": "2", "key": null, "value": null},
-            { "id": "2", "key": null, "value": null}
-          ]);
-        });
+      ]);
+      const queryFun = await createView(db, {
+        map: function () {
+          emit(null);
+          emit(null);
+        }
       });
+
+      const res = await db.query(queryFun);
+      const rows = mapToRows(res);
+
+      assert.deepEqual(rows, [
+        { "id": "1", "key": null, "value": null},
+        { "id": "1", "key": null, "value": null},
+        { "id": "2", "key": null, "value": null},
+        { "id": "2", "key": null, "value": null}
+      ]);
     });
 
-    it('Test duplicate collation of booleans', function () {
+    it('Test duplicate collation of booleans', async () => {
       const db = new PouchDB(dbName);
-      return db.bulkDocs([
+      await db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
-      ]).then(function () {
-        return createView(db, {
-          map: function () {
-            emit(true);
-            emit(true);
-          }
-        });
-      }).then(function (queryFun) {
-        return db.query(queryFun).then(function (res) {
-          const rows = res.rows.map(function (x) {
-            return {
-              id: x.id,
-              key: x.key,
-              value: x.value
-            };
-          });
-          assert.deepEqual(rows, [
-            { "id": "1", "key": true, "value": null},
-            { "id": "1", "key": true, "value": null},
-            { "id": "2", "key": true, "value": null},
-            { "id": "2", "key": true, "value": null}
-          ]);
-        });
+      ]);
+
+      const queryFun = await createView(db, {
+        map: function () {
+          emit(true);
+          emit(true);
+        }
       });
+
+      const res = await db.query(queryFun);
+      const rows = mapToRows(res);
+
+      assert.deepEqual(rows, [
+        { "id": "1", "key": true, "value": null},
+        { "id": "1", "key": true, "value": null},
+        { "id": "2", "key": true, "value": null},
+        { "id": "2", "key": true, "value": null}
+      ]);
     });
 
-    it('Test collation of different objects', function () {
+    it('Test collation of different objects', async () => {
       const db = new PouchDB(dbName);
-      return db.bulkDocs([
+      await db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
-      ]).then(function () {
-        return createView(db, {
-          map: function () {
-            emit({ a: 'b' }, { a: 'a' });
-            emit({ a: 'a' }, { b: 'b' });
-          }
-        });
-      }).then(function (queryFun) {
-        return db.query(queryFun).then(function (res) {
-          const rows = res.rows.map(function (x) {
-            return {
-              id: x.id,
-              key: x.key,
-              value: x.value
-            };
-          });
-          assert.deepEqual(rows, [
-            { "id": "1", "key": { "a": "a" }, "value": { "b": "b" } },
-            { "id": "2", "key": { "a": "a" }, "value": { "b": "b" } },
-            { "id": "1", "key": { "a": "b" }, "value": { "a": "a" } },
-            { "id": "2", "key": { "a": "b" }, "value": { "a": "a" } }
-          ]);
-        });
+      ]);
+
+      const queryFun = await createView(db, {
+        map: function () {
+          emit({ a: 'b' }, { a: 'a' });
+          emit({ a: 'a' }, { b: 'b' });
+        }
       });
+
+      const res = await db.query(queryFun);
+      const rows = mapToRows(res);
+
+      assert.deepEqual(rows, [
+        { "id": "1", "key": { "a": "a" }, "value": { "b": "b" } },
+        { "id": "2", "key": { "a": "a" }, "value": { "b": "b" } },
+        { "id": "1", "key": { "a": "b" }, "value": { "a": "a" } },
+        { "id": "2", "key": { "a": "b" }, "value": { "a": "a" } }
+      ]);
     });
 
-    it('Test collation of different objects 2', function () {
+    it('Test collation of different objects 2', async () => {
       const db = new PouchDB(dbName);
-      return db.bulkDocs([
+      await db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
-      ]).then(function () {
-        return createView(db, {
-          map: function () {
-            emit({ a: 'b', b: 'c' }, { a: 'a' });
-            emit({ a: 'a' }, { b: 'b' });
-          }
-        });
-      }).then(function (queryFun) {
-        return db.query(queryFun).then(function (res) {
-          const rows = res.rows.map(function (x) {
-            return {
-              id: x.id,
-              key: x.key,
-              value: x.value
-            };
-          });
-          assert.deepEqual(rows, [
-            { "id": "1", "key": { "a": "a" }, "value": { "b": "b" } },
-            { "id": "2", "key": { "a": "a" }, "value": { "b": "b" } },
-            { "id": "1", "key": { "a": "b", "b": "c" }, "value": { "a": "a" } },
-            { "id": "2", "key": { "a": "b", "b": "c" }, "value": { "a": "a" } }
-          ]);
-        });
+      ]);
+
+      const queryFun =  await createView(db, {
+        map: function () {
+          emit({ a: 'b', b: 'c' }, { a: 'a' });
+          emit({ a: 'a' }, { b: 'b' });
+        }
       });
+
+      const res = await db.query(queryFun);
+      const rows = mapToRows(res);
+
+      assert.deepEqual(rows, [
+        { "id": "1", "key": { "a": "a" }, "value": { "b": "b" } },
+        { "id": "2", "key": { "a": "a" }, "value": { "b": "b" } },
+        { "id": "1", "key": { "a": "b", "b": "c" }, "value": { "a": "a" } },
+        { "id": "2", "key": { "a": "b", "b": "c" }, "value": { "a": "a" } }
+      ]);
     });
 
-    it('Test collation of different objects 3', function () {
+    it('Test collation of different objects 3', async () => {
       const db = new PouchDB(dbName);
-      return db.bulkDocs([
+      await db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
-      ]).then(function () {
-        return createView(db, {
-          map: function () {
-            emit({ a: 'a' }, { b: 'b' });
-            emit({ a: 'b'}, { a: 'a' });
-          }
-        });
-      }).then(function (queryFun) {
-        return db.query(queryFun).then(function (res) {
-          const rows = res.rows.map(function (x) {
-            return {
-              id: x.id,
-              key: x.key,
-              value: x.value
-            };
-          });
-          assert.deepEqual(rows, [
-            { "id": "1", "key": { "a": "a" }, "value": { "b": "b" } },
-            { "id": "2", "key": { "a": "a" }, "value": { "b": "b" } },
-            { "id": "1", "key": { "a": "b" }, "value": { "a": "a" } },
-            { "id": "2", "key": { "a": "b" }, "value": { "a": "a" } }
-          ]);
-        });
+      ]);
+
+      const queryFun = await createView(db, {
+        map: function () {
+          emit({ a: 'a' }, { b: 'b' });
+          emit({ a: 'b'}, { a: 'a' });
+        }
       });
+
+      const res = await db.query(queryFun);
+      const rows = mapToRows(res);
+
+      assert.deepEqual(rows, [
+        { "id": "1", "key": { "a": "a" }, "value": { "b": "b" } },
+        { "id": "2", "key": { "a": "a" }, "value": { "b": "b" } },
+        { "id": "1", "key": { "a": "b" }, "value": { "a": "a" } },
+        { "id": "2", "key": { "a": "b" }, "value": { "a": "a" } }
+      ]);
     });
 
-    it('Test collation of different objects 4', function () {
+    it('Test collation of different objects 4', async () => {
       const db = new PouchDB(dbName);
-      return db.bulkDocs([
+      await db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
-      ]).then(function () {
-        return createView(db, {
-          map: function () {
-            emit({ a: 'a'});
-            emit({ b: 'b'});
-          }
-        });
-      }).then(function (queryFun) {
-        return db.query(queryFun).then(function (res) {
-          const rows = res.rows.map(function (x) {
-            return {
-              id: x.id,
-              key: x.key,
-              value: x.value
-            };
-          });
-          assert.deepEqual(rows, [
-            { "id": "1", "key": { "a": "a" }, "value": null },
-            { "id": "2", "key": { "a": "a" }, "value": null },
-            { "id": "1", "key": { "b": "b" }, "value": null },
-            { "id": "2", "key": { "b": "b" }, "value": null }
-          ]);
-        });
+      ]);
+
+      const queryFun = await createView(db, {
+        map: function () {
+          emit({ a: 'a'});
+          emit({ b: 'b'});
+        }
       });
+
+      const res = await db.query(queryFun);
+      const rows = mapToRows(res);
+
+      assert.deepEqual(rows, [
+        { "id": "1", "key": { "a": "a" }, "value": null },
+        { "id": "2", "key": { "a": "a" }, "value": null },
+        { "id": "1", "key": { "b": "b" }, "value": null },
+        { "id": "2", "key": { "b": "b" }, "value": null }
+      ]);
     });
 
-    it('Test collation of different objects 5', function () {
+    it('Test collation of different objects 5', async () => {
       const db = new PouchDB(dbName);
-      return db.bulkDocs([
+      await db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
-      ]).then(function () {
-        return createView(db, {
-          map: function () {
-            emit({ a: 'a'});
-            emit({ a: 'a', b: 'b'});
-          }
-        });
-      }).then(function (queryFun) {
-        return db.query(queryFun).then(function (res) {
-          const rows = res.rows.map(function (x) {
-            return {
-              id: x.id,
-              key: x.key,
-              value: x.value
-            };
-          });
-          assert.deepEqual(rows, [
-            { "id": "1", "key": { "a": "a" }, "value": null },
-            { "id": "2", "key": { "a": "a" }, "value": null },
-            { "id": "1", "key": { "a": "a", "b": "b" }, "value": null },
-            { "id": "2", "key": { "a": "a", "b": "b" }, "value": null }
-          ]);
-        });
+      ]);
+
+      const queryFun = await createView(db, {
+        map: function () {
+          emit({ a: 'a'});
+          emit({ a: 'a', b: 'b'});
+        }
       });
+
+      const res = await db.query(queryFun);
+      const rows = mapToRows(res);
+
+      assert.deepEqual(rows, [
+        { "id": "1", "key": { "a": "a" }, "value": null },
+        { "id": "2", "key": { "a": "a" }, "value": null },
+        { "id": "1", "key": { "a": "a", "b": "b" }, "value": null },
+        { "id": "2", "key": { "a": "a", "b": "b" }, "value": null }
+      ]);
     });
 
-    it('Test collation of different objects 6', function () {
+    it('Test collation of different objects 6', async () => {
       const db = new PouchDB(dbName);
-      return db.bulkDocs([
+      await db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
-      ]).then(function () {
-        return createView(db, {
-          map: function () {
-            emit({ a: 'a'});
-            emit({ a: 'a', b: 'b'});
-          }
-        });
-      }).then(function (queryFun) {
-        return db.query(queryFun).then(function (res) {
-          const rows = res.rows.map(function (x) {
-            return {
-              id: x.id,
-              key: x.key,
-              value: x.value
-            };
-          });
-          assert.deepEqual(rows, [
-            { "id": "1", "key": { "a": "a" }, "value": null },
-            { "id": "2", "key": { "a": "a" }, "value": null },
-            { "id": "1", "key": { "a": "a", "b": "b" }, "value": null },
-            { "id": "2", "key": { "a": "a", "b": "b" }, "value": null }
-          ]);
-        });
+      ]);
+
+      const queryFun = await createView(db, {
+        map: function () {
+          emit({ a: 'a'});
+          emit({ a: 'a', b: 'b'});
+        }
       });
+
+      const res = await db.query(queryFun);
+      const rows = mapToRows(res);
+
+      assert.deepEqual(rows, [
+        { "id": "1", "key": { "a": "a" }, "value": null },
+        { "id": "2", "key": { "a": "a" }, "value": null },
+        { "id": "1", "key": { "a": "a", "b": "b" }, "value": null },
+        { "id": "2", "key": { "a": "a", "b": "b" }, "value": null }
+      ]);
     });
 
-    it('Test collation of different booleans', function () {
+    it('Test collation of different booleans', async () => {
       const db = new PouchDB(dbName);
-      return db.bulkDocs([
+      await db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
-      ]).then(function () {
-        return createView(db, {
-          map: function () {
-            emit(true);
-            emit(false);
-          }
-        });
-      }).then(function (queryFun) {
-        return db.query(queryFun).then(function (res) {
-          const rows = res.rows.map(function (x) {
-            return {
-              id: x.id,
-              key: x.key,
-              value: x.value
-            };
-          });
-          assert.deepEqual(rows, [
-            { "id": "1", "key": false, "value": null },
-            { "id": "2", "key": false, "value": null },
-            { "id": "1", "key": true, "value": null },
-            { "id": "2", "key": true, "value": null }
-          ]);
-        });
+      ]);
+
+      const queryFun = await createView(db, {
+        map: function () {
+          emit(true);
+          emit(false);
+        }
       });
+
+      const res = await db.query(queryFun);
+      const rows = mapToRows(res);
+
+      assert.deepEqual(rows, [
+        { "id": "1", "key": false, "value": null },
+        { "id": "2", "key": false, "value": null },
+        { "id": "1", "key": true, "value": null },
+        { "id": "2", "key": true, "value": null }
+      ]);
     });
 
-    it('Test collation of different booleans 2', function () {
+    it('Test collation of different booleans 2', async () => {
       const db = new PouchDB(dbName);
-      return db.bulkDocs([
+      await db.bulkDocs([
         { _id: '1' },
         { _id: '2' }
-      ]).then(function () {
-        return createView(db, {
-          map: function () {
-            emit(false);
-            emit(true);
-          }
-        });
-      }).then(function (queryFun) {
-        return db.query(queryFun).then(function (res) {
-          const rows = res.rows.map(function (x) {
-            return {
-              id: x.id,
-              key: x.key,
-              value: x.value
-            };
-          });
-          assert.deepEqual(rows, [
-            { "id": "1", "key": false, "value": null },
-            { "id": "2", "key": false, "value": null },
-            { "id": "1", "key": true, "value": null },
-            { "id": "2", "key": true, "value": null }
-          ]);
-        });
+      ]);
+
+      const queryFun = await createView(db, {
+        map: function () {
+          emit(false);
+          emit(true);
+        }
       });
+
+      const res = await db.query(queryFun);
+      const rows = mapToRows(res);
+
+      assert.deepEqual(rows, [
+        { "id": "1", "key": false, "value": null },
+        { "id": "2", "key": false, "value": null },
+        { "id": "1", "key": true, "value": null },
+        { "id": "2", "key": true, "value": null }
+      ]);
     });
 
-    it("Test joins", function () {
+    it("Test joins", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           if (doc.doc_id) {
             emit(doc._id, {_id: doc.doc_id});
           }
         }
-      }).then(function (queryFun) {
-        return db.bulkDocs({docs: [
-          {_id: 'mydoc', foo: 'bar'},
-          { doc_id: 'mydoc' }
-        ]}).then(function () {
-          return db.query(queryFun, {include_docs: true, reduce: false});
-        }).then(function (res) {
-          should.exist(res.rows[0].doc);
-          return res.rows[0].doc._id;
-        });
-      }).should.become('mydoc', 'mydoc included');
+      });
+
+      await db.bulkDocs({docs: [
+        {_id: 'mydoc', foo: 'bar'},
+        { doc_id: 'mydoc' }
+      ]});
+
+      const res = await db.query(queryFun, {include_docs: true, reduce: false});
+
+      should.exist(res.rows[0].doc);
+      res.rows[0].doc._id.should.equal('mydoc', 'mydoc included');
     });
 
-    it("No reduce function", function () {
+    it("No reduce function", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function () {
           emit('key', 'val');
         }
-      }).then(function (queryFun) {
-        return db.post({foo: 'bar'}).then(function () {
-          return db.query(queryFun);
-        });
-      }).should.be.fulfilled;
+      });
+
+      await db.post({foo: 'bar'});
+
+      await db.query(queryFun).should.be.fulfilled;
     });
 
-    it("Query after db.close", function () {
-      let db = new PouchDB(dbName);
-      return createView(db, {
+    it("Query after db.close", async () => {
+      const db = new PouchDB(dbName);
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.foo, 'val');
         }
-      }).then(function (queryFun) {
-        return db.put({_id: 'doc', foo: 'bar'}).then(function () {
-          return db.query(queryFun);
-        }).then(function (res) {
-          res.rows.should.deep.equal([
-            {
-              id: 'doc',
-              key: 'bar',
-              value: 'val'
-            }
-          ]);
-          return db.close();
-        }).then(function () {
-          db = new PouchDB(dbName);
-          return db.query(queryFun).then(function (res) {
-            res.rows.should.deep.equal([
-              {
-                id: 'doc',
-                key: 'bar',
-                value: 'val'
-              }
-            ]);
-          });
-        });
       });
+
+      await db.put({_id: 'doc', foo: 'bar'});
+      const res = await db.query(queryFun);
+
+      res.rows.should.deep.equal([
+        {
+          id: 'doc',
+          key: 'bar',
+          value: 'val'
+        }
+      ]);
+
+      await db.close();
+      const dbReopened = new PouchDB(dbName);
+
+      const resAfterClosingDb = await dbReopened.query(queryFun);
+      resAfterClosingDb.rows.should.deep.equal([
+        {
+          id: 'doc',
+          key: 'bar',
+          value: 'val'
+        }
+      ]);
     });
 
-    it("Built in _sum reduce function", function () {
+    it("Built in _sum reduce function", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.val, 1);
         },
         reduce: "_sum"
-      }).then(function (queryFun) {
-        return db.bulkDocs({
-          docs: [
-            { val: 'bar' },
-            { val: 'bar' },
-            { val: 'baz' }
-          ]
-        }).then(function () {
-          return db.query(queryFun, {reduce: true, group_level: 999});
-        }).then(function (resp) {
-          return resp.rows.map(function (row) {
-            return row.value;
-          });
-        });
-      }).should.become([2, 1]);
+      });
+
+      await db.bulkDocs({
+        docs: [
+          { val: 'bar' },
+          { val: 'bar' },
+          { val: 'baz' }
+        ]
+      });
+
+      const res = await db.query(queryFun, {reduce: true, group_level: 999});
+      const mapped = res.rows.map(row => row.value);
+
+      mapped.should.deep.equal([2, 1]);
     });
 
-    it("Built in _count reduce function", function () {
+    it("Built in _count reduce function", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.val, doc.val);
         },
         reduce: "_count"
-      }).then(function (queryFun) {
-        return db.bulkDocs({
-          docs: [
-            { val: 'bar' },
-            { val: 'bar' },
-            { val: 'baz' }
-          ]
-        }).then(function () {
-          return db.query(queryFun, {reduce: true, group_level: 999});
-        }).then(function (resp) {
-          return resp.rows.map(function (row) {
-            return row.value;
-          });
-        });
-      }).should.become([2, 1]);
+      });
+
+      await db.bulkDocs({
+        docs: [
+          { val: 'bar' },
+          { val: 'bar' },
+          { val: 'baz' }
+        ]
+      });
+
+      const res = await db.query(queryFun, {reduce: true, group_level: 999});
+      const mapped = res.rows.map(row => row.value);
+
+      mapped.should.deep.equal([2,1]);
     });
 
-    it("Built in _stats reduce function", function () {
+    it("Built in _stats reduce function", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: "function(doc){emit(doc.val, 1);}",
         reduce: "_stats"
-      }).then(function (queryFun) {
-        return db.bulkDocs({
-          docs: [
-            { val: 'bar' },
-            { val: 'bar' },
-            { val: 'baz' }
-          ]
-        }).then(function () {
-          return db.query(queryFun, {reduce: true, group_level: 999});
-        }).then(function (res) {
-          return res.rows[0].value;
-        });
-      }).should.become({
+      });
+
+      await db.bulkDocs({
+        docs: [
+          { val: 'bar' },
+          { val: 'bar' },
+          { val: 'baz' }
+        ]
+      });
+
+      const res =  await db.query(queryFun, {reduce: true, group_level: 999});
+
+      res.rows[0].value.should.deep.equal({
         sum: 2,
         count: 2,
         min: 1,
@@ -1065,24 +951,24 @@ function tests(suiteName, dbName, dbType, viewType) {
       });
     });
 
-    it("Built in _stats reduce function can be used with lists of numbers", function () {
+    it("Built in _stats reduce function can be used with lists of numbers", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: "function(doc){emit(null, doc.val);}",
         reduce: "_stats"
-      }).then(function (queryFun) {
-        return db.bulkDocs({
+      });
+
+      await db.bulkDocs({
           docs: [
             { _id: '1', val: [1, 2, 3] },
             { _id: '2', val: [4, 5, 6] },
             { _id: '3', val: [7, 8, 9] },
           ]
-        }).then(function () {
-          return db.query(queryFun, {reduce: true, group_level: 999});
-        }).then(function (res) {
-          return res.rows[0].value;
         });
-      }).should.become([
+
+      const res = await db.query(queryFun, {reduce: true, group_level: 999});
+
+      res.rows[0].value.should.deep.equal([
         { sum: 12, count: 3, min: 1, max: 7, sumsqr: 66  },
         { sum: 15, count: 3, min: 2, max: 8, sumsqr: 93  },
         { sum: 18, count: 3, min: 3, max: 9, sumsqr: 126 }
@@ -1090,187 +976,189 @@ function tests(suiteName, dbName, dbType, viewType) {
     });
 
     it("Built in _stats reduce function should throw an error when confronted with strings",
-      function () {
-      const db = new PouchDB(dbName);
-      return createView(db, {
-        map: "function(doc){emit(doc.val, 'lala');}",
-        reduce: "_stats"
-      }).then(function (queryFun) {
-        return db.bulkDocs({
+      async () => {
+        const db = new PouchDB(dbName);
+        const queryFun = await createView(db, {
+          map: "function(doc){emit(doc.val, 'lala');}",
+          reduce: "_stats"
+        });
+
+        await db.bulkDocs({
           docs: [
             { val: 'bar' },
             { val: 'bar' },
             { val: 'baz' }
           ]
-        }).then(function () {
-          return db.query(queryFun, {reduce: true, group_level: 999});
         });
-      }).should.be.rejected;
+
+        await db.query(queryFun, {reduce: true, group_level: 999}).should.be.rejected;
     });
 
     it("Built in _stats reduce function should throw an error when confronted with a mix of numbers and arrays",
-      function () {
-      const db = new PouchDB(dbName);
-      return createView(db, {
-        map: "function(doc){emit(null, doc.val);}",
-        reduce: "_stats"
-      }).then(function (queryFun) {
-        return db.bulkDocs({
+      async () => {
+        const db = new PouchDB(dbName);
+        const queryFun = await createView(db, {
+          map: "function(doc){emit(null, doc.val);}",
+          reduce: "_stats"
+        });
+
+        await db.bulkDocs({
           docs: [
             { _id: '1', val: [1, 2, 3] },
             { _id: '2', val: 4 }
           ]
-        }).then(function () {
-          return db.query(queryFun, {reduce: true, group_level: 999});
         });
-      }).should.be.rejected;
+
+        await db.query(queryFun, {reduce: true, group_level: 999}).should.be.rejected;
     });
 
     it("Built in _stats reduce function should throw an error when confronted with arrays of inconsistent length",
-      function () {
-      const db = new PouchDB(dbName);
-      return createView(db, {
-        map: "function(doc){emit(null, doc.val);}",
-        reduce: "_stats"
-      }).then(function (queryFun) {
-        return db.bulkDocs({
+      async () => {
+        const db = new PouchDB(dbName);
+        const queryFun = await createView(db, {
+          map: "function(doc){emit(null, doc.val);}",
+          reduce: "_stats"
+        });
+
+        await db.bulkDocs({
           docs: [
             { _id: '1', val: [1, 2, 3] },
             { _id: '2', val: [1, 2] }
           ]
-        }).then(function () {
-          return db.query(queryFun, {reduce: true, group_level: 999});
         });
-      }).should.be.rejected;
+
+        await db.query(queryFun, {reduce: true, group_level: 999}).should.be.rejected;
     });
 
-    it("Built in _sum reduce function should throw an error with a promise",
-      function () {
+    it("Built in _sum reduce function should throw an error with a promise", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: "function(doc){emit(null, doc.val);}",
         reduce: "_sum"
-      }).then(function (queryFun) {
-        return db.bulkDocs({
-          docs: [
-            { val: 1 },
-            { val: 2 },
-            { val: 'baz' }
-          ]
-        }).then(function () {
-          return db.query(queryFun, {reduce: true, group: true});
-        });
-      }).should.be.rejected;
-    });
-
-    it("Built in _sum reduce function with num arrays should throw an error",
-      function () {
-      const db = new PouchDB(dbName);
-      return createView(db, {
-        map: "function(doc){emit(null, doc.val);}",
-        reduce: "_sum"
-      }).then(function (queryFun) {
-        return db.bulkDocs({
-          docs: [
-            { val: [1, 2, 3] },
-            { val: 2 },
-            { val: ['baz']}
-          ]
-        }).then(function () {
-          return db.query(queryFun, {reduce: true, group: true});
-        });
-      }).should.be.rejected;
-    });
-
-    it("Built in _sum can be used with lists of numbers", function () {
-      const db = new PouchDB(dbName);
-      return createView(db, {
-        map: "function(doc){emit(null, doc.val);}",
-        reduce: "_sum"
-      }).then(function (queryFun) {
-        return db.bulkDocs({
-          docs: [
-            { _id: '1', val: 2 },
-            { _id: '2', val: [1, 2, 3, 4] },
-            { _id: '3', val: [3, 4] },
-            { _id: '4', val: 1 }
-          ]
-        }).then(function () {
-          return db.query(queryFun, {reduce: true, group: true});
-        }).then(function (res) {
-          res.should.deep.equal({rows : [{
-            key : null,
-            value : [7, 6, 3, 4]
-          }]});
-        });
       });
+
+      await db.bulkDocs({
+        docs: [
+          { val: 1 },
+          { val: 2 },
+          { val: 'baz' }
+        ]
+      });
+
+      await db.query(queryFun, {reduce: true, group: true}).should.be.rejected;
     });
 
-    it("#6364 Recognize built in reduce functions with trailing garbage", function () {
+    it("Built in _sum reduce function with num arrays should throw an error", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
+        map: "function(doc){emit(null, doc.val);}",
+        reduce: "_sum"
+      });
+
+      await db.bulkDocs({
+        docs: [
+          { val: [1, 2, 3] },
+          { val: 2 },
+          { val: ['baz']}
+        ]
+      });
+
+      await db.query(queryFun, {reduce: true, group: true}).should.be.rejected;
+    });
+
+    it("Built in _sum can be used with lists of numbers", async () => {
+      const db = new PouchDB(dbName);
+      const queryFun = await createView(db, {
+        map: "function(doc){emit(null, doc.val);}",
+        reduce: "_sum"
+      });
+
+      await db.bulkDocs({
+        docs: [
+          { _id: '1', val: 2 },
+          { _id: '2', val: [1, 2, 3, 4] },
+          { _id: '3', val: [3, 4] },
+          { _id: '4', val: 1 }
+        ]
+      });
+
+      const res = await db.query(queryFun, {reduce: true, group: true});
+
+      res.should.deep.equal({rows : [{
+        key : null,
+        value : [7, 6, 3, 4]
+      }]});
+    });
+
+    it("#6364 Recognize built in reduce functions with trailing garbage", async () => {
+      const db = new PouchDB(dbName);
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.val, 1);
         },
         reduce: "_sum\n \r\nandothergarbage"
-      }).then(function (queryFun) {
-        return db.bulkDocs({
-          docs: [
-            { val: 'bar' },
-            { val: 'bar' },
-            { val: 'baz' }
-          ]
-        }).then(function () {
-          return db.query(queryFun, {reduce: true, group_level: 999});
-        }).then(function (resp) {
-          return resp.rows.map(function (row) {
-            return row.value;
-          });
-        });
-      }).should.become([2, 1]);
+      });
+
+      await db.bulkDocs({
+        docs: [
+          { val: 'bar' },
+          { val: 'bar' },
+          { val: 'baz' }
+        ]
+      });
+
+      const res =  await db.query(queryFun, {reduce: true, group_level: 999});
+      const mapped = res.rows.map(row => row.value);
+
+      mapped.should.deep.equal([2, 1]);
     });
 
-    it("Starts with _ but not a built in reduce function should throw",
-      function () {
+    it("Starts with _ but not a built in reduce function should throw", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
-        map: "function(doc){emit(null, doc.val);}",
-        reduce: "_product"
-      }).then(function (queryFun) {
-        return db.bulkDocs({
-          docs: [
-            { val: 1 },
-            { val: 2 },
-            { val: 3 }
-          ]
-        }).then(function () {
-          return db.query(queryFun, {reduce: true, group: true});
+      await db.bulkDocs({
+        docs: [
+          { val: 1 },
+          { val: 2 },
+          { val: 3 }
+        ]
+      });
+
+      try {
+        const queryFun = await createView(db, {
+          map: "function(doc){emit(null, doc.val);}",
+          reduce: "_product"
         });
-      }).should.be.rejected;
+        await db.query(queryFun, {reduce: true, group: true});
+        throw new Error('should fail');
+      } catch (err) {
+        err.message.should.include('_product');
+      }
     });
 
     if (viewType === 'temp' && dbType !== 'http') {
-      it("No reduce function, passing just a function", function () {
+      it("No reduce function, passing just a function", async () => {
         const db = new PouchDB(dbName);
-        return db.post({foo: 'bar'}).then(function () {
-          const queryFun = function () {
-            emit('key', 'val');
-          };
-          return db.query(queryFun);
-        }).should.be.fulfilled;
+        await db.post({foo: 'bar'});
+
+        const queryFun = function () {
+          emit('key', 'val');
+        };
+
+        await db.query(queryFun).should.be.fulfilled;
       });
     }
 
-    it('Query result should include _conflicts', function () {
+    it('Query result should include _conflicts', async () => {
       const db2name = testUtils.adapterUrl(dbType, 'test2b');
-      const cleanup = function () {
-        return new PouchDB(db2name).destroy();
-      };
+      const cleanup = () => new PouchDB(db2name).destroy();
+
       const doc1 = {_id: '1', foo: 'bar'};
       const doc2 = {_id: '1', foo: 'baz'};
       const db = new PouchDB(dbName);
-      return testUtils.fin(db.info().then(function () {
-        return db.put({
+
+      try {
+        await db.info();
+        await db.put({
           _id: '_design/test',
           views: {
             test: {
@@ -1282,24 +1170,24 @@ function tests(suiteName, dbName, dbType, viewType) {
             }
           }
         });
-      }).then(function () {
+
         const remote = new PouchDB(db2name);
-        return remote.info().then(function () {
-          const replicate = testUtils.promisify(db.replicate.from, db.replicate);
-          return db.post(doc1).then(function () {
-            return remote.post(doc2);
-          }).then(function () {
-            return replicate(remote);
-          }).then(function () {
-            return db.query('test', {include_docs : true, conflicts: true});
-          }).then(function (res) {
-            should.exist(res.rows[0].doc._conflicts);
-            return db.get(res.rows[0].doc._id, {conflicts: true});
-          }).then(function (res) {
-            should.exist(res._conflicts);
-          });
-        });
-      }), cleanup);
+        await remote.info();
+
+        await db.post(doc1);
+        await remote.post(doc2);
+        await db.replicate.from(remote);
+
+        const queryRes =  await db.query('test', {include_docs : true, conflicts: true});
+
+        queryRes.rows[0].doc._conflicts.should.exist;
+
+        const docWithConflicts = await db.get(queryRes.rows[0].doc._id, {conflicts: true});
+
+        docWithConflicts._conflicts.should.exist;
+      } finally {
+        await cleanup();
+      }
     });
 
     const icons = [
@@ -1320,13 +1208,12 @@ function tests(suiteName, dbName, dbType, viewType) {
 
     const iconLengths = [1047, 789, 967, 527, 1108];
 
-    it('#190 Query works with attachments=true', function () {
-
+    it('#190 Query works with attachments=true', async () => {
       const db = new PouchDB(dbName);
       const docs = [];
       for (let i = 0; i < 5; i++) {
         docs.push({
-          _id: i.toString(),
+          _id: `${i}`,
           _attachments: {
             'foo.png': {
               data: icons[i],
@@ -1335,59 +1222,59 @@ function tests(suiteName, dbName, dbType, viewType) {
           }
         });
       }
-      return db.bulkDocs(docs).then(function () {
-        return createView(db, {
-          map: function (doc) {
-            emit(doc._id);
-          }
-        });
-      }).then(function (queryFun) {
-        return db.query(queryFun, {
-          include_docs: true,
-          attachments: true
-        }).then(function (res) {
-          const attachments = res.rows.map(function (row) {
-            const doc = row.doc;
-            delete doc._attachments['foo.png'].revpos;
-            return doc._attachments;
-          });
-          attachments.should.deep.equal(icons.map(function (icon, i) {
-            return {
-              "foo.png": {
-                "content_type": "image/png",
-                "data": icon,
-                "digest": iconDigests[i]
-              }
-            };
-          }), 'works with attachments=true');
-          return db.query(queryFun, {include_docs: true});
-        }).then(function (res) {
-          const attachments = res.rows.map(function (row) {
-            const doc = row.doc;
-            delete doc._attachments['foo.png'].revpos;
-            return doc._attachments['foo.png'];
-          });
-          attachments.should.deep.equal(icons.map(function (icon, i) {
-            return {
-              "content_type": "image/png",
-              stub: true,
-              "digest": iconDigests[i],
-              length: iconLengths[i]
-            };
-          }), 'works with attachments=false');
+      await db.bulkDocs(docs);
 
-          return db.query(queryFun, {attachments: true});
-        }).then(function (res) {
-          res.rows.should.have.length(5);
-          res.rows.forEach(function (row) {
-            should.not.exist(row.doc, 'ignored if include_docs=false');
-          });
-        });
+      const queryFun = await createView(db, {
+        map: function (doc) {
+          emit(doc._id);
+        }
       });
+
+      const resAttatchmentsTrue = await db.query(queryFun, {
+        include_docs: true,
+        attachments: true
+      });
+
+      const attachments = resAttatchmentsTrue.rows.map((row) => {
+        const doc = row.doc;
+        delete doc._attachments['foo.png'].revpos;
+        return doc._attachments;
+      });
+
+      attachments.should.deep.equal(icons.map((icon, i) => {
+        return {
+          "foo.png": {
+            "content_type": "image/png",
+            "data": icon,
+            "digest": iconDigests[i]
+          }
+        };
+      }), 'works with attachments=true');
+
+      const resAttatchmentsFalse = await db.query(queryFun, {include_docs: true});
+
+      const attachments1 = resAttatchmentsFalse.rows.map((row) => {
+        const doc = row.doc;
+        delete doc._attachments['foo.png'].revpos;
+        return doc._attachments['foo.png'];
+      });
+
+      attachments1.should.deep.equal(icons.map((icon, i) => {
+        return {
+          "content_type": "image/png",
+          stub: true,
+          "digest": iconDigests[i],
+          length: iconLengths[i]
+        };
+      }), 'works with attachments=false');
+
+      const resWithoutIncludeDocs = await db.query(queryFun, {attachments: true});
+
+      resWithoutIncludeDocs.rows.should.have.length(5);
+      resWithoutIncludeDocs.rows.forEach(row => should.not.exist(row.doc, 'ignored if include_docs=false'));
     });
 
-    it('#2858 Query works with attachments=true, binary=true 1', function () {
-
+    it('#2858 Query works with attachments=true, binary=true 1', async () => {
       // Need to avoid the cache to workaround
       // https://issues.apache.org/jira/browse/COUCHDB-2880
       const db = new PouchDB(dbName, {
@@ -1399,7 +1286,7 @@ function tests(suiteName, dbName, dbType, viewType) {
       const docs = [];
       for (let i = 0; i < 5; i++) {
         docs.push({
-          _id: i.toString(),
+          _id: `${i}`,
           _attachments: {
             'foo.png': {
               data: icons[i],
@@ -1408,32 +1295,33 @@ function tests(suiteName, dbName, dbType, viewType) {
           }
         });
       }
-      return db.bulkDocs(docs).then(function () {
-        return createView(db, {
-          map: function (doc) {
-            emit(doc._id);
-          }
-        });
-      }).then(function (queryFun) {
-        return db.query(queryFun, {
-          include_docs: true,
-          attachments: true,
-          binary: true
-        }).then(function (res) {
-          res.rows.forEach(function (row) {
-            const doc = row.doc;
-            Object.keys(doc._attachments).forEach(function (attName) {
-              const att = doc._attachments[attName];
-              should.not.exist(att.stub);
-              att.data.should.not.be.a('string');
-            });
-          });
+
+      await db.bulkDocs(docs);
+
+      const queryFun = await createView(db, {
+        map: function (doc) {
+          emit(doc._id);
+        }
+      });
+
+      const res = await db.query(queryFun, {
+        include_docs: true,
+        attachments: true,
+        binary: true
+      });
+
+      res.rows.forEach((row) => {
+        const doc = row.doc;
+        Object.keys(doc._attachments).forEach((attName) => {
+          const att = doc._attachments[attName];
+
+          should.not.exist(att.stub);
+          att.data.should.not.be.a('string');
         });
       });
     });
 
-    it('#2858 Query works with attachments=true, binary=true 2', function () {
-
+    it('#2858 Query works with attachments=true, binary=true 2', async () => {
       // Need to avoid the cache to workaround
       // https://issues.apache.org/jira/browse/COUCHDB-2880
       const db = new PouchDB(dbName, {
@@ -1445,81 +1333,83 @@ function tests(suiteName, dbName, dbType, viewType) {
       const docs = [];
       for (let i = 0; i < 5; i++) {
         docs.push({
-          _id: i.toString()
+          _id: `${i}`
         });
       }
-      return db.bulkDocs(docs).then(function () {
-        return createView(db, {
-          map: function (doc) {
-            emit(doc._id);
-          }
-        });
-      }).then(function (queryFun) {
-        return db.query(queryFun, {
-          include_docs: true,
-          attachments: true,
-          binary: true
-        }).then(function (res) {
-          res.rows.forEach(function (row) {
-            const doc = row.doc;
-            should.not.exist(doc._attachments);
-          });
-        });
+
+      await db.bulkDocs(docs);
+
+      const queryFun = await createView(db, {
+        map: function (doc) {
+          emit(doc._id);
+        }
+      });
+
+      const res =  await db.query(queryFun, {
+        include_docs: true,
+        attachments: true,
+        binary: true
+      });
+
+      res.rows.forEach((row) => {
+        const doc = row.doc;
+
+        should.not.exist(doc._attachments);
       });
     });
 
-    it('#242 conflicts at the root level', function () {
+    it('#242 conflicts at the root level', async () => {
       const db = new PouchDB(dbName);
-
-      return db.bulkDocs([
+      await db.bulkDocs([
         {
           foo: '1',
           _id: 'foo',
           _rev: '1-w',
           _revisions: {start: 1, ids: ['w']}
         }
-      ], {new_edits: false}).then(function () {
-        return createView(db, {
-          map: function (doc) {
-            emit(doc.foo);
-          }
-        }).then(function (queryFun) {
-          return db.query(queryFun).then(function (res) {
-            res.rows[0].key.should.equal('1');
-            return db.bulkDocs([
-              {
-                foo: '2',
-                _id: 'foo',
-                _rev: '1-x',
-                _revisions: {start: 1, ids: ['x']}
-              }
-            ], {new_edits: false}).then(function () {
-              return db.query(queryFun);
-            }).then(function (res) {
-              res.rows[0].key.should.equal('2');
-              return db.bulkDocs([
-                {
-                  foo: '3',
-                  _id: 'foo',
-                  _rev: '1-y',
-                  _deleted: true,
-                  _revisions: {start: 1, ids: ['y']}
-                }
-              ], {new_edits: false});
-            }).then(function () {
-              return db.query(queryFun);
-            }).then(function (res) {
-              res.rows[0].key.should.equal('2');
-            });
-          });
-        });
+      ], {new_edits: false});
+
+      const queryFun = await createView(db, {
+        map: function (doc) {
+          emit(doc.foo);
+        }
       });
+
+      const queryRes = await db.query(queryFun);
+
+      queryRes.rows[0].key.should.equal('1');
+
+      await db.bulkDocs([
+        {
+          foo: '2',
+          _id: 'foo',
+          _rev: '1-x',
+          _revisions: {start: 1, ids: ['x']}
+        }
+      ], {new_edits: false});
+
+      const resWinningRevX = await db.query(queryFun);
+
+      resWinningRevX.rows[0].key.should.equal('2');
+
+      await db.bulkDocs([
+        {
+          foo: '3',
+          _id: 'foo',
+          _rev: '1-y',
+          _deleted: true,
+          _revisions: {start: 1, ids: ['y']}
+        }
+      ], {new_edits: false});
+
+      const resWinningRevStillX =  await db.query(queryFun);
+
+      resWinningRevStillX.rows[0].key.should.equal('2');
     });
 
-    it('#242 conflicts at the root+1 level', function () {
+    it('#242 conflicts at the root+1 level', async () => {
       const db = new PouchDB(dbName);
-
-      return db.bulkDocs([
+      await db.bulkDocs([
         {
           foo: '2',
           _id: 'foo',
@@ -1533,105 +1423,108 @@ function tests(suiteName, dbName, dbType, viewType) {
           _deleted: true,
           _revisions: {start: 2, ids: ['y', 'x']}
         }
+      ], {new_edits: false});
 
-      ], {new_edits: false}).then(function () {
-        return createView(db, {
-          map: function (doc) {
-            emit(doc.foo);
-          }
-        }).then(function (queryFun) {
-          return db.query(queryFun).then(function (res) {
-            res.rows.length.should.equal(0);
-            return db.bulkDocs([
-              {
-                foo: '1',
-                _id: 'foo',
-                _rev: '1-w',
-                _revisions: {start: 1, ids: ['w']}
-              }
-            ], {new_edits: false}).then(function () {
-              return db.query(queryFun);
-            }).then(function (res) {
-              res.rows[0].key.should.equal('1');
-              return db.bulkDocs([
-                {
-                  foo: '4',
-                  _id: 'foo',
-                  _rev: '1-z',
-                  _revisions: {start: 1, ids: ['z']}
-                }
-              ], {new_edits: false});
-            }).then(function () {
-              return db.query(queryFun);
-            }).then(function (res) {
-              res.rows[0].key.should.equal('4');
-            });
-          });
-        });
+      const queryFun = await createView(db, {
+        map: function (doc) {
+          emit(doc.foo);
+        }
       });
+
+      const resDeletedDoc = await db.query(queryFun);
+
+      resDeletedDoc.rows.length.should.equal(0);
+
+      await db.bulkDocs([
+        {
+          foo: '1',
+          _id: 'foo',
+          _rev: '1-w',
+          _revisions: {start: 1, ids: ['w']}
+        }
+      ], {new_edits: false});
+
+      const res = await db.query(queryFun);
+
+      res.rows[0].key.should.equal('1');
+
+      await db.bulkDocs([
+        {
+          foo: '4',
+          _id: 'foo',
+          _rev: '1-z',
+          _revisions: {start: 1, ids: ['z']}
+        }
+      ], {new_edits: false});
+
+      const resWinningRevZ = await db.query(queryFun);
+
+      resWinningRevZ.rows[0].key.should.equal('4');
     });
 
-    it('Views should include _conflicts', function () {
+    it('Views should include _conflicts', async () => {
       const db2name = testUtils.adapterUrl(dbType, 'test2');
-      const cleanup = function () {
-        return new PouchDB(db2name).destroy();
-      };
+      const cleanup = () =>  new PouchDB(db2name).destroy();
+
       const doc1 = {_id: '1', foo: 'bar'};
       const doc2 = {_id: '1', foo: 'baz'};
       const db = new PouchDB(dbName);
-      return testUtils.fin(db.info().then(function () {
+
+      try {
+        await db.info();
         const remote = new PouchDB(db2name);
-        return remote.info().then(function () {
-          return createView(db, {
-            map : function (doc) {
-              emit(doc._id, !!doc._conflicts);
-            }
-          }).then(function (queryFun) {
-            const replicate = testUtils.promisify(db.replicate.from, db.replicate);
-            return db.post(doc1).then(function () {
-              return remote.post(doc2);
-            }).then(function () {
-              return replicate(remote);
-            }).then(function () {
-              return db.get(doc1._id, {conflicts: true});
-            }).then(function (res) {
-              should.exist(res._conflicts);
-              return db.query(queryFun);
-            }).then(function (res) {
-              res.rows[0].value.should.equal(true);
-            });
-          });
+        await remote.info();
+
+        const queryFun = await createView(db, {
+          map: function (doc) {
+            emit(doc._id, !!doc._conflicts);
+          }
         });
-      }), cleanup);
+
+        await db.post(doc1);
+        await remote.post(doc2);
+        await db.replicate.from(remote);
+
+        const docWithConflicts = await db.get(doc1._id, {conflicts: true});
+
+        should.exist(docWithConflicts._conflicts);
+
+        const queryRes = await db.query(queryFun);
+
+        queryRes.rows[0].value.should.equal(true);
+
+      } finally {
+        await cleanup();
+      }
     });
 
-    it("Test view querying with limit option", function () {
+    it("Test view querying with limit option", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
-        map : function (doc) {
+      const queryFun = await createView(db, {
+        map: function (doc) {
           if (doc.foo === 'bar') {
             emit(doc.foo);
           }
         }
-      }).then(function (queryFun) {
-        return db.bulkDocs({
-          docs: [
-            { foo: 'bar' },
-            { foo: 'bar' },
-            { foo: 'baz' }
-          ]
-        }).then(function () {
-          return db.query(queryFun, { limit: 1 });
-        }).then(function (res) {
-          res.total_rows.should.equal(2, 'Correctly returns total rows');
-          res.rows.should.have.length(1, 'Correctly limits returned rows');
-        });
       });
+
+      await db.bulkDocs({
+        docs: [
+          { foo: 'bar' },
+          { foo: 'bar' },
+          { foo: 'baz' }
+        ]
+      });
+
+      const res = await db.query(queryFun, { limit: 1 });
+
+      res.total_rows.should.equal(2, 'Correctly returns total rows');
+      res.rows.should.have.length(1, 'Correctly limits returned rows');
     });
 
-    it("Test view querying with custom reduce function", function () {
+    it("Test view querying with custom reduce function", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.foo);
         },
@@ -1639,7 +1532,7 @@ function tests(suiteName, dbName, dbType, viewType) {
           if (keys) {
             return keys.map(function (keyId) {
               const key = keyId[0];
-              // const id = keyId[1];
+              // var id = keyId[1];
               return key.join('');
             });
           } else {
@@ -1652,318 +1545,332 @@ function tests(suiteName, dbName, dbType, viewType) {
             return result;
           }
         }
-      }).then(function (queryFun) {
-        return db.bulkDocs({
-          docs: [
-            { foo: ['foo', 'bar'] },
-            { foo: ['foo', 'bar'] },
-            { foo: ['foo', 'bar', 'baz'] },
-            { foo: ['baz'] },
-            { foo: ['baz', 'bar'] }
-          ]
-        }).then(function () {
-          return db.query(queryFun, { reduce: true });
-        }).then(function (res) {
-          // We're using `chai.assert` here because the usual `chai.should()`
-          // object extension magic won't work when executing functions in a
-          // sandbox using node's `vm` module.
-          // c.f. https://stackoverflow.com/a/16273649/680742
-          assert.lengthOf(res.rows, 1, 'Correctly reduced returned rows');
-          assert.isNull(res.rows[0].key, 'Correct, non-existing key');
-          assert.lengthOf(res.rows[0].value, 5);
-          assert.include(res.rows[0].value, 'foobarbaz');
-          assert.include(res.rows[0].value, 'foobar'); // twice
-          assert.include(res.rows[0].value, 'bazbar');
-          assert.include(res.rows[0].value, 'baz');
-          return db.query(queryFun, { group_level: 1, reduce: true });
-        }).then(function (res) {
-          // We're using `chai.assert` here because the usual `chai.should()`
-          // object extension magic won't work when executing functions in a
-          // sandbox using node's `vm` module.
-          // c.f. https://stackoverflow.com/a/16273649/680742
-          assert.lengthOf(res.rows, 2, 'Correctly group reduced rows');
-          assert.deepEqual(res.rows[0].key, ['baz']);
-          assert.lengthOf(res.rows[0].value, 2);
-          assert.include(res.rows[0].value, 'bazbar');
-          assert.include(res.rows[0].value, 'baz');
-          assert.deepEqual(res.rows[1].key, ['foo']);
-          assert.lengthOf(res.rows[1].value, 3);
-          assert.include(res.rows[1].value, 'foobarbaz');
-          assert.include(res.rows[1].value, 'foobar'); // twice
-        });
       });
+
+      await db.bulkDocs({
+        docs: [
+          { foo: ['foo', 'bar'] },
+          { foo: ['foo', 'bar'] },
+          { foo: ['foo', 'bar', 'baz'] },
+          { foo: ['baz'] },
+          { foo: ['baz', 'bar'] }
+        ]
+      });
+
+      const res = await db.query(queryFun, { reduce: true });
+      // We're using `chai.assert` here because the usual `chai.should()`
+      // object extension magic won't work when executing functions in a
+      // sandbox using node's `vm` module.
+      // c.f. https://stackoverflow.com/a/16273649/680742
+      assert.lengthOf(res.rows, 1, 'Correctly reduced returned rows');
+      assert.isNull(res.rows[0].key, 'Correct, non-existing key');
+      assert.lengthOf(res.rows[0].value, 5);
+      assert.include(res.rows[0].value, 'foobarbaz');
+      assert.include(res.rows[0].value, 'foobar'); // twice
+      assert.include(res.rows[0].value, 'bazbar');
+      assert.include(res.rows[0].value, 'baz');
+
+      const resGrouped =  await db.query(queryFun, { group_level: 1, reduce: true });
+      // We're using `chai.assert` here because the usual `chai.should()`
+      // object extension magic won't work when executing functions in a
+      // sandbox using node's `vm` module.
+      // c.f. https://stackoverflow.com/a/16273649/680742
+      assert.lengthOf(resGrouped.rows, 2, 'Correctly group reduced rows');
+      assert.deepEqual(resGrouped.rows[0].key, ['baz']);
+      assert.lengthOf(resGrouped.rows[0].value, 2);
+      assert.include(resGrouped.rows[0].value, 'bazbar');
+      assert.include(resGrouped.rows[0].value, 'baz');
+      assert.deepEqual(resGrouped.rows[1].key, ['foo']);
+      assert.lengthOf(resGrouped.rows[1].value, 3);
+      assert.include(resGrouped.rows[1].value, 'foobarbaz');
+      assert.include(resGrouped.rows[1].value, 'foobar'); // twice
     });
 
-    it("Test view querying with group_level option and reduce", function () {
+    it("Test view querying with group_level option and reduce", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.foo);
         },
         reduce: '_count'
-      }).then(function (queryFun) {
-        return db.bulkDocs({
-          docs: [
-            { foo: ['foo', 'bar'] },
-            { foo: ['foo', 'bar'] },
-            { foo: ['foo', 'bar', 'baz'] },
-            { foo: ['baz'] },
-            { foo: ['baz', 'bar'] }
-          ]
-        }).then(function () {
-          return db.query(queryFun, { group_level: 1, reduce: true});
-        }).then(function (res) {
-          res.rows.should.have.length(2, 'Correctly group returned rows');
-          res.rows[0].key.should.deep.equal(['baz']);
-          res.rows[0].value.should.equal(2);
-          res.rows[1].key.should.deep.equal(['foo']);
-          res.rows[1].value.should.equal(3);
-          return db.query(queryFun, { group_level: 999, reduce: true});
-        }).then(function (res) {
-          res.rows.should.have.length(4, 'Correctly group returned rows');
-          res.rows[2].key.should.deep.equal(['foo', 'bar']);
-          res.rows[2].value.should.equal(2);
-          return db.query(queryFun, { group_level: '999', reduce: true});
-        }).then(function (res) {
-          res.rows.should.have.length(4, 'Correctly group returned rows');
-          res.rows[2].key.should.deep.equal(['foo', 'bar']);
-          res.rows[2].value.should.equal(2);
-          return db.query(queryFun, { group_level: 0, reduce: true});
-        }).then(function (res) {
-          res.rows.should.have.length(1, 'Correctly group returned rows');
-          res.rows[0].value.should.equal(5);
-        });
       });
+
+      await db.bulkDocs({
+        docs: [
+          { foo: ['foo', 'bar'] },
+          { foo: ['foo', 'bar'] },
+          { foo: ['foo', 'bar', 'baz'] },
+          { foo: ['baz'] },
+          { foo: ['baz', 'bar'] }
+        ]
+      });
+
+      const resGrouped = await db.query(queryFun, { group_level: 1, reduce: true});
+
+      resGrouped.rows.should.have.length(2, 'Correctly group returned rows');
+      resGrouped.rows[0].key.should.deep.equal(['baz']);
+      resGrouped.rows[0].value.should.equal(2);
+      resGrouped.rows[1].key.should.deep.equal(['foo']);
+      resGrouped.rows[1].value.should.equal(3);
+
+      const resGrouped1 = await db.query(queryFun, { group_level: 999, reduce: true});
+
+      resGrouped1.rows.should.have.length(4, 'Correctly group returned rows');
+      resGrouped1.rows[2].key.should.deep.equal(['foo', 'bar']);
+      resGrouped1.rows[2].value.should.equal(2);
+
+      const resGrouped2 = await db.query(queryFun, { group_level: '999', reduce: true});
+
+      resGrouped2.rows.should.have.length(4, 'Correctly group returned rows');
+      resGrouped2.rows[2].key.should.deep.equal(['foo', 'bar']);
+      resGrouped2.rows[2].value.should.equal(2);
+
+      const resGrouped3 = await db.query(queryFun, { group_level: 0, reduce: true});
+
+      resGrouped3.rows.should.have.length(1, 'Correctly group returned rows');
+      resGrouped3.rows[0].value.should.equal(5);
     });
 
-    it("Test view querying with invalid group_level options", function () {
+    it("Test view querying with invalid group_level options", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.foo);
         },
         reduce: '_count'
-      }).then(function (queryFun) {
-        return db.query(queryFun, {group_level: -1, reduce: true}).then(function (res) {
-          res.should.not.exist('expected error on invalid group_level');
-        }).catch(function (err) {
-          err.status.should.be.oneOf([400, 500]);
-          err.message.should.be.a('string');
-          return db.query(queryFun, { group_level: 'exact', reduce: true});
-        }).then(function (res) {
-          res.should.not.exist('expected error on invalid group_level');
-        }).catch(function (err) {
-          err.status.should.be.oneOf([400, 500]);
-          err.message.should.be.a('string');
-        });
       });
+      try {
+        const res = await db.query(queryFun, {group_level: -1, reduce: true});
+        res.should.not.exist('expected error on invalid group_level');
+      } catch (err) {
+        err.status.should.be.oneOf([400, 500]);
+        err.message.should.be.a('string');
+      }
+
+      try {
+        const res = await db.query(queryFun, { group_level: 'exact', reduce: true});
+        res.should.not.exist('expected error on invalid group_level');
+      } catch (err) {
+        err.status.should.be.oneOf([400, 500]);
+        err.message.should.be.a('string');
+      }
     });
 
-    it("Test view querying with limit option and reduce", function () {
+    it("Test view querying with limit option and reduce", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.foo);
         },
         reduce: '_count'
-      }).then(function (queryFun) {
-        return db.bulkDocs({
-          docs: [
-            { foo: 'bar' },
-            { foo: 'bar' },
-            { foo: 'baz' }
-          ]
-        }).then(function () {
-          return db.query(queryFun, { limit: 1, group: true, reduce: true});
-        }).then(function (res) {
-          res.rows.should.have.length(1, 'Correctly limits returned rows');
-          res.rows[0].key.should.equal('bar');
-          res.rows[0].value.should.equal(2);
-        }).then(function () {
-          return db.query(queryFun, { limit: '1', group: true, reduce: true});
-        }).then(function (res) {
-          res.rows.should.have.length(1, 'Correctly limits returned rows');
-          res.rows[0].key.should.equal('bar');
-          res.rows[0].value.should.equal(2);
-        });
       });
+
+      await db.bulkDocs({
+        docs: [
+          { foo: 'bar' },
+          { foo: 'bar' },
+          { foo: 'baz' }
+        ]
+      });
+
+      const resWithLimit = await db.query(queryFun, { limit: 1, group: true, reduce: true});
+
+      resWithLimit.rows.should.have.length(1, 'Correctly limits returned rows');
+      resWithLimit.rows[0].key.should.equal('bar');
+      resWithLimit.rows[0].value.should.equal(2);
+
+      const resWithLimitString = await db.query(queryFun, { limit: '1', group: true, reduce: true});
+
+      resWithLimitString.rows.should.have.length(1, 'Correctly limits returned rows');
+      resWithLimitString.rows[0].key.should.equal('bar');
+      resWithLimitString.rows[0].value.should.equal(2);
     });
 
-    it("Test view querying with invalid limit option and reduce", function () {
+    it("Test view querying with invalid limit option and reduce", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.foo);
         },
         reduce: '_count'
-      }).then(function (queryFun) {
-        return db.bulkDocs({
-          docs: [
-            { foo: 'bar' },
-            { foo: 'bar' },
-            { foo: 'baz' }
-          ]
-        }).then(function () {
-          return db.query(queryFun, { limit: -1, group: true, reduce: true});
-        }).then(function (res) {
-          res.should.not.exist('expected error on invalid group_level');
-        }).catch(function (err) {
-          err.status.should.be.oneOf([400, 500]);
-          err.message.should.be.a('string');
-          return db.query(queryFun, { limit: '1a', group: true, reduce: true});
-        }).then(function (res) {
-          res.should.not.exist('expected error on invalid group_level');
-        }).catch(function (err) {
-          err.status.should.be.oneOf([400, 500]);
-          err.message.should.be.a('string');
-        });
       });
+
+      await db.bulkDocs({
+        docs: [
+          { foo: 'bar' },
+          { foo: 'bar' },
+          { foo: 'baz' }
+        ]
+      });
+
+      try {
+        const res = await db.query(queryFun, { limit: -1, group: true, reduce: true});
+        res.should.not.exist('expected error on invalid group_level');
+      } catch (err) {
+        err.status.should.be.oneOf([400, 500]);
+        err.message.should.be.a('string');
+      }
+      try {
+        const res = await db.query(queryFun, { limit: '1a', group: true, reduce: true});
+        res.should.not.exist('expected error on invalid group_level');
+      } catch (err) {
+        err.status.should.be.oneOf([400, 500]);
+        err.message.should.be.a('string');
+      }
     });
 
-    it('Test unsafe object usage (#244)', function () {
+    it('Test unsafe object usage (#244)', async () => {
       const db = new PouchDB(dbName);
-      return db.bulkDocs([
+      const writeRes = await db.bulkDocs([
         {_id: 'constructor'}
-      ]).then(function (res) {
-        let rev = res[0].rev;
-        return createView(db, {
-          map: function (doc) {
-            emit(doc._id);
+      ]);
+      const rev = writeRes[0].rev;
+
+      const queryFun =  await createView(db, {
+        map: function (doc) {
+          emit(doc._id);
+        },
+      });
+
+      const queryRes = await db.query(queryFun, {include_docs: true});
+
+      queryRes.rows.should.deep.equal([
+        {
+          "key": "constructor",
+          "id": "constructor",
+          "value": null,
+          "doc": {
+            "_id": "constructor",
+            "_rev": rev
           }
-        }).then(function (queryFun) {
-          return db.query(queryFun, {include_docs: true}).then(function (res) {
-            res.rows.should.deep.equal([
-              {
-                "key": "constructor",
-                "id": "constructor",
-                "value": null,
-                "doc": {
-                  "_id": "constructor",
-                  "_rev": rev
-                }
-              }
-            ]);
-            return db.bulkDocs([
-              {_id: 'constructor', _rev: rev}
-            ]);
-          }).then(function (res) {
-            rev = res[0].rev;
-            return db.query(queryFun, {include_docs: true});
-          }).then(function (res) {
-            res.rows.should.deep.equal([
-              {
-                "key": "constructor",
-                "id": "constructor",
-                "value": null,
-                "doc": {
-                  "_id": "constructor",
-                  "_rev": rev
-                }
-              }
-            ]);
-            return db.bulkDocs([
-              {_id: 'constructor', _rev: rev, _deleted: true}
-            ]);
-          }).then(function (res) {
-            rev = res[0].rev;
-            return db.query(queryFun, {include_docs: true});
-          }).then(function (res) {
-            res.rows.should.deep.equal([]);
-          });
-        });
-      });
+        }
+      ]);
+
+      const writeResWithRev = await db.bulkDocs([
+          {_id: 'constructor', _rev: rev}
+        ]);
+
+      const rev1 = writeResWithRev[0].rev;
+
+      const queryRes1 = await db.query(queryFun, {include_docs: true});
+
+      queryRes1.rows.should.deep.equal([
+        {
+          "key": "constructor",
+          "id": "constructor",
+          "value": null,
+          "doc": {
+            "_id": "constructor",
+            "_rev": rev1
+          }
+        }
+      ]);
+
+      const deletedDoc = await db.bulkDocs([
+        {_id: 'constructor', _rev: rev1, _deleted: true}
+      ]);
+
+      const rev2 = deletedDoc[0].rev;
+
+      const queryRes2 = await db.query(queryFun, {include_docs: true});
+
+      queryRes2.rows.should.deep.equal([]);
+      rev2[0].should.equal('3');
     });
 
-    it("Test view querying with a skip option and reduce", function () {
-      let qf;
+    it("Test view querying with a skip option and reduce", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.foo);
         },
         reduce: '_count'
-      }).then(function (queryFun) {
-        qf = queryFun;
-        return db.bulkDocs({
-          docs: [
-            { foo: 'bar' },
-            { foo: 'bar' },
-            { foo: 'baz' }
-          ]
-        }).then(function () {
-          return db.query(queryFun, {skip: 1, group: true, reduce: true});
-        });
-      }).then(function (res) {
-        res.rows.should.have.length(1, 'Correctly limits returned rows');
-        res.rows[0].key.should.equal('baz');
-        res.rows[0].value.should.equal(1);
-      }).then(function () {
-        return db.query(qf, {skip: '1', group: true, reduce: true});
-      }).then(function (res) {
-        res.rows.should.have.length(1, 'Correctly limits returned rows');
-        res.rows[0].key.should.equal('baz');
-        res.rows[0].value.should.equal(1);
       });
+      const qf = queryFun;
+
+      await db.bulkDocs({
+        docs: [
+          { foo: 'bar' },
+          { foo: 'bar' },
+          { foo: 'baz' }
+        ]
+      });
+
+      const res = await db.query(queryFun, {skip: 1, group: true, reduce: true});
+
+      res.rows.should.have.length(1, 'Correctly limits returned rows');
+      res.rows[0].key.should.equal('baz');
+      res.rows[0].value.should.equal(1);
+
+      const resQf =  await db.query(qf, {skip: '1', group: true, reduce: true});
+
+      resQf.rows.should.have.length(1, 'Correctly limits returned rows');
+      resQf.rows[0].key.should.equal('baz');
+      resQf.rows[0].value.should.equal(1);
     });
 
-    it("Test view querying with invalid skip option and reduce", function () {
+    it("Test view querying with invalid skip option and reduce", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.foo);
         },
         reduce: '_count'
-      }).then(function (queryFun) {
-        return db.bulkDocs({
-          docs: [
-            { foo: 'bar' },
-            { foo: 'bar' },
-            { foo: 'baz' }
-          ]
-        }).then(function () {
-          return db.query(queryFun, { skip: -1, group: true, reduce: true});
-        }).then(function (res) {
-          res.should.not.exist('expected error on invalid group_level');
-        }).catch(function (err) {
-          err.status.should.be.oneOf([400, 500]);
-          err.message.should.be.a('string');
-          return db.query(queryFun, { skip: '1a', group: true, reduce: true});
-        }).then(function (res) {
-          res.should.not.exist('expected error on invalid group_level');
-        }).catch(function (err) {
-          err.status.should.be.oneOf([400, 500]);
-          err.message.should.be.a('string');
-        });
       });
+
+      await db.bulkDocs({
+        docs: [
+          { foo: 'bar' },
+          { foo: 'bar' },
+          { foo: 'baz' }
+        ]
+      });
+
+      try {
+        const res = await db.query(queryFun, { skip: -1, group: true, reduce: true});
+
+        res.should.not.exist('expected error on invalid group_level');
+      } catch (err) {
+        err.status.should.be.oneOf([400, 500]);
+        err.message.should.be.a('string');
+      }
+
+      try {
+        const res = await db.query(queryFun, { skip: '1a', group: true, reduce: true});
+
+        res.should.not.exist('expected error on invalid group_level');
+      } catch (err) {
+        err.status.should.be.oneOf([400, 500]);
+        err.message.should.be.a('string');
+      }
     });
 
-    it("Special document member _doc_id_rev should never leak outside",
-      function () {
+    it("Special document member _doc_id_rev should never leak outside", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           if (doc.foo === 'bar') {
             emit(doc.foo);
           }
         }
-      }).then(function (queryFun) {
-        return db.bulkDocs({
-          docs: [
-            { foo: 'bar' }
-          ]
-        }).then(function () {
-          return db.query(queryFun, { include_docs: true });
-        }).then(function (res) {
-          should.not.exist(res.rows[0].doc._doc_id_rev, '_doc_id_rev is leaking but should not');
-        });
       });
+
+      await db.bulkDocs({
+        docs: [
+          { foo: 'bar' }
+        ]
+      });
+
+      const res = await db.query(queryFun, { include_docs: true });
+
+      should.not.exist(res.rows[0].doc._doc_id_rev, '_doc_id_rev is leaking but should not');
     });
 
-    it('multiple view creations and cleanups', function () {
+    it('multiple view creations and cleanups', async () => {
       const db = new PouchDB(dbName);
       const map = function (doc) { emit(doc.num); };
       function createView(name) {
-        const storableViewObj = { map: map.toString() };
+        const storableViewObj = { map: `${map}` };
         return  db.put({
           _id: '_design/' + name,
           views: {
@@ -1971,277 +1878,278 @@ function tests(suiteName, dbName, dbType, viewType) {
           }
         });
       }
-      return db.bulkDocs({
+
+      await db.bulkDocs({
         docs: [
           {_id: 'test1'}
         ]
-      }).then(function () {
-        function sequence(name) {
-          return createView(name).then(function () {
-            return db.query(name + '/theView').then(function () {
-              return db.viewCleanup();
-            });
-          });
-        }
-        const attempts = [];
-        const numAttempts = 10;
-        for (let i = 0; i < numAttempts; i++) {
-          attempts.push(sequence('test' + i));
-        }
-        return Promise.all(attempts).then(function () {
-          const keys = [];
-          for (let i = 0; i < numAttempts; i++) {
-            keys.push('_design/test' + i);
-          }
-          return db.allDocs({keys, include_docs : true});
-        }).then(function (res) {
-          const docs = res.rows.map(function (row) {
-            row.doc._deleted = true;
-            return row.doc;
-          });
-          return db.bulkDocs({docs});
-        }).then(function () {
-          return db.viewCleanup();
-        }).then(function (res) {
-          if (res.error) {
-            res.error.should.equal('not_found');
-          } else {
-            res.ok.should.equal(true);
-          }
-        });
       });
+
+      const sequence = async (name) => {
+        await createView(name);
+        await db.query(name + '/theView');
+        await db.viewCleanup();
+      };
+
+      const attempts = [];
+      const numAttempts = 10;
+      for (let i = 0; i < numAttempts; i++) {
+        attempts.push(sequence('test' + i));
+      }
+
+      await Promise.all(attempts);
+
+      const keys = [];
+      for (let i = 0; i < numAttempts; i++) {
+        keys.push('_design/test' + i);
+      }
+
+      const res = await db.allDocs({keys, include_docs : true});
+
+      const docs = res.rows.map((row) => {
+        row.doc._deleted = true;
+        return row.doc;
+      });
+
+      await db.bulkDocs({docs});
+
+      const viewCleanUpResult = await db.viewCleanup();
+
+      if (viewCleanUpResult.error) {
+        viewCleanUpResult.error.should.equal('not_found');
+      } else {
+        viewCleanUpResult.ok.should.equal(true);
+      }
     });
 
-    it('If reduce function returns 0, resulting value should not be null', function () {
+    it('If reduce function returns 0, resulting value should not be null', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.foo);
         },
         reduce: function () {
           return 0;
         }
-      }).then(function (queryFun) {
-        return db.bulkDocs({
-          docs: [
-            { foo: 'bar' }
-          ]
-        }).then(function () {
-          return db.query(queryFun).then(function (data) {
-            should.exist(data.rows[0].value);
-          });
-        });
       });
+
+      await db.bulkDocs({
+        docs: [
+          { foo: 'bar' }
+        ]
+      });
+
+      const res = await db.query(queryFun);
+
+      should.exist(res.rows[0].value);
     });
 
-    it('Testing skip with a view', function () {
+    it('Testing skip with a view', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map : function (doc) {
           emit(doc.foo);
         }
-      }).then(function (queryFun) {
-        return db.bulkDocs({
-          docs: [
-            { foo: 'bar' },
-            { foo: 'baz' },
-            { foo: 'baf' }
-          ]
-        }).then(function () {
-          return db.query(queryFun, {skip: 1});
-        }).then(function (data) {
-          data.rows.should.have.length(2);
-          data.offset.should.equal(1);
-          data.total_rows.should.equal(3);
-        });
       });
+
+      await db.bulkDocs({
+        docs: [
+          { foo: 'bar' },
+          { foo: 'baz' },
+          { foo: 'baf' }
+        ]
+      });
+
+      const res = await db.query(queryFun, {skip: 1});
+
+      res.rows.should.have.length(2);
+      res.offset.should.equal(1);
+      res.total_rows.should.equal(3);
     });
 
-    it('Map documents on 0/null/undefined/empty string', function () {
+    it('Map documents on 0/null/undefined/empty string', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map : function (doc) {
           emit(doc.num);
         }
-      }).then(function (mapFunction) {
-        const docs = [
-          {_id: '0', num: 0},
-          {_id: '1', num: 1},
-          {_id: 'undef' /* num is undefined */},
-          {_id: 'null', num: null},
-          {_id: 'empty', num: ''},
-          {_id: 'nan', num: NaN},
-          {_id: 'inf', num: Infinity},
-          {_id: 'neginf', num: -Infinity}
-        ];
-        return db.bulkDocs({docs}).then(function () {
-          return db.query(mapFunction, {key: 0});
-        }).then(function (data) {
-          data.rows.should.have.length(1);
-          data.rows[0].id.should.equal('0');
-
-          return db.query(mapFunction, {key: ''});
-        }).then(function (data) {
-          data.rows.should.have.length(1);
-          data.rows[0].id.should.equal('empty');
-
-          return db.query(mapFunction, {key: undefined});
-        }).then(function (data) {
-          data.rows.should.have.length(8); // everything
-
-          // keys that should all resolve to null
-          const emptyKeys = [null, NaN, Infinity, -Infinity];
-          return Promise.all(emptyKeys.map(function (emptyKey) {
-            return db.query(mapFunction, {key: emptyKey}).then(function (data) {
-              data.rows.map(function (row) {
-                return row.id;
-              }).should.deep.equal(['inf', 'nan', 'neginf', 'null', 'undef']);
-            });
-          }));
-        });
       });
+
+      const docs = [
+        {_id: '0', num: 0},
+        {_id: '1', num: 1},
+        {_id: 'undef' /* num is undefined */},
+        {_id: 'null', num: null},
+        {_id: 'empty', num: ''},
+        {_id: 'nan', num: NaN},
+        {_id: 'inf', num: Infinity},
+        {_id: 'neginf', num: -Infinity}
+      ];
+
+      await db.bulkDocs({docs});
+
+      const res = await db.query(queryFun, {key: 0});
+
+      res.rows.should.have.length(1);
+      res.rows[0].id.should.equal('0');
+
+      const resEmptyKey = await db.query(queryFun, {key: ''});
+
+      resEmptyKey.rows.should.have.length(1);
+      resEmptyKey.rows[0].id.should.equal('empty');
+
+      const resUndefinedKey = await db.query(queryFun, {key: undefined});
+
+      resUndefinedKey.rows.should.have.length(8); // everything
+
+      // keys that should all resolve to null
+      const emptyKeys = [null, NaN, Infinity, -Infinity];
+      await Promise.all(emptyKeys.map(async (emptyKey) => {
+        const data = await db.query(queryFun, {key: emptyKey});
+        const rows = data.rows.map(row => row.id);
+
+        rows.should.deep.equal(['inf', 'nan', 'neginf', 'null', 'undef']);
+      }));
     });
 
-    it('Testing query with keys', function () {
+    it('Testing query with keys', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.field);
         }
-      }).then(function (queryFun) {
-        const opts = {include_docs: true};
-        return db.bulkDocs({
-          docs: [
-            {_id: 'doc_0', field: 0},
-            {_id: 'doc_1', field: 1},
-            {_id: 'doc_2', field: 2},
-            {_id: 'doc_empty', field: ''},
-            {_id: 'doc_null', field: null},
-            {_id: 'doc_undefined' /* field undefined */},
-            {_id: 'doc_foo', field: 'foo'}
-          ]
-        }).then(function () {
-          return db.query(queryFun, opts);
-        }).then(function (data) {
-          data.rows.should.have.length(7, 'returns all docs');
-          opts.keys = [];
-          return db.query(queryFun, opts);
-        }).then(function (data) {
-          data.rows.should.have.length(0, 'returns 0 docs');
-          opts.keys = [0];
-          // When passed an empty keys array (above), query mutates opts by deleting the
-          // keys array and adding limit = 0. That behavior breaks this test result when
-          // implementing limit and skip (#8370); it is correct (and necessary) to clean
-          // up that side effect here.
-          delete opts.limit;
-          return db.query(queryFun, opts);
-        }).then(function (data) {
-          data.rows.should.have.length(1, 'returns one doc');
-          data.rows[0].doc._id.should.equal('doc_0');
-
-          opts.keys = [2, 'foo', 1, 0, null, ''];
-          return db.query(queryFun, opts);
-        }).then(function (data) {
-          // check that the returned ordering fits opts.keys
-          data.rows.should.have.length(7, 'returns 7 docs in correct order');
-          data.rows[0].doc._id.should.equal('doc_2');
-          data.rows[1].doc._id.should.equal('doc_foo');
-          data.rows[2].doc._id.should.equal('doc_1');
-          data.rows[3].doc._id.should.equal('doc_0');
-          data.rows[4].doc._id.should.equal('doc_null');
-          data.rows[5].doc._id.should.equal('doc_undefined');
-          data.rows[6].doc._id.should.equal('doc_empty');
-
-          opts.keys = [3, 1, 4, 2];
-          return db.query(queryFun, opts);
-        }).then(function (data) {
-          // nonexistent keys just give us holes in the list
-          data.rows.should.have.length(2, 'returns 2 non-empty docs');
-          data.rows[0].key.should.equal(1);
-          data.rows[0].doc._id.should.equal('doc_1');
-          data.rows[1].key.should.equal(2);
-          data.rows[1].doc._id.should.equal('doc_2');
-
-          opts.keys = [2, 1, 2, 0, 2, 1];
-          return db.query(queryFun, opts);
-        }).then(function (data) {
-          // with duplicates, we return multiple docs
-          data.rows.should.have.length(6, 'returns 6 docs with duplicates');
-          data.rows[0].doc._id.should.equal('doc_2');
-          data.rows[1].doc._id.should.equal('doc_1');
-          data.rows[2].doc._id.should.equal('doc_2');
-          data.rows[3].doc._id.should.equal('doc_0');
-          data.rows[4].doc._id.should.equal('doc_2');
-          data.rows[5].doc._id.should.equal('doc_1');
-
-          opts.keys = [2, 1, 2, 3, 2];
-          return db.query(queryFun, opts);
-        }).then(function (data) {
-          // duplicates and unknowns at the same time, for maximum weirdness
-          data.rows.should.have.length(4, 'returns 2 docs with duplicates/unknowns');
-          data.rows[0].doc._id.should.equal('doc_2');
-          data.rows[1].doc._id.should.equal('doc_1');
-          data.rows[2].doc._id.should.equal('doc_2');
-          data.rows[3].doc._id.should.equal('doc_2');
-
-          opts.keys = [3];
-          return db.query(queryFun, opts);
-        }).then(function (data) {
-          data.rows.should.have.length(0, 'returns 0 doc due to unknown key');
-
-          opts.include_docs = false;
-          opts.keys = [3, 2];
-          return db.query(queryFun, opts);
-        }).then(function (data) {
-          data.rows.should.have.length(1, 'returns 1 doc due to unknown key');
-          data.rows[0].id.should.equal('doc_2');
-          should.not.exist(data.rows[0].doc, 'no doc, since include_docs=false');
-        });
       });
+      const opts = {include_docs: true};
+      await db.bulkDocs({
+        docs: [
+          {_id: 'doc_0', field: 0},
+          {_id: 'doc_1', field: 1},
+          {_id: 'doc_2', field: 2},
+          {_id: 'doc_empty', field: ''},
+          {_id: 'doc_null', field: null},
+          {_id: 'doc_undefined' /* field undefined */},
+          {_id: 'doc_foo', field: 'foo'}
+        ]
+      });
+
+        const res = await db.query(queryFun, opts);
+
+        res.rows.should.have.length(7, 'returns all docs');
+
+        opts.keys = [];
+        const resEmptyKeys = await db.query(queryFun, opts);
+
+        resEmptyKeys.rows.should.have.length(0, 'returns 0 docs');
+
+        // When passed an empty keys array (above), query mutates opts by deleting the
+        // keys array and adding limit = 0. That behavior breaks this test result when
+        // implementing limit and skip (#8370); it is correct (and necessary) to clean
+        // up that side effect here.
+        opts.keys = [0];
+        delete opts.limit;
+        const resDeletedLimit = await db.query(queryFun, opts);
+
+        resDeletedLimit.rows.should.have.length(1, 'returns one doc');
+        resDeletedLimit.rows[0].doc._id.should.equal('doc_0');
+
+        // check that the returned ordering fits opts.keys
+        opts.keys = [2, 'foo', 1, 0, null, ''];
+        const resWithKeys = await db.query(queryFun, opts);
+
+        resWithKeys.rows.should.have.length(7, 'returns 7 docs in correct order');
+        resWithKeys.rows[0].doc._id.should.equal('doc_2');
+        resWithKeys.rows[1].doc._id.should.equal('doc_foo');
+        resWithKeys.rows[2].doc._id.should.equal('doc_1');
+        resWithKeys.rows[3].doc._id.should.equal('doc_0');
+        resWithKeys.rows[4].doc._id.should.equal('doc_null');
+        resWithKeys.rows[5].doc._id.should.equal('doc_undefined');
+        resWithKeys.rows[6].doc._id.should.equal('doc_empty');
+
+        // nonexistent keys just give us holes in the list
+        opts.keys = [3, 1, 4, 2];
+        const resInclNonExistentKeys = await db.query(queryFun, opts);
+
+        resInclNonExistentKeys.rows.should.have.length(2, 'returns 2 non-empty docs');
+        resInclNonExistentKeys.rows[0].key.should.equal(1);
+        resInclNonExistentKeys.rows[0].doc._id.should.equal('doc_1');
+        resInclNonExistentKeys.rows[1].key.should.equal(2);
+        resInclNonExistentKeys.rows[1].doc._id.should.equal('doc_2');
+
+        // with duplicates, we return multiple docs
+        opts.keys = [2, 1, 2, 0, 2, 1];
+        const resWithDuplicateKeys = await db.query(queryFun, opts);
+
+        resWithDuplicateKeys.rows.should.have.length(6, 'returns 6 docs with duplicates');
+        resWithDuplicateKeys.rows[0].doc._id.should.equal('doc_2');
+        resWithDuplicateKeys.rows[1].doc._id.should.equal('doc_1');
+        resWithDuplicateKeys.rows[2].doc._id.should.equal('doc_2');
+        resWithDuplicateKeys.rows[3].doc._id.should.equal('doc_0');
+        resWithDuplicateKeys.rows[4].doc._id.should.equal('doc_2');
+        resWithDuplicateKeys.rows[5].doc._id.should.equal('doc_1');
+
+        // duplicates and unknowns at the same time, for maximum weirdness
+        opts.keys = [2, 1, 2, 3, 2];
+        const resWithDuplicateAndUnknownKeys = await db.query(queryFun, opts);
+
+        resWithDuplicateAndUnknownKeys.rows.should.have.length(4, 'returns 2 docs with duplicates/unknowns');
+        resWithDuplicateAndUnknownKeys.rows[0].doc._id.should.equal('doc_2');
+        resWithDuplicateAndUnknownKeys.rows[1].doc._id.should.equal('doc_1');
+        resWithDuplicateAndUnknownKeys.rows[2].doc._id.should.equal('doc_2');
+        resWithDuplicateAndUnknownKeys.rows[3].doc._id.should.equal('doc_2');
+
+        opts.keys = [3];
+        const resWithUnknownKey = await db.query(queryFun, opts);
+
+        resWithUnknownKey.rows.should.have.length(0, 'returns 0 doc due to unknown key');
+
+        opts.include_docs = false;
+        opts.keys = [3, 2];
+
+        const resWithoutDocs = await db.query(queryFun, opts);
+
+        resWithoutDocs.rows.should.have.length(1, 'returns 1 doc due to unknown key');
+        resWithoutDocs.rows[0].id.should.equal('doc_2');
+        should.not.exist(resWithoutDocs.rows[0].doc, 'no doc, since include_docs=false');
     });
 
-    it('Testing query with multiple keys, multiple docs', function () {
-      function ids(row) {
-        return row.id;
-      }
+    it('Testing query with multiple keys, multiple docs', async () => {
       const opts = {keys: [0, 1, 2]};
-      let spec;
+
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.field1);
           emit(doc.field2);
         }
-      }).then(function (mapFunction) {
-        return db.bulkDocs({
-          docs: [
-            {_id: '0', field1: 0},
-            {_id: '1a', field1: 1},
-            {_id: '1b', field1: 1},
-            {_id: '1c', field1: 1},
-            {_id: '2+3', field1: 2, field2: 3},
-            {_id: '4+5', field1: 4, field2: 5},
-            {_id: '3+5', field1: 3, field2: 5},
-            {_id: '3+4', field1: 3, field2: 4}
-          ]
-        }).then(function () {
-          spec = ['0', '1a', '1b', '1c', '2+3'];
-          return db.query(mapFunction, opts);
-        }).then(function (data) {
-          data.rows.map(ids).should.deep.equal(spec);
-
-          opts.keys = [3, 5, 4, 3];
-          spec = ['2+3', '3+4', '3+5', '3+5', '4+5', '3+4', '4+5', '2+3', '3+4', '3+5'];
-          return db.query(mapFunction, opts);
-        }).then(function (data) {
-          data.rows.map(ids).should.deep.equal(spec);
-        });
       });
+
+      await db.bulkDocs({
+        docs: [
+          {_id: '0', field1: 0},
+          {_id: '1a', field1: 1},
+          {_id: '1b', field1: 1},
+          {_id: '1c', field1: 1},
+          {_id: '2+3', field1: 2, field2: 3},
+          {_id: '4+5', field1: 4, field2: 5},
+          {_id: '3+5', field1: 3, field2: 5},
+          {_id: '3+4', field1: 3, field2: 4}
+        ]
+      });
+
+      const res = await db.query(queryFun, opts);
+
+      res.rows.map(row => row.id).should.deep.equal(['0', '1a', '1b', '1c', '2+3']);
+
+      opts.keys = [3, 5, 4, 3];
+      const res1 = await db.query(queryFun, opts);
+
+      res1.rows.map(row => row.id).should.deep.equal(
+        ['2+3', '3+4', '3+5', '3+5', '4+5', '3+4', '4+5', '2+3', '3+4', '3+5']);
     });
 
-    it('Testing multiple emissions (issue #14)', function () {
+    it('Testing multiple emissions (issue #14)', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map : function (doc) {
           emit(doc.foo);
           emit(doc.bar);
@@ -2249,134 +2157,218 @@ function tests(suiteName, dbName, dbType, viewType) {
           emit(doc.bar, 'multiple values!');
           emit(doc.bar, 'crayon!');
         }
-      }).then(function (mapFunction) {
-        return db.bulkDocs({
-          docs: [
-            {_id: 'doc1', foo : 'foo', bar : 'bar'},
-            {_id: 'doc2', foo : 'foo', bar : 'bar'}
-          ]
-        }).then(function () {
-          const opts = {keys: ['foo', 'bar']};
-
-          return db.query(mapFunction, opts);
-        });
-      }).then(function (data) {
-        data.rows.should.have.length(10);
-
-        data.rows[0].key.should.equal('foo');
-        data.rows[0].id.should.equal('doc1');
-        data.rows[1].key.should.equal('foo');
-        data.rows[1].id.should.equal('doc1');
-
-        data.rows[2].key.should.equal('foo');
-        data.rows[2].id.should.equal('doc2');
-        data.rows[3].key.should.equal('foo');
-        data.rows[3].id.should.equal('doc2');
-
-        data.rows[4].key.should.equal('bar');
-        data.rows[4].id.should.equal('doc1');
-        should.not.exist(data.rows[4].value);
-        data.rows[5].key.should.equal('bar');
-        data.rows[5].id.should.equal('doc1');
-        data.rows[5].value.should.equal('crayon!');
-        data.rows[6].key.should.equal('bar');
-        data.rows[6].id.should.equal('doc1');
-        data.rows[6].value.should.equal('multiple values!');
-
-        data.rows[7].key.should.equal('bar');
-        data.rows[7].id.should.equal('doc2');
-        should.not.exist(data.rows[7].value);
-        data.rows[8].key.should.equal('bar');
-        data.rows[8].id.should.equal('doc2');
-        data.rows[8].value.should.equal('crayon!');
-        data.rows[9].key.should.equal('bar');
-        data.rows[9].id.should.equal('doc2');
-        data.rows[9].value.should.equal('multiple values!');
       });
+
+      await db.bulkDocs({
+        docs: [
+          {_id: 'doc1', foo : 'foo', bar : 'bar'},
+          {_id: 'doc2', foo : 'foo', bar : 'bar'}
+        ]
+      });
+
+      const opts = {keys: ['foo', 'bar']};
+      const res = await db.query(queryFun, opts);
+
+      res.rows.should.have.length(10);
+
+      res.rows[0].key.should.equal('foo');
+      res.rows[0].id.should.equal('doc1');
+      res.rows[1].key.should.equal('foo');
+      res.rows[1].id.should.equal('doc1');
+
+      res.rows[2].key.should.equal('foo');
+      res.rows[2].id.should.equal('doc2');
+      res.rows[3].key.should.equal('foo');
+      res.rows[3].id.should.equal('doc2');
+
+      res.rows[4].key.should.equal('bar');
+      res.rows[4].id.should.equal('doc1');
+      should.not.exist(res.rows[4].value);
+      res.rows[5].key.should.equal('bar');
+      res.rows[5].id.should.equal('doc1');
+      res.rows[5].value.should.equal('crayon!');
+      res.rows[6].key.should.equal('bar');
+      res.rows[6].id.should.equal('doc1');
+      res.rows[6].value.should.equal('multiple values!');
+
+      res.rows[7].key.should.equal('bar');
+      res.rows[7].id.should.equal('doc2');
+      should.not.exist(res.rows[7].value);
+      res.rows[8].key.should.equal('bar');
+      res.rows[8].id.should.equal('doc2');
+      res.rows[8].value.should.equal('crayon!');
+      res.rows[9].key.should.equal('bar');
+      res.rows[9].id.should.equal('doc2');
+      res.rows[9].value.should.equal('multiple values!');
     });
 
-    it('Testing multiple emissions (complex keys)', function () {
+    it('Testing multiple emissions (complex keys)', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function () {
           emit(['a'], 1);
           emit(['b'], 3);
           emit(['a'], 2);
         }
-      }).then(function (mapFunction) {
-        return db.bulkDocs({
-          docs: [
-            {_id: 'doc1', foo: 'foo', bar: 'bar'}
-          ]
-        }).then(function () {
-          return db.query(mapFunction);
-        });
-      }).then(function (data) {
-        data.rows.should.have.length(3);
-        data.rows[0].key.should.eql(['a']);
-        data.rows[0].value.should.equal(1);
-        data.rows[1].key.should.eql(['a']);
-        data.rows[1].value.should.equal(2);
-        data.rows[2].key.should.eql(['b']);
-        data.rows[2].value.should.equal(3);
       });
+
+      await db.bulkDocs({
+        docs: [
+          {_id: 'doc1', foo: 'foo', bar: 'bar'}
+        ]
+      });
+
+      const res = await db.query(queryFun);
+
+      res.rows.should.have.length(3);
+      res.rows[0].key.should.eql(['a']);
+      res.rows[0].value.should.equal(1);
+      res.rows[1].key.should.eql(['a']);
+      res.rows[1].value.should.equal(2);
+      res.rows[2].key.should.eql(['b']);
+      res.rows[2].value.should.equal(3);
+
     });
 
-    it('Testing empty startkeys and endkeys', function () {
-      let opts = {startkey: null, endkey: ''};
-      function ids(row) {
-        return row.id;
-      }
-      let spec;
+    it('Testing empty startkeys and endkeys', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map : function (doc) {
           emit(doc.field);
         }
-      }).then(function (mapFunction) {
-        return db.bulkDocs({
-          docs: [
-            {_id: 'doc_empty', field: ''},
-            {_id: 'doc_null', field: null},
-            {_id: 'doc_undefined' /* field undefined */},
-            {_id: 'doc_foo', field: 'foo'}
-          ]
-        }).then(function () {
-          spec = ['doc_null', 'doc_undefined', 'doc_empty'];
-          return db.query(mapFunction, opts);
-        }).then(function (data) {
-          data.rows.map(ids).should.deep.equal(spec);
-
-          opts = {startkey: '', endkey: 'foo'};
-          spec = ['doc_empty', 'doc_foo'];
-          return db.query(mapFunction, opts);
-        }).then(function (data) {
-          data.rows.map(ids).should.deep.equal(spec);
-
-          opts = {startkey: null, endkey: null};
-          spec = ['doc_null', 'doc_undefined'];
-          return db.query(mapFunction, opts);
-        }).then(function (data) {
-          data.rows.map(ids).should.deep.equal(spec);
-
-          opts.descending = true;
-          spec.reverse();
-          return db.query(mapFunction, opts);
-        }).then(function (data) {
-          data.rows.map(ids).should.deep.equal(spec);
-        });
       });
+
+      await db.bulkDocs({
+        docs: [
+          {_id: 'doc_empty', field: ''},
+          {_id: 'doc_null', field: null},
+          {_id: 'doc_undefined' /* field undefined */},
+          {_id: 'doc_foo', field: 'foo'}
+        ]
+      });
+
+      const opts = {startkey: null, endkey: ''};
+      const data = await db.query(queryFun, opts);
+
+      data.rows.map(row => row.id).should.deep.equal(['doc_null', 'doc_undefined', 'doc_empty']);
+
+      const opts1 = {startkey: '', endkey: 'foo'};
+      const data1 = await db.query(queryFun, opts1);
+
+      data1.rows.map(row => row.id).should.deep.equal(['doc_empty', 'doc_foo']);
+
+      const opts2 = {startkey: null, endkey: null};
+      const data2 = await db.query(queryFun, opts2);
+
+      data2.rows.map(row => row.id).should.deep.equal(['doc_null', 'doc_undefined']);
+
+      opts2.descending = true;
+      const data3 = await db.query(queryFun, opts2);
+
+      data3.rows.map(row => row.id).should.deep.equal(['doc_undefined', 'doc_null']);
     });
 
-    it('#238 later non-winning revisions', function () {
+    it('#238 later non-winning revisions', async () => {
       const db = new PouchDB(dbName);
-
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.name);
         }
-      }).then(function (mapFun) {
-        return db.bulkDocs([{
+      });
+
+      await db.bulkDocs([{
+        _id: 'doc',
+        name: 'zoot',
+        _rev: '2-x',
+        _revisions: {
+          start: 2,
+          ids: ['x', 'y']
+        }
+      }], {new_edits: false});
+
+      const res = await db.query(queryFun);
+
+      res.rows.should.have.length(1);
+      res.rows[0].id.should.equal('doc');
+      res.rows[0].key.should.equal('zoot');
+
+      await db.bulkDocs([{
+        _id: 'doc',
+        name: 'suit',
+        _rev: '2-w',
+        _revisions: {
+          start: 2,
+          ids: ['w', 'y']
+        }
+      }], {new_edits: false});
+
+      const res1 = await db.query(queryFun);
+
+      res1.rows.should.have.length(1);
+      res1.rows[0].id.should.equal('doc');
+      res1.rows[0].key.should.equal('zoot');
+    });
+
+    it('#238 later non-winning deleted revisions', async () => {
+      const db = new PouchDB(dbName);
+      const queryFun = await createView(db, {
+        map: function (doc) {
+          emit(doc.name);
+        }
+      });
+
+      await db.bulkDocs([{
+        _id: 'doc',
+        name: 'zoot',
+        _rev: '2-x',
+        _revisions: {
+          start: 2,
+          ids: ['x', 'y']
+        }
+      }], {new_edits: false});
+
+      const res = await db.query(queryFun);
+
+      res.rows.should.have.length(1);
+      res.rows[0].id.should.equal('doc');
+      res.rows[0].key.should.equal('zoot');
+
+      await db.bulkDocs([{
+        _id: 'doc',
+        name: 'suit',
+        _deleted: true,
+        _rev: '2-z',
+        _revisions: {
+          start: 2,
+          ids: ['z', 'y']
+        }
+      }], {new_edits: false});
+
+      const res1 = await db.query(queryFun);
+
+      res1.rows.should.have.length(1);
+      res1.rows[0].id.should.equal('doc');
+      res1.rows[0].key.should.equal('zoot');
+    });
+
+    it('#238 query with conflicts', async () => {
+      const db = new PouchDB(dbName);
+      const queryFun = await createView(db, {
+        map: function (doc) {
+          emit(doc.name);
+        }
+      });
+
+      await db.bulkDocs([
+        {
+          _id: 'doc',
+          name: 'zab',
+          _rev: '2-y',
+          _revisions: {
+            start: 1,
+            ids: ['y']
+          }
+        }, {
           _id: 'doc',
           name: 'zoot',
           _rev: '2-x',
@@ -2384,272 +2376,172 @@ function tests(suiteName, dbName, dbType, viewType) {
             start: 2,
             ids: ['x', 'y']
           }
-        }], {new_edits: false}).then(function () {
-          return db.query(mapFun);
-        }).then(function (res) {
-          res.rows.should.have.length(1);
-          res.rows[0].id.should.equal('doc');
-          res.rows[0].key.should.equal('zoot');
-          return db.bulkDocs([{
-            _id: 'doc',
-            name: 'suit',
-            _rev: '2-w',
-            _revisions: {
-              start: 2,
-              ids: ['w', 'y']
-            }
-          }], {new_edits: false});
-        }).then(function () {
-          return db.query(mapFun);
-        }).then(function (res) {
-          res.rows.should.have.length(1);
-          res.rows[0].id.should.equal('doc');
-          res.rows[0].key.should.equal('zoot');
-        });
-      });
-    });
-
-    it('#238 later non-winning deleted revisions', function () {
-      const db = new PouchDB(dbName);
-
-      return createView(db, {
-        map: function (doc) {
-          emit(doc.name);
         }
-      }).then(function (mapFun) {
-        return db.bulkDocs([{
+      ], {new_edits: false});
+
+      const res = await db.query(queryFun);
+
+      res.rows.should.have.length(1);
+      res.rows[0].id.should.equal('doc');
+      res.rows[0].key.should.equal('zoot');
+
+      await db.bulkDocs([
+        {
           _id: 'doc',
-          name: 'zoot',
-          _rev: '2-x',
+          name: 'suit',
+          _rev: '2-w',
           _revisions: {
             start: 2,
-            ids: ['x', 'y']
+            ids: ['w', 'y']
           }
-        }], {new_edits: false}).then(function () {
-          return db.query(mapFun);
-        }).then(function (res) {
-          res.rows.should.have.length(1);
-          res.rows[0].id.should.equal('doc');
-          res.rows[0].key.should.equal('zoot');
-          return db.bulkDocs([{
-            _id: 'doc',
-            name: 'suit',
-            _deleted: true,
-            _rev: '2-z',
-            _revisions: {
-              start: 2,
-              ids: ['z', 'y']
-            }
-          }], {new_edits: false});
-        }).then(function () {
-          return db.query(mapFun);
-        }).then(function (res) {
-          res.rows.should.have.length(1);
-          res.rows[0].id.should.equal('doc');
-          res.rows[0].key.should.equal('zoot');
-        });
-      });
-    });
-
-    it('#238 query with conflicts', function () {
-      const db = new PouchDB(dbName);
-
-      return createView(db, {
-        map: function (doc) {
-          emit(doc.name);
+        }, {
+          _id: 'doc',
+          name: 'zorb',
+          _rev: '2-z',
+          _revisions: {
+            start: 2,
+            ids: ['z', 'y']
+          }
         }
-      }).then(function (mapFun) {
-        return db.bulkDocs([
+      ], {new_edits: false});
 
-          {
-            _id: 'doc',
-            name: 'zab',
-            _rev: '2-y',
-            _revisions: {
-              start: 1,
-              ids: ['y']
-            }
-          }, {
-            _id: 'doc',
-            name: 'zoot',
-            _rev: '2-x',
-            _revisions: {
-              start: 2,
-              ids: ['x', 'y']
-            }
-          }
-        ], {new_edits: false}).then(function () {
-          return db.query(mapFun);
-        }).then(function (res) {
-          res.rows.should.have.length(1);
-          res.rows[0].id.should.equal('doc');
-          res.rows[0].key.should.equal('zoot');
-          return db.bulkDocs([
-            {
-              _id: 'doc',
-              name: 'suit',
-              _rev: '2-w',
-              _revisions: {
-                start: 2,
-                ids: ['w', 'y']
-              }
-            }, {
-              _id: 'doc',
-              name: 'zorb',
-              _rev: '2-z',
-              _revisions: {
-                start: 2,
-                ids: ['z', 'y']
-              }
-            }
-          ], {new_edits: false});
-        }).then(function () {
-          return db.query(mapFun);
-        }).then(function (res) {
-          res.rows.should.have.length(1);
-          res.rows[0].id.should.equal('doc');
-          res.rows[0].key.should.equal('zorb');
-        });
-      });
+      const res1 = await db.query(queryFun);
+
+      res1.rows.should.have.length(1);
+      res1.rows[0].id.should.equal('doc');
+      res1.rows[0].key.should.equal('zorb');
     });
 
-    it('Testing ordering with startkey/endkey/key', function () {
-      let opts = {startkey: '1', endkey: '4'};
-      function ids(row) {
-        return row.id;
-      }
-      let spec;
+    it('Testing ordering with startkey/endkey/key', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map : function (doc) {
           emit(doc.field, null);
         }
-      }).then(function (mapFunction) {
-        return db.bulkDocs({
-          docs: [
-            {_id: 'h', field: '4'},
-            {_id: 'a', field: '1'},
-            {_id: 'e', field: '2'},
-            {_id: 'c', field: '1'},
-            {_id: 'f', field: '3'},
-            {_id: 'g', field: '4'},
-            {_id: 'd', field: '2'},
-            {_id: 'b', field: '1'}
-          ]
-        }).then(function () {
-          spec = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
-          return db.query(mapFunction, opts);
-        }).then(function (data) {
-          data.rows.map(ids).should.deep.equal(spec);
-
-          opts = {key: '1'};
-          spec = ['a', 'b', 'c'];
-          return db.query(mapFunction, opts);
-        }).then(function (data) {
-          data.rows.map(ids).should.deep.equal(spec);
-
-          opts = {key: '2'};
-          spec = ['d', 'e'];
-          return db.query(mapFunction, opts);
-        }).then(function (data) {
-          data.rows.map(ids).should.deep.equal(spec);
-
-          opts.descending = true;
-          spec.reverse();
-          return db.query(mapFunction, opts);
-        }).then(function (data) {
-          data.rows.map(ids).should.deep.equal(spec, 'reverse order');
-        });
       });
+
+      await db.bulkDocs({
+        docs: [
+          {_id: 'h', field: '4'},
+          {_id: 'a', field: '1'},
+          {_id: 'e', field: '2'},
+          {_id: 'c', field: '1'},
+          {_id: 'f', field: '3'},
+          {_id: 'g', field: '4'},
+          {_id: 'd', field: '2'},
+          {_id: 'b', field: '1'}
+        ]
+      });
+
+      const opts = {startkey: '1', endkey: '4'};
+      const res = await db.query(queryFun, opts);
+
+      res.rows.map(row => row.id)
+        .should.deep.equal(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']);
+
+      const opts1 = {key: '1'};
+      const res1 = await db.query(queryFun, opts1);
+
+      res1.rows.map(row => row.id)
+        .should.deep.equal(['a', 'b', 'c']);
+
+      const opts2 = {key: '2'};
+      const res2 = await db.query(queryFun, opts2);
+
+      res2.rows.map(row => row.id)
+        .should.deep.equal(['d', 'e']);
+
+      opts2.descending = true;
+      const res3 = await db.query(queryFun, opts2);
+
+      res3.rows.map(row => row.id)
+        .should.deep.equal(['e', 'd'], 'reverse order');
     });
 
-    it('opts.keys should work with complex keys', function () {
+    it('opts.keys should work with complex keys', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.foo, doc.foo);
         }
-      }).then(function (mapFunction) {
-        const keys = [
-          {key: 'missing'},
-          ['test', 1],
-          {key1: 'value1'},
-          ['missing'],
-          [0, 0]
-        ];
-        return db.bulkDocs({
-          docs: [
-            {foo: {key2: 'value2'}},
-            {foo: {key1: 'value1'}},
-            {foo: [0, 0]},
-            {foo: ['test', 1]},
-            {foo: [0, false]}
-          ]
-        }).then(function () {
-          const opts = {keys};
-          return db.query(mapFunction, opts);
-        }).then(function (data) {
-          data.rows.should.have.length(3);
-          data.rows[0].value.should.deep.equal(keys[1]);
-          data.rows[1].value.should.deep.equal(keys[2]);
-          data.rows[2].value.should.deep.equal(keys[4]);
-        });
       });
+
+      const keys = [
+        {key: 'missing'},
+        ['test', 1],
+        {key1: 'value1'},
+        ['missing'],
+        [0, 0]
+      ];
+
+      await db.bulkDocs({
+        docs: [
+          {foo: {key2: 'value2'}},
+          {foo: {key1: 'value1'}},
+          {foo: [0, 0]},
+          {foo: ['test', 1]},
+          {foo: [0, false]}
+        ]
+      });
+
+      const opts = {keys};
+      const res = await db.query(queryFun, opts);
+
+      res.rows.should.have.length(3);
+      res.rows[0].value.should.deep.equal(keys[1]);
+      res.rows[1].value.should.deep.equal(keys[2]);
+      res.rows[2].value.should.deep.equal(keys[4]);
     });
 
-    it('Testing ordering with dates', function () {
-      function ids(row) {
-        return row.id;
-      }
+    it('Testing ordering with dates', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map : function (doc) {
           emit(doc.date, null);
         }
-      }).then(function (mapFunction) {
-        return db.bulkDocs({
-          docs: [
-            {_id: '1969', date: '1969 was when Space Oddity hit'},
-            {_id: '1971', date : new Date('1971-12-17T00:00:00.000Z')}, // Hunky Dory was released
-            {_id: '1972', date: '1972 was when Ziggy landed on Earth'},
-            {_id: '1977', date: new Date('1977-01-14T00:00:00.000Z')}, // Low was released
-            {_id: '1985', date: '1985+ is better left unmentioned'}
-          ]
-        }).then(function () {
-          return db.query(mapFunction);
-        }).then(function (data) {
-          data.rows.map(ids).should.deep.equal(['1969', '1971', '1972', '1977', '1985']);
-        });
       });
+
+      await db.bulkDocs({
+        docs: [
+          {_id: '1969', date: '1969 was when Space Oddity hit'},
+          {_id: '1971', date : new Date('1971-12-17T00:00:00.000Z')}, // Hunky Dory was released
+          {_id: '1972', date: '1972 was when Ziggy landed on Earth'},
+          {_id: '1977', date: new Date('1977-01-14T00:00:00.000Z')}, // Low was released
+          {_id: '1985', date: '1985+ is better left unmentioned'}
+        ]
+      });
+
+      const data = await db.query(queryFun);
+
+      data.rows.map(row => row.id)
+        .should.deep.equal(['1969', '1971', '1972', '1977', '1985']);
     });
 
-    it('should work with a joined doc', function () {
-      function change(row) {
-        return [row.key, row.doc._id, row.doc.val];
-      }
+    it('should work with a joined doc', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           if (doc.join) {
             emit(doc.color, {_id : doc.join});
           }
         }
-      }).then(function (mapFunction) {
-        return db.bulkDocs({
-          docs: [
-            {_id: 'a', join: 'b', color: 'green'},
-            {_id: 'b', val: 'c'},
-            {_id: 'd', join: 'f', color: 'red'}
-          ]
-        }).then(function () {
-          return db.query(mapFunction, {include_docs: true});
-        }).then(function (resp) {
-          return change(resp.rows[0]).should.deep.equal(['green', 'b', 'c']);
-        });
       });
+
+      await db.bulkDocs({
+        docs: [
+          {_id: 'a', join: 'b', color: 'green'},
+          {_id: 'b', val: 'c'},
+          {_id: 'd', join: 'f', color: 'red'}
+        ]
+      });
+
+      const res = await db.query(queryFun, {include_docs: true});
+      const firstRow = res.rows[0];
+      [firstRow.key, firstRow.doc._id, firstRow.doc.val]
+        .should.deep.equal(['green', 'b', 'c']);
     });
 
-    it('should query correctly with a constiety of criteria', function () {
+    it('should query correctly with a constiety of criteria', async () => {
       const db = new PouchDB(dbName);
       const ddoc = {
         _id: '_design/test',
@@ -2661,111 +2553,132 @@ function tests(suiteName, dbName, dbType, viewType) {
           }
         }
       };
-      const mapFun = 'test';
-      return db.put(ddoc).then(function () {
-        const docs = [
-          {_id : '0'},
-          {_id : '1'},
-          {_id : '2'},
-          {_id : '3'},
-          {_id : '4'},
-          {_id : '5'},
-          {_id : '6'},
-          {_id : '7'},
-          {_id : '8'},
-          {_id : '9'}
-        ];
-        return db.bulkDocs({docs}).then(function (res) {
-          docs[3]._deleted = true;
-          docs[7]._deleted = true;
-          docs[3]._rev = res[3].rev;
-          docs[7]._rev = res[7].rev;
-          return db.remove(docs[3]);
-        }).then(function () {
-          return db.remove(docs[7]);
-        }).then(function () {
-          return db.query(mapFun, {});
-        }).then(function (res) {
-          res.rows.should.have.length(8, 'correctly return rows');
-          res.total_rows.should.equal(8, 'correctly return total_rows');
-          return db.query(mapFun, {startkey : '5'});
-        }).then(function (res) {
-          res.rows.should.have.length(4, 'correctly return rows');
-          res.total_rows.should.equal(8, 'correctly return total_rows');
-          return db.query(mapFun, {startkey : '5', skip : 2, limit : 10});
-        }).then(function (res) {
-          res.rows.should.have.length(2, 'correctly return rows');
-          res.total_rows.should.equal(8, 'correctly return total_rows');
-          return db.query(mapFun, {startkey : '5', descending : true, skip : 1});
-        }).then(function (res) {
-          res.rows.should.have.length(4, 'correctly return rows');
-          res.total_rows.should.equal(8, 'correctly return total_rows');
-          return db.query(mapFun, {startkey : '5', endkey : 'z'});
-        }).then(function (res) {
-          res.rows.should.have.length(4, 'correctly return rows');
-          res.total_rows.should.equal(8, 'correctly return total_rows');
-          return db.query(mapFun, {startkey : '5', endkey : '5'});
-        }).then(function (res) {
-          res.rows.should.have.length(1, 'correctly return rows');
-          res.total_rows.should.equal(8, 'correctly return total_rows');
-          return db.query(mapFun, {startkey : '5', endkey : '4', descending : true});
-        }).then(function (res) {
-          res.rows.should.have.length(2, 'correctly return rows');
-          res.total_rows.should.equal(8, 'correctly return total_rows');
-          return db.query(mapFun, {startkey : '3', endkey : '7', descending : false});
-        }).then(function (res) {
-          res.rows.should.have.length(3, 'correctly return rows');
-          res.total_rows.should.equal(8, 'correctly return total_rows');
-          return db.query(mapFun, {startkey : '7', endkey : '3', descending : true});
-        }).then(function (res) {
-          res.rows.should.have.length(3, 'correctly return rows');
-          res.total_rows.should.equal(8, 'correctly return total_rows');
-          return db.query(mapFun, {startkey : '', endkey : '0'});
-        }).then(function (res) {
-          res.rows.should.have.length(1, 'correctly return rows');
-          res.total_rows.should.equal(8, 'correctly return total_rows');
-          return db.query(mapFun, {keys : ['0', '1', '3']});
-        }).then(function (res) {
-          res.rows.should.have.length(2, 'correctly return rows');
-          res.total_rows.should.equal(8, 'correctly return total_rows');
-          return db.query(mapFun, {keys : ['0', '1', '0', '2', '1', '1']});
-        }).then(function (res) {
-          res.rows.should.have.length(6, 'correctly return rows');
-          res.rows.map(function (row) { return row.key; }).should.deep.equal(
-            ['0', '1', '0', '2', '1', '1']);
-          res.total_rows.should.equal(8, 'correctly return total_rows');
-          return db.query(mapFun, {keys : []});
-        }).then(function (res) {
-          res.rows.should.have.length(0, 'correctly return rows');
-          res.total_rows.should.equal(8, 'correctly return total_rows');
-          return db.query(mapFun, {keys : ['7']});
-        }).then(function (res) {
-          res.rows.should.have.length(0, 'correctly return rows');
-          res.total_rows.should.equal(8, 'correctly return total_rows');
-          return db.query(mapFun, {key : '3'});
-        }).then(function (res) {
-          res.rows.should.have.length(0, 'correctly return rows');
-          res.total_rows.should.equal(8, 'correctly return total_rows');
-          return db.query(mapFun, {key : '2'});
-        }).then(function (res) {
-          res.rows.should.have.length(1, 'correctly return rows');
-          res.total_rows.should.equal(8, 'correctly return total_rows');
-          return db.query(mapFun, {key : 'z'});
-        }).then(function (res) {
-          res.rows.should.have.length(0, 'correctly return rows');
-          res.total_rows.should.equal(8, 'correctly return total_rows');
+      const queryFun = 'test';
 
-          return db.query(mapFun, {startkey : '5', endkey : '4'}).then(function (res) {
-            res.should.not.exist('expected error on reversed start/endkey');
-          }).catch(function (err) {
-            err.status.should.be.oneOf([400, 500]);
-            err.message.should.be.a('string');
-          });
-        });
-      });
+      await db.put(ddoc);
+
+      const docs = [
+      {_id : '0'},
+      {_id : '1'},
+      {_id : '2'},
+      {_id : '3'},
+      {_id : '4'},
+      {_id : '5'},
+      {_id : '6'},
+      {_id : '7'},
+      {_id : '8'},
+      {_id : '9'}
+      ];
+
+      const res = await db.bulkDocs({docs});
+
+      docs[3]._deleted = true;
+      docs[7]._deleted = true;
+      docs[3]._rev = res[3].rev;
+      docs[7]._rev = res[7].rev;
+
+      await db.remove(docs[3]);
+      await db.remove(docs[7]);
+
+      const queryRes = await db.query(queryFun, {});
+
+      queryRes.rows.should.have.length(8, 'correctly return rows');
+      queryRes.total_rows.should.equal(8, 'correctly return total_rows');
+
+      const queryRes1 = await db.query(queryFun, {startkey : '5'});
+
+      queryRes1.rows.should.have.length(4, 'correctly return rows');
+      queryRes1.total_rows.should.equal(8, 'correctly return total_rows');
+
+      const queryRes2 = await db.query(queryFun, {startkey : '5', skip : 2, limit : 10});
+
+      queryRes2.rows.should.have.length(2, 'correctly return rows');
+      queryRes2.total_rows.should.equal(8, 'correctly return total_rows');
+
+      const queryRes3 = await db.query(queryFun, {startkey : '5', descending : true, skip : 1});
+
+      queryRes3.rows.should.have.length(4, 'correctly return rows');
+      queryRes3.total_rows.should.equal(8, 'correctly return total_rows');
+
+      const queryRes4 = await db.query(queryFun, {startkey : '5', endkey : 'z'});
+
+      queryRes4.rows.should.have.length(4, 'correctly return rows');
+      queryRes4.total_rows.should.equal(8, 'correctly return total_rows');
+
+      const queryRes5 = await db.query(queryFun, {startkey : '5', endkey : '5'});
+
+      queryRes5.rows.should.have.length(1, 'correctly return rows');
+      queryRes5.total_rows.should.equal(8, 'correctly return total_rows');
+
+      const queryRes6 = await db.query(queryFun, {startkey : '5', endkey : '4', descending : true});
+
+      queryRes6.rows.should.have.length(2, 'correctly return rows');
+      queryRes6.total_rows.should.equal(8, 'correctly return total_rows');
+
+      const queryRes7 = await db.query(queryFun, {startkey : '3', endkey : '7', descending : false});
+
+      queryRes7.rows.should.have.length(3, 'correctly return rows');
+      queryRes7.total_rows.should.equal(8, 'correctly return total_rows');
+
+      const queryRes8 = await db.query(queryFun, {startkey : '7', endkey : '3', descending : true});
+
+      queryRes8.rows.should.have.length(3, 'correctly return rows');
+      queryRes8.total_rows.should.equal(8, 'correctly return total_rows');
+
+      const queryRes9 = await db.query(queryFun, {startkey : '', endkey : '0'});
+
+      queryRes9.rows.should.have.length(1, 'correctly return rows');
+      queryRes9.total_rows.should.equal(8, 'correctly return total_rows');
+
+      const queryRes10 = await db.query(queryFun, {keys : ['0', '1', '3']});
+
+      queryRes10.rows.should.have.length(2, 'correctly return rows');
+      queryRes10.total_rows.should.equal(8, 'correctly return total_rows');
+
+      const queryRes11 = await db.query(queryFun, {keys : ['0', '1', '0', '2', '1', '1']});
+
+      queryRes11.rows.should.have.length(6, 'correctly return rows');
+      const resKeys =  queryRes11.rows.map( row => row.key);
+
+      resKeys.should.deep.equal(['0', '1', '0', '2', '1', '1']);
+      queryRes11.total_rows.should.equal(8, 'correctly return total_rows');
+
+      const queryRes12 = await db.query(queryFun, {keys : []});
+
+      queryRes12.rows.should.have.length(0, 'correctly return rows');
+      queryRes12.total_rows.should.equal(8, 'correctly return total_rows');
+
+      const queryRes13 = await db.query(queryFun, {keys : ['7']});
+
+      queryRes13.rows.should.have.length(0, 'correctly return rows');
+      queryRes13.total_rows.should.equal(8, 'correctly return total_rows');
+
+      const queryRes14 = await db.query(queryFun, {key : '3'});
+
+      queryRes14.rows.should.have.length(0, 'correctly return rows');
+      queryRes14.total_rows.should.equal(8, 'correctly return total_rows');
+
+      const queryRes15 = await db.query(queryFun, {key : '2'});
+
+      queryRes15.rows.should.have.length(1, 'correctly return rows');
+      queryRes15.total_rows.should.equal(8, 'correctly return total_rows');
+
+      const queryRes16 = await db.query(queryFun, {key : 'z'});
+
+      queryRes16.rows.should.have.length(0, 'correctly return rows');
+      queryRes16.total_rows.should.equal(8, 'correctly return total_rows');
+
+      try {
+        const queryRes17 = await db.query(queryFun, {startkey : '5', endkey : '4'});
+
+        queryRes17.should.not.exist('expected error on reversed start/endkey');
+      } catch (err) {
+        err.status.should.be.oneOf([400, 500]);
+        err.message.should.be.a('string');
+      }
     });
 
-    it('should query correctly with skip/limit and multiple keys/values', function () {
+    it('should query correctly with skip/limit and multiple keys/values', async () => {
       const db = new PouchDB(dbName);
       const docs = {
         docs: [
@@ -2773,14 +2686,10 @@ function tests(suiteName, dbName, dbType, viewType) {
           {_id: 'doc2', foo : 'foo', bar : 'bar'}
         ]
       };
-      const getValues = function (res) {
-        return res.value;
-      };
-      const getIds = function (res) {
-        return res.id;
-      };
+      const getValues = row => row.value;
+      const getIds = row => row.id;
 
-      return createView(db, {
+      const queryFun = await createView(db, {
         map : function (doc) {
           emit(doc.foo, 'fooValue');
           emit(doc.foo);
@@ -2789,78 +2698,88 @@ function tests(suiteName, dbName, dbType, viewType) {
           emit(doc.bar, 'multiple values!');
           emit(doc.bar, 'crayon!');
         }
-      }).then(function (mapFun) {
-
-        return db.bulkDocs(docs).then(function () {
-          return db.query(mapFun, {});
-        }).then(function (res) {
-          res.rows.should.have.length(12, 'correctly return rows');
-          res.total_rows.should.equal(12, 'correctly return total_rows');
-          res.rows.map(getValues).should.deep.equal(
-            [null, 'crayon!', 'crayon!', 'multiple values!',
-              null, 'crayon!', 'crayon!', 'multiple values!',
-              null, 'fooValue', null, 'fooValue']);
-          res.rows.map(getIds).should.deep.equal(
-            ['doc1', 'doc1', 'doc1', 'doc1',
-              'doc2', 'doc2', 'doc2', 'doc2',
-              'doc1', 'doc1', 'doc2', 'doc2']);
-          return db.query(mapFun, {startkey : 'foo'});
-        }).then(function (res) {
-          res.rows.should.have.length(4, 'correctly return rows');
-          res.total_rows.should.equal(12, 'correctly return total_rows');
-          res.rows.map(getValues).should.deep.equal(
-            [null, 'fooValue', null, 'fooValue']);
-          res.rows.map(getIds).should.deep.equal(
-            ['doc1', 'doc1', 'doc2', 'doc2']);
-          return db.query(mapFun, {startkey : 'foo', endkey : 'foo'});
-        }).then(function (res) {
-          res.rows.should.have.length(4, 'correctly return rows');
-          res.total_rows.should.equal(12, 'correctly return total_rows');
-          return db.query(mapFun, {startkey : 'bar', endkey : 'bar'});
-        }).then(function (res) {
-          res.rows.should.have.length(8, 'correctly return rows');
-          res.total_rows.should.equal(12, 'correctly return total_rows');
-          return db.query(mapFun, {startkey : 'foo', limit : 1});
-        }).then(function (res) {
-          res.rows.should.have.length(1, 'correctly return rows');
-          res.total_rows.should.equal(12, 'correctly return total_rows');
-          res.rows.map(getValues).should.deep.equal([null]);
-          res.rows.map(getIds).should.deep.equal(['doc1']);
-          return db.query(mapFun, {startkey : 'foo', limit : 2});
-        }).then(function (res) {
-          res.rows.should.have.length(2, 'correctly return rows');
-          res.total_rows.should.equal(12, 'correctly return total_rows');
-          return db.query(mapFun, {startkey : 'foo', limit : 1000});
-        }).then(function (res) {
-          res.rows.should.have.length(4, 'correctly return rows');
-          res.total_rows.should.equal(12, 'correctly return total_rows');
-          return db.query(mapFun, {startkey : 'foo', skip : 1});
-        }).then(function (res) {
-          res.rows.should.have.length(3, 'correctly return rows');
-          res.total_rows.should.equal(12, 'correctly return total_rows');
-          return db.query(mapFun, {startkey : 'foo', skip : 3, limit : 0});
-        }).then(function (res) {
-          res.rows.should.have.length(0, 'correctly return rows');
-          res.total_rows.should.equal(12, 'correctly return total_rows');
-          return db.query(mapFun, {startkey : 'foo', skip : 3, limit : 1});
-        }).then(function (res) {
-          res.rows.should.have.length(1, 'correctly return rows');
-          res.total_rows.should.equal(12, 'correctly return total_rows');
-          res.rows.map(getValues).should.deep.equal(['fooValue']);
-          res.rows.map(getIds).should.deep.equal(['doc2']);
-          return db.query(mapFun, {startkey : 'quux', skip : 3, limit : 1});
-        }).then(function (res) {
-          res.rows.should.have.length(0, 'correctly return rows');
-          res.total_rows.should.equal(12, 'correctly return total_rows');
-          return db.query(mapFun, {startkey : 'bar', limit : 2});
-        }).then(function (res) {
-          res.rows.should.have.length(2, 'correctly return rows');
-          res.total_rows.should.equal(12, 'correctly return total_rows');
-        });
       });
+
+      await db.bulkDocs(docs);
+
+      const queryRes = await db.query(queryFun, {});
+
+      queryRes.rows.should.have.length(12, 'correctly return rows');
+      queryRes.total_rows.should.equal(12, 'correctly return total_rows');
+      queryRes.rows.map(getValues).should.deep.equal(
+        [null, 'crayon!', 'crayon!', 'multiple values!',
+          null, 'crayon!', 'crayon!', 'multiple values!',
+          null, 'fooValue', null, 'fooValue']);
+      queryRes.rows.map(getIds).should.deep.equal(
+        ['doc1', 'doc1', 'doc1', 'doc1',
+          'doc2', 'doc2', 'doc2', 'doc2',
+          'doc1', 'doc1', 'doc2', 'doc2']);
+
+      const queryRes1 = await db.query(queryFun, {startkey : 'foo'});
+
+      queryRes1.rows.should.have.length(4, 'correctly return rows');
+      queryRes1.total_rows.should.equal(12, 'correctly return total_rows');
+      queryRes1.rows.map(getValues).should.deep.equal(
+        [null, 'fooValue', null, 'fooValue']);
+      queryRes1.rows.map(getIds).should.deep.equal(
+      ['doc1', 'doc1', 'doc2', 'doc2']);
+
+      const queryRes2 = await db.query(queryFun, {startkey : 'foo', endkey : 'foo'});
+
+      queryRes2.rows.should.have.length(4, 'correctly return rows');
+      queryRes2.total_rows.should.equal(12, 'correctly return total_rows');
+
+      const queryRes3 = await db.query(queryFun, {startkey : 'bar', endkey : 'bar'});
+
+      queryRes3.rows.should.have.length(8, 'correctly return rows');
+      queryRes3.total_rows.should.equal(12, 'correctly return total_rows');
+
+      const queryRes4 = await db.query(queryFun, {startkey : 'foo', limit : 1});
+
+      queryRes4.rows.should.have.length(1, 'correctly return rows');
+      queryRes4.total_rows.should.equal(12, 'correctly return total_rows');
+      queryRes4.rows.map(getValues).should.deep.equal([null]);
+      queryRes4.rows.map(getIds).should.deep.equal(['doc1']);
+
+      const queryRes5 = await db.query(queryFun, {startkey : 'foo', limit : 2});
+
+      queryRes5.rows.should.have.length(2, 'correctly return rows');
+      queryRes5.total_rows.should.equal(12, 'correctly return total_rows');
+
+      const queryRes6 = await db.query(queryFun, {startkey : 'foo', limit : 1000});
+
+      queryRes6.rows.should.have.length(4, 'correctly return rows');
+      queryRes6.total_rows.should.equal(12, 'correctly return total_rows');
+
+      const queryRes7 = await db.query(queryFun, {startkey : 'foo', skip : 1});
+
+      queryRes7.rows.should.have.length(3, 'correctly return rows');
+      queryRes7.total_rows.should.equal(12, 'correctly return total_rows');
+
+      const queryRes8 = await db.query(queryFun, {startkey : 'foo', skip : 3, limit : 0});
+
+      queryRes8.rows.should.have.length(0, 'correctly return rows');
+      queryRes8.total_rows.should.equal(12, 'correctly return total_rows');
+
+      const queryRes9 = await db.query(queryFun, {startkey : 'foo', skip : 3, limit : 1});
+
+      queryRes9.rows.should.have.length(1, 'correctly return rows');
+      queryRes9.total_rows.should.equal(12, 'correctly return total_rows');
+      queryRes9.rows.map(getValues).should.deep.equal(['fooValue']);
+      queryRes9.rows.map(getIds).should.deep.equal(['doc2']);
+
+      const queryRes10 = await db.query(queryFun, {startkey : 'quux', skip : 3, limit : 1});
+
+      queryRes10.rows.should.have.length(0, 'correctly return rows');
+      queryRes10.total_rows.should.equal(12, 'correctly return total_rows');
+
+      const queryRes11 = await db.query(queryFun, {startkey : 'bar', limit : 2});
+
+      queryRes11.rows.should.have.length(2, 'correctly return rows');
+      queryRes11.total_rows.should.equal(12, 'correctly return total_rows');
     });
 
-    it('should query correctly with undefined key/values', function () {
+    it('should query correctly with undefined key/values', async () => {
       const db = new PouchDB(dbName);
       const docs = {
         docs: [
@@ -2868,523 +2787,508 @@ function tests(suiteName, dbName, dbType, viewType) {
           {_id: 'doc2'}
         ]
       };
-      return createView(db, {
+      const queryFun = await createView(db, {
         map : function () {
           emit();
         }
-      }).then(function (mapFun) {
-        return db.bulkDocs(docs).then(function () {
-          return db.query(mapFun, {});
-        }).then(function (res) {
-          res.total_rows.should.equal(2, 'correctly return total_rows');
-          res.rows.should.deep.equal([
-            {
-              key : null,
-              value : null,
-              id : 'doc1'
-            },
-            {
-              key : null,
-              value : null,
-              id : 'doc2'
-            }
-          ]);
-        });
       });
+
+      await db.bulkDocs(docs);
+
+      const res = await db.query(queryFun, {});
+
+      res.total_rows.should.equal(2, 'correctly return total_rows');
+      res.rows.should.deep.equal([
+        {
+          key : null,
+          value : null,
+          id : 'doc1'
+        },
+        {
+          key : null,
+          value : null,
+          id : 'doc2'
+        }
+      ]);
     });
 
-    it('should query correctly with no docs', function () {
+    it('should query correctly with no docs', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map : function () {
           emit();
         }
-      }).then(function (queryFun) {
-        return db.query(queryFun).then(function (res) {
-          res.total_rows.should.equal(0, 'total_rows');
-          res.offset.should.equal(0);
-          res.rows.should.deep.equal([]);
-        });
       });
+      const res = await db.query(queryFun);
+
+      res.total_rows.should.equal(0, 'total_rows');
+      res.offset.should.equal(0);
+      res.rows.should.deep.equal([]);
     });
 
-    it('should query correctly with no emits', function () {
+    it('should query correctly with no emits', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map : function () {
         }
-      }).then(function (queryFun) {
-        return db.bulkDocs({docs : [
-          {_id : 'foo'},
-          {_id : 'bar'}
-        ]}).then(function () {
-          return db.query(queryFun).then(function (res) {
-            res.total_rows.should.equal(0, 'total_rows');
-            res.offset.should.equal(0);
-            res.rows.should.deep.equal([]);
-          });
-        });
       });
+
+      await db.bulkDocs({docs : [
+        {_id : 'foo'},
+        {_id : 'bar'}
+      ]});
+
+      const res = await db.query(queryFun);
+
+      res.total_rows.should.equal(0, 'total_rows');
+      res.offset.should.equal(0);
+      res.rows.should.deep.equal([]);
     });
 
-    it('should correctly return results when reducing or not reducing', function () {
+    it('should correctly return results when reducing or not reducing', async () => {
+      const keyValues = row => ({key: row.key, value: row.value });
+      const keys = row => row.key;
+      const values = row => row.value;
+      const docIds = row => row.doc._id;
 
-      function keyValues(row) {
-        return { key: row.key, value: row.value };
-      }
-      function keys(row) {
-        return row.key;
-      }
-      function values(row) {
-        return row.value;
-      }
-      function docIds(row) {
-        return row.doc._id;
-      }
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map : function (doc) {
           emit(doc.name);
         },
         reduce : '_count'
-      }).then(function (queryFun) {
-        return db.bulkDocs({docs : [
-          {name : 'foo', _id : '1'},
-          {name : 'bar', _id : '2'},
-          {name : 'foo', _id : '3'},
-          {name : 'quux', _id : '4'},
-          {name : 'foo', _id : '5'},
-          {name : 'foo', _id : '6'},
-          {name : 'foo', _id : '7'}
-
-        ]}).then(function () {
-          return db.query(queryFun);
-        }).then(function (res) {
-          Object.keys(res.rows[0]).sort().should.deep.equal(['key', 'value'],
-                                                            'object only have 2 keys');
-          should.not.exist(res.total_rows, 'no total_rows1');
-          should.not.exist(res.offset, 'no offset1');
-          res.rows.map(keyValues).should.deep.equal([
-            {
-              key   : null,
-              value : 7
-            }
-          ]);
-          return db.query(queryFun, {group : true});
-        }).then(function (res) {
-          Object.keys(res.rows[0]).sort().should.deep.equal(['key', 'value'],
-                                                            'object only have 2 keys');
-          should.not.exist(res.total_rows, 'no total_rows2');
-          should.not.exist(res.offset, 'no offset2');
-          res.rows.map(keyValues).should.deep.equal([
-            {
-              key : 'bar',
-              value : 1
-            },
-            {
-              key : 'foo',
-              value : 5
-            },
-            {
-              key : 'quux',
-              value : 1
-            }
-          ]);
-          return db.query(queryFun, {reduce : false});
-        }).then(function (res) {
-          Object.keys(res.rows[0]).sort().should.deep.equal(['id', 'key', 'value'],
-                                                            'object only have 3 keys');
-          res.total_rows.should.equal(7, 'total_rows1');
-          res.offset.should.equal(0, 'offset1');
-          res.rows.map(keys).should.deep.equal([
-            'bar', 'foo', 'foo', 'foo', 'foo', 'foo', 'quux'
-          ]);
-          res.rows.map(values).should.deep.equal([
-            null, null, null, null, null, null, null
-          ]);
-          return db.query(queryFun, {reduce : false, skip : 3});
-        }).then(function (res) {
-          Object.keys(res.rows[0]).sort().should.deep.equal(['id', 'key', 'value'],
-                                                            'object only have 3 keys');
-          res.total_rows.should.equal(7, 'total_rows2');
-          res.offset.should.equal(3, 'offset2');
-          res.rows.map(keys).should.deep.equal([
-            'foo', 'foo', 'foo', 'quux'
-          ]);
-          return db.query(queryFun, {reduce : false, include_docs : true});
-        }).then(function (res) {
-          Object.keys(res.rows[0]).sort().should.deep.equal(['doc', 'id', 'key', 'value'],
-                                                            'object only have 4 keys');
-          res.total_rows.should.equal(7, 'total_rows3');
-          res.offset.should.equal(0, 'offset3');
-          res.rows.map(keys).should.deep.equal([
-            'bar', 'foo', 'foo', 'foo', 'foo', 'foo', 'quux'
-          ]);
-          res.rows.map(values).should.deep.equal([
-            null, null, null, null, null, null, null
-          ]);
-          res.rows.map(docIds).should.deep.equal([
-            '2', '1', '3', '5', '6', '7', '4'
-          ]);
-          return db.query(queryFun, {include_docs : true}).then(function (res) {
-            should.not.exist(res);
-          }).catch(function (err) {
-            err.status.should.be.oneOf([400, 500]);
-            err.message.should.be.a('string');
-            // include_docs is invalid for reduce
-          });
-        });
       });
+
+      await db.bulkDocs({docs : [
+        {name : 'foo', _id : '1'},
+        {name : 'bar', _id : '2'},
+        {name : 'foo', _id : '3'},
+        {name : 'quux', _id : '4'},
+        {name : 'foo', _id : '5'},
+        {name : 'foo', _id : '6'},
+        {name : 'foo', _id : '7'}
+      ]});
+
+      const queryRes = await db.query(queryFun);
+      const sortedKeys = Object.keys(queryRes.rows[0]).sort();
+
+      sortedKeys.should.deep.equal(['key', 'value'], 'object only have 2 keys');
+      should.not.exist(queryRes.total_rows, 'no total_rows1');
+      should.not.exist(queryRes.offset, 'no offset1');
+      queryRes.rows.map(keyValues).should.deep.equal([
+        {
+          key   : null,
+          value : 7
+        }
+      ]);
+
+      const queryRes1 = await db.query(queryFun, {group : true});
+      const sortedKeys1 = Object.keys(queryRes1.rows[0]).sort();
+
+      sortedKeys1.should.deep.equal(['key', 'value'], 'object only have 2 keys');
+      should.not.exist(queryRes1.total_rows, 'no total_rows2');
+      should.not.exist(queryRes1.offset, 'no offset2');
+      queryRes1.rows.map(keyValues).should.deep.equal([
+        {
+          key : 'bar',
+          value : 1
+        },
+        {
+          key : 'foo',
+          value : 5
+        },
+        {
+          key : 'quux',
+          value : 1
+        }
+      ]);
+
+      const queryRes2 = await db.query(queryFun, {reduce : false});
+
+      const sortedKeys2 = Object.keys(queryRes2.rows[0]).sort();
+      sortedKeys2.should.deep.equal(['id', 'key', 'value'], 'object only have 3 keys');
+      queryRes2.total_rows.should.equal(7, 'total_rows1');
+      queryRes2.offset.should.equal(0, 'offset1');
+      queryRes2.rows.map(keys).should.deep.equal([
+        'bar', 'foo', 'foo', 'foo', 'foo', 'foo', 'quux'
+      ]);
+      queryRes2.rows.map(values).should.deep.equal([
+        null, null, null, null, null, null, null
+      ]);
+
+      const queryRes3 = await db.query(queryFun, {reduce : false, skip : 3});
+      const sortedKeys3 = Object.keys(queryRes3.rows[0]).sort();
+
+      sortedKeys3.should.deep.equal(['id', 'key', 'value'], 'object only have 3 keys');
+      queryRes3.total_rows.should.equal(7, 'total_rows2');
+      queryRes3.offset.should.equal(3, 'offset2');
+      queryRes3.rows.map(keys).should.deep.equal(['foo', 'foo', 'foo', 'quux']);
+
+      const queryRes4 = await db.query(queryFun, {reduce : false, include_docs : true});
+
+      const sortedKeys4 = Object.keys(queryRes4.rows[0]).sort();
+      sortedKeys4.should.deep.equal(['doc', 'id', 'key', 'value'], 'object only have 4 keys');
+      queryRes4.total_rows.should.equal(7, 'total_rows3');
+      queryRes4.offset.should.equal(0, 'offset3');
+      queryRes4.rows.map(keys).should.deep.equal([
+        'bar', 'foo', 'foo', 'foo', 'foo', 'foo', 'quux'
+      ]);
+      queryRes4.rows.map(values).should.deep.equal([
+        null, null, null, null, null, null, null
+      ]);
+      queryRes4.rows.map(docIds).should.deep.equal([
+        '2', '1', '3', '5', '6', '7', '4'
+      ]);
+
+      try {
+        const queryRes5 = await db.query(queryFun, {include_docs : true});
+
+        should.not.exist(queryRes5);
+      } catch (err) {
+        err.status.should.be.oneOf([400, 500]);
+        err.message.should.be.a('string');
+        // include_docs is invalid for reduce
+      }
     });
 
-    it('should query correctly after replicating and other ddoc', function () {
+    it('should query correctly after replicating and other ddoc', async () => {
       const db = new PouchDB(dbName);
       const db2 = new PouchDB(testUtils.adapterUrl(dbType, 'local-other'));
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.name);
         }
-      }).then(function (queryFun) {
-        return db.bulkDocs({docs: [{name: 'foobar'}]}).then(function () {
-          return db.query(queryFun);
-        }).then(function (res) {
-          res.rows.map(function (x) {return x.key; }).should.deep.equal([
-            'foobar'
-          ], 'test db before replicating');
-          return db.replicate.to(db2).then(function () {
-            return db.query(queryFun);
-          }).then(function (res) {
-            res.rows.map(function (x) {return x.key; }).should.deep.equal([
-              'foobar'
-            ], 'test db after replicating');
-            return db.put({
-              _id: '_design/other_ddoc',
-              views: {
-                test: {
-                  map: "function(doc) { emit(doc._id); }"
-                }
-              }
-            });
-          }).then(function () {
-            // the random ddoc adds a single change that we don't
-            // care about. testing this increases our coverage
-            return db.query(queryFun);
-          }).then(function (res) {
-            res.rows.map(function (x) {return x.key; }).should.deep.equal([
-              'foobar'
-            ], 'test db after adding random ddoc');
-            return db2.query(queryFun);
-          }).then(function (res) {
-            res.rows.map(function (x) {return x.key; }).should.deep.equal([
-              'foobar'
-            ], 'test db2');
-          }).catch(function (err) {
-            return db2.destroy().then(function () {
-              throw err;
-            });
-          }).then(function () {
-            return db2.destroy();
-          });
-        });
       });
+
+      await db.bulkDocs({docs: [{name: 'foobar'}]});
+
+      const resBeforeReplicating = await db.query(queryFun);
+
+      resBeforeReplicating.rows.map(x => x.key).should.deep.equal(
+        ['foobar'], 'test db before replicating');
+
+      await db.replicate.to(db2);
+
+      const resAfterReplicating = await db.query(queryFun);
+
+      resAfterReplicating.rows.map(x => x.key).should.deep.equal(
+        ['foobar'], 'test db after replicating');
+
+      await db.put({
+        _id: '_design/other_ddoc',
+        views: {
+          test: {
+            map: "function(doc) { emit(doc._id); }"
+          }
+        }
+      });
+
+      // the random ddoc adds a single change that we don't
+      // care about. testing this increases our coverage
+      const resAfterAdding = await db.query(queryFun);
+
+      resAfterAdding.rows.map(x => x.key).should.deep.equal(
+        ['foobar'], 'test db after adding random ddoc');
+
+      try {
+        const resFromDb2 = await db2.query(queryFun);
+
+        resFromDb2.rows.map(x => x.key).should.deep.equal([
+          'foobar'
+        ], 'test db2');
+      } finally {
+          await db2.destroy();
+      }
     });
 
-    it('should query correctly after many edits', function () {
+    it('should query correctly after many edits', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map : function (doc) {
           emit(doc.name, doc.likes);
         }
-      }).then(function (queryFun) {
-        const docs = [
-          { _id: '1', name: 'leonardo' },
-          { _id: '2', name: 'michelangelo' },
-          { _id: '3', name: 'donatello' },
-          { _id: '4', name: 'rafael' },
-          { _id: '5', name: 'april o\'neil' },
-          { _id: '6', name: 'splinter' },
-          { _id: '7', name: 'shredder' },
-          { _id: '8', name: 'krang' },
-          { _id: '9', name: 'rocksteady' },
-          { _id: 'a', name: 'bebop' },
-          { _id: 'b', name: 'casey jones' },
-          { _id: 'c', name: 'casey jones' },
-          { _id: 'd', name: 'baxter stockman' },
-          { _id: 'e', name: 'general chaos' },
-          { _id: 'f', name: 'rahzar' },
-          { _id: 'g', name: 'tokka' },
-          { _id: 'h', name: 'usagi yojimbo' },
-          { _id: 'i', name: 'rat king' },
-          { _id: 'j', name: 'metalhead' },
-          { _id: 'k', name: 'slash' },
-          { _id: 'l', name: 'ace duck' }
-        ];
-
-        for (let i = 0; i < 100; i++) {
-          docs.push({
-            _id: 'z-' + (i + 1000), // for correct string ordering
-            name: 'random foot soldier #' + i
-          });
-        }
-
-        const byId = Object.fromEntries(docs.map((doc) => [doc._id, doc]));
-
-        function update(res, docFun) {
-          for (let i  = 0; i < res.length; i++) {
-            const doc = byId[res[i].id];
-            doc._rev = res[i].rev;
-            docFun(doc);
-          }
-          return db.bulkDocs({docs});
-        }
-        return db.bulkDocs({docs}).then(function (res) {
-          return update(res, function (doc) { doc.likes = 'pizza'; });
-        }).then(function (res) {
-          return update(res, function (doc) { doc.knows = 'kung fu'; });
-        }).then(function (res) {
-          return update(res, function (doc) { doc.likes = 'fighting'; });
-        }).then(function (res) {
-          return update(res, function (doc) { doc._deleted = true; });
-        }).then(function (res) {
-          return update(res, function (doc) { doc._deleted = false; });
-        }).then(function (res) {
-          return update(res, function (doc) { doc.name = doc.name + '1'; });
-        }).then(function (res) {
-          return update(res, function (doc) { doc.name = doc.name + '2'; });
-        }).then(function (res) {
-          return update(res, function (doc) { doc.name = 'nameless'; });
-        }).then(function (res) {
-          return update(res, function (doc) { doc._deleted = true; });
-        }).then(function (res) {
-          return update(res, function (doc) { doc.likes = 'turtles'; });
-        }).then(function (res) {
-          return update(res, function (doc) { doc._deleted = false; });
-        }).then(function (res) {
-          return update(res, function (doc) { doc.whatever = 'quux'; });
-        }).then(function (res) {
-          return update(res, function (doc) { doc.stuff = 'baz'; });
-        }).then(function (res) {
-          return update(res, function (doc) { doc.things = 'foo'; });
-        }).then(function () {
-          return db.query(queryFun);
-        }).then(function (res) {
-          res.total_rows.should.equal(docs.length, 'expected total_rows');
-          res.rows.map(function (row) {
-            return [row.id, row.key, row.value];
-          }).should.deep.equal(docs.map(function (doc) {
-            return [doc._id, 'nameless', 'turtles'];
-          }), 'key values match');
-        });
       });
+
+      const docs = [
+        { _id: '1', name: 'leonardo' },
+        { _id: '2', name: 'michelangelo' },
+        { _id: '3', name: 'donatello' },
+        { _id: '4', name: 'rafael' },
+        { _id: '5', name: 'april o\'neil' },
+        { _id: '6', name: 'splinter' },
+        { _id: '7', name: 'shredder' },
+        { _id: '8', name: 'krang' },
+        { _id: '9', name: 'rocksteady' },
+        { _id: 'a', name: 'bebop' },
+        { _id: 'b', name: 'casey jones' },
+        { _id: 'c', name: 'casey jones' },
+        { _id: 'd', name: 'baxter stockman' },
+        { _id: 'e', name: 'general chaos' },
+        { _id: 'f', name: 'rahzar' },
+        { _id: 'g', name: 'tokka' },
+        { _id: 'h', name: 'usagi yojimbo' },
+        { _id: 'i', name: 'rat king' },
+        { _id: 'j', name: 'metalhead' },
+        { _id: 'k', name: 'slash' },
+        { _id: 'l', name: 'ace duck' }
+      ];
+
+      for (let i = 0; i < 100; i++) {
+        docs.push({
+          _id: 'z-' + (i + 1000), // for correct string ordering
+          name: 'random foot soldier #' + i
+        });
+      }
+
+      const byId = Object.fromEntries(docs.map(doc => [doc._id, doc]));
+
+      const update = (res, docFun) => {
+        for (let i  = 0; i < res.length; i++) {
+          const doc = byId[res[i].id];
+          doc._rev = res[i].rev;
+          docFun(doc);
+        }
+        return db.bulkDocs({docs});
+      };
+
+      const res = await db.bulkDocs({docs});
+
+      const updated = await update(res, doc => doc.likes = 'pizza');
+      const updated1 = await update(updated, doc => doc.knows = 'kung fu');
+      const updated2 = await update(updated1, doc =>  doc.likes = 'fighting');
+      const updated3 = await update(updated2, doc => doc._deleted = true);
+      const updated4 = await update(updated3, doc => doc._deleted = false);
+      const updated5 = await update(updated4, doc => doc.name = doc.name + '1');
+      const updated6 = await update(updated5, doc => doc.name = doc.name + '2');
+      const updated7 = await update(updated6, doc => doc.name = 'nameless');
+      const updated8 = await update(updated7, doc => doc._deleted = true);
+      const updated9 = await update(updated8, doc => doc.likes = 'turtles');
+      const updated10 = await update(updated9, doc => doc._deleted = false);
+      const updated11 = await update(updated10, doc => doc.whatever = 'quux');
+      const updated12 = await update(updated11, doc => doc.stuff = 'baz');
+      await update(updated12, doc => doc.things = 'foo');
+
+      const queryRes = await db.query(queryFun);
+
+      queryRes.total_rows.should.equal(docs.length, 'expected total_rows');
+      queryRes.rows.map(row => [row.id, row.key, row.value])
+      .should.deep.equal(docs.map(doc => [doc._id, 'nameless', 'turtles'])
+      , 'key values match');
     });
 
-    it('should query correctly with staggered seqs', function () {
+    it('should query correctly with staggered seqs', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map : function (doc) {
           emit(doc.name);
         }
-      }).then(function (queryFun) {
-        const docs = [];
-
-        for (let i = 0; i < 200; i++) {
-          docs.push({
-            _id: 'doc-' + (i + 1000), // for correct string ordering
-            name: 'gen1'
-          });
-        }
-        return db.bulkDocs({docs}).then(function (infos) {
-          docs.forEach(function (doc) {
-            doc._rev = infos.find((info) => info.id === doc._id).rev;
-            doc.name = 'gen2';
-          });
-          docs.reverse();
-          return db.bulkDocs({docs});
-        }).then(function (infos) {
-          docs.forEach(function (doc) {
-            doc._rev = infos.find((info) => info.id === doc._id).rev;
-            doc.name = 'gen-3';
-          });
-          docs.reverse();
-          return db.bulkDocs({docs});
-        }).then(function (infos) {
-          docs.forEach(function (doc) {
-            doc._rev = infos.find((info) => info.id === doc._id).rev;
-            doc.name = 'gen-4-odd';
-          });
-          const docsToUpdate = docs.filter(function (doc, i) {
-            return i % 2 === 1;
-          });
-          docsToUpdate.reverse();
-          return db.bulkDocs({docs: docsToUpdate});
-        }).then(function () {
-          return db.query(queryFun);
-        }).then(function (res) {
-          const expected = docs.map(function (doc, i) {
-            const key = i % 2 === 1 ? 'gen-4-odd' : 'gen-3';
-            return {key, id: doc._id, value: null};
-          });
-          expected.sort(function (a, b) {
-            if (a.key !== b.key) {
-              return a.key < b.key ? -1 : 1;
-            }
-            return a.id < b.id ? -1 : 1;
-          });
-          res.rows.should.deep.equal(expected);
-        });
       });
+
+      const docs = [];
+      for (let i = 0; i < 200; i++) {
+        docs.push({
+          _id: 'doc-' + (i + 1000), // for correct string ordering
+          name: 'gen1'
+        });
+      }
+      const bulkDocsRes = await db.bulkDocs({docs});
+
+      docs.forEach(doc => {
+        doc._rev = bulkDocsRes.find((info) => info.id === doc._id).rev;
+        doc.name = 'gen2';
+      });
+      docs.reverse();
+
+      const bulkDocsRes1 = await db.bulkDocs({docs});
+
+      docs.forEach(doc => {
+        doc._rev = bulkDocsRes1.find((info) => info.id === doc._id).rev;
+        doc.name = 'gen-3';
+      });
+      docs.reverse();
+
+      const bulkDocsRes2 = await db.bulkDocs({docs});
+
+      docs.forEach(doc => {
+        doc._rev = bulkDocsRes2.find((info) => info.id === doc._id).rev;
+        doc.name = 'gen-4-odd';
+      });
+      const docsToUpdate = docs.filter((doc, i) => {
+        return i % 2 === 1;
+      });
+      docsToUpdate.reverse();
+
+      await db.bulkDocs({docs: docsToUpdate});
+
+      const queryRes = await db.query(queryFun);
+
+      const expected = docs.map((doc, i) => {
+        const key = i % 2 === 1 ? 'gen-4-odd' : 'gen-3';
+        return {key, id: doc._id, value: null};
+      });
+      expected.sort((a, b) => {
+        if (a.key !== b.key) {
+          return a.key < b.key ? -1 : 1;
+        }
+        return a.id < b.id ? -1 : 1;
+      });
+
+      queryRes.rows.should.deep.equal(expected);
     });
 
-    it('should handle removes/undeletes/updates', function () {
-      const theDoc = {name : 'bar', _id : '1'};
-
+    it('should handle removes/undeletes/updates', async () => {
+      const doc = {name : 'bar', _id : '1'};
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.name);
         }
-      }).then(function (queryFun) {
-        return db.put(theDoc).then(function (info) {
-          theDoc._rev = info.rev;
-          return db.query(queryFun);
-        }).then(function (res) {
-          res.rows.length.should.equal(1);
-          theDoc._deleted = true;
-          return db.post(theDoc);
-        }).then(function (info) {
-          theDoc._rev = info.rev;
-          return db.query(queryFun);
-        }).then(function (res) {
-          res.rows.length.should.equal(0);
-          theDoc._deleted = false;
-          delete theDoc._rev;
-          return db.put(theDoc);
-        }).then(function (info) {
-          theDoc._rev = info.rev;
-          return db.query(queryFun);
-        }).then(function (res) {
-          res.rows.length.should.equal(1);
-          theDoc.name = 'foo';
-          return db.post(theDoc);
-        }).then(function (info) {
-          theDoc._rev = info.rev;
-          return db.query(queryFun);
-        }).then(function (res) {
-          res.rows.length.should.equal(1);
-          res.rows[0].key.should.equal('foo');
-          theDoc._deleted = true;
-          return db.post(theDoc);
-        }).then(function (info) {
-          theDoc._rev = info.rev;
-          return db.query(queryFun);
-        }).then(function (res) {
-          res.rows.length.should.equal(0);
-        });
       });
+
+      const putDoc = await db.put(doc);
+      doc._rev = putDoc.rev;
+      const queryRes = await db.query(queryFun);
+
+      queryRes.rows.length.should.equal(1);
+
+      doc._deleted = true;
+      const putDeleted = await db.post(doc);
+      doc._rev = putDeleted.rev;
+      const queryRes1 = await db.query(queryFun);
+
+      queryRes1.rows.length.should.equal(0);
+
+      doc._deleted = false;
+      delete doc._rev;
+      const putUnDeleted = await db.put(doc);
+      doc._rev = putUnDeleted.rev;
+      const queryRes2 = await db.query(queryFun);
+
+      queryRes2.rows.length.should.equal(1);
+
+      doc.name = 'foo';
+      const postDocWithName = await db.post(doc);
+      doc._rev = postDocWithName.rev;
+      const queryRes3 = await db.query(queryFun);
+
+      queryRes3.rows.length.should.equal(1);
+      queryRes3.rows[0].key.should.equal('foo');
+
+      doc._deleted = true;
+      const postDeleted = await db.post(doc);
+      doc._rev = postDeleted.rev;
+      const queryRes4 = await db.query(queryFun);
+
+      queryRes4.rows.length.should.equal(0);
     });
 
-    it('should return error when multi-key fetch & group=false', function () {
+    it('should return error when multi-key fetch & group=false', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) { emit(doc._id); },
         reduce: '_sum'
-      }).then(function (queryFun) {
-        const keys = ['1', '2'];
-        let opts = {
-          keys,
-          group: false
-        };
-        return db.query(queryFun, opts).then(function (res) {
-          should.not.exist(res);
-        }).catch(function (err) {
-          err.status.should.be.oneOf([400, 500]);
-          opts = {keys};
-          return db.query(queryFun, opts).then(function (res) {
-            should.not.exist(res);
-          }).catch(function (err) {
-            err.status.should.be.oneOf([400, 500]);
-            opts = {keys, reduce : false};
-            return db.query(queryFun, opts).then(function () {
-              opts = {keys, group: true};
-              return db.query(queryFun, opts);
-            });
-          });
-        });
       });
+
+    const keys = ['1', '2'];
+    const opts = {
+      keys,
+      group: false
+    };
+
+    try {
+      const res = await db.query(queryFun, opts);
+      should.not.exist(res);
+    } catch (err) {
+      err.status.should.be.oneOf([400, 500]);
+    }
+
+    try {
+      const opts1 = {keys};
+      const res = await  db.query(queryFun, opts1);
+      should.not.exist(res);
+    } catch (err) {
+      err.status.should.be.oneOf([400, 500]);
+    }
+    const opts2 =  {keys, reduce : false};
+    await db.query(queryFun, opts2).should.be.fulfilled;
+
+    const opts3 = {keys, group: true};
+    await db.query(queryFun, opts3).should.be.fulfilled;
     });
 
-    it('should handle user errors in map functions', function () {
+    it('should handle user errors in map functions', async () => {
       const db = new PouchDB(dbName);
       let err;
-      db.on('error', function (e) { err = e; });
-      return createView(db, {
+      db.on('error', e => err = e);
+      const queryFun = await createView(db, {
         map : function (doc) {
           emit(doc.nonexistent.foo);
         }
-      }).then(function (queryFun) {
-        return db.put({name : 'bar', _id : '1'}).then(function () {
-          return db.query(queryFun);
-        }).then(function (res) {
-          res.rows.should.have.length(0);
-          if (dbType === 'local') {
-            should.exist(err);
-          }
-        });
       });
+
+      await db.put({name : 'bar', _id : '1'});
+      const res = await db.query(queryFun);
+
+      res.rows.should.have.length(0);
+      if (dbType === 'local') {
+        should.exist(err);
+      }
     });
 
-    it('should handle user errors in reduce functions', function () {
+    it('should handle user errors in reduce functions', async () => {
       const db = new PouchDB(dbName);
       let err;
-      db.on('error', function (e) { err = e; });
-      return createView(db, {
+      db.on('error', e => err = e);
+      const queryFun =  await createView(db, {
         map : function (doc) {
           emit(doc.name);
         },
         reduce : function (keys) {
           return keys[0].foo.bar;
         }
-      }).then(function (queryFun) {
-        return db.put({name : 'bar', _id : '1'}).then(function () {
-          return db.query(queryFun, {group: true});
-        }).then(function (res) {
-          res.rows.map(function (row) {return row.key; }).should.deep.equal(['bar']);
-          return db.query(queryFun, {reduce: false});
-        }).then(function (res) {
-          res.rows.map(function (row) {return row.key; }).should.deep.equal(['bar']);
-          if (dbType === 'local') {
-            should.exist(err);
-          }
-        });
       });
+
+      await db.put({name : 'bar', _id : '1'});
+
+      const resGrouped = await db.query(queryFun, {group: true});
+
+      resGrouped.rows.map(row => row.key).should.deep.equal(['bar']);
+
+      const resNotReduced = await db.query(queryFun, {reduce: false});
+
+      resNotReduced.rows.map(row => row.key).should.deep.equal(['bar']);
+      if (dbType === 'local') {
+        should.exist(err);
+      }
     });
 
-    it('should handle reduce returning undefined', function () {
+    it('should handle reduce returning undefined', async () => {
       const db = new PouchDB(dbName);
       let err;
-      db.on('error', function (e) { err = e; });
-      return createView(db, {
+      db.on('error', e => err = e);
+      const queryFun = await createView(db, {
         map : function (doc) {
           emit(doc.name);
         },
         reduce : function () {
         }
-      }).then(function (queryFun) {
-        return db.put({name : 'bar', _id : '1'}).then(function () {
-          return db.query(queryFun, {group: true});
-        }).then(function (res) {
-          res.rows.map(function (row) {return row.key; }).should.deep.equal(['bar']);
-          return db.query(queryFun, {reduce: false});
-        }).then(function (res) {
-          res.rows.map(function (row) {return row.key; }).should.deep.equal(['bar']);
-          should.not.exist(err);
-        });
       });
+
+      await db.put({name : 'bar', _id : '1'});
+
+      const resGrouped = await db.query(queryFun, {group: true});
+
+      resGrouped.rows.map(row => row.key).should.deep.equal(['bar']);
+
+      const resNotReduced = await db.query(queryFun, {reduce: false});
+
+      resNotReduced.rows.map(row => row.key).should.deep.equal(['bar']);
+      should.not.exist(err);
     });
 
-    it('should properly query custom reduce functions', function () {
+    it('should properly query custom reduce functions', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map : function (doc) {
           emit(doc.name, doc.count);
         },
@@ -3407,157 +3311,169 @@ function tests(suiteName, dbName, dbType, viewType) {
             };
           }
         }
-      }).then(function (queryFun) {
-        return db.bulkDocs({docs : [
-          {name : 'foo', count : 1},
-          {name : 'bar', count : 7},
-          {name : 'foo', count : 3},
-          {name : 'quux', count : 3},
-          {name : 'foo', count : 3},
-          {name : 'foo', count : 0},
-          {name : 'foo', count : 4},
-          {name : 'baz', count : 3},
-          {name : 'baz', count : 0},
-          {name : 'baz', count : 2}
-        ]}).then(function () {
-          return db.query(queryFun, {group : true});
-        }).then(function (res) {
-          res.should.deep.equal({rows : [
-            {
-              key : 'bar',
-              value : { sum: 7, count: 1, average : 7}
-            },
-            {
-              key : 'baz',
-              value : { sum: 5, count: 3, average: (5 / 3) }
-            },
-            {
-              key : 'foo',
-              value : { sum: 11, count: 5, average: (11 / 5) }
-            },
-            {
-              key : 'quux',
-              value : { sum: 3, count: 1, average: 3 }
-            }
-          ]}, 'all');
-          return db.query(queryFun, {group : false});
-        }).then(function (res) {
-          res.should.deep.equal({rows : [
-            {
-              key : null,
-              value : { sum: 26, count: 10, average: 2.6 }
-            }
-          ]}, 'group=false');
-          return db.query(queryFun, {group : true, startkey : 'bar', endkey : 'baz', skip : 1});
-        }).then(function (res) {
-          res.should.deep.equal({rows : [
-            {
-              key : 'baz',
-              value : { sum: 5, count: 3, average: (5 / 3) }
-            }
-          ]}, 'bar-baz skip 1');
-          return db.query(queryFun, {group : true, endkey : 'baz'});
-        }).then(function (res) {
-          res.should.deep.equal({rows : [
-            {
-              key : 'bar',
-              value : { sum: 7, count: 1, average : 7}
-            },
-            {
-              key : 'baz',
-              value : { sum: 5, count: 3, average: (5 / 3) }
-            }
-          ]}, '-baz');
-          return db.query(queryFun, {group : true, startkey : 'foo'});
-        }).then(function (res) {
-          res.should.deep.equal({rows : [
-            {
-              key : 'foo',
-              value : { sum: 11, count: 5, average: (11 / 5) }
-            },
-            {
-              key : 'quux',
-              value : { sum: 3, count: 1, average: 3 }
-            }
-          ]}, 'foo-');
-          return db.query(queryFun, {group : true, startkey : 'foo', descending : true});
-        }).then(function (res) {
-          res.should.deep.equal({rows : [
-            {
-              key : 'foo',
-              value : { sum: 11, count: 5, average: (11 / 5) }
-            },
-            {
-              key : 'baz',
-              value : { sum: 5, count: 3, average: (5 / 3) }
-            },
-            {
-              key : 'bar',
-              value : { sum: 7, count: 1, average : 7}
-            }
-          ]}, 'foo- descending=true');
-          return db.query(queryFun, {group : true, startkey : 'quux', skip : 1});
-        }).then(function (res) {
-          res.should.deep.equal({rows : [
-          ]}, 'quux skip 1');
-          return db.query(queryFun, {group : true, startkey : 'quux', limit : 0});
-        }).then(function (res) {
-          res.should.deep.equal({rows : [
-          ]}, 'quux limit 0');
-          return db.query(queryFun, {group : true, startkey : 'bar', endkey : 'baz'});
-        }).then(function (res) {
-          res.should.deep.equal({rows : [
-            {
-              key : 'bar',
-              value : { sum: 7, count: 1, average : 7}
-            },
-            {
-              key : 'baz',
-              value : { sum: 5, count: 3, average: (5 / 3) }
-            }
-          ]}, 'bar-baz');
-          return db.query(queryFun, {group : true, keys : ['bar', 'baz'], limit : 1});
-        }).then(function (res) {
-          res.should.deep.equal({rows : [
-            {
-              key : 'bar',
-              value : { sum: 7, count: 1, average : 7}
-            }
-          ]}, 'bar & baz');
-          return db.query(queryFun, {group : true, keys : ['bar', 'baz'], limit : 0});
-        }).then(function (res) {
-          res.should.deep.equal({rows : [
-          ]}, 'bar & baz limit 0');
-          return db.query(queryFun, {group : true, key : 'bar', limit : 0});
-        }).then(function (res) {
-          res.should.deep.equal({rows : [
-          ]}, 'key=bar limit 0');
-          return db.query(queryFun, {group : true, key : 'bar'});
-        }).then(function (res) {
-          res.should.deep.equal({rows : [
-            {
-              key : 'bar',
-              value : { sum: 7, count: 1, average : 7}
-            }
-          ]}, 'key=bar');
-          return db.query(queryFun, {group : true, key : 'zork'});
-        }).then(function (res) {
-          res.should.deep.equal({rows : [
-          ]}, 'zork');
-          return db.query(queryFun, {group : true, keys : []});
-        }).then(function (res) {
-          res.should.deep.equal({rows : [
-          ]}, 'keys=[]');
-          return db.query(queryFun, {group : true, key : null});
-        }).then(function (res) {
-          res.should.deep.equal({rows : [
-          ]}, 'key=null');
-        });
       });
+
+      await db.bulkDocs({docs : [
+        {name : 'foo', count : 1},
+        {name : 'bar', count : 7},
+        {name : 'foo', count : 3},
+        {name : 'quux', count : 3},
+        {name : 'foo', count : 3},
+        {name : 'foo', count : 0},
+        {name : 'foo', count : 4},
+        {name : 'baz', count : 3},
+        {name : 'baz', count : 0},
+        {name : 'baz', count : 2}
+      ]});
+
+      const queryRes = await db.query(queryFun, {group : true});
+
+      queryRes.should.deep.equal({rows : [
+        {
+          key : 'bar',
+          value : { sum: 7, count: 1, average : 7}
+        },
+        {
+          key : 'baz',
+          value : { sum: 5, count: 3, average: (5 / 3) }
+        },
+        {
+          key : 'foo',
+          value : { sum: 11, count: 5, average: (11 / 5) }
+        },
+        {
+          key : 'quux',
+          value : { sum: 3, count: 1, average: 3 }
+        }
+      ]}, 'all');
+
+      const queryRes1 = await db.query(queryFun, {group : false});
+
+      queryRes1.should.deep.equal({rows : [
+        {
+          key : null,
+          value : { sum: 26, count: 10, average: 2.6 }
+        }
+      ]}, 'group=false');
+
+      const queryRes2 = await db.query(queryFun, {group : true, startkey : 'bar', endkey : 'baz', skip : 1});
+
+      queryRes2.should.deep.equal({rows : [
+        {
+          key : 'baz',
+          value : { sum: 5, count: 3, average: (5 / 3) }
+        }
+      ]}, 'bar-baz skip 1');
+
+      const queryRes3 = await db.query(queryFun, {group : true, endkey : 'baz'});
+
+      queryRes3.should.deep.equal({rows : [
+        {
+          key : 'bar',
+          value : { sum: 7, count: 1, average : 7}
+        },
+        {
+          key : 'baz',
+          value : { sum: 5, count: 3, average: (5 / 3) }
+        }
+      ]}, '-baz');
+
+      const queryRes4 = await db.query(queryFun, {group : true, startkey : 'foo'});
+
+      queryRes4.should.deep.equal({rows : [
+        {
+          key : 'foo',
+          value : { sum: 11, count: 5, average: (11 / 5) }
+        },
+        {
+          key : 'quux',
+          value : { sum: 3, count: 1, average: 3 }
+        }
+      ]}, 'foo-');
+
+      const queryRes5 = await db.query(queryFun, {group : true, startkey : 'foo', descending : true});
+
+      queryRes5.should.deep.equal({rows : [
+        {
+          key : 'foo',
+          value : { sum: 11, count: 5, average: (11 / 5) }
+        },
+        {
+          key : 'baz',
+          value : { sum: 5, count: 3, average: (5 / 3) }
+        },
+        {
+          key : 'bar',
+          value : { sum: 7, count: 1, average : 7}
+        }
+      ]}, 'foo- descending=true');
+
+      const queryRes6 = await db.query(queryFun, {group : true, startkey : 'quux', skip : 1});
+
+      queryRes6.should.deep.equal({rows : [
+      ]}, 'quux skip 1');
+      const queryRes7 = await db.query(queryFun, {group : true, startkey : 'quux', limit : 0});
+
+      queryRes7.should.deep.equal({rows : [
+      ]}, 'quux limit 0');
+      const queryRes8 = await db.query(queryFun, {group : true, startkey : 'bar', endkey : 'baz'});
+
+      queryRes8.should.deep.equal({rows : [
+        {
+          key : 'bar',
+          value : { sum: 7, count: 1, average : 7}
+        },
+        {
+          key : 'baz',
+          value : { sum: 5, count: 3, average: (5 / 3) }
+        }
+      ]}, 'bar-baz');
+
+      const queryRes9 = await db.query(queryFun, {group : true, keys : ['bar', 'baz'], limit : 1});
+
+      queryRes9.should.deep.equal({rows : [
+        {
+          key : 'bar',
+          value : { sum: 7, count: 1, average : 7}
+        }
+      ]}, 'bar & baz');
+
+      const queryRes10 = await db.query(queryFun, {group : true, keys : ['bar', 'baz'], limit : 0});
+
+      queryRes10.should.deep.equal({rows : [
+      ]}, 'bar & baz limit 0');
+
+      const queryRes11 = await db.query(queryFun, {group : true, key : 'bar', limit : 0});
+
+      queryRes11.should.deep.equal({rows : [
+      ]}, 'key=bar limit 0');
+
+      const queryRes12 = await db.query(queryFun, {group : true, key : 'bar'});
+
+      queryRes12.should.deep.equal({rows : [
+        {
+          key : 'bar',
+          value : { sum: 7, count: 1, average : 7}
+        }
+      ]}, 'key=bar');
+
+      const queryRes13 = await db.query(queryFun, {group : true, key : 'zork'});
+
+      queryRes13.should.deep.equal({rows : [
+      ]}, 'zork');
+
+      const queryRes14 = await db.query(queryFun, {group : true, keys : []});
+
+      queryRes14.should.deep.equal({rows : [
+      ]}, 'keys=[]');
+
+      const queryRes15 = await db.query(queryFun, {group : true, key : null});
+
+      queryRes15.should.deep.equal({rows : [
+      ]}, 'key=null');
     });
 
-    it('should handle many doc changes', function () {
-
+    it('should handle many doc changes', async () => {
       let docs = [{_id: '0'}, {_id : '1'}, {_id: '2'}];
 
       const keySets = [
@@ -3575,54 +3491,40 @@ function tests(suiteName, dbName, dbType, viewType) {
       ];
 
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map : function (doc) {
           doc.keys.forEach(function (key) {
             emit(key);
           });
         }
-      }).then(function (mapFun) {
-        return db.bulkDocs({docs}).then(function () {
-          const tasks = keySets.map(function (keys, i) {
-            return function () {
-              const expectedResponseKeys = [];
-              return db.allDocs({
-                keys : ['0', '1', '2'],
-                include_docs: true
-              }).then(function (res) {
-                docs = res.rows.map(function (x) { return x.doc; });
-                docs.forEach(function (doc, j) {
-                  doc.keys = keySets[(i + j) % keySets.length];
-                  doc.keys.forEach(function (key) {
-                    expectedResponseKeys.push(key);
-                  });
-                });
-                expectedResponseKeys.sort();
-                return db.bulkDocs({docs});
-              }).then(function () {
-                return db.query(mapFun);
-              }).then(function (res) {
-                const actualKeys = res.rows.map(function (x) {
-                  return x.key;
-                });
-                actualKeys.should.deep.equal(expectedResponseKeys);
-              });
-            };
-          });
-          const chain = tasks.shift()();
-          function getNext() {
-            const task = tasks.shift();
-            return task && function () {
-              return task().then(getNext());
-            };
-          }
-          return chain.then(getNext());
-        });
       });
+
+      await db.bulkDocs({docs});
+
+      for (let i = 0; i < keySets.length; i++) {
+        const expectedResponseKeys = [];
+        const res = await db.allDocs({
+          keys : ['0', '1', '2'],
+          include_docs: true
+        });
+
+        docs = res.rows.map(x => x.doc);
+        docs.forEach((doc, j) => {
+          doc.keys = keySets[(i + j) % keySets.length];
+          doc.keys.forEach(key => expectedResponseKeys.push(key));
+        });
+        expectedResponseKeys.sort();
+
+        await db.bulkDocs({docs});
+        const queryRes = await db.query(queryFun);
+        const actualKeys = queryRes.rows.map(x => x.key);
+
+        actualKeys.should.deep.equal(expectedResponseKeys);
+        }
     });
 
-    it('should handle many doc changes', function () {
-
+    //TODO
+    it('should handle many doc changes', async () => {
       let docs = [{_id: '0'}, {_id : '1'}, {_id: '2'}];
 
       const keySets = [
@@ -3640,329 +3542,309 @@ function tests(suiteName, dbName, dbType, viewType) {
       ];
 
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map : function (doc) {
           doc.keys.forEach(function (key) {
             emit(key);
           });
         }
-      }).then(function (mapFun) {
-        return db.bulkDocs({docs}).then(function () {
-          const tasks = keySets.map(function (keys, i) {
-            return function () {
-              const expectedResponseKeys = [];
-              return db.allDocs({
-                keys : ['0', '1', '2'],
-                include_docs: true
-              }).then(function (res) {
-                docs = res.rows.map(function (x) { return x.doc; });
-                docs.forEach(function (doc, j) {
-                  doc.keys = keySets[(i + j) % keySets.length];
-                  doc.keys.forEach(function (key) {
-                    expectedResponseKeys.push(key);
-                  });
-                });
-                expectedResponseKeys.sort(function (a, b) {
-                  return a - b;
-                });
-                return db.bulkDocs({docs});
-              }).then(function () {
-                return db.query(mapFun);
-              }).then(function (res) {
-                const actualKeys = res.rows.map(function (x) {
-                  return x.key;
-                });
-                actualKeys.should.deep.equal(expectedResponseKeys);
-              });
-            };
-          });
-          function getNext() {
-            const task = tasks.shift();
-            if (task) {
-              return task().then(getNext);
-            }
-          }
-          return getNext();
-        });
       });
+
+      await db.bulkDocs({docs});
+
+      for (let i = 0; i < keySets.length; i++) {
+        const expectedResponseKeys = [];
+
+        const res = await db.allDocs({
+          keys : ['0', '1', '2'],
+          include_docs: true
+        });
+
+        docs = res.rows.map(x => x.doc);
+        docs.forEach((doc, j) => {
+          doc.keys = keySets[(i + j) % keySets.length];
+          doc.keys.forEach(key => expectedResponseKeys.push(key));
+        });
+        expectedResponseKeys.sort((a, b)=>  a - b);
+
+        await db.bulkDocs({docs});
+        const queryRes = await db.query(queryFun);
+        const actualKeys = queryRes.rows.map(x => x.key);
+
+        actualKeys.should.deep.equal(expectedResponseKeys);
+      }
     });
 
-    it('should work with post', function () {
+    it('should work with post', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: function (doc) { emit(doc._id); }
-      }).then(async function (mapFun) {
-        return db.bulkDocs({docs: [{_id : 'bazbazbazb'}]}).then(function () {
-          const keys = ['bazbazbazb'];
-          return db.query(mapFun, {keys}).then(function (resp) {
-            resp.total_rows.should.equal(1);
-            resp.rows.should.have.length(1);
-            return resp.rows.every(function (row) {
-              return row.id === 'bazbazbazb' && row.key === 'bazbazbazb';
-            });
-          });
-        }).should.become(true);
       });
+
+      await db.bulkDocs({docs: [{_id : 'bazbazbazb'}]});
+
+      const keys = ['bazbazbazb'];
+      const res = await db.query(queryFun, {keys});
+
+      res.total_rows.should.equal(1);
+      res.rows.should.have.length(1);
+      res.rows.every(row => row.id === 'bazbazbazb' && row.key === 'bazbazbazb').should.be.true;
     });
 
-    it("should accept trailing ';' in a map definition (#178)", function () {
+    it("should accept trailing ';' in a map definition (#178)", async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: "function(doc){};\n"
-      }).then(function (queryFun) {
-        return db.query(queryFun);
-      }).should.become({
+      });
+
+      const res = await db.query(queryFun);
+
+      res.should.deep.equal({
         offset: 0,
         rows: [],
         total_rows: 0
       });
     });
 
-    it('should throw a 404 when no funcs found in ddoc (#181)', function () {
+    it('should throw a 404 when no funcs found in ddoc (#181)', async () => {
       const db = new PouchDB(dbName);
-      return db.put({
+      await db.put({
         _id: '_design/test'
-      }).then(function () {
-        return db.query('test/unexisting');
-      }).then(function () {
+      });
+
+      try {
+        await db.query('test/unexisting');
         //shouldn't happen
         true.should.equal(false);
-      }).catch(function (err) {
+      } catch (err) {
         err.status.should.be.oneOf([404, 500]);
-      });
+      }
     });
 
-    it('should continue indexing when map eval fails (#214)', function () {
+    it('should continue indexing when map eval fails (#214)', async () => {
       const db = new PouchDB(dbName);
       let err;
-      db.on('error', function (e) {
-        err = e;
-      });
-      return createView(db, {
+      db.on('error', e => err = e);
+      const view = await createView(db, {
         map: function (doc) {
           emit(doc.foo.bar, doc);
         }
-      }).then(function (view) {
-        return db.bulkDocs({docs: [
-          {
-            foo: {
-              bar: "foobar"
-            }
-          },
-          { notfoo: "thisWillThrow" },
-          {
-            foo: {
-              bar: "otherFoobar"
-            }
-          }
-        ]}).then(function () {
-          return db.query(view);
-        }).then(function (res) {
-          if (dbType === 'local') {
-            should.exist(err);
-          }
-          res.rows.should.have.length(2, 'Ignore the wrongly formatted doc');
-          return db.query(view);
-        }).then(function (res) {
-          res.rows.should.have.length(2, 'Ignore the wrongly formatted doc');
-        });
-
       });
+
+      await db.bulkDocs({docs: [
+        {
+          foo: {
+            bar: "foobar"
+          }
+        },
+        { notfoo: "thisWillThrow" },
+        {
+          foo: {
+            bar: "otherFoobar"
+          }
+        }
+      ]});
+
+      const res = await db.query(view);
+
+      if (dbType === 'local') {
+        should.exist(err);
+      }
+
+      res.rows.should.have.length(2, 'Ignore the wrongly formatted doc');
+
+      const res1 = await db.query(view);
+
+      res1.rows.should.have.length(2, 'Ignore the wrongly formatted doc');
     });
 
     it('should continue indexing when map eval fails, ' +
-        'even without a listener (#214)', function () {
+        'even without a listener (#214)', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const view = await createView(db, {
         map: function (doc) {
           emit(doc.foo.bar, doc);
         }
-      }).then(function (view) {
-        return db.bulkDocs({docs: [
-          {
-            foo: {
-              bar: "foobar"
-            }
-          },
-          { notfoo: "thisWillThrow" },
-          {
-            foo: {
-              bar: "otherFoobar"
-            }
-          }
-        ]}).then(function () {
-          return db.query(view);
-        }).then(function (res) {
-          res.rows.should.have.length(2, 'Ignore the wrongly formatted doc');
-          return db.query(view);
-        }).then(function (res) {
-          res.rows.should.have.length(2, 'Ignore the wrongly formatted doc');
-        });
-
       });
+
+      await db.bulkDocs({docs: [
+        {
+          foo: {
+            bar: "foobar"
+          }
+        },
+        { notfoo: "thisWillThrow" },
+        {
+          foo: {
+            bar: "otherFoobar"
+          }
+        }
+      ]});
+
+      const res = await db.query(view);
+
+      res.rows.should.have.length(2, 'Ignore the wrongly formatted doc');
+
+      const res1 = await db.query(view);
+
+      res1.rows.should.have.length(2, 'Ignore the wrongly formatted doc');
     });
 
-    it('should update the emitted value', function () {
+    it('should update the emitted value', async () => {
       const db = new PouchDB(dbName);
       const docs = [];
       for (let i = 0; i < 300; i++) {
         docs.push({
-          _id: i.toString(),
+          _id: `${i}`,
           name: 'foo',
           count: 1
         });
       }
 
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: "function(doc){emit(doc.name, doc.count);};\n"
-      }).then(function (queryFun) {
-        return db.bulkDocs({docs}).then(function (res) {
-          for (let i = 0; i < res.length; i++) {
-            docs[i]._rev = res[i].rev;
-          }
-          return db.query(queryFun);
-        }).then(function (res) {
-          const values = res.rows.map(function (x) { return x.value; });
-          values.should.have.length(docs.length);
-          values[0].should.equal(1);
-          docs.forEach(function (doc) {
-            doc.count = 2;
-          });
-          return db.bulkDocs({docs});
-        }).then(function () {
-          return db.query(queryFun);
-        }).then(function (res) {
-          const values = res.rows.map(function (x) { return x.value; });
-          values.should.have.length(docs.length);
-          values[0].should.equal(2);
-        });
       });
+
+      const writeRes = await db.bulkDocs({docs});
+
+      for (let i = 0; i < writeRes.length; i++) {
+        docs[i]._rev = writeRes[i].rev;
+      }
+      const queryRes = await db.query(queryFun);
+      const values = queryRes.rows.map(x => x.value);
+
+      values.should.have.length(docs.length);
+      values[0].should.equal(1);
+
+      docs.forEach(doc => doc.count = 2);
+      await db.bulkDocs({docs});
+
+      const queryRes1 = await db.query(queryFun);
+
+      const values1 = queryRes1.rows.map(x => x.value);
+      values1.should.have.length(docs.length);
+      values1[0].should.equal(2);
     });
 
-    it('#6230 Test db.query() opts update_seq: false', function () {
+    it('#6230 Test db.query() opts update_seq: false', async () => {
       const db = new PouchDB(dbName);
       const docs = [];
       for (let i = 0; i < 4; i++) {
         docs.push({
-          _id: i.toString(),
+          _id: `${i}`,
           name: 'foo',
         });
       }
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: "function(doc){emit(doc.name);};\n"
-      }).then(function (queryFun) {
-        return db.bulkDocs({ docs }).then(function () {
-          return db.query(queryFun, { update_seq: false });
-        }).then(function (result) {
-          result.rows.should.have.length(4);
-          should.not.exist(result.update_seq);
-        });
       });
+
+      await db.bulkDocs({ docs });
+      const res = await db.query(queryFun, { update_seq: false });
+
+      res.rows.should.have.length(4);
+      should.not.exist(res.update_seq);
     });
 
 
-    it('#6230 Test db.query() opts update_seq: true', function () {
+    it('#6230 Test db.query() opts update_seq: true', async () => {
+      const normalizeSeq = (seq) => (typeof seq === 'string' && seq.indexOf('-') > 0)
+        ? parseInt(seq.substring(0, seq.indexOf('-'))) : seq;
 
       const db = new PouchDB(dbName);
       const docs = [];
       for (let i = 0; i < 4; i++) {
         docs.push({
-          _id: i.toString(),
+          _id: `${i}`,
           name: 'foo',
         });
       }
 
-      return db.bulkDocs({ docs }).then(function () {
-        return createView(db, {
-          map: "function(doc){emit(doc.name);};\n"
-        });
-      }).then(function (queryFun) {
-        return db.query(queryFun, { update_seq: true });
-      }).then(function (result) {
-        result.rows.should.have.length(4);
-        should.exist(result.update_seq);
-        result.update_seq.should.satisfy(function (update_seq) {
-          if (typeof update_seq === 'number' || typeof update_seq === 'string') {
-            return true;
-          } else {
-            return false;
-          }
-        });
-        const normSeq = normalizeSeq(result.update_seq);
-        normSeq.should.be.a('number');
-      });
+      await db.bulkDocs({ docs });
 
-      function normalizeSeq(seq) {
-        try {
-          if (typeof seq === 'string' && seq.indexOf('-') > 0) {
-            return parseInt(seq.substring(0, seq.indexOf('-')));
-          }
-          return seq;
-        } catch (err) {
-          return seq;
-        }
-      }
-    });
-
-    it('#6230 Test db.query() opts with update_seq missing', function () {
-      const db = new PouchDB(dbName);
-      const docs = [];
-      for (let i = 0; i < 4; i++) {
-        docs.push({
-          _id: i.toString(),
-          name: 'foo',
-        });
-      }
-      return createView(db, {
+      const queryFun = await createView(db, {
         map: "function(doc){emit(doc.name);};\n"
-      }).then(function (queryFun) {
-        return db.bulkDocs({ docs }).then(function () {
-          return db.query(queryFun);
-        }).then(function (result) {
-          result.rows.should.have.length(4);
-          should.not.exist(result.update_seq);
-        });
       });
+
+      const result = await db.query(queryFun, { update_seq: true });
+
+      result.rows.should.have.length(4);
+      should.exist(result.update_seq);
+      ['number', 'string'].should.include(typeof result.update_seq);
+
+      const normSeq = normalizeSeq(result.update_seq);
+      normSeq.should.be.a('number');
     });
 
-    it("#8370 keys queries should support skip and limit", function () {
+    it('#6230 Test db.query() opts with update_seq missing', async () => {
       const db = new PouchDB(dbName);
-      return createView(db, {
+      const docs = [];
+      for (let i = 0; i < 4; i++) {
+        docs.push({
+          _id: `${i}`,
+          name: 'foo',
+        });
+      }
+      const queryFun = await createView(db, {
+        map: "function(doc){emit(doc.name);};\n"
+      });
+
+      await db.bulkDocs({ docs });
+
+      const result = await db.query(queryFun);
+
+      result.rows.should.have.length(4);
+      should.not.exist(result.update_seq);
+    });
+
+    it("#8370 keys queries should support skip and limit", async () => {
+      const db = new PouchDB(dbName);
+      const queryFun = await createView(db, {
         map: function (doc) {
           emit(doc.field);
         }
-      }).then(function (queryFun) {
-        const opts = {include_docs: true};
-        return db.bulkDocs({
-          docs: [
-            { _id: "doc_0", field: 0 },
-            { _id: "doc_1", field: 1 },
-            { _id: "doc_2", field: 2 },
-            { _id: "doc_3", field: 3 },
-          ]
-        }).then(function () {
-          opts.keys = [1, 0, 3, 2];
-          opts.limit = 2;
-          return db.query(queryFun, opts);
-        }).then(function (data) {
-          data.rows.should.have.length(2, "returns 2 docs due to limit");
-          data.rows[0].doc._id.should.equal("doc_1");
-          data.rows[1].doc._id.should.equal("doc_0");
-          delete opts.limit;
-          opts.skip = 2;
-          return db.query(queryFun, opts);
-        }).then(function (data) {
-          data.rows.should.have.length(2, "returns 2 docs due to skip");
-          data.rows[0].doc._id.should.equal("doc_3");
-          data.rows[1].doc._id.should.equal("doc_2");
-          opts.limit = 2;
-          opts.skip = 3;
-          return db.query(queryFun, opts);
-        }).then(function (data) {
-          data.rows.should.have.length(1, "returns 1 doc due to limit and skip");
-          data.rows[0].doc._id.should.equal("doc_2");
-        });
       });
+
+      await db.bulkDocs({
+        docs: [
+          { _id: "doc_0", field: 0 },
+          { _id: "doc_1", field: 1 },
+          { _id: "doc_2", field: 2 },
+          { _id: "doc_3", field: 3 },
+        ]
+      });
+
+      const opts = {include_docs: true};
+      opts.keys = [1, 0, 3, 2];
+      opts.limit = 2;
+      const queryRes = await db.query(queryFun, opts);
+
+      queryRes.rows.should.have.length(2, "returns 2 docs due to limit");
+      queryRes.rows[0].doc._id.should.equal("doc_1");
+      queryRes.rows[1].doc._id.should.equal("doc_0");
+
+      delete opts.limit;
+      opts.skip = 2;
+      const queryRes1 = await db.query(queryFun, opts);
+
+      queryRes1.rows.should.have.length(2, "returns 2 docs due to skip");
+      queryRes1.rows[0].doc._id.should.equal("doc_3");
+      queryRes1.rows[1].doc._id.should.equal("doc_2");
+
+      opts.limit = 2;
+      opts.skip = 3;
+      const queryRes2 = await db.query(queryFun, opts);
+
+      queryRes2.rows.should.have.length(1, "returns 1 doc due to limit and skip");
+      queryRes2.rows[0].doc._id.should.equal("doc_2");
     });
   });
 }
+
+const mapToRows = (res) => {
+  return res.rows.map((x) => ({
+    id: x.id,
+    key: x.key,
+    value: x.value
+  }));
+};

--- a/tests/mapreduce/test.persisted.js
+++ b/tests/mapreduce/test.persisted.js
@@ -12,10 +12,10 @@ describe('test.persisted.js', function () {
 
   function createView(db, viewObj) {
     const storableViewObj = {
-      map : viewObj.map.toString()
+      map : `${viewObj.map}`
     };
     if (viewObj.reduce) {
-      storableViewObj.reduce = viewObj.reduce.toString();
+      storableViewObj.reduce = `${viewObj.reduce}`;
     }
     return new Promise(function (resolve, reject) {
       db.put({

--- a/tests/mapreduce/test.persisted.js
+++ b/tests/mapreduce/test.persisted.js
@@ -1,8 +1,8 @@
 'use strict';
 
 describe('test.persisted.js', function () {
-  var dbType = testUtils.adapterType();
-  var dbName = testUtils.adapterUrl(dbType, 'testdb');
+  const dbType = testUtils.adapterType();
+  const dbName = testUtils.adapterUrl(dbType, 'testdb');
 
   function setTimeoutPromise(time) {
     return new Promise(function (resolve) {
@@ -11,7 +11,7 @@ describe('test.persisted.js', function () {
   }
 
   function createView(db, viewObj) {
-    var storableViewObj = {
+    const storableViewObj = {
       map : viewObj.map.toString()
     };
     if (viewObj.reduce) {
@@ -38,8 +38,8 @@ describe('test.persisted.js', function () {
   });
 
   it('Test destroyed event on auxiliary db', function () {
-    var db = new PouchDB(dbName);
-    var rev;
+    const db = new PouchDB(dbName);
+    let rev;
     return db.put({
       _id: '_design/name',
       views: {
@@ -82,7 +82,7 @@ describe('test.persisted.js', function () {
     }).then(function () {
       return db.viewCleanup();
     }).then(function () {
-      var views = ['name', 'title'];
+      const views = ['name', 'title'];
       return Promise.all(views.map(function (view) {
         return db.query(view).then(function () {
           throw new Error('expected an error');
@@ -116,14 +116,14 @@ describe('test.persisted.js', function () {
   });
 
   it('Returns ok for viewCleanup on empty db', function () {
-    var db = new PouchDB(dbName);
+    const db = new PouchDB(dbName);
     return db.viewCleanup().then(function (res) {
       res.ok.should.equal(true);
     });
   });
 
   it('Returns ok for viewCleanup on empty db, callback style', function () {
-    var db = new PouchDB(dbName);
+    const db = new PouchDB(dbName);
     return new Promise(function (resolve, reject) {
       db.viewCleanup(function (err, res) {
         if (err) {
@@ -137,8 +137,8 @@ describe('test.persisted.js', function () {
   });
 
   it('Returns ok for viewCleanup after modifying view', function () {
-    var db = new PouchDB(dbName);
-    var ddoc = {
+    const db = new PouchDB(dbName);
+    const ddoc = {
       _id: '_design/myview',
       views: {
         myview: {
@@ -148,7 +148,7 @@ describe('test.persisted.js', function () {
         }
       }
     };
-    var doc = {
+    const doc = {
       _id: 'foo',
       firstName: 'Foobar',
       lastName: 'Bazman'
@@ -175,8 +175,8 @@ describe('test.persisted.js', function () {
   });
 
   it('Return ok for viewCleanup after modding view, old format', function () {
-    var db = new PouchDB(dbName);
-    var ddoc = {
+    const db = new PouchDB(dbName);
+    const ddoc = {
       _id: '_design/myddoc',
       views: {
         myview: {
@@ -186,7 +186,7 @@ describe('test.persisted.js', function () {
         }
       }
     };
-    var doc = {
+    const doc = {
       _id: 'foo',
       firstName: 'Foobar',
       lastName: 'Bazman'
@@ -213,8 +213,8 @@ describe('test.persisted.js', function () {
   });
 
   it("Query non existing view throws error", function () {
-    var db = new PouchDB(dbName);
-    var doc = {
+    const db = new PouchDB(dbName);
+    const doc = {
       _id: '_design/barbar',
       views: {
         scores: {
@@ -228,8 +228,8 @@ describe('test.persisted.js', function () {
   });
 
   it("Query non-string view throws error", function () {
-    var db = new PouchDB(dbName);
-    var doc = {
+    const db = new PouchDB(dbName);
+    const doc = {
       _id: '_design/barbar',
       views: {
         scores: {
@@ -244,21 +244,21 @@ describe('test.persisted.js', function () {
 
   it('many simultaneous persisted views', function () {
     this.timeout(120000);
-    var db = new PouchDB(dbName);
+    const db = new PouchDB(dbName);
 
-    var views = [];
-    var doc = {_id: 'foo'};
-    for (var i = 0; i < 20; i++) {
+    const views = [];
+    const doc = {_id: 'foo'};
+    for (let i = 0; i < 20; i++) {
       views.push('foo_' + i);
       doc['foo_' + i] = 'bar_' + i;
     }
 
     return db.put(doc).then(function () {
       return Promise.all(views.map(function (_, i) {
-        var fun = "function (doc) { emit(doc.foo_" + i + ");}";
+        const fun = "function (doc) { emit(doc.foo_" + i + ");}";
 
-        var ddocId = 'theViewDoc_' + i;
-        var ddoc = {
+        const ddocId = 'theViewDoc_' + i;
+        const ddoc = {
           _id: '_design/' + ddocId,
           views: {
             theView : {map: fun}
@@ -287,7 +287,7 @@ describe('test.persisted.js', function () {
   });
 
   it('should error with a callback', function (done) {
-    var db = new PouchDB(dbName);
+    const db = new PouchDB(dbName);
     db.query('fake/thing', function (err) {
       should.exist(err);
       done();
@@ -295,7 +295,7 @@ describe('test.persisted.js', function () {
   });
 
   it('should query correctly when stale', function () {
-    var db = new PouchDB(dbName);
+    const db = new PouchDB(dbName);
     return createView(db, {
       map : function (doc) {
         emit(doc.name);
@@ -358,14 +358,14 @@ describe('test.persisted.js', function () {
   });
 
   it('should query correctly with stale update_after', function () {
-    var pouch = new PouchDB(dbName);
+    const pouch = new PouchDB(dbName);
 
     return createView(pouch, {map: function (doc) {
       emit(doc.foo);
     }}).then(function (queryFun) {
-      var docs = [];
+      const docs = [];
 
-      for (var i = 0; i < 10; i++) {
+      for (let i = 0; i < 10; i++) {
         docs.push({foo: 'bar'});
       }
 
@@ -383,8 +383,8 @@ describe('test.persisted.js', function () {
   });
 
   it('should delete duplicate indexes', function () {
-    var docs = [];
-    for (var i = 0; i < 10; i++) {
+    const docs = [];
+    for (let i = 0; i < 10; i++) {
       docs.push(
         {
           _id : '_design/view' + i,
@@ -396,10 +396,10 @@ describe('test.persisted.js', function () {
         }
       );
     }
-    var db = new PouchDB(dbName);
+    const db = new PouchDB(dbName);
     return db.bulkDocs({docs}).then(function (responses) {
-      var tasks = [];
-      for (var i = 0; i < docs.length; i++) {
+      const tasks = [];
+      for (let i = 0; i < docs.length; i++) {
         docs[i]._rev = responses[i].rev;
         tasks.push(db.query('view' + i + '/view'));
       }
@@ -418,11 +418,11 @@ describe('test.persisted.js', function () {
       // can't test this in Node due to the vm
       (typeof process === 'undefined' || process.browser)) {
     it('issue 4967 map() called twice', function () {
-      var db = new PouchDB(dbName);
-      var globalObj = (typeof process !== 'undefined' && !process.browser) ?
+      const db = new PouchDB(dbName);
+      const globalObj = (typeof process !== 'undefined' && !process.browser) ?
         global : window;
       globalObj.__mapreduce_called = {};
-      var docs = Array.apply(null, Array(5)).map(function (_, i) {
+      const docs = Array.apply(null, Array(5)).map(function (_, i) {
         return {
           _id: 'doc_' + i,
           data: Math.random().toString(36).slice(2)
@@ -459,9 +459,9 @@ describe('test.persisted.js', function () {
   }
 
   it('test docs with reserved IDs', function () {
-    var db = new PouchDB(dbName);
+    const db = new PouchDB(dbName);
 
-    var docs = [
+    const docs = [
       {_id: 'constructor'},
       {_id: 'isPrototypeOf'},
       {_id: 'hasOwnProperty'},
@@ -477,7 +477,7 @@ describe('test.persisted.js', function () {
     return db.bulkDocs(docs).then(function () {
       return db.query('view/view', {include_docs: true});
     }).then(function (res) {
-      var rows = res.rows.map(function (row) {
+      const rows = res.rows.map(function (row) {
         return {
           id: row.id,
           key: row.key,
@@ -511,7 +511,7 @@ describe('test.persisted.js', function () {
   });
 
   it('should handle user errors in design doc names', function () {
-    var db = new PouchDB(dbName);
+    const db = new PouchDB(dbName);
     return db.put({
       _id : '_design/theViewDoc'
     }).then(function () {
@@ -540,7 +540,7 @@ describe('test.persisted.js', function () {
     function getKey(row) {
       return row.key;
     }
-    var db = new PouchDB(dbName);
+    const db = new PouchDB(dbName);
     return db.put({
       _id : '_design/foo',
       views : {
@@ -611,8 +611,8 @@ describe('test.persisted.js', function () {
   });
 
   it('should allow view names without slashes', function () {
-    var ddocRev;
-    var db = new PouchDB(dbName);
+    let ddocRev;
+    const db = new PouchDB(dbName);
     return db.put({
       _id : '_design/foo',
       views : {
@@ -631,7 +631,7 @@ describe('test.persisted.js', function () {
   });
 
   it('test 304s in Safari (issue 69)', function () {
-    var db = new PouchDB(dbName);
+    const db = new PouchDB(dbName);
     return createView(db, {
       map : function (doc) {
         emit(doc.name);
@@ -653,16 +653,16 @@ describe('test.persisted.js', function () {
     });
   });
 
-  var isNode = typeof window === 'undefined';
+  const isNode = typeof window === 'undefined';
   if (dbType === 'local' && isNode) {
     it('#239 test memdown db', function () {
-      var destroyedDBs = [];
+      const destroyedDBs = [];
       PouchDB.on('destroyed', function (db) {
         destroyedDBs.push(db);
       });
 
       // make sure prefixed DBs are tied to regular DBs
-      var db = new PouchDB(dbName, {db: require('memdown')});
+      const db = new PouchDB(dbName, {db: require('memdown')});
       return testUtils.fin(createView(db, {
         map: function (doc) {
           emit(doc.name);
@@ -673,7 +673,7 @@ describe('test.persisted.js', function () {
         }).then(function (res) {
           res.rows.should.have.length(1);
           res.rows[0].key.should.equal('foo');
-          var ddocId = '_design/' + queryFun.split('/')[0];
+          const ddocId = '_design/' + queryFun.split('/')[0];
           return db.get(ddocId);
         }).then(function (ddoc) {
           return db.remove(ddoc);
@@ -682,13 +682,13 @@ describe('test.persisted.js', function () {
         });
       }), function () {
         return db.destroy().then(function () {
-          var chain = Promise.resolve();
+          let chain = Promise.resolve();
           // for each of the supposedly destroyed DBs,
           // check that there isn't a normal DB hanging around
           destroyedDBs.forEach(function (dbName) {
             chain = chain.then(function () {
-              var db = new PouchDB(dbName);
-              var promise = db.info().then(function (info) {
+              const db = new PouchDB(dbName);
+              const promise = db.info().then(function (info) {
                 info.update_seq.should.equal(0);
               });
               return testUtils.fin(promise, function () {
@@ -704,14 +704,14 @@ describe('test.persisted.js', function () {
     });
 
     it('#239 test prefixed db', function () {
-      var destroyedDBs = [];
+      const destroyedDBs = [];
       PouchDB.on('destroyed', function (db) {
         destroyedDBs.push(db);
       });
 
       // make sure prefixed DBs are tied to regular DBs
       require('fs').mkdirSync('./myprefix_./tmp/', { recursive:true }); // TODO: bit hacky
-      var db = new PouchDB(dbName, {prefix: './myprefix_'});
+      const db = new PouchDB(dbName, {prefix: './myprefix_'});
       return testUtils.fin(createView(db, {
         map: function (doc) {
           emit(doc.name);
@@ -722,7 +722,7 @@ describe('test.persisted.js', function () {
         }).then(function (res) {
           res.rows.should.have.length(1);
           res.rows[0].key.should.equal('foo');
-          var ddocId = '_design/' + queryFun.split('/')[0];
+          const ddocId = '_design/' + queryFun.split('/')[0];
           return db.get(ddocId);
         }).then(function (ddoc) {
           return db.remove(ddoc);
@@ -731,13 +731,13 @@ describe('test.persisted.js', function () {
         });
       }), function () {
         return db.destroy().then(function () {
-          var chain = Promise.resolve();
+          let chain = Promise.resolve();
           // for each of the supposedly destroyed DBs,
           // check that there isn't a normal DB hanging around
           destroyedDBs.forEach(function (dbName) {
             chain = chain.then(function () {
-              var db = new PouchDB(dbName);
-              var promise = db.info().then(function (info) {
+              const db = new PouchDB(dbName);
+              const promise = db.info().then(function (info) {
                 info.update_seq.should.equal(0);
               });
               return testUtils.fin(promise, function () {

--- a/tests/mapreduce/test.persisted.js
+++ b/tests/mapreduce/test.persisted.js
@@ -226,6 +226,7 @@ describe('test.persisted.js', () => {
     try {
       await db.post(doc);
       await db.query('barbar/scores', {key: 'bar'});
+      throw new Error('should fail');
     } catch (err) {
       err.message.should.include('string');
     }
@@ -437,7 +438,7 @@ describe('test.persisted.js', () => {
     });
   }
 
-  it('test docs with reserved IDs', function () {
+  it('test docs with reserved IDs', async () => {
     const db = new PouchDB(dbName);
 
     const docs = [
@@ -453,66 +454,71 @@ describe('test.persisted.js', () => {
         }
       }
     ];
-    return db.bulkDocs(docs).then(function () {
-      return db.query('view/view', {include_docs: true});
-    }).then(function (res) {
-      const rows = res.rows.map(function (row) {
-        return {
-          id: row.id,
-          key: row.key,
-          docId: row.doc._id
-        };
-      });
-      assert.deepEqual(rows, [
-        { "id": "constructor",
-          "key": "constructor",
-          "docId": "constructor"
-        },
-        {
-          "id": "hasOwnProperty",
-          "key": "hasOwnProperty",
-          "docId": "hasOwnProperty"
-        },
-        {
-          "id": "isPrototypeOf",
-          "key": "isPrototypeOf",
-          "docId": "isPrototypeOf"
-        }
-      ]);
-      return db.viewCleanup();
-    }).then(function () {
-      return db.get('_design/view');
-    }).then(function (doc) {
-      return db.remove(doc);
-    }).then(function () {
-      return db.viewCleanup();
-    });
+    await db.bulkDocs(docs);
+
+    const res = await db.query('view/view', {include_docs: true});
+
+    const rows = res.rows.map(row =>  ({
+      id: row.id,
+      key: row.key,
+      docId: row.doc._id
+    }));
+
+    assert.deepEqual(rows, [
+      { "id": "constructor",
+        "key": "constructor",
+        "docId": "constructor"
+      },
+      {
+        "id": "hasOwnProperty",
+        "key": "hasOwnProperty",
+        "docId": "hasOwnProperty"
+      },
+      {
+        "id": "isPrototypeOf",
+        "key": "isPrototypeOf",
+        "docId": "isPrototypeOf"
+      }
+    ]);
+
+    await db.viewCleanup();
+
+    const doc = await db.get('_design/view');
+    await db.remove(doc);
+    await db.viewCleanup();
   });
 
-  it('should handle user errors in design doc names', function () {
+  it('should handle user errors in design doc names', async () => {
     const db = new PouchDB(dbName);
-    return db.put({
+
+    await db.put({
       _id : '_design/theViewDoc'
-    }).then(function () {
-      return db.query('foo/bar');
-    }).then(function (res) {
-      should.not.exist(res);
-    }).catch(function (err) {
-      err.status.should.equal(404);
-      return db.put(
-        {_id : '_design/void', views : {1 : null}}
-      ).then(function () {
-        return db.query('void/1');
-      }).then(function (res) {
-        should.not.exist(res);
-      }).catch(function (err) {
-        err.status.should.be.a('number');
-        // this might throw due to erroneous ddoc, but that's ok
-        return db.viewCleanup().catch(function (err) {
-          err.status.should.equal(500);
-        });
-      });
     });
+
+    try {
+      await db.query('foo/bar');
+      throw new Error('should fail');
+    } catch (err) {
+      err.status.should.equal(404);
+    }
+
+    await db.put(
+      {_id : '_design/void', views : {1 : null}}
+    );
+
+    try {
+      await db.query('void/1');
+      throw new Error("should fail");
+    } catch (err) {
+      err.status.should.be.a('number');
+    }
+
+    // this might throw due to erroneous ddoc, but that's ok
+    try {
+      await db.viewCleanup();
+    } catch (err) {
+      err.status.should.equal(500);
+    }
   });
 
   it('should allow the user to create many design docs', function () {

--- a/tests/mapreduce/test.persisted.js
+++ b/tests/mapreduce/test.persisted.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('test.persisted.js', function () {
+describe('test.persisted.js', () => {
   const dbType = testUtils.adapterType();
   const dbName = testUtils.adapterUrl(dbType, 'testdb');
 
@@ -10,37 +10,29 @@ describe('test.persisted.js', function () {
     });
   }
 
-  function createView(db, viewObj) {
+  const createView = async (db, viewObj) => {
     const storableViewObj = {
       map : `${viewObj.map}`
     };
     if (viewObj.reduce) {
       storableViewObj.reduce = `${viewObj.reduce}`;
     }
-    return new Promise(function (resolve, reject) {
-      db.put({
-        _id: '_design/theViewDoc',
-        views: {
-          'theView' : storableViewObj
-        }
-      }, function (err) {
-        if (err) {
-          reject(err);
-        } else {
-          resolve('theViewDoc/theView');
-        }
-      });
+    await db.put({
+      _id: '_design/theViewDoc',
+      views: {
+        'theView' : storableViewObj
+      }
     });
-  }
+    return 'theViewDoc/theView';
+  };
 
-  afterEach(function () {
-    return new PouchDB(dbName).destroy();
+  afterEach(async () => {
+    await new PouchDB(dbName).destroy();
   });
 
-  it('Test destroyed event on auxiliary db', function () {
+  it('Test destroyed event on auxiliary db', async () => {
     const db = new PouchDB(dbName);
-    let rev;
-    return db.put({
+    const putNameView = await db.put({
       _id: '_design/name',
       views: {
         name: {
@@ -49,94 +41,82 @@ describe('test.persisted.js', function () {
           }.toString()
         }
       }
-    }).then(function (res) {
-      rev = res.rev;
-      return db.bulkDocs([
-        {_id: 'foo', name: 'foo', title: 'yo'},
-        {_id: 'baz', name: 'bar', title: 'hey'},
-        {_id: 'bar', name: 'baz', title: 'wuzzup'}
-      ]);
-    }).then(function () {
-      return db.query('name');
-    }).then(function () {
-      return db.remove('_design/name', rev);
-    }).then(function () {
-      return db.viewCleanup();
-    }).then(function () {
-      return db.put({
-        _id: '_design/title',
-        views: {
-          title: {
-            map: function (doc) {
-              emit(doc.title);
-            }.toString()
-          }
-        }
-      });
-    }).then(function (res) {
-      rev = res.rev;
-    }).then(function () {
-      return db.query('title');
-    }).then(function () {
-      return db.remove('_design/title', rev);
-    }).then(function () {
-      return db.viewCleanup();
-    }).then(function () {
-      const views = ['name', 'title'];
-      return Promise.all(views.map(function (view) {
-        return db.query(view).then(function () {
-          throw new Error('expected an error');
-        }, function (err) {
-          should.exist(err);
-        });
-      }));
-    }).then(function () {
-      return db.put({
-        _id: '_design/name',
-        views: {
-          name: {
-            map: function (doc) {
-              emit(doc.name);
-            }.toString()
-          }
-        }
-      }).then(function (res) {
-        rev = res.rev;
-        return db.query('name');
-      }).then(function (res) {
-        res.rows.map(function (row) {
-          return [row.id, row.key];
-        }).should.deep.equal([
-            ['baz', 'bar'],
-            ['bar', 'baz'],
-            ['foo', 'foo']
-          ]);
-      });
     });
+    const nameViewRev = putNameView.rev;
+
+    await db.bulkDocs([
+      {_id: 'foo', name: 'foo', title: 'yo'},
+      {_id: 'baz', name: 'bar', title: 'hey'},
+      {_id: 'bar', name: 'baz', title: 'wuzzup'}
+    ]);
+
+    await db.query('name');
+    await db.remove('_design/name', nameViewRev);
+    await db.viewCleanup();
+
+    const putTitleView = await db.put({
+      _id: '_design/title',
+      views: {
+        title: {
+          map: function (doc) {
+            emit(doc.title);
+          }.toString()
+        }
+      }
+    });
+    const titleViewRev = putTitleView.rev;
+
+    await db.query('title');
+    await db.remove('_design/title', titleViewRev);
+    await db.viewCleanup();
+
+    const views = ['name', 'title'];
+
+    await Promise.all(views.map((view) => {
+      return db.query(view).should.be.rejected;
+    }));
+
+    await db.put({
+      _id: '_design/name',
+      views: {
+        name: {
+          map: function (doc) {
+            emit(doc.name);
+          }.toString()
+        }
+      }
+    });
+
+    const queryRes = await db.query('name');
+
+    queryRes.rows.map(row => [row.id, row.key]).should.deep.equal([
+      ['baz', 'bar'],
+      ['bar', 'baz'],
+      ['foo', 'foo']
+    ]);
   });
 
-  it('Returns ok for viewCleanup on empty db', function () {
+
+  it('Returns ok for viewCleanup on empty db', async () => {
     const db = new PouchDB(dbName);
-    return db.viewCleanup().then(function (res) {
-      res.ok.should.equal(true);
-    });
+    const res = await db.viewCleanup();
+
+    res.ok.should.equal(true);
   });
 
-  it('Returns ok for viewCleanup on empty db, callback style', function () {
+  it('Returns ok for viewCleanup on empty db, callback style', async () => {
     const db = new PouchDB(dbName);
-    return new Promise(function (resolve, reject) {
-      db.viewCleanup(function (err, res) {
-        if (err) {
-          return reject(err);
-        }
+    const res = await new Promise((resolve, reject) => {
+      db.viewCleanup((err, res) => {
+        if (err)  {return reject(err);}
         resolve(res);
       });
-    }).then(function (res) {
-      res.ok.should.equal(true);
     });
+
+    res.ok.should.equal(true);
   });
 
-  it('Returns ok for viewCleanup after modifying view', function () {
+  it('Returns ok for viewCleanup after modifying view', async () => {
     const db = new PouchDB(dbName);
     const ddoc = {
       _id: '_design/myview',
@@ -153,28 +133,31 @@ describe('test.persisted.js', function () {
       firstName: 'Foobar',
       lastName: 'Bazman'
     };
-    return db.bulkDocs({docs: [ddoc, doc]}).then(function (info) {
-      ddoc._rev = info[0].rev;
-      return db.query('myview');
-    }).then(function (res) {
-      res.rows.should.deep.equal([
-        {id: 'foo', key: 'Foobar', value: null}
-      ]);
-      ddoc.views.myview.map = function (doc) {
-        emit(doc.lastName);
-      }.toString();
-      return db.put(ddoc);
-    }).then(function () {
-      return db.query('myview');
-    }).then(function (res) {
-      res.rows.should.deep.equal([
+
+    const info = await db.bulkDocs({docs: [ddoc, doc]});
+    ddoc._rev = info[0].rev;
+
+    const queryRes = await db.query('myview');
+
+    queryRes.rows.should.deep.equal([
+      {id: 'foo', key: 'Foobar', value: null}
+    ]);
+
+    ddoc.views.myview.map = function (doc) {
+      emit(doc.lastName);
+    }.toString();
+
+    await db.put(ddoc);
+    const queryResAfterMod = await db.query('myview');
+
+    queryResAfterMod.rows.should.deep.equal([
         {id: 'foo', key: 'Bazman', value: null}
       ]);
-      return db.viewCleanup();
-    });
+
+    await db.viewCleanup();
   });
 
-  it('Return ok for viewCleanup after modding view, old format', function () {
+  it('Return ok for viewCleanup after modding view, old format', async () => {
     const db = new PouchDB(dbName);
     const ddoc = {
       _id: '_design/myddoc',
@@ -191,28 +174,30 @@ describe('test.persisted.js', function () {
       firstName: 'Foobar',
       lastName: 'Bazman'
     };
-    return db.bulkDocs({docs: [ddoc, doc]}).then(function (info) {
-      ddoc._rev = info[0].rev;
-      return db.query('myddoc/myview');
-    }).then(function (res) {
-      res.rows.should.deep.equal([
-        {id: 'foo', key: 'Foobar', value: null}
-      ]);
-      ddoc.views.myview.map = function (doc) {
-        emit(doc.lastName);
-      }.toString();
-      return db.put(ddoc);
-    }).then(function () {
-      return db.query('myddoc/myview');
-    }).then(function (res) {
-      res.rows.should.deep.equal([
-        {id: 'foo', key: 'Bazman', value: null}
-      ]);
-      return db.viewCleanup();
-    });
+    const info = await db.bulkDocs({docs: [ddoc, doc]});
+    ddoc._rev = info[0].rev;
+
+    const queryRes = await db.query('myddoc/myview');
+
+    queryRes.rows.should.deep.equal([
+      {id: 'foo', key: 'Foobar', value: null}
+    ]);
+
+    ddoc.views.myview.map = function (doc) {
+      emit(doc.lastName);
+    }.toString();
+
+    await db.put(ddoc);
+    const queryResAfterMod = await db.query('myddoc/myview');
+
+    queryResAfterMod.rows.should.deep.equal([
+      {id: 'foo', key: 'Bazman', value: null}
+    ]);
+
+    return db.viewCleanup();
   });
 
-  it("Query non existing view throws error", function () {
+  it("Query non existing view throws error", async () => {
     const db = new PouchDB(dbName);
     const doc = {
       _id: '_design/barbar',
@@ -222,12 +207,12 @@ describe('test.persisted.js', function () {
         }
       }
     };
-    return db.post(doc).then(function () {
-      return db.query('barbar/dontExist', {key: 'bar'}).should.be.rejected;
-    });
+    await db.post(doc);
+
+    await db.query('barbar/dontExist', {key: 'bar'}).should.be.rejected;
   });
 
-  it("Query non-string view throws error", function () {
+  it("Query non-string view throws error", async () => {
     const db = new PouchDB(dbName);
     const doc = {
       _id: '_design/barbar',
@@ -237,13 +222,12 @@ describe('test.persisted.js', function () {
         }
       }
     };
-    return db.post(doc).then(function () {
-      return db.query('barbar/scores', {key: 'bar'});
-    }).should.be.rejected;
+    await db.post(doc);
+
+    await db.query('barbar/scores', {key: 'bar'}).should.be.rejected;
   });
 
-  it('many simultaneous persisted views', function () {
-    this.timeout(120000);
+  it('many simultaneous persisted views', async () => {
     const db = new PouchDB(dbName);
 
     const views = [];
@@ -252,40 +236,35 @@ describe('test.persisted.js', function () {
       views.push('foo_' + i);
       doc['foo_' + i] = 'bar_' + i;
     }
+    await db.put(doc);
 
-    return db.put(doc).then(function () {
-      return Promise.all(views.map(function (_, i) {
-        const fun = "function (doc) { emit(doc.foo_" + i + ");}";
+    await Promise.all(views.map(async (_, i) => {
+      const fun = "function (doc) { emit(doc.foo_" + i + ");}";
 
-        const ddocId = 'theViewDoc_' + i;
-        const ddoc = {
-          _id: '_design/' + ddocId,
-          views: {
-            theView : {map: fun}
-          }
-        };
+      const ddocId = 'theViewDoc_' + i;
+      const ddoc = {
+        _id: '_design/' + ddocId,
+        views: {
+          theView : {map: fun}
+        }
+      };
 
-        return db.put(ddoc).then(function (res) {
-          ddoc._rev = res.rev;
-          return db.query(ddocId + '/theView');
-        }).then(function (res) {
-          res.rows.should.have.length(1);
-          res.rows[0].key.should.equal('bar_' + i);
-          res.rows[0].id.should.equal('foo');
-          return db.remove(ddoc);
-        }).then(function () {
-          return db.viewCleanup();
-        }).then(function () {
-          return db.query(ddocId + '/theView').then(function () {
-            throw new Error('view should have been deleted');
-          }, function (err) {
-            should.exist(err);
-          });
-        });
-      }));
-    });
-  });
+      const putRes = await db.put(ddoc);
+      ddoc._rev = putRes.rev;
+      const queryRes = await db.query(ddocId + '/theView');
 
+      queryRes.rows.should.have.length(1);
+      queryRes.rows[0].key.should.equal('bar_' + i);
+      queryRes.rows[0].id.should.equal('foo');
+
+      await db.remove(ddoc);
+      await db.viewCleanup();
+
+      await db.query(ddocId + '/theView').should.be.rejected;
+    }));
+  }).timeout(120000);
+
+  //ToDo: rm done but keep callback
   it('should error with a callback', function (done) {
     const db = new PouchDB(dbName);
     db.query('fake/thing', function (err) {
@@ -294,95 +273,96 @@ describe('test.persisted.js', function () {
     });
   });
 
-  it('should query correctly when stale', function () {
+  it('should query correctly when stale', async () => {
     const db = new PouchDB(dbName);
-    return createView(db, {
+    const queryFun = await createView(db, {
       map : function (doc) {
         emit(doc.name);
       }
-    }).then(function (queryFun) {
-      return db.bulkDocs({docs : [
-        {name : 'bar', _id : '1'},
-        {name : 'foo', _id : '2'}
-      ]}).then(function () {
-        return db.query(queryFun, {stale : 'ok'});
-      }).then(function (res) {
-        res.total_rows.should.be.within(0, 2);
-        res.offset.should.equal(0);
-        res.rows.length.should.be.within(0, 2);
-        return db.query(queryFun, {stale : 'update_after'});
-      }).then(function (res) {
-        res.total_rows.should.be.within(0, 2);
-        res.rows.length.should.be.within(0, 2);
-        return setTimeoutPromise(50);
-      }).then(function () {
-        return db.query(queryFun, {stale : 'ok'});
-      }).then(function (res) {
-        res.total_rows.should.equal(2);
-        res.rows.length.should.equal(2);
-        return db.get('2');
-      }).then(function (doc2) {
-        return db.remove(doc2);
-      }).then(function () {
-        return db.query(queryFun, {stale : 'ok', include_docs : true});
-      }).then(function (res) {
-        res.total_rows.should.be.within(1, 2);
-        res.rows.length.should.be.within(1, 2);
-        if (res.rows.length === 2) {
-          res.rows[1].key.should.equal('foo');
-          should.not.exist(res.rows[1].doc,
-                            'should not throw if doc removed');
-        }
-        return db.query(queryFun);
-      }).then(function (res) {
-        res.total_rows.should.equal(1, 'equals1-1');
-        res.rows.length.should.equal(1, 'equals1-2');
-        return db.get('1');
-      }).then(function (doc1) {
-        doc1.name = 'baz';
-        return db.post(doc1);
-      }).then(function () {
-        return db.query(queryFun, {stale : 'update_after'});
-      }).then(function (res) {
-        res.rows.length.should.equal(1);
-        ['baz', 'bar'].indexOf(res.rows[0].key).should.be
-          .above(-1, 'key might be stale, thats ok');
-        return setTimeoutPromise(1000);
-      }).then(function () {
-        return db.query(queryFun, {stale : 'ok'});
-      }).then(function (res) {
-        res.rows.length.should.equal(1);
-        res.rows[0].key.should.equal('baz');
-      });
     });
+
+    await db.bulkDocs({docs : [
+      {name : 'bar', _id : '1'},
+      {name : 'foo', _id : '2'}
+    ]});
+
+    const resStaleOk = await db.query(queryFun, {stale : 'ok'});
+
+    resStaleOk.total_rows.should.be.within(0, 2);
+    resStaleOk.offset.should.equal(0);
+    resStaleOk.rows.length.should.be.within(0, 2);
+
+    const resStaleUpdateAfter = await db.query(queryFun, {stale : 'update_after'});
+
+    resStaleUpdateAfter.total_rows.should.be.within(0, 2);
+    resStaleUpdateAfter.rows.length.should.be.within(0, 2);
+
+    await setTimeoutPromise(50);
+    const resUpdated = await db.query(queryFun, {stale : 'ok'});
+
+    resUpdated.total_rows.should.equal(2);
+    resUpdated.rows.length.should.equal(2);
+
+    const doc2 = await db.get('2');
+    await db.remove(doc2);
+    const resStaleOkRemovedDoc = await db.query(queryFun, {stale : 'ok', include_docs : true});
+
+    resStaleOkRemovedDoc.total_rows.should.be.within(1, 2);
+    resStaleOkRemovedDoc.rows.length.should.be.within(1, 2);
+    if (resStaleOkRemovedDoc.rows.length === 2) {
+      resStaleOkRemovedDoc.rows[1].key.should.equal('foo');
+      should.not.exist(resStaleOkRemovedDoc.rows[1].doc,
+                        'should not throw if doc removed');
+    }
+
+    const resNotStale = await db.query(queryFun);
+
+    resNotStale.total_rows.should.equal(1, 'equals1-1');
+    resNotStale.rows.length.should.equal(1, 'equals1-2');
+
+    const doc1 = await db.get('1');
+    doc1.name = 'baz';
+    await db.post(doc1);
+
+    const resUpdateAfterUpdatedDoc1 = await db.query(queryFun, {stale : 'update_after'});
+
+    resUpdateAfterUpdatedDoc1.rows.length.should.equal(1);
+    ['baz', 'bar'].indexOf(resUpdateAfterUpdatedDoc1.rows[0].key).should.be
+      .above(-1, 'key might be stale, thats ok');
+    await setTimeoutPromise(1000);
+
+    const resUpdatedDoc1 = await db.query(queryFun, {stale : 'ok'});
+
+    resUpdatedDoc1.rows.length.should.equal(1);
+    resUpdatedDoc1.rows[0].key.should.equal('baz');
   });
 
-  it('should query correctly with stale update_after', function () {
-    const pouch = new PouchDB(dbName);
+  it('should query correctly with stale update_after', async () => {
+    const db = new PouchDB(dbName);
 
-    return createView(pouch, {map: function (doc) {
+    const queryFun = await createView(db, {map: function (doc) {
       emit(doc.foo);
-    }}).then(function (queryFun) {
-      const docs = [];
+    }});
 
-      for (let i = 0; i < 10; i++) {
-        docs.push({foo: 'bar'});
-      }
+    const docs = [];
+    for (let i = 0; i < 10; i++) {
+      docs.push({foo: 'bar'});
+    }
+    await db.bulkDocs(docs);
 
-      return pouch.bulkDocs(docs).then(function () {
-        return pouch.query(queryFun, {stale: 'update_after'});
-      }).then(function (res) {
-        res.rows.should.have.length(0, 'query() returned immediately');
-        return setTimeoutPromise(1000);
-      }).then(function () {
-        return pouch.query(queryFun, {stale: 'ok'});
-      }).then(function (res) {
-        res.rows.should.have.length(10, 'index was built in background');
-      });
-    });
+    const resUpdateAfter = await db.query(queryFun, {stale: 'update_after'});
+
+    resUpdateAfter.rows.should.have.length(0, 'query() returned immediately');
+
+    await setTimeoutPromise(1000);
+    const resUpdated = await db.query(queryFun, {stale: 'ok'});
+
+    resUpdated.rows.should.have.length(10, 'index was built in background');
   });
 
-  it('should delete duplicate indexes', function () {
+  it('should delete duplicate indexes', async () => {
+    const db = new PouchDB(dbName);
+
     const docs = [];
     for (let i = 0; i < 10; i++) {
       docs.push(
@@ -396,38 +376,32 @@ describe('test.persisted.js', function () {
         }
       );
     }
-    const db = new PouchDB(dbName);
-    return db.bulkDocs({docs}).then(function (responses) {
-      const tasks = [];
-      for (let i = 0; i < docs.length; i++) {
-        docs[i]._rev = responses[i].rev;
-        tasks.push(db.query('view' + i + '/view'));
-      }
-      return Promise.all(tasks);
-    }).then(function () {
-      docs.forEach(function (doc) {
-        doc._deleted = true;
-      });
-      return db.bulkDocs({docs});
-    }).then(function () {
-      return db.viewCleanup();
-    });
+    const responses = await db.bulkDocs({docs});
+
+    await Promise.all(docs.map((doc, i) => {
+      docs[i]._rev = responses[i].rev;
+      return db.query('view' + i + '/view');
+    }));
+
+    docs.forEach(doc  => doc._deleted = true);
+    await db.bulkDocs({docs});
+    await db.viewCleanup();
   });
 
   if (dbType === 'local' &&
       // can't test this in Node due to the vm
       (typeof process === 'undefined' || process.browser)) {
-    it('issue 4967 map() called twice', function () {
+    it('issue 4967 map() called twice', async () => {
       const db = new PouchDB(dbName);
+
       const globalObj = (typeof process !== 'undefined' && !process.browser) ?
         global : window;
       globalObj.__mapreduce_called = {};
-      const docs = Array.apply(null, Array(5)).map(function (_, i) {
-        return {
+
+      const docs = Array.from({length: 5}, (_, i) => ({
           _id: 'doc_' + i,
           data: Math.random().toString(36).slice(2)
-        };
-      }).concat({
+        })).concat({
         _id: '_design/test',
         views: {
           test: {
@@ -440,21 +414,22 @@ describe('test.persisted.js', function () {
           }
         }
       });
-      return db.bulkDocs(docs).then(function () {
-        return Promise.all([
-          db.query('test', {}),
-          db.query('test', {})
-        ]);
-      }).then(function () {
-        globalObj.__mapreduce_called.should.deep.equal({
-          doc_0 : 1,
-          doc_1 : 1,
-          doc_2 : 1,
-          doc_3 : 1,
-          doc_4 : 1
-        });
-        delete globalObj.__mapreduce_called;
+      await db.bulkDocs(docs);
+
+      await Promise.all([
+        db.query('test', {}),
+        db.query('test', {})
+      ]);
+
+      globalObj.__mapreduce_called.should.deep.equal({
+        doc_0 : 1,
+        doc_1 : 1,
+        doc_2 : 1,
+        doc_3 : 1,
+        doc_4 : 1
       });
+
+      delete globalObj.__mapreduce_called;
     });
   }
 

--- a/tests/mapreduce/test.persisted.js
+++ b/tests/mapreduce/test.persisted.js
@@ -222,9 +222,13 @@ describe('test.persisted.js', () => {
         }
       }
     };
-    await db.post(doc);
 
-    await db.query('barbar/scores', {key: 'bar'}).should.be.rejected;
+    try {
+      await db.post(doc);
+      await db.query('barbar/scores', {key: 'bar'});
+    } catch (err) {
+      err.message.should.include('string');
+    }
   });
 
   it('many simultaneous persisted views', async () => {

--- a/tests/mapreduce/test.views.js
+++ b/tests/mapreduce/test.views.js
@@ -230,7 +230,7 @@ describe('test.views.js', function () {
     const db = new PouchDB(dbs.name);
     const docs = values.map(function (x, i) {
       return {
-        _id: i.toString(),
+        _id: `${i}`,
         foo: x
       };
     });

--- a/tests/mapreduce/test.views.js
+++ b/tests/mapreduce/test.views.js
@@ -1,10 +1,10 @@
 'use strict';
 
 describe('test.views.js', function () {
-  var dbType = testUtils.adapterType();
+  const dbType = testUtils.adapterType();
   if (dbType === 'http') { return; }
 
-  var dbs = {};
+  const dbs = {};
 
   beforeEach(function (done) {
     dbs.name = testUtils.adapterUrl(dbType, 'testdb');
@@ -18,7 +18,7 @@ describe('test.views.js', function () {
 
 
   it('Test basic view', function (done) {
-    var db = new PouchDB(dbs.name);
+    const db = new PouchDB(dbs.name);
     db.bulkDocs({
       docs: [
         { foo: 'bar' },
@@ -28,7 +28,7 @@ describe('test.views.js', function () {
         }
       ]
     }, {}, function () {
-      var queryFun = {
+      const queryFun = {
         map: function (doc) {
           emit(doc.foo, doc);
         }
@@ -55,7 +55,7 @@ describe('test.views.js', function () {
   });
 
   it('Test passing just a function', function (done) {
-    var db = new PouchDB(dbs.name);
+    const db = new PouchDB(dbs.name);
     db.bulkDocs({
       docs: [
         { foo: 'bar' },
@@ -65,7 +65,7 @@ describe('test.views.js', function () {
         }
       ]
     }, {}, function () {
-      var queryFun = function (doc) {
+      const queryFun = function (doc) {
         emit(doc.foo, doc);
       };
       db.get('volatile', function (_, doc) {
@@ -89,7 +89,7 @@ describe('test.views.js', function () {
   });
 
   it('Test opts.startkey/opts.endkey', function (done) {
-    var db = new PouchDB(dbs.name);
+    const db = new PouchDB(dbs.name);
     db.bulkDocs({
       docs: [
         { key: 'key1' },
@@ -99,7 +99,7 @@ describe('test.views.js', function () {
         { key: 'key5' }
       ]
     }, {}, function () {
-      var queryFun = {
+      const queryFun = {
         map: function (doc) {
           emit(doc.key, doc);
         }
@@ -135,7 +135,7 @@ describe('test.views.js', function () {
   });
 
   it('Test opts.key', function (done) {
-    var db = new PouchDB(dbs.name);
+    const db = new PouchDB(dbs.name);
     db.bulkDocs({
       docs: [
         { key: 'key1' },
@@ -144,7 +144,7 @@ describe('test.views.js', function () {
         { key: 'key3' }
       ]
     }, {}, function () {
-      var queryFun = {
+      const queryFun = {
         map: function (doc) {
           emit(doc.key, doc);
         }
@@ -166,7 +166,7 @@ describe('test.views.js', function () {
   });
 
   it.skip('Test basic view collation', function (done) {
-    var values = [];
+    const values = [];
     // special values sort before all other types
     values.push(null);
     values.push(false);
@@ -227,15 +227,15 @@ describe('test.views.js', function () {
       b: 2,
       c: 2
     });
-    var db = new PouchDB(dbs.name);
-    var docs = values.map(function (x, i) {
+    const db = new PouchDB(dbs.name);
+    const docs = values.map(function (x, i) {
       return {
         _id: i.toString(),
         foo: x
       };
     });
     db.bulkDocs({ docs }, {}, function (err) {
-      var queryFun = {
+      const queryFun = {
         map: function (doc) {
           emit(doc.foo, null);
         }
@@ -269,7 +269,7 @@ describe('test.views.js', function () {
   });
 
   it('Test joins', function (done) {
-    var db = new PouchDB(dbs.name);
+    const db = new PouchDB(dbs.name);
     db.bulkDocs({
       docs: [
         {
@@ -279,7 +279,7 @@ describe('test.views.js', function () {
         { doc_id: 'mydoc' }
       ]
     }, {}, function () {
-      var queryFun = {
+      const queryFun = {
         map: function (doc) {
           if (doc.doc_id) {
             emit(doc._id, { _id: doc.doc_id });
@@ -298,9 +298,9 @@ describe('test.views.js', function () {
   });
 
   it('No reduce function', function (done) {
-    var db = new PouchDB(dbs.name);
+    const db = new PouchDB(dbs.name);
     db.post({ foo: 'bar' }, function () {
-      var queryFun = {
+      const queryFun = {
         map: function () {
           emit('key', 'val');
         }
@@ -312,7 +312,7 @@ describe('test.views.js', function () {
   });
 
   it('Built in _sum reduce function', function (done) {
-    var db = new PouchDB(dbs.name);
+    const db = new PouchDB(dbs.name);
     db.bulkDocs({
       docs: [
         { val: 'bar' },
@@ -320,7 +320,7 @@ describe('test.views.js', function () {
         { val: 'baz' }
       ]
     }, null, function () {
-      var queryFun = {
+      const queryFun = {
         map: function (doc) {
           emit(doc.val, 1);
         },
@@ -339,7 +339,7 @@ describe('test.views.js', function () {
   });
 
   it('Built in _count reduce function', function (done) {
-    var db = new PouchDB(dbs.name);
+    const db = new PouchDB(dbs.name);
     db.bulkDocs({
       docs: [
         { val: 'bar' },
@@ -347,7 +347,7 @@ describe('test.views.js', function () {
         { val: 'baz' }
       ]
     }, null, function () {
-      var queryFun = {
+      const queryFun = {
         map: function (doc) {
           emit(doc.val, doc.val);
         },
@@ -366,7 +366,7 @@ describe('test.views.js', function () {
   });
 
   it('Built in _stats reduce function', function (done) {
-    var db = new PouchDB(dbs.name);
+    const db = new PouchDB(dbs.name);
     db.bulkDocs({
       docs: [
         { val: 'bar' },
@@ -374,7 +374,7 @@ describe('test.views.js', function () {
         { val: 'baz' }
       ]
     }, null, function () {
-      var queryFun = {
+      const queryFun = {
         map: function (doc) {
           emit(doc.val, 1);
         },
@@ -384,7 +384,7 @@ describe('test.views.js', function () {
         reduce: true,
         group_level: 999
       }, function (err, res) {
-        var stats = res.rows[0].value;
+        const stats = res.rows[0].value;
         stats.sum.should.equal(2);
         stats.count.should.equal(2);
         stats.min.should.equal(1);
@@ -396,9 +396,9 @@ describe('test.views.js', function () {
   });
 
   it('No reduce function, passing just a  function', function (done) {
-    var db = new PouchDB(dbs.name);
+    const db = new PouchDB(dbs.name);
     db.post({ foo: 'bar' }, function () {
-      var queryFun = function () {
+      const queryFun = function () {
         emit('key', 'val');
       };
       db.query(queryFun, function () {
@@ -408,19 +408,19 @@ describe('test.views.js', function () {
   });
 
   it('Views should include _conflicts', function (done) {
-    var doc1 = {
+    const doc1 = {
       _id: '1',
       foo: 'bar'
     };
-    var doc2 = {
+    const doc2 = {
       _id: '1',
       foo: 'baz'
     };
-    var queryFun = function (doc) {
+    const queryFun = function (doc) {
       emit(doc._id, !!doc._conflicts);
     };
-    var db = new PouchDB(dbs.name);
-    var remote = new PouchDB(dbs.remote);
+    const db = new PouchDB(dbs.name);
+    const remote = new PouchDB(dbs.remote);
     db.post(doc1, function () {
       remote.post(doc2, function () {
         db.replicate.from(remote, function () {
@@ -437,7 +437,7 @@ describe('test.views.js', function () {
   });
 
   it('Map only documents with _conflicts (#1000)', function (done) {
-    var docs1 = [
+    const docs1 = [
       {
         _id: '1',
         foo: 'bar'
@@ -447,25 +447,25 @@ describe('test.views.js', function () {
         name: 'two'
       }
     ];
-    var doc2 = {
+    const doc2 = {
       _id: '1',
       foo: 'baz'
     };
-    var queryFun = function (doc) {
+    const queryFun = function (doc) {
       if (doc._conflicts) {
         emit(doc._id, doc._conflicts);
       }
     };
-    var db = new PouchDB(dbs.name);
-    var remote = new PouchDB(dbs.remote);
+    const db = new PouchDB(dbs.name);
+    const remote = new PouchDB(dbs.remote);
     db.bulkDocs({ docs: docs1 }, function (err, res) {
-      var revId1 = res[0].rev;
+      const revId1 = res[0].rev;
       remote.post(doc2, function (err, res) {
-        var revId2 = res.rev;
+        const revId2 = res.rev;
         db.replicate.from(remote, function () {
           db.get(docs1[0]._id, { conflicts: true }, function (err, res) {
-            var winner = res._rev;
-            var looser = winner === revId1 ? revId2 : revId1;
+            const winner = res._rev;
+            const looser = winner === revId1 ? revId2 : revId1;
             should.exist(res._conflicts);
             db.query(queryFun, function (err, res) {
               res.rows.should.have.length(1, 'One doc with conflicts');
@@ -482,7 +482,7 @@ describe('test.views.js', function () {
   });
 
   it('Test view querying with limit option', function (done) {
-    var db = new PouchDB(dbs.name);
+    const db = new PouchDB(dbs.name);
     db.bulkDocs({
       docs: [
         { foo: 'bar' },
@@ -503,8 +503,8 @@ describe('test.views.js', function () {
   });
 
   it('Query non existing view returns error', function (done) {
-    var db = new PouchDB(dbs.name);
-    var doc = {
+    const db = new PouchDB(dbs.name);
+    const doc = {
       _id: '_design/barbar',
       views:
         { scores:
@@ -525,7 +525,7 @@ describe('test.views.js', function () {
   });
 
   it('Special document member _doc_id_rev', function (done) {
-    var db = new PouchDB(dbs.name);
+    const db = new PouchDB(dbs.name);
     db.bulkDocs({ docs: [{ foo: 'bar' }] }, null, function () {
       db.query(function (doc) {
         if (doc.foo === 'bar') {
@@ -539,7 +539,7 @@ describe('test.views.js', function () {
   });
 
   it('If reduce function returns 0', function (done) {
-    var db = new PouchDB(dbs.name);
+    const db = new PouchDB(dbs.name);
     db.bulkDocs({ docs: [{ foo: 'bar' }] }, null, function () {
       db.query({
         map: function (doc) {
@@ -556,7 +556,7 @@ describe('test.views.js', function () {
   });
 
   it('Testing skip with a view', function (done) {
-    var db = new PouchDB(dbs.name);
+    const db = new PouchDB(dbs.name);
     db.bulkDocs({
       docs: [
         { foo: 'bar' },
@@ -575,7 +575,7 @@ describe('test.views.js', function () {
   });
 
   it('Testing skip with allDocs', function (done) {
-    var db = new PouchDB(dbs.name);
+    const db = new PouchDB(dbs.name);
     db.bulkDocs({
       docs: [
         { foo: 'bar' },
@@ -592,8 +592,8 @@ describe('test.views.js', function () {
   });
 
   it('Destroy view when db created with {name: foo}', function () {
-    var db = new PouchDB({name: dbs.name});
-    var doc = {
+    const db = new PouchDB({name: dbs.name});
+    const doc = {
       _id: '_design/index',
       views: {
         index:
@@ -608,8 +608,8 @@ describe('test.views.js', function () {
   });
 
   it('Map documents on 0/null/undefined/empty string', function (done) {
-    var db = new PouchDB(dbs.name);
-    var docs = [
+    const db = new PouchDB(dbs.name);
+    const docs = [
       {
         _id: 'doc0',
         num: 0
@@ -629,7 +629,7 @@ describe('test.views.js', function () {
       }
     ];
     db.bulkDocs({ docs }, function () {
-      var mapFunction = function (doc) {
+      const mapFunction = function (doc) {
         emit(doc.num, null);
       };
       db.query(mapFunction, {
@@ -665,10 +665,10 @@ describe('test.views.js', function () {
     });
   });
   if (typeof window === 'undefined' && !process.browser) {
-    var fs = require('fs');
+    const fs = require('fs');
     it.skip("destroy using prototype", function () {
-      var db = new PouchDB(dbs.name + 1);
-      var doc = {
+      const db = new PouchDB(dbs.name + 1);
+      const doc = {
         _id: '_design/barbar',
         views: {
           scores: {

--- a/tests/unit/test.mapreduce.js
+++ b/tests/unit/test.mapreduce.js
@@ -6,63 +6,51 @@ var upsert = PouchDB.utils.upsert;
 var utils = PouchDB.utils.mapReduceUtils;
 
 describe('test.mapreduce.js-upsert', function () {
-  it('should throw an error if the doc errors', function () {
-    return upsert({
-      get: function () {
-        return Promise.reject(new Error('a fake error!'));
-      }
-    }, 'foo')
-    .then(function () {
+  it('should throw an error if the doc errors', async function () {
+    try {
+      await upsert({
+        get: () => Promise.reject(new Error('a fake error!')),
+      }, 'foo');
+
       should.fail("Expected promise to be rejected");
-    })
-    .catch(function (err) {
+    } catch (err) {
       err.message.should.equal("a fake error!");
-    });
+    }
   });
-  it('should fulfill if the diff returns false', function () {
-    return upsert({
-      get: function () {
-        return Promise.resolve({ _rev: 'xyz' });
-      }
-    }, 'foo', function () {
-      return false;
-    }).then(function (res) {
-      res.updated.should.equal(false);
-      res.rev.should.equal('xyz');
-    });
+
+  it('should fulfill if the diff returns false', async function () {
+    const res = await upsert({
+      get: () => Promise.resolve({ _rev: 'xyz' }),
+    }, 'foo', () => false
+  );
+
+    res.updated.should.equal(false);
+    res.rev.should.equal('xyz');
   });
-  it('should put if get throws 404', function () {
-    return upsert({
-      get: function () {
-        return Promise.reject({ status: 404 });
-      },
-      put: function () {
-        return Promise.resolve({ rev: 'abc' });
-      }
-    }, 'foo', function () {
-      return { difference: "something" };
-    }).then(function (res) {
-      res.updated.should.equal(true);
-      res.rev.should.equal('abc');
-    });
+
+  it('should put if get throws 404', async function () {
+    const res = await upsert({
+      get: () => Promise.reject({ status: 404 }),
+      put: () => Promise.resolve({ rev: 'abc' }),
+    }, 'foo', () => ({ difference: "something" })
+    );
+
+    res.updated.should.equal(true);
+    res.rev.should.equal('abc');
   });
-  it('should error if it can\'t put', function () {
-    return upsert({
-      get: function () {
-        return Promise.resolve({ _rev: 'xyz' });
-      },
-      put: function () {
-        return Promise.reject(new Error('falala'));
-      }
-    }, 'foo', function () {
-      return { difference: "something" };
-    })
-    .then(function () {
+
+  it('should error if it can\'t put', async function () {
+    try {
+      await upsert({
+        get: () => Promise.resolve({ _rev: 'xyz' }),
+        put: () => Promise.reject(new Error('falala')),
+      }, 'foo', () => ({ difference: "something" })
+      );
+
       should.fail("Expected promise to be rejected");
-    })
-    .catch(function (err) {
+    } catch (err) {
       err.message.should.equal("falala");
-    });
+    }
   });
 });
 


### PR DESCRIPTION
**tests/unit**
- rewrote the unit tests for `mapreduce.js-upsert` using `async/await`
(left the `mapreduce.js-utils` tests as they are, because they are more readable & straightforward with the current syntax)

**tests/mapreduce (in process)**
- started with some ES6 refactoring of the tests by replacing var with const/let
- rewrote promise chains to async/await
- used arrow functions
- rewrote mocha chai should syntax: (before: `should.become ` to `should.deep.equal` for objects or `should.be.true` for boolean)
- replaced `.toString()` with template literals (except on view map function declarations)

**tests/mapreduce/test.mapreduce.js**
in test _Query_ _result_ _should_ _include_ __conflicts_ and _Views should include_ _conflicts_ :
- replaced the use of `testUtils.fin()` with `try/finally block`
- replaced the use of `promisify` with simply awaiting the replication - so that `testUtils.promisify(remote, db.replicate);` becomes  `await db.replicate.from(remote);`

in test _Test view querying with custom reduce function_:
- in custom reduce function: replaced nested unrolling of values with `values.flat()`
- removed unneccesary line pulling out `keyId[0]` 
- ? can the comment  `//const id = keyId[1]; ` be deleted? 

in test _should query correctly after replicating and other ddoc_:
- moved cleanup (`db2.destroy`) that was in `catch` block and after to `finally` block

in the two tests _should handle many doc changes_:
- replaced the whole `nextTask()` logic to for loop and using `async/await`