### PR TITLE
Add workflow to deploy PouchDB website to pouchdb-site/asf-site 

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,3 +30,36 @@ jobs:
         with:
           node-version: 24
       - run: BUILD=1 npm run build-site
+      - name: Setup SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+      - name: Checkout pouchdb-www repo
+        uses: actions/checkout@v4
+        with:
+          repository: neighbourhoodie/pouchdb-www
+          ref: asf-site
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+          path: checked-out-pouchdb-www
+          fetch-depth: 0
+      - name: Commit and push if changed
+        run: |
+          cd checked-out-pouchdb-www
+          git config user.name "CI"
+          git config user.email "ci@users.noreply.github.com"
+
+          # Juuust in case
+          git checkout asf-site
+
+          git rm -rf . || true
+
+          cp -R ../docs/_site/. .
+
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "Committing changes…"
+            git add -A
+            git commit -m "Deploy site from ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
+            git push git@github.com:neighbourhoodie/pouchdb-www.git asf-site --force
+          else
+            echo "No changes to commit"
+          fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,18 +33,18 @@ jobs:
       - name: Setup SSH agent
         uses: webfactory/ssh-agent@v0.9.0
         with:
-          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
-      - name: Checkout pouchdb-www repo
+          ssh-private-key: ${{ secrets.POUCHDB_WEBSITE_BUILD }}
+      - name: Checkout pouchdb-site repo
         uses: actions/checkout@v4
         with:
-          repository: neighbourhoodie/pouchdb-www
+          repository: apache/pouchdb-site
           ref: asf-site
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
-          path: checked-out-pouchdb-www
+          ssh-key: ${{ secrets.POUCHDB_WEBSITE_BUILD }}
+          path: checked-out-pouchdb-site
           fetch-depth: 0
       - name: Commit and push if changed
         run: |
-          cd checked-out-pouchdb-www
+          cd checked-out-pouchdb-site
           git config user.name "CI"
           git config user.email "ci@users.noreply.github.com"
 
@@ -59,7 +59,7 @@ jobs:
             echo "Committing changes…"
             git add -A
             git commit -m "Deploy site from ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
-            git push git@github.com:neighbourhoodie/pouchdb-www.git asf-site --force
+            git push git@github.com:apache/pouchdb-site.git asf-site --force
           else
             echo "No changes to commit"
           fi

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Using PouchDB
 
 To get started using PouchDB, check out the [web site](https://pouchdb.com) and [API documentation](https://pouchdb.com/api.html).
 
+Deploying the Documentation Site www.pouchdb.com
+------------------------------------------------
+
+Doc website deployment is handled automatically once the changes land in `master`.
+
 Getting Help
 ------------
 


### PR DESCRIPTION
## Overview

Hello 👋 This PR adds a GH workflow to deploy the PouchDB website to the branch `asf-site` in the repo `apache/pouchdb-site`, from where it will then be hosted somehow.

The workflow builds the site  via `npm run build-site` , checks out the `apache/pouchdb-site` repo and pushes the build folder contents into `asf-site`.

## Testing recommendations

This will need some manual testing after merging into `master`, since the workflow only runs on that branch. Make small changes to anything in the `docs` folder on `master`, and observe whether https://github.com/apache/pouchdb-site/tree/asf-site and the associated https://pouchdb.apache.org/ now contain the changes you made.

## Checklist

- [x] I am not a bot
- [x] This is my own work, I did not use AI, LLM's or similar technology for code or docs generation
- [x] Code is written and works correctly 👉 Deployment action works in our org at least  
