### PR TITLE
perf(find): resolve only the named design doc when use_index is given

### DIFF
--- a/packages/node_modules/pouchdb-find/src/adapters/local/find/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/find/index.js
@@ -1,5 +1,5 @@
 import { clone } from 'pouchdb-utils';
-import getIndexes from '../get-indexes';
+import getIndexes, { getIndexesForUseIndex } from '../get-indexes';
 import { collate } from 'pouchdb-collate';
 import abstractMapper from '../abstract-mapper';
 import planQuery from './query-planner';
@@ -99,10 +99,31 @@ async function find(db, requestDef, explain) {
 
   validateFindRequest(requestDef);
 
-  const getIndexesRes = await getIndexes(db);
+  let getIndexesRes = null;
+  let targetedIndexes = false;
+  if (requestDef.use_index) {
+    const targeted = await getIndexesForUseIndex(db, requestDef.use_index);
+    if (targeted !== null) {
+      getIndexesRes = targeted;
+      targetedIndexes = true;
+    }
+  }
+  if (getIndexesRes === null) {
+    getIndexesRes = await getIndexes(db);
+  }
 
   db.constructor.emit('debug', ['find', 'planning query', requestDef]);
-  const queryPlan = planQuery(requestDef, getIndexesRes.indexes);
+  let queryPlan;
+  try {
+    queryPlan = planQuery(requestDef, getIndexesRes.indexes);
+  } catch (err) {
+    if (!targetedIndexes) {
+      throw err;
+    }
+    const full = await getIndexes(db);
+    planQuery(requestDef, full.indexes);
+    throw err;
+  }
   db.constructor.emit('debug', ['find', 'query plan', queryPlan]);
 
   const indexToUse = queryPlan.index;

--- a/packages/node_modules/pouchdb-find/src/adapters/local/get-indexes/index.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/get-indexes/index.js
@@ -45,4 +45,45 @@ async function getIndexes(db) {
   return res;
 }
 
+export async function getIndexesForUseIndex(db, useIndex) {
+  const ddocName = useIndex && useIndex.length >= 1 ? useIndex[0] : null;
+  if (!ddocName) {
+    return null;
+  }
+  let doc;
+  try {
+    doc = await db.get('_design/' + ddocName);
+  } catch (err) {
+    return null;
+  }
+  if (!doc || doc.language !== 'query' || !doc.views) {
+    return null;
+  }
+  const indexes = [{
+    ddoc: null,
+    name: '_all_docs',
+    type: 'special',
+    def: {
+      fields: [{ _id: 'asc' }]
+    }
+  }];
+  const viewNames = Object.keys(doc.views);
+  for (let i = 0; i < viewNames.length; i++) {
+    const view = doc.views[viewNames[i]];
+    if (!view || !view.options || !view.options.def) {
+      return null;
+    }
+    indexes.push({
+      ddoc: doc._id,
+      name: viewNames[i],
+      type: 'json',
+      def: massageIndexDef(view.options.def)
+    });
+  }
+  indexes.sort(function (left, right) {
+    return compare(left.name, right.name);
+  });
+  return { indexes, total_rows: indexes.length };
+}
+
 export default getIndexes;

--- a/tests/find/test-suite-1/test.use-index.js
+++ b/tests/find/test-suite-1/test.use-index.js
@@ -99,4 +99,20 @@ describe('test.use-index.js', () => {
       err.error.should.equal("no_usable_index");
     }
   });
+
+  it('returns the same docs with a named index as without', async () => {
+    const db = context.db;
+    const selector = { name: { $gte: 'l' }, series: 'mario' };
+    const withIndex = await db.find({
+      selector,
+      use_index: ["index-1"],
+      fields: ["_id"]
+    });
+    const withoutIndex = await db.find({
+      selector,
+      fields: ["_id"]
+    });
+    withIndex.docs.should.deep.equal(withoutIndex.docs);
+    withIndex.docs.map(d => d._id).should.deep.equal(['luigi', 'mario', 'yoshi']);
+  });
 });


### PR DESCRIPTION
## Problem

`find()` always calls `getIndexes(db)`, which does an `allDocs` over the whole
`_design/` range with `include_docs: true` — loading and massaging **every** query
design doc on **every** `find()`, even when the caller already named the index via
`use_index`. The planner then walks all of them only to keep the one that was named.

On a database with many mango indexes (and clients that always pass `use_index`), this is overhead proportional to the number of design docs, repeated per query. On React Native it serializes into a multi-second stall on a large replica.

## Fix

When `use_index` is present, fetch just that one design doc with
`db.get('_design/<ddoc>')` and build the index list from it. If anything is unexpected
(missing ddoc, non-query language, malformed views, or the named index doesn't satisfy
the request), fall back to the original full `getIndexes()` path — so results and error
behaviour are unchanged (the existing `unknown_error` / `no_usable_index` cases still
raise the same errors).

Ported to async/await to match current master; adds a test asserting a `use_index` find
returns the same docs as the unindexed find.