### PR TITLE
CI: add missing .asf.yml for automatic deployment

### DIFF
--- a/docs/asf.yml.liquid
+++ b/docs/asf.yml.liquid
@@ -1,0 +1,9 @@
+---
+permalink: /.asf.yml
+---
+staging:
+  profile: ~
+  whoami:  asf-staging
+
+publish:
+  whoami:  asf-site


### PR DESCRIPTION
Just a small addendum to #9244, adds a missing file necessary for the deployment from `apache/pouchdb-site` to work. 