### PR TITLE
Restrict trigger push branch for GitHub Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,9 @@
 name: PouchDB CI
 
 on:
-  push: {}
+  push:
+    branches:
+      - master
   pull_request:
     branches: [master]
 


### PR DESCRIPTION
Feature branches rarely need their own CI runs: the code is already tested when a pull request is opened against a release branch. If the push trigger has no branch restriction and pull_request is also configured, every push to a branch with an open PR runs the workflow twice: once for the push and once for the PR synchronisation.

Always give the push trigger an explicit list of branches: this stops branches created from a release branch from inheriting its workflow runs.

see https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=430408443#GitHubActionsRecommendedPractices-Restrictthepushtriggertospecificbranches

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that PouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     PouchDB committer.

     Artificial Intelligence and Large Language Models Contributions Policy

     It is expressly forbidden to contribute material generated by
     AI, LLMs, and similar technologies, to the PouchDB project. 
     This includes, but is not limited to, source code, documentation,
     commit messages, or any other areas of the project.

-->

## Overview

<!-- Please give a summary of the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] I am not a bot
- [x] This is my own work, I did not use AI, LLM's or similar technology for code or docs generation
- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] I modified the [types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/pouchdb) to reflect the changes, if necessary
- [x] Documentation changes were made in the `docs` folder
