### PR TITLE
ci: avoid azure mirrors if possible

### DIFF
--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -83,11 +83,14 @@ pouchdb-build-node() {
 }
 
 if [[ $CI = true ]] && [[ $CLIENT != node ]]; then
-  # npx playwright install --with-deps "$CLIENT"
-  # The full install with deps was glacially slow on CI 
-  npx playwright install "$CLIENT"
-  sudo apt-get update
-  sudo apt-get install -y libwoff1 libvpx9 libevent-2.1-7t64 libopus0 libgstreamer-plugins-base1.0-0 libgstreamer-gl1.0-0 libgstreamer-plugins-bad1.0-0 libflite1 libavif16 libharfbuzz-icu0 libsecret-1-0 libhyphen0 libwayland-server0 libmanette-0.2-0 libgles2 gstreamer1.0-libav
+  # Change Ubuntu mirror priorities. 
+  # azure.archive.ubuntu.com is very slow, especially if the US is awake.
+  # From https://github.com/servo/servo/pull/39190
+  sudo sed -i '/archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:2/priority:0/' /etc/apt/apt-mirrors.txt
+  sudo sed -i '/azure.archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:0/priority:1/' /etc/apt/apt-mirrors.txt
+  sudo sed -i '/security.ubuntu.com\/ubuntu\/\tpriority/ s/priority:3/priority:2/' /etc/apt/apt-mirrors.txt
+  sudo cat /etc/apt/apt-mirrors.txt
+  npx playwright install --with-deps "$CLIENT"
 fi
 
 if [[ -n $SERVER ]]; then


### PR DESCRIPTION
## Overview

Avoid the Azure Ubuntu mirrors if possible, since they can slow down CI immensely. Other project also do this, this particular PR is inspired by: https://github.com/servo/servo/pull/39190

I've added this change directly in the `bin/run-test.sh` file just before we install Playwright, which is where all these dependencies come from. We previously tried doing this in the GH workflow yaml, but that didn’t take, maybe this approach is better. 

This PR also reverts my previous attempt at speeding this process up by installing fewer dependencies for Playwright, but that turned out to not have any effect.

## Testing recommendations

Trigger a CI run and compare it to a `master` run _at about the same time of day_ (important!). The speed of the Azure mirrors fluctuates a lot. 

## Measurements

**1. Comparison against `apache/pouchdb master`:**

[Today 11:58 CEST](https://github.com/apache/pouchdb/actions/runs/24392804652/usage) (master) -> [11:43 CEST](https://github.com/neighbourhoodie/pouchdb/actions/runs/24392191849/usage) (this branch)
👉 **44m 23s -> 14m 44s**

Slowest tests compared:

`browser-adapter (firefox, idb, TYPE=mapreduce npm test)`
18m 45s	-> 1m 21s	
`browser-adapter (firefox, memory, TYPE=find PLUGINS=pouchdb-find npm test)`
41m 35s	-> 1m 16s	
`browser-adapter (chromium, memory, npm test)`
43m 57s	-> 3m 43s	
`browser-adapter (chromium, indexeddb, TYPE=find PLUGINS=pouchdb-find npm test)`
38m 14s	-> 1m 6s	
`browser-adapter (firefox, idb, npm test)`
21m 57s	-> 5m 21s	

**2. Comparison against an unimproved branch:**

[Today at 10:35 AM CEST](https://github.com/neighbourhoodie/pouchdb/actions/runs/24389257255/usage) (unimproved branch on our fork) -> [11:43 AM CEST](https://github.com/neighbourhoodie/pouchdb/actions/runs/24392191849/usage)  (this branch) 
👉  **47m 39s -> 14m 44s**

Slowest tests compared:

`couchdb-browser (3.1, firefox, TYPE=mapreduce ADAPTERS=http npm test)`
21m 19s -> 1m 35s
`browser-adapter (firefox, idb, npm test)`
22m 35s -> 5m 21s
`browser-adapter (webkit, memory, TYPE=find PLUGINS=pouchdb-find npm test)`
18m 28s -> 1m 21s
`browser-adapter (firefox, idb, TYPE=find PLUGINS=pouchdb-find npm test)`
47m 8s -> 2m 7s

## Checklist

- [x] I am not a bot
- [x] This is my own work, I did not use AI, LLM's or similar technology for code or docs generation
- [x] Code is written and works correctly
- [ ] Changes are covered by tests -> Not applicable
- [ ] Documentation changes were made in the `docs` folder -> Not applicable

