### PR TITLE
refactor gen replication id unit tests 

### DIFF
--- a/tests/unit/test.gen-replication-id.js
+++ b/tests/unit/test.gen-replication-id.js
@@ -1,163 +1,106 @@
 'use strict';
 
-var memdown = require('memdown');
-var PouchDB = require('../../packages/node_modules/pouchdb-for-coverage');
-var genReplicationId = PouchDB.utils.generateReplicationId;
-var sourceDb = new PouchDB({name: 'local_db', db: memdown});
-var targetDb = new PouchDB({name: 'target_db', db: memdown});
+const memdown = require('memdown');
+const PouchDB = require('../../packages/node_modules/pouchdb-for-coverage');
+const genReplicationId = PouchDB.utils.generateReplicationId;
+const sourceDb = new PouchDB({name: 'local_db', db: memdown});
+const targetDb = new PouchDB({name: 'target_db', db: memdown});
 
 require('chai').should();
 
 describe('test.gen-replication-id.js', function () {
-  it('is different with different `doc_ids` option', function () {
-    var opts2 = {doc_ids: ["1"]};
-    var opts1 = {doc_ids: ["2"]};
+  it('is different with different `doc_ids` option', async function () {
+    const opts2 = {doc_ids: ["1"]};
+    const opts1 = {doc_ids: ["2"]};
 
-    return genReplicationId(sourceDb, targetDb, opts1).then(
-      function (replicationId1) {
-        return genReplicationId(sourceDb, targetDb, opts2).then(
-          function (replicationId2) {
-            replicationId2.should.not.eql(replicationId1);
-          }
-        );
-      }
-    );
+    const [ id1, id2 ] = await generateReplicationIds(sourceDb, targetDb, opts1, opts2);
+
+    id2.should.not.eql(id1);
   });
 
   it('ignores the order of array elements in the `doc_ids` option',
-    function () {
-      var opts1 = {doc_ids: ["1", "2", "3"]};
-      var opts2 = {doc_ids: ["3", "2", "1"]};
+    async function () {
+      const opts1 = {doc_ids: ["1", "2", "3"]};
+      const opts2 = {doc_ids: ["3", "2", "1"]};
 
-      return genReplicationId(sourceDb, targetDb, opts1).then(
-        function (replicationId1) {
-          return genReplicationId(sourceDb, targetDb, opts2).then(
-            function (replicationId2) {
-              replicationId2.should.eql(replicationId1);
-            }
-          );
-        }
-      );
+      const [ id1, id2 ] = await generateReplicationIds(sourceDb, targetDb, opts1, opts2);
+
+      id2.should.eql(id1);
     }
   );
 
-  it('is different with different `filter` option', function () {
-    var opts1 = {filter: 'ddoc/filter'};
-    var opts2 = {filter: 'ddoc/other_filter'};
+  it('is different with different `filter` option', async function () {
+    const opts1 = {filter: 'ddoc/filter'};
+    const opts2 = {filter: 'ddoc/other_filter'};
 
-    return genReplicationId(sourceDb, targetDb, opts1).then(
-      function (replicationId1) {
-        return genReplicationId(sourceDb, targetDb, opts2).then(
-          function (replicationId2) {
-            replicationId2.should.not.eql(replicationId1);
-          }
-        );
-      }
-    );
+    const [ id1, id2 ] = await generateReplicationIds(sourceDb, targetDb, opts1, opts2);
+
+    id2.should.not.eql(id1);
   });
 
   it('ignores the `query_params` option if there\'s no `filter` option',
-    function () {
-      var opts1 = {query_params: {foo: 'bar'}};
-      var opts2 = {query_params: {bar: 'baz'}};
+    async function () {
+      const opts1 = {query_params: {foo: 'bar'}};
+      const opts2 = {query_params: {bar: 'baz'}};
 
-      return genReplicationId(sourceDb, targetDb, opts1).then(
-        function (replicationId1) {
-          return genReplicationId(sourceDb, targetDb, opts2).then(
-            function (replicationId2) {
-              replicationId2.should.eql(replicationId1);
-            }
-          );
-        }
-      );
+      const [ id1, id2 ] = await generateReplicationIds(sourceDb, targetDb, opts1, opts2);
+
+      id2.should.eql(id1);
     }
   );
 
   it('is different with same `filter` but different `query_params` option',
-    function () {
-      var opts1 = {filter: 'ddoc/filter', query_params: {foo: 'bar'}};
-      var opts2 = {filter: 'ddoc/other_filter'};
+    async function () {
+      const opts1 = {filter: 'ddoc/filter', query_params: {foo: 'bar'}};
+      const opts2 = {filter: 'ddoc/other_filter'};
 
-      return genReplicationId(sourceDb, targetDb, opts1).then(
-        function (replicationId1) {
-          return genReplicationId(sourceDb, targetDb, opts2).then(
-            function (replicationId2) {
-              replicationId2.should.not.eql(replicationId1);
-            }
-          );
-        }
-      );
+      const [ id1, id2 ] = await generateReplicationIds(sourceDb, targetDb, opts1, opts2);
+
+      id2.should.not.eql(id1);
     }
   );
 
   it('ignores the order of object properties in the `query_params` option',
-    function () {
-      var opts1 = {
+    async function () {
+      const opts1 = {
         filter: 'ddoc/filter',
         query_params: {foo: 'bar', bar: 'baz'}
       };
-      var opts2 = {
+      const opts2 = {
         filter: 'ddoc/filter',
         query_params: {bar: 'baz', foo: 'bar'}
       };
 
-      return genReplicationId(sourceDb, targetDb, opts1).then(
-        function (replicationId1) {
-          return genReplicationId(sourceDb, targetDb, opts2).then(
-            function (replicationId2) {
-              replicationId2.should.eql(replicationId1);
-            }
-          );
-        }
-      );
+      const [ id1, id2 ] = await generateReplicationIds(sourceDb, targetDb, opts1, opts2);
+
+      id2.should.eql(id1);
     }
   );
 
   it('it ignores the `view` option unless the `filter` option value ' +
-     'is `_view`',
-    function () {
-      var opts1 = {view: 'ddoc/view'};
-      var opts2 = {view: 'ddoc/other_view'};
-      var opts3 = {filter: 'ddoc/view', view: 'ddoc/view'};
-      var opts4 = {filter: 'ddoc/view', view: 'ddoc/other_view'};
-      var opts5 = {filter: '_view', view: 'ddoc/other_view'};
-      var opts6 = {filter: '_view', view: 'ddoc/view'};
+    'is `_view`',
+    async function () {
+      const opts1 = {view: 'ddoc/view'};
+      const opts2 = {view: 'ddoc/other_view'};
+      const opts3 = {filter: 'ddoc/view', view: 'ddoc/view'};
+      const opts4 = {filter: 'ddoc/view', view: 'ddoc/other_view'};
+      const opts5 = {filter: '_view', view: 'ddoc/other_view'};
+      const opts6 = {filter: '_view', view: 'ddoc/view'};
 
-      return genReplicationId(sourceDb, targetDb, opts1).then(
-        function (replicationId1) {
-          return genReplicationId(sourceDb, targetDb, opts2).then(
-            function (replicationId2) {
-              replicationId2.should.eql(replicationId1);
-              return replicationId2;
-            }
-          );
-        }
-      ).then(function (replicationId2) {
-        return genReplicationId(sourceDb, targetDb, opts3).then(
-          function (replicationId3) {
-            replicationId3.should.not.eql(replicationId2);
+      const [ id1, id2, id3, id4, id5, id6 ] = await generateReplicationIds(
+        sourceDb, targetDb, opts1, opts2, opts3, opts4, opts5, opts6);
 
-            return genReplicationId(sourceDb, targetDb, opts4).then(
-              function (replicationId4) {
-                replicationId4.should.eql(replicationId3);
-                return replicationId4;
-              }
-            );
-          }
-        );
-      }).then(function (replicationId4) {
-        return genReplicationId(sourceDb, targetDb, opts5).then(
-          function (replicationId5) {
-            replicationId5.should.not.eql(replicationId4);
-
-            return genReplicationId(sourceDb, targetDb, opts6).then(
-              function (replicationId6) {
-                replicationId6.should.not.eql(replicationId5);
-              }
-            );
-          }
-        );
-      });
+      id2.should.eql(id1);
+      id3.should.not.eql(id2);
+      id4.should.eql(id3);
+      id5.should.not.eql(id4);
+      id6.should.not.eql(id5);
     }
   );
 });
+
+const generateReplicationIds = async (sourceDb, targetDb, ...allOpts) => {
+  return Promise.all(
+    allOpts.map(opts => genReplicationId(sourceDb, targetDb, opts))
+  );
+};


### PR DESCRIPTION
Did some ES6 refactoring: 
- replaced `var` with `const`
- replaced promise chains with an asynchronous helper function `generateReplicationIds`, that takes `sourceDB, targetDB `and any amount of `options` objects and generates a `replicationId` for each of them 