### PR TITLE
Upgrade uuid to 11.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "readable-stream": "1.1.14",
         "spark-md5": "3.0.2",
         "through2": "3.0.2",
-        "uuid": "8.3.2",
+        "uuid": "11.1.1",
         "vuvuzela": "1.0.3"
       },
       "devDependencies": {
@@ -9926,6 +9926,17 @@
         "uuid": "8.3.2"
       }
     },
+    "node_modules/pouchdb-utils/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/pouchdb-validation": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pouchdb-validation/-/pouchdb-validation-4.2.0.tgz",
@@ -12524,11 +12535,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "readable-stream": "1.1.14",
     "spark-md5": "3.0.2",
     "through2": "3.0.2",
-    "uuid": "8.3.2",
+    "uuid": "11.1.1",
     "vuvuzela": "1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Overview

Solves CVE: https://github.com/advisories/GHSA-w5hq-g745-h8pq

Upgrading to **v11.1.1** instead of latest, as this version supports CommonJS, whereas the latest does not. 

## Testing recommendations

Should be no behaviour change.

## Related Issues or Pull Requests

N/A

## Checklist

- [x] I am not a bot
- [x] This is my own work, I did not use AI, LLM's or similar technology for code or docs generation
- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] I modified the [types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/pouchdb) to reflect the changes, if necessary
- [x] Documentation changes were made in the `docs` folder
