### PR TITLE
Fix: surface HTTP 413 and other 4xx errors via replication error event (issue #9165)

### DIFF
--- a/packages/node_modules/pouchdb-replication/src/replicate.js
+++ b/packages/node_modules/pouchdb-replication/src/replicate.js
@@ -304,6 +304,11 @@ function replicate(src, target, opts, returnValue, result) {
       if (errorName === 'unauthorized' || errorName === 'forbidden') {
         returnValue.emit('error', fatalError);
         returnValue.removeAllListeners();
+      } else if (fatalError.status >= 400 && fatalError.status < 500) {
+        // Surface 4xx client errors (e.g. 413 Content Too Large from _bulk_docs)
+        // via the error event instead of retrying, since retrying won't fix them.
+        returnValue.emit('error', fatalError);
+        returnValue.removeAllListeners();
       } else {
         backOff(opts, returnValue, fatalError, function () {
           replicate(src, target, opts, returnValue);


### PR DESCRIPTION
## Summary
Fixes #9165 — HTTP 413 during live replication is not surfaced via replication events.

## Problem
When using PouchDB live replication with CouchDB, a \413 Content Too Large\ response from \_bulk_docs\ is visible in DevTools but **not exposed through any replication event**. The \paused(err)\ event receives \err === undefined\.

## Root Cause
In \completeReplication()\, only \'unauthorized'\ (401) and \'forbidden'\ (403) errors are emitted via the \'error'\ event. All other errors (including HTTP 413 Payload Too Large from \_bulk_docs\) fall through to the backoff/retry path, causing infinite retries without surfacing the error.

## Fix
Treat 4xx client errors (except 401/403 already handled) the same as auth errors — emit them via the \'error'\ event and stop retrying. This is correct because 4xx errors indicate a problem with the request itself (e.g., content too large, bad request) that retrying cannot fix.

The fix is in \packages/node_modules/pouchdb-replication/src/replicate.js\:

\\\javascript
} else if (fatalError.status >= 400 && fatalError.status < 500) {
  // Surface 4xx client errors (e.g. 413 Content Too Large from _bulk_docs)
  // via the error event instead of retrying, since retrying won't fix them.
  returnValue.emit('error', fatalError);
  returnValue.removeAllListeners();
}
\\\

## Behavior Change
- **Before**: 413 errors during \ulkDocs\ would silently retry forever; \paused(err)\ got \undefined\
- **After**: 413 (and other 4xx) errors are emitted via the \'error'\ event, so \eplication.on('error', err => ...)\ receives the actual error with status/details