### PR TITLE
Fix elemMatch null object array handling

### DIFF
--- a/packages/node_modules/pouchdb-selector-core/src/in-memory-filter.js
+++ b/packages/node_modules/pouchdb-selector-core/src/in-memory-filter.js
@@ -219,9 +219,15 @@ var matchers = {
       return false;
     }
 
-    if (typeof docFieldValue[0] === 'object' &&  docFieldValue[0] !== null) {
+    var userValueKeys = Object.keys(userValue);
+    var userValueHasNonOperator = userValueKeys.some(function (key) {
+      return key.indexOf('$') !== 0;
+    });
+
+    if (userValueHasNonOperator) {
       return docFieldValue.some(function (val) {
-        return rowFilter(val, userValue, Object.keys(userValue));
+        return typeof val === 'object' && val !== null &&
+          rowFilter(val, userValue, userValueKeys);
       });
     }
 

--- a/tests/find/test-suite-1/test.elem-match.js
+++ b/tests/find/test-suite-1/test.elem-match.js
@@ -80,6 +80,26 @@ describe('test.elem-match.js', () => {
     }).should.deep.equal(['2', '3']);
   });
 
+  it('with null element in object array', async () => {
+    const db = context.db;
+    const docs = [
+      {_id: 'null-after-object', test: [{foo: 'blub'}, null]},
+      {_id: 'only-null', test: [null]},
+      {_id: 'no-match', test: [{foo: 'nope'}, null]}
+    ];
+
+    await db.bulkDocs(docs);
+    const resp = await db.find({
+      selector: {
+        test: {$elemMatch: {foo: 'blub'}},
+      },
+      fields: ['_id']
+    });
+    resp.docs.map((doc) => {
+      return doc._id;
+    }).should.deep.equal(['null-after-object']);
+  });
+
   it('should error for non-object query value', async () => {
     const db = context.db;
     try {


### PR DESCRIPTION
Fixes #9103

### Summary

This updates `$elemMatch` handling for arrays that contain both objects and `null` values.

Previously, `$elemMatch` decided whether to use `rowFilter()` based only on the first array element. If the first element was an object, later `null` entries were still passed into `rowFilter()`, which could throw a TypeError when resolving nested fields.

The updated logic checks each array element before applying object-field matching, so `null` entries are ignored for object-field `$elemMatch` selectors instead of throwing.

### Testing

* Added a regression test for `$elemMatch` with an object array containing `null`.
* Verified the new test fails before the fix with:
  `TypeError: Cannot read properties of null`
* Verified after the fix:
  `1 passing`
* Verified the full elem-match test file:
  `7 passing`
* Ran ESLint on the changed source and test files.
